### PR TITLE
Rework ability generation in Random Battles

### DIFF
--- a/data/random-battles/gen2/teams.ts
+++ b/data/random-battles/gen2/teams.ts
@@ -140,7 +140,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 	// Generate random moveset for a given species, role, preferred type.
 	randomMoveset(
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -402,7 +402,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 		const ivs = {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30};
 
 		const types = species.types;
-		const abilities = new Set(Object.values(species.abilities));
+		const abilities: string[] = [];
 
 		// Get moves
 		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, movePool,

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -4,11 +4,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowergrass", "leechseed", "sleeppowder", "sludgebomb", "substitute"]
+                "movepool": ["hiddenpowergrass", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "hiddenpowerghost", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"],
+                "abilities": ["Overgrow"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -19,16 +21,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["dragondance", "earthquake", "fireblast", "hiddenpowerflying", "rockslide"],
+                "abilities": ["Blaze"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["bellydrum", "earthquake", "hiddenpowerflying", "rockslide", "substitute"],
+                "abilities": ["Blaze"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["dragonclaw", "fireblast", "hiddenpowergrass", "substitute"]
+                "movepool": ["dragonclaw", "fireblast", "hiddenpowergrass", "substitute"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -37,15 +42,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "rapidspin", "refresh", "roar", "surf", "toxic"]
+                "movepool": ["icebeam", "rapidspin", "refresh", "roar", "surf", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "refresh", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "refresh", "surf", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -55,6 +63,7 @@
             {
                 "role": "Generalist",
                 "movepool": ["hiddenpowerfire", "morningsun", "psychic", "sleeppowder", "stunspore", "toxic"],
+                "abilities": ["Compound Eyes"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -65,11 +74,13 @@
             {
                 "role": "Berry Sweeper",
                 "movepool": ["brickbreak", "endure", "hiddenpowerbug", "sludgebomb", "swordsdance"],
+                "abilities": ["Swarm"],
                 "preferredTypes": ["Bug"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["brickbreak", "doubleedge", "hiddenpowerbug", "sludgebomb", "swordsdance"]
+                "movepool": ["brickbreak", "doubleedge", "hiddenpowerbug", "sludgebomb", "swordsdance"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -79,11 +90,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aerialace", "doubleedge", "hiddenpowerground", "quickattack", "return", "toxic"],
+                "abilities": ["Keen Eye"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["aerialace", "hiddenpowerground", "return", "substitute"]
+                "movepool": ["aerialace", "hiddenpowerground", "return", "substitute"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -92,15 +105,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "hiddenpowerground", "quickattack", "return", "shadowball"]
+                "movepool": ["doubleedge", "hiddenpowerground", "quickattack", "return", "shadowball"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "facade", "hiddenpowerground", "return", "shadowball"]
+                "movepool": ["doubleedge", "facade", "hiddenpowerground", "return", "shadowball"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["return", "reversal", "shadowball", "substitute"]
+                "movepool": ["return", "reversal", "shadowball", "substitute"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -109,7 +125,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "return"]
+                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "return"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -119,6 +136,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "hiddenpowerghost", "rest", "rockslide", "sleeptalk", "sludgebomb"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -129,11 +147,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["encore", "hiddenpowerice", "substitute", "surf", "thunderbolt"],
+                "abilities": ["Static"],
                 "preferredTypes": ["Ice", "Water"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerice", "surf", "thunderbolt", "volttackle"]
+                "movepool": ["hiddenpowerice", "surf", "thunderbolt", "volttackle"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -143,11 +163,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["encore", "hiddenpowerice", "surf", "thunderbolt", "thunderwave", "toxic"],
+                "abilities": ["Static"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["hiddenpowerice", "substitute", "surf", "thunderbolt"]
+                "movepool": ["hiddenpowerice", "substitute", "surf", "thunderbolt"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -157,6 +179,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "hiddenpowerbug", "rapidspin", "rockslide", "swordsdance", "toxic"],
+                "abilities": ["Sand Veil"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -166,7 +189,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "shadowball", "sludgebomb", "substitute", "thunderbolt"]
+                "movepool": ["earthquake", "fireblast", "icebeam", "shadowball", "sludgebomb", "substitute", "thunderbolt"],
+                "abilities": ["Poison Point"]
             }
         ]
     },
@@ -175,7 +199,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "shadowball", "sludgebomb", "substitute", "thunderbolt"]
+                "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "shadowball", "sludgebomb", "substitute", "thunderbolt"],
+                "abilities": ["Poison Point"]
             }
         ]
     },
@@ -184,11 +209,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "return", "shadowball", "softboiled", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "return", "shadowball", "softboiled", "thunderwave", "toxic"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"]
+                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"],
+                "abilities": ["Cute Charm"]
             }
         ]
     },
@@ -197,7 +224,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hypnosis", "substitute", "toxic", "willowisp"]
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hypnosis", "substitute", "toxic", "willowisp"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -206,15 +234,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "fireblast", "protect", "wish"]
+                "movepool": ["bodyslam", "fireblast", "protect", "wish"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"]
+                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Cute Charm"]
             }
         ]
     },
@@ -223,7 +254,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "hiddenpowerfire", "hiddenpowergrass", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["aromatherapy", "hiddenpowerfire", "hiddenpowergrass", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -233,6 +265,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aromatherapy", "gigadrain", "hiddenpowerbug", "return", "spore", "stunspore"],
+                "abilities": ["Effect Spore"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -242,11 +275,13 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["batonpass", "hiddenpowerfire", "psychic", "signalbeam", "sleeppowder", "sludgebomb", "substitute"]
+                "movepool": ["batonpass", "hiddenpowerfire", "psychic", "signalbeam", "sleeppowder", "sludgebomb", "substitute"],
+                "abilities": ["Shield Dust"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfire", "psychic", "signalbeam", "sleeppowder", "sludgebomb"]
+                "movepool": ["hiddenpowerfire", "psychic", "signalbeam", "sleeppowder", "sludgebomb"],
+                "abilities": ["Shield Dust"]
             }
         ]
     },
@@ -255,7 +290,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "hiddenpowerbug", "rockslide", "sludgebomb"]
+                "movepool": ["earthquake", "hiddenpowerbug", "rockslide", "sludgebomb"],
+                "abilities": ["Arena Trap"]
             }
         ]
     },
@@ -264,11 +300,13 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["hiddenpowerground", "irontail", "return", "shadowball", "substitute"]
+                "movepool": ["hiddenpowerground", "irontail", "return", "shadowball", "substitute"],
+                "abilities": ["Limber"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerground", "hypnosis", "irontail", "return", "shadowball"]
+                "movepool": ["hiddenpowerground", "hypnosis", "irontail", "return", "shadowball"],
+                "abilities": ["Limber"]
             }
         ]
     },
@@ -278,6 +316,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowergrass", "hydropump", "hypnosis", "icebeam", "substitute", "surf"],
+                "abilities": ["Cloud Nine"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -287,15 +326,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "rockslide"]
+                "movepool": ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "rockslide"],
+                "abilities": ["Vital Spirit"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bulkup", "crosschop", "hiddenpowerghost", "rockslide", "substitute"]
+                "movepool": ["bulkup", "crosschop", "hiddenpowerghost", "rockslide", "substitute"],
+                "abilities": ["Vital Spirit"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["bulkup", "hiddenpowerghost", "reversal", "substitute"]
+                "movepool": ["bulkup", "hiddenpowerghost", "reversal", "substitute"],
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -304,16 +346,19 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "toxic"]
+                "movepool": ["flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "toxic"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "extremespeed", "fireblast", "hiddenpowerrock", "irontail"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Steel"]
             },
             {
                 "role": "Staller",
-                "movepool": ["flamethrower", "hiddenpowergrass", "hiddenpowerrock", "protect", "toxic"]
+                "movepool": ["flamethrower", "hiddenpowergrass", "hiddenpowerrock", "protect", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -322,15 +367,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["brickbreak", "bulkup", "earthquake", "hiddenpowerghost", "hydropump", "hypnosis", "substitute"]
+                "movepool": ["brickbreak", "bulkup", "earthquake", "hiddenpowerghost", "hydropump", "hypnosis", "substitute"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["brickbreak", "hiddenpowerghost", "hydropump", "hypnosis", "icebeam", "rest", "sleeptalk", "toxic"]
+                "movepool": ["brickbreak", "hiddenpowerghost", "hydropump", "hypnosis", "icebeam", "rest", "sleeptalk", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["focuspunch", "hydropump", "icebeam", "substitute", "toxic"]
+                "movepool": ["focuspunch", "hydropump", "icebeam", "substitute", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -340,6 +388,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "encore", "firepunch", "icepunch", "psychic", "recover", "substitute", "thunderpunch"],
+                "abilities": ["Synchronize"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -349,11 +398,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "rockslide"]
+                "movepool": ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "rockslide"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crosschop", "hiddenpowerghost", "rest", "rockslide", "sleeptalk"]
+                "movepool": ["crosschop", "hiddenpowerghost", "rest", "rockslide", "sleeptalk"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -362,16 +413,19 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerfire", "sludgebomb", "solarbeam", "sunnyday"]
+                "movepool": ["hiddenpowerfire", "sludgebomb", "solarbeam", "sunnyday"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["hiddenpowerground", "magicalleaf", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Chlorophyll"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerground", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"]
+                "movepool": ["hiddenpowerground", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -380,7 +434,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hydropump", "icebeam", "rapidspin", "sludgebomb", "surf", "toxic"]
+                "movepool": ["hydropump", "icebeam", "rapidspin", "sludgebomb", "surf", "toxic"],
+                "abilities": ["Clear Body", "Liquid Ooze"]
             }
         ]
     },
@@ -389,11 +444,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "rockslide", "toxic"]
+                "movepool": ["earthquake", "protect", "rockslide", "toxic"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "earthquake", "explosion", "hiddenpowerbug", "rockslide", "toxic"]
+                "movepool": ["doubleedge", "earthquake", "explosion", "hiddenpowerbug", "rockslide", "toxic"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -402,7 +459,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fireblast", "hiddenpowergrass", "hiddenpowerrock", "substitute", "toxic"]
+                "movepool": ["fireblast", "hiddenpowergrass", "hiddenpowerrock", "substitute", "toxic"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -411,15 +469,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "psychic", "rest", "sleeptalk", "surf", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "icebeam", "psychic", "rest", "sleeptalk", "surf", "thunderwave", "toxic"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "psychic", "rest", "surf"]
+                "movepool": ["calmmind", "psychic", "rest", "surf"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "rest", "sleeptalk", "surf"]
+                "movepool": ["calmmind", "rest", "sleeptalk", "surf"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -428,11 +489,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"]
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Magnet Pull"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerice", "rest", "sleeptalk", "thunderbolt"]
+                "movepool": ["hiddenpowerice", "rest", "sleeptalk", "thunderbolt"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -441,7 +504,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "batonpass", "return", "swordsdance"]
+                "movepool": ["agility", "batonpass", "return", "swordsdance"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -450,11 +514,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "return"]
+                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "return"],
+                "abilities": ["Early Bird"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["drillpeck", "flail", "hiddenpowerground", "quickattack", "substitute"]
+                "movepool": ["drillpeck", "flail", "hiddenpowerground", "quickattack", "substitute"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -463,11 +529,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -477,11 +545,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["explosion", "fireblast", "hiddenpowerground", "rest", "sludgebomb", "toxic"],
+                "abilities": ["Sticky Hold"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["curse", "hiddenpowerground", "rest", "sludgebomb"]
+                "movepool": ["curse", "hiddenpowerground", "rest", "sludgebomb"],
+                "abilities": ["Sticky Hold"]
             }
         ]
     },
@@ -490,11 +560,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["explosion", "icebeam", "rapidspin", "spikes", "surf", "toxic"]
+                "movepool": ["explosion", "icebeam", "rapidspin", "spikes", "surf", "toxic"],
+                "abilities": ["Shell Armor"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["explosion", "rapidspin", "spikes", "surf", "toxic"]
+                "movepool": ["explosion", "rapidspin", "spikes", "surf", "toxic"],
+                "abilities": ["Shell Armor"]
             }
         ]
     },
@@ -504,6 +576,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["destinybond", "explosion", "firepunch", "icepunch", "substitute", "thunderbolt", "willowisp"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Electric", "Ice"]
             }
         ]
@@ -513,15 +586,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "firepunch", "psychic"]
+                "movepool": ["batonpass", "calmmind", "firepunch", "psychic"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["firepunch", "protect", "psychic", "toxic", "wish"]
+                "movepool": ["firepunch", "protect", "psychic", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -530,7 +606,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["doubleedge", "hiddenpowerghost", "hiddenpowerground", "surf", "swordsdance"]
+                "movepool": ["doubleedge", "hiddenpowerghost", "hiddenpowerground", "surf", "swordsdance"],
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },
@@ -539,7 +616,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["explosion", "hiddenpowerice", "substitute", "thunderbolt", "toxic"]
+                "movepool": ["explosion", "hiddenpowerice", "substitute", "thunderbolt", "toxic"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -548,15 +626,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "hiddenpowerfire", "psychic", "sleeppowder", "stunspore", "synthesis"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "psychic", "sleeppowder", "stunspore", "synthesis"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["explosion", "gigadrain", "hiddenpowerfire", "leechseed", "psychic", "sleeppowder", "stunspore", "substitute"]
+                "movepool": ["explosion", "gigadrain", "hiddenpowerfire", "leechseed", "psychic", "sleeppowder", "stunspore", "substitute"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfire", "psychic", "solarbeam", "sunnyday"]
+                "movepool": ["hiddenpowerfire", "psychic", "solarbeam", "sunnyday"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -565,11 +646,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["doubleedge", "earthquake", "rockslide", "swordsdance"]
+                "movepool": ["doubleedge", "earthquake", "rockslide", "swordsdance"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["bonemerang", "doubleedge", "rockslide", "swordsdance"]
+                "movepool": ["bonemerang", "doubleedge", "rockslide", "swordsdance"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -579,11 +662,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rockslide"],
+                "abilities": ["Limber"],
                 "preferredTypes": ["Ghost"]
             },
             {
                 "role": "Berry Sweeper",
                 "movepool": ["earthquake", "hiddenpowerghost", "reversal", "rockslide", "substitute"],
+                "abilities": ["Limber"],
                 "preferredTypes": ["Ghost"]
             }
         ]
@@ -594,6 +679,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bulkup", "earthquake", "hiddenpowerghost", "machpunch", "rapidspin", "rockslide", "skyuppercut", "toxic"],
+                "abilities": ["Keen Eye"],
                 "preferredTypes": ["Ghost"]
             }
         ]
@@ -603,15 +689,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "earthquake", "protect", "wish"]
+                "movepool": ["bodyslam", "earthquake", "protect", "wish"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "knockoff", "protect", "seismictoss", "wish"]
+                "movepool": ["healbell", "knockoff", "protect", "seismictoss", "wish"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -620,7 +709,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["explosion", "fireblast", "haze", "painsplit", "sludgebomb", "toxic", "willowisp"]
+                "movepool": ["explosion", "fireblast", "haze", "painsplit", "sludgebomb", "toxic", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -629,11 +719,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "megahorn", "rockslide", "substitute", "swordsdance"]
+                "movepool": ["earthquake", "megahorn", "rockslide", "substitute", "swordsdance"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "megahorn", "rockslide"]
+                "movepool": ["doubleedge", "earthquake", "megahorn", "rockslide"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -642,11 +734,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowergrass", "leechseed", "morningsun", "sleeppowder", "stunspore", "toxic"]
+                "movepool": ["hiddenpowergrass", "leechseed", "morningsun", "sleeppowder", "stunspore", "toxic"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfire", "morningsun", "sleeppowder", "solarbeam", "sunnyday"]
+                "movepool": ["hiddenpowerfire", "morningsun", "sleeppowder", "solarbeam", "sunnyday"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -656,11 +750,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["doubleedge", "earthquake", "rest", "return", "shadowball", "toxic"],
+                "abilities": ["Early Bird"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "earthquake", "protect", "return", "wish"]
+                "movepool": ["bodyslam", "earthquake", "protect", "return", "wish"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -669,7 +765,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "megahorn", "raindance"]
+                "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "megahorn", "raindance"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -678,7 +775,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hydropump", "icebeam", "psychic", "recover", "surf", "thunderbolt"]
+                "movepool": ["hydropump", "icebeam", "psychic", "recover", "surf", "thunderbolt"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -687,7 +785,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "encore", "firepunch", "hypnosis", "psychic", "substitute", "thunderbolt"]
+                "movepool": ["batonpass", "calmmind", "encore", "firepunch", "hypnosis", "psychic", "substitute", "thunderbolt"],
+                "abilities": ["Soundproof"]
             }
         ]
     },
@@ -697,6 +796,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["aerialace", "batonpass", "hiddenpowerground", "silverwind", "swordsdance"],
+                "abilities": ["Swarm"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -706,7 +806,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerfire", "icebeam", "lovelykiss", "psychic", "substitute"]
+                "movepool": ["calmmind", "hiddenpowerfire", "icebeam", "lovelykiss", "psychic", "substitute"],
+                "abilities": ["Oblivious"]
             }
         ]
     },
@@ -716,11 +817,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crosschop", "firepunch", "focuspunch", "hiddenpowergrass", "icepunch", "substitute", "thunderbolt"],
+                "abilities": ["Static"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Berry Sweeper",
                 "movepool": ["firepunch", "hiddenpowergrass", "icepunch", "substitute", "thunderbolt"],
+                "abilities": ["Static"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -731,11 +834,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crosschop", "fireblast", "flamethrower", "focuspunch", "hiddenpowergrass", "hiddenpowerice", "psychic", "substitute", "thunderpunch"],
+                "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Berry Sweeper",
                 "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "psychic", "substitute", "thunderpunch"],
+                "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -745,11 +850,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "hiddenpowerbug", "rockslide", "swordsdance"]
+                "movepool": ["earthquake", "hiddenpowerbug", "rockslide", "swordsdance"],
+                "abilities": ["Hyper Cutter"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "hiddenpowerbug", "rockslide"]
+                "movepool": ["doubleedge", "earthquake", "hiddenpowerbug", "rockslide"],
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },
@@ -758,7 +865,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "hiddenpowerghost", "return"]
+                "movepool": ["doubleedge", "earthquake", "hiddenpowerghost", "return"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -768,11 +876,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "dragondance", "earthquake", "hiddenpowerflying", "hydropump"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "dragondance", "earthquake", "hiddenpowerflying", "substitute"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -782,11 +892,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["healbell", "icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "toxic"]
+                "movepool": ["healbell", "icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["healbell", "icebeam", "rest", "sleeptalk", "thunderbolt", "toxic"]
+                "movepool": ["healbell", "icebeam", "rest", "sleeptalk", "thunderbolt", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -795,7 +907,8 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["transform"]
+                "movepool": ["transform"],
+                "abilities": ["Limber"]
             }
         ]
     },
@@ -804,7 +917,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "protect", "surf", "toxic", "wish"]
+                "movepool": ["icebeam", "protect", "surf", "toxic", "wish"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -813,11 +927,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"]
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Volt Absorb"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["batonpass", "hiddenpowerice", "substitute", "thunderbolt"]
+                "movepool": ["batonpass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -826,11 +942,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["flamethrower", "hiddenpowergrass", "protect", "toxic", "wish"]
+                "movepool": ["flamethrower", "hiddenpowergrass", "protect", "toxic", "wish"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "fireblast", "hiddenpowergrass", "hiddenpowerrock", "irontail", "shadowball", "toxic"]
+                "movepool": ["doubleedge", "fireblast", "hiddenpowergrass", "hiddenpowerrock", "irontail", "shadowball", "toxic"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -839,11 +957,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "spikes", "surf"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "spikes", "surf"],
+                "abilities": ["Shell Armor", "Swift Swim"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -852,7 +972,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["brickbreak", "hiddenpowerflying", "rockslide", "surf", "swordsdance"]
+                "movepool": ["brickbreak", "hiddenpowerflying", "rockslide", "surf", "swordsdance"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             }
         ]
     },
@@ -861,11 +982,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "hiddenpowerflying", "rockslide"]
+                "movepool": ["doubleedge", "earthquake", "hiddenpowerflying", "rockslide"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["earthquake", "hiddenpowerflying", "rockslide", "substitute"]
+                "movepool": ["earthquake", "hiddenpowerflying", "rockslide", "substitute"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -874,15 +997,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bodyslam", "earthquake", "return", "selfdestruct", "shadowball"]
+                "movepool": ["bodyslam", "earthquake", "return", "selfdestruct", "shadowball"],
+                "abilities": ["Immunity"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "curse", "rest", "sleeptalk"]
+                "movepool": ["bodyslam", "curse", "rest", "sleeptalk"],
+                "abilities": ["Immunity"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "earthquake", "rest"]
+                "movepool": ["bodyslam", "curse", "earthquake", "rest"],
+                "abilities": ["Immunity"]
             }
         ]
     },
@@ -891,11 +1017,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["healbell", "hiddenpowerfire", "icebeam", "protect", "toxic"]
+                "movepool": ["healbell", "hiddenpowerfire", "icebeam", "protect", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerfire", "icebeam", "rest", "sleeptalk"]
+                "movepool": ["hiddenpowerfire", "icebeam", "rest", "sleeptalk"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -904,15 +1032,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"]
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["batonpass", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave", "toxic"]
+                "movepool": ["batonpass", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerice", "rest", "sleeptalk", "thunderbolt"]
+                "movepool": ["hiddenpowerice", "rest", "sleeptalk", "thunderbolt"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -921,7 +1052,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "morningsun", "substitute", "toxic", "willowisp"]
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "morningsun", "substitute", "toxic", "willowisp"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -931,11 +1063,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "dragondance", "earthquake", "healbell", "hiddenpowerflying", "rest", "substitute"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["brickbreak", "doubleedge", "earthquake", "fireblast", "hiddenpowerflying"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -945,11 +1079,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "flamethrower", "psychic", "recover"]
+                "movepool": ["calmmind", "flamethrower", "psychic", "recover"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "flamethrower", "icebeam", "psychic", "thunderbolt"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -959,15 +1095,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["explosion", "flamethrower", "psychic", "softboiled", "thunderwave", "transform"]
+                "movepool": ["explosion", "flamethrower", "psychic", "softboiled", "thunderwave", "transform"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "flamethrower", "psychic", "softboiled", "thunderbolt"]
+                "movepool": ["calmmind", "flamethrower", "psychic", "softboiled", "thunderbolt"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["brickbreak", "earthquake", "explosion", "rockslide", "softboiled", "swordsdance"],
+                "abilities": ["Synchronize"],
                 "preferredTypes": ["Ground", "Rock"]
             }
         ]
@@ -977,11 +1116,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["bodyslam", "earthquake", "hiddenpowergrass", "leechseed", "synthesis", "toxic"]
+                "movepool": ["bodyslam", "earthquake", "hiddenpowergrass", "leechseed", "synthesis", "toxic"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bodyslam", "earthquake", "hiddenpowerrock", "swordsdance", "synthesis"],
+                "abilities": ["Overgrow"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -991,11 +1132,13 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowerice", "substitute", "thunderpunch"]
+                "movepool": ["fireblast", "flamethrower", "hiddenpowerice", "substitute", "thunderpunch"],
+                "abilities": ["Blaze"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "fireblast", "flamethrower", "focuspunch", "hiddenpowerice", "substitute", "thunderpunch", "toxic"],
+                "abilities": ["Blaze"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -1006,6 +1149,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "hiddenpowerflying", "hydropump", "rockslide", "swordsdance"],
+                "abilities": ["Torrent"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1015,15 +1159,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["brickbreak", "doubleedge", "quickattack", "return", "shadowball"]
+                "movepool": ["brickbreak", "doubleedge", "quickattack", "return", "shadowball"],
+                "abilities": ["Keen Eye"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["brickbreak", "doubleedge", "return", "shadowball", "trick"]
+                "movepool": ["brickbreak", "doubleedge", "return", "shadowball", "trick"],
+                "abilities": ["Keen Eye"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["return", "reversal", "shadowball", "substitute"]
+                "movepool": ["return", "reversal", "shadowball", "substitute"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -1032,7 +1179,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerfire", "hypnosis", "return", "toxic", "whirlwind"]
+                "movepool": ["hiddenpowerfire", "hypnosis", "return", "toxic", "whirlwind"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -1041,11 +1189,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "batonpass", "silverwind", "swordsdance"]
+                "movepool": ["agility", "batonpass", "silverwind", "swordsdance"],
+                "abilities": ["Swarm"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["batonpass", "silverwind", "substitute", "swordsdance"]
+                "movepool": ["batonpass", "silverwind", "substitute", "swordsdance"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1054,16 +1204,19 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "batonpass", "signalbeam", "sludgebomb"]
+                "movepool": ["agility", "batonpass", "signalbeam", "sludgebomb"],
+                "abilities": ["Insomnia", "Swarm"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["batonpass", "signalbeam", "sludgebomb", "spiderweb", "toxic"],
+                "abilities": ["Insomnia", "Swarm"],
                 "preferredTypes": ["Bug"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["agility", "batonpass", "sludgebomb", "spiderweb"]
+                "movepool": ["agility", "batonpass", "sludgebomb", "spiderweb"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -1073,6 +1226,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aerialace", "haze", "hiddenpowerground", "shadowball", "sludgebomb", "toxic"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1082,7 +1236,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "toxic"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "toxic"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -1091,7 +1246,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["charm", "encore", "flamethrower", "seismictoss", "softboiled", "thunderwave", "toxic"]
+                "movepool": ["charm", "encore", "flamethrower", "seismictoss", "softboiled", "thunderwave", "toxic"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -1100,15 +1256,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "psychic", "rest"]
+                "movepool": ["calmmind", "hiddenpowerfire", "psychic", "rest"],
+                "abilities": ["Early Bird"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerfire", "protect", "psychic", "wish"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "protect", "psychic", "wish"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "psychic", "thunderwave", "toxic", "wish"]
+                "movepool": ["protect", "psychic", "thunderwave", "toxic", "wish"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1118,6 +1277,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["firepunch", "healbell", "hiddenpowerice", "thunderbolt", "toxic"],
+                "abilities": ["Static"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1127,7 +1287,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerfire", "leechseed", "magicalleaf", "moonlight", "sleeppowder", "stunspore"]
+                "movepool": ["hiddenpowerfire", "leechseed", "magicalleaf", "moonlight", "sleeppowder", "stunspore"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1137,6 +1298,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["brickbreak", "doubleedge", "hiddenpowerghost", "hydropump", "rest", "return", "sleeptalk"],
+                "abilities": ["Huge Power"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -1147,6 +1309,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["brickbreak", "doubleedge", "earthquake", "explosion", "rockslide", "toxic"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1157,15 +1320,18 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["hiddenpowergrass", "hypnosis", "icebeam", "rest", "surf", "toxic"],
+                "abilities": ["Water Absorb"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -1174,11 +1340,13 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["encore", "hiddenpowerflying", "sleeppowder", "synthesis", "toxic"]
+                "movepool": ["encore", "hiddenpowerflying", "sleeppowder", "synthesis", "toxic"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerflying", "leechseed", "protect", "substitute"]
+                "movepool": ["hiddenpowerflying", "leechseed", "protect", "substitute"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1188,15 +1356,18 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["brickbreak", "focuspunch", "return", "shadowball", "substitute", "thunderwave", "toxic"],
+                "abilities": ["Pickup", "Run Away"],
                 "preferredTypes": ["Ghost"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["batonpass", "brickbreak", "return", "shadowball", "substitute", "thunderwave", "toxic"]
+                "movepool": ["batonpass", "brickbreak", "return", "shadowball", "substitute", "thunderwave", "toxic"],
+                "abilities": ["Pickup", "Run Away"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["batonpass", "brickbreak", "doubleedge", "return", "shadowball"]
+                "movepool": ["batonpass", "brickbreak", "doubleedge", "return", "shadowball"],
+                "abilities": ["Pickup", "Run Away"]
             }
         ]
     },
@@ -1205,11 +1376,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerfire", "leechseed", "razorleaf", "synthesis", "toxic"]
+                "movepool": ["hiddenpowerfire", "leechseed", "razorleaf", "synthesis", "toxic"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerfire", "solarbeam", "sunnyday", "synthesis"]
+                "movepool": ["hiddenpowerfire", "solarbeam", "sunnyday", "synthesis"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1218,11 +1391,13 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["hiddenpowerflying", "hypnosis", "reversal", "shadowball", "substitute"]
+                "movepool": ["hiddenpowerflying", "hypnosis", "reversal", "shadowball", "substitute"],
+                "abilities": ["Compound Eyes", "Speed Boost"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["aerialace", "doubleedge", "hiddenpowerground", "hypnosis", "signalbeam", "toxic"],
+                "abilities": ["Compound Eyes", "Speed Boost"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1232,11 +1407,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "icebeam", "protect", "toxic"]
+                "movepool": ["earthquake", "icebeam", "protect", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["earthquake", "icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -1245,7 +1422,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "substitute"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "substitute"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1254,11 +1432,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerfire", "hiddenpowerground", "protect", "toxic", "wish"]
+                "movepool": ["hiddenpowerfire", "hiddenpowerground", "protect", "toxic", "wish"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["batonpass", "protect", "toxic", "wish"]
+                "movepool": ["batonpass", "protect", "toxic", "wish"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1267,15 +1447,18 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "substitute"]
+                "movepool": ["drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "substitute"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball"]
+                "movepool": ["doubleedge", "drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "thunderwave", "toxic"]
+                "movepool": ["drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "thunderwave", "toxic"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -1284,15 +1467,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "psychic", "rest", "sleeptalk", "surf", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "icebeam", "psychic", "rest", "sleeptalk", "surf", "thunderwave", "toxic"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "psychic", "rest", "surf"]
+                "movepool": ["calmmind", "psychic", "rest", "surf"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "rest", "sleeptalk", "surf"]
+                "movepool": ["calmmind", "rest", "sleeptalk", "surf"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -1301,15 +1487,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerice", "painsplit", "shadowball", "thunderbolt", "thunderwave", "toxic"]
+                "movepool": ["hiddenpowerice", "painsplit", "shadowball", "thunderbolt", "thunderwave", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Staller",
-                "movepool": ["meanlook", "perishsong", "protect", "shadowball"]
+                "movepool": ["meanlook", "perishsong", "protect", "shadowball"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerice", "substitute", "thunderbolt"]
+                "movepool": ["calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1318,11 +1507,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerpsychic"]
+                "movepool": ["hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerbug", "hiddenpowerfighting"]
+                "movepool": ["hiddenpowerbug", "hiddenpowerfighting"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1331,7 +1522,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"]
+                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"],
+                "abilities": ["Shadow Tag"]
             }
         ]
     },
@@ -1340,11 +1532,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "crunch", "psychic", "rest", "substitute", "thunderbolt"]
+                "movepool": ["batonpass", "calmmind", "crunch", "psychic", "rest", "substitute", "thunderbolt"],
+                "abilities": ["Early Bird"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "protect", "psychic", "return", "shadowball", "thunderbolt", "thunderwave", "toxic", "wish"]
+                "movepool": ["doubleedge", "earthquake", "protect", "psychic", "return", "shadowball", "thunderbolt", "thunderwave", "toxic", "wish"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -1353,11 +1547,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"]
+                "movepool": ["earthquake", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"]
+                "movepool": ["explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1366,11 +1562,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "earthquake", "rest", "shadowball"]
+                "movepool": ["bodyslam", "curse", "earthquake", "rest", "shadowball"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headbutt", "shadowball", "thunderwave"]
+                "movepool": ["earthquake", "headbutt", "shadowball", "thunderwave"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -1379,7 +1577,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "hiddenpowerflying", "quickattack", "rockslide", "substitute", "swordsdance"]
+                "movepool": ["earthquake", "hiddenpowerflying", "quickattack", "rockslide", "substitute", "swordsdance"],
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },
@@ -1388,11 +1587,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "earthquake", "explosion", "hiddenpowerrock", "irontail", "rest", "roar", "toxic"]
+                "movepool": ["doubleedge", "earthquake", "explosion", "hiddenpowerrock", "irontail", "rest", "roar", "toxic"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Staller",
-                "movepool": ["doubleedge", "earthquake", "hiddenpowerrock", "protect", "toxic"]
+                "movepool": ["doubleedge", "earthquake", "hiddenpowerrock", "protect", "toxic"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -1401,15 +1602,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "rest", "return", "sleeptalk"]
+                "movepool": ["doubleedge", "earthquake", "rest", "return", "sleeptalk"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulkup", "doubleedge", "earthquake", "overheat", "shadowball"]
+                "movepool": ["bulkup", "doubleedge", "earthquake", "overheat", "shadowball"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "healbell", "return", "shadowball", "thunderwave"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1419,11 +1623,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hydropump", "selfdestruct", "shadowball", "sludgebomb", "swordsdance"]
+                "movepool": ["hydropump", "selfdestruct", "shadowball", "sludgebomb", "swordsdance"],
+                "abilities": ["Poison Point", "Swift Swim"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["destinybond", "hydropump", "selfdestruct", "sludgebomb", "spikes"]
+                "movepool": ["destinybond", "hydropump", "selfdestruct", "sludgebomb", "spikes"],
+                "abilities": ["Poison Point", "Swift Swim"]
             }
         ]
     },
@@ -1432,11 +1638,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "hiddenpowerground", "morningsun", "silverwind", "steelwing", "swordsdance"]
+                "movepool": ["batonpass", "hiddenpowerground", "morningsun", "silverwind", "steelwing", "swordsdance"],
+                "abilities": ["Swarm"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["agility", "batonpass", "hiddenpowerground", "silverwind", "steelwing"]
+                "movepool": ["agility", "batonpass", "hiddenpowerground", "silverwind", "steelwing"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1445,7 +1653,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["encore", "rest", "toxic", "wrap"]
+                "movepool": ["encore", "rest", "toxic", "wrap"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1455,15 +1664,18 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["brickbreak", "earthquake", "hiddenpowerghost", "megahorn", "rockslide"],
+                "abilities": ["Guts"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["brickbreak", "megahorn", "rockslide", "swordsdance"]
+                "movepool": ["brickbreak", "megahorn", "rockslide", "swordsdance"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["endure", "megahorn", "reversal", "rockslide", "substitute"]
+                "movepool": ["endure", "megahorn", "reversal", "rockslide", "substitute"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1473,11 +1685,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["brickbreak", "hiddenpowerflying", "shadowball", "substitute", "swordsdance"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Fighting", "Ghost"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["brickbreak", "doubleedge", "hiddenpowerflying", "shadowball", "swordsdance"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Fighting", "Ghost"]
             }
         ]
@@ -1487,15 +1701,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "focuspunch", "hiddenpowerghost", "return"]
+                "movepool": ["earthquake", "focuspunch", "hiddenpowerghost", "return"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "facade", "hiddenpowerghost", "return"]
+                "movepool": ["earthquake", "facade", "hiddenpowerghost", "return"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "hiddenpowerghost", "return", "swordsdance"]
+                "movepool": ["earthquake", "hiddenpowerghost", "return", "swordsdance"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -1504,11 +1721,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "toxic"]
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "toxic"],
+                "abilities": ["Flame Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "protect", "toxic"]
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "protect", "toxic"],
+                "abilities": ["Flame Body"]
             }
         ]
     },
@@ -1517,11 +1736,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "icebeam", "protect", "toxic"]
+                "movepool": ["earthquake", "icebeam", "protect", "toxic"],
+                "abilities": ["Oblivious"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "icebeam", "rest", "rockslide", "sleeptalk"]
+                "movepool": ["doubleedge", "earthquake", "icebeam", "rest", "rockslide", "sleeptalk"],
+                "abilities": ["Oblivious"]
             }
         ]
     },
@@ -1530,7 +1751,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "recover", "surf", "toxic"]
+                "movepool": ["calmmind", "icebeam", "recover", "surf", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1540,6 +1762,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["fireblast", "hiddenpowerelectric", "hiddenpowergrass", "icebeam", "surf", "thunderwave"],
+                "abilities": ["Suction Cups"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1550,6 +1773,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aerialace", "doubleedge", "focuspunch", "hiddenpowerground", "icebeam", "quickattack"],
+                "abilities": ["Hustle"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1559,15 +1783,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowergrass", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["hiddenpowergrass", "icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["haze", "icebeam", "protect", "surf", "toxic"]
+                "movepool": ["haze", "icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1576,15 +1803,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["drillpeck", "protect", "rest", "spikes", "toxic"]
+                "movepool": ["drillpeck", "protect", "rest", "spikes", "toxic"],
+                "abilities": ["Keen Eye"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["drillpeck", "spikes", "toxic", "whirlwind"]
+                "movepool": ["drillpeck", "spikes", "toxic", "whirlwind"],
+                "abilities": ["Keen Eye"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "spikes", "toxic", "whirlwind"]
+                "movepool": ["protect", "spikes", "toxic", "whirlwind"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -1593,11 +1823,13 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["crunch", "fireblast", "hiddenpowergrass", "substitute"]
+                "movepool": ["crunch", "fireblast", "hiddenpowergrass", "substitute"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "fireblast", "hiddenpowergrass", "pursuit", "willowisp"]
+                "movepool": ["crunch", "fireblast", "hiddenpowergrass", "pursuit", "willowisp"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -1607,6 +1839,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "substitute", "surf"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1616,7 +1849,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "rapidspin", "rest", "rockslide", "sleeptalk", "toxic"]
+                "movepool": ["earthquake", "rapidspin", "rest", "rockslide", "sleeptalk", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1625,7 +1859,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "recover", "return", "thunderbolt", "thunderwave", "toxic"]
+                "movepool": ["icebeam", "recover", "return", "thunderbolt", "thunderwave", "toxic"],
+                "abilities": ["Trace"]
             }
         ]
     },
@@ -1635,6 +1870,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "hypnosis", "return", "shadowball", "thunderbolt", "thunderwave"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1644,7 +1880,8 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["encore", "explosion", "spikes", "spore"]
+                "movepool": ["encore", "explosion", "spikes", "spore"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -1654,6 +1891,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rapidspin", "rockslide", "toxic"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ghost"]
             }
         ]
@@ -1662,12 +1900,9 @@
         "level": 78,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "earthquake", "milkdrink"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["bodyslam", "earthquake", "healbell", "milkdrink", "toxic"]
+                "role": "Bulky Attacker",
+                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -1676,15 +1911,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "thunderwave", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "thunderwave", "toxic"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"]
+                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1694,11 +1932,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "crunch", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerice", "rest", "sleeptalk", "thunderbolt"]
+                "movepool": ["hiddenpowerice", "rest", "sleeptalk", "thunderbolt"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1707,15 +1947,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["flamethrower", "rest", "sleeptalk", "toxic"]
+                "movepool": ["flamethrower", "rest", "sleeptalk", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Staller",
-                "movepool": ["flamethrower", "protect", "substitute", "toxic"]
+                "movepool": ["flamethrower", "protect", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "substitute"]
+                "movepool": ["calmmind", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "substitute"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1724,11 +1967,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "rest", "sleeptalk", "surf"]
+                "movepool": ["calmmind", "rest", "sleeptalk", "surf"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "rest", "substitute", "surf"]
+                "movepool": ["calmmind", "icebeam", "rest", "substitute", "surf"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1738,15 +1983,18 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "fireblast", "hiddenpowerflying", "rockslide"],
+                "abilities": ["Sand Stream"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "rockslide", "thunderwave"]
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "rockslide", "thunderwave"],
+                "abilities": ["Sand Stream"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "fireblast", "hiddenpowerflying", "rest", "rockslide", "sleeptalk"],
+                "abilities": ["Sand Stream"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1756,11 +2004,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "psychic", "recover", "substitute", "toxic"]
+                "movepool": ["earthquake", "psychic", "recover", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "recover", "thunderbolt"]
+                "movepool": ["calmmind", "icebeam", "recover", "thunderbolt"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1769,11 +2019,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "recover", "sacredfire", "substitute", "thunderbolt", "toxic"]
+                "movepool": ["earthquake", "recover", "sacredfire", "substitute", "thunderbolt", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "recover", "sacredfire", "thunderbolt"]
+                "movepool": ["calmmind", "recover", "sacredfire", "thunderbolt"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1782,11 +2034,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "hiddenpowergrass", "psychic", "recover"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "hiddenpowergrass", "psychic", "recover"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerfire", "hiddenpowergrass", "leechseed", "psychic", "recover", "toxic"]
+                "movepool": ["healbell", "hiddenpowerfire", "hiddenpowergrass", "leechseed", "psychic", "recover", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1795,15 +2049,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerfire", "hiddenpowerice", "leafblade", "leechseed", "substitute"]
+                "movepool": ["hiddenpowerfire", "hiddenpowerice", "leafblade", "leechseed", "substitute"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["hiddenpowerice", "leafblade", "substitute", "thunderpunch"]
+                "movepool": ["hiddenpowerice", "leafblade", "substitute", "thunderpunch"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "hiddenpowerice", "leafblade", "thunderpunch", "toxic"],
+                "abilities": ["Overgrow"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1813,15 +2070,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "fireblast", "hiddenpowerice", "rockslide", "skyuppercut", "thunderpunch"]
+                "movepool": ["earthquake", "fireblast", "hiddenpowerice", "rockslide", "skyuppercut", "thunderpunch"],
+                "abilities": ["Blaze"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["endure", "fireblast", "reversal", "swordsdance"]
+                "movepool": ["endure", "fireblast", "reversal", "swordsdance"],
+                "abilities": ["Blaze"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "fireblast", "rockslide", "skyuppercut", "swordsdance"]
+                "movepool": ["earthquake", "fireblast", "rockslide", "skyuppercut", "swordsdance"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -1830,15 +2090,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hydropump", "protect", "surf", "toxic"]
+                "movepool": ["earthquake", "hydropump", "protect", "surf", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "hydropump", "rest", "sleeptalk", "surf"]
+                "movepool": ["earthquake", "hydropump", "rest", "sleeptalk", "surf"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "hydropump", "icebeam", "refresh", "surf", "toxic"]
+                "movepool": ["earthquake", "hydropump", "icebeam", "refresh", "surf", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -1848,6 +2111,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["crunch", "doubleedge", "healbell", "hiddenpowerfighting", "shadowball", "toxic"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -1857,11 +2121,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "extremespeed", "hiddenpowerfighting", "shadowball"]
+                "movepool": ["bellydrum", "extremespeed", "hiddenpowerfighting", "shadowball"],
+                "abilities": ["Pickup"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bellydrum", "hiddenpowerground", "return", "shadowball", "substitute"],
+                "abilities": ["Pickup"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1871,7 +2137,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerfire", "morningsun", "psychic", "toxic"]
+                "movepool": ["hiddenpowerfire", "morningsun", "psychic", "toxic"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1880,7 +2147,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerground", "moonlight", "sludgebomb", "toxic", "whirlwind"]
+                "movepool": ["hiddenpowerground", "moonlight", "sludgebomb", "toxic", "whirlwind"],
+                "abilities": ["Shield Dust"]
             }
         ]
     },
@@ -1889,7 +2157,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1898,11 +2167,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["brickbreak", "explosion", "shadowball", "swordsdance"]
+                "movepool": ["brickbreak", "explosion", "shadowball", "swordsdance"],
+                "abilities": ["Chlorophyll", "Early Bird"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerdark", "leechseed", "substitute", "toxic"]
+                "movepool": ["hiddenpowerdark", "leechseed", "substitute", "toxic"],
+                "abilities": ["Chlorophyll", "Early Bird"]
             }
         ]
     },
@@ -1911,11 +2182,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["aerialace", "doubleedge", "hiddenpowerground", "quickattack", "return"]
+                "movepool": ["aerialace", "doubleedge", "hiddenpowerground", "quickattack", "return"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "doubleedge", "facade", "hiddenpowerground", "return"]
+                "movepool": ["aerialace", "doubleedge", "facade", "hiddenpowerground", "return"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -1924,11 +2197,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Keen Eye"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -1938,6 +2213,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "firepunch", "hypnosis", "icepunch", "psychic", "substitute", "thunderbolt"],
+                "abilities": ["Trace"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -1947,7 +2223,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hydropump", "icebeam", "stunspore", "substitute", "toxic"]
+                "movepool": ["hydropump", "icebeam", "stunspore", "substitute", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1956,11 +2233,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerghost", "hiddenpowerrock", "machpunch", "skyuppercut", "spore", "substitute", "swordsdance"]
+                "movepool": ["hiddenpowerghost", "hiddenpowerrock", "machpunch", "skyuppercut", "spore", "substitute", "swordsdance"],
+                "abilities": ["Effect Spore"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["focuspunch", "hiddenpowerghost", "hiddenpowerrock", "spore", "substitute"]
+                "movepool": ["focuspunch", "hiddenpowerghost", "hiddenpowerrock", "spore", "substitute"],
+                "abilities": ["Effect Spore"]
             }
         ]
     },
@@ -1969,7 +2248,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "bulkup", "earthquake", "return", "shadowball", "slackoff"]
+                "movepool": ["bodyslam", "bulkup", "earthquake", "return", "shadowball", "slackoff"],
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -1978,7 +2258,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "hyperbeam", "return", "shadowball"]
+                "movepool": ["doubleedge", "earthquake", "hyperbeam", "return", "shadowball"],
+                "abilities": ["Truant"]
             }
         ]
     },
@@ -1987,11 +2268,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "hiddenpowerflying", "substitute", "swordsdance"]
+                "movepool": ["batonpass", "hiddenpowerflying", "substitute", "swordsdance"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "hiddenpowerflying", "protect", "swordsdance"]
+                "movepool": ["batonpass", "hiddenpowerflying", "protect", "swordsdance"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -2000,7 +2283,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["agility", "batonpass", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "silverwind", "toxic"]
+                "movepool": ["agility", "batonpass", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "silverwind", "toxic"],
+                "abilities": ["Wonder Guard"]
             }
         ]
     },
@@ -2009,11 +2293,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "overheat", "return", "shadowball"]
+                "movepool": ["doubleedge", "earthquake", "overheat", "return", "shadowball"],
+                "abilities": ["Soundproof"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "flamethrower", "icebeam", "return", "shadowball", "substitute"],
+                "abilities": ["Soundproof"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2023,11 +2309,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "knockoff", "rockslide"]
+                "movepool": ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "knockoff", "rockslide"],
+                "abilities": ["Guts", "Thick Fat"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crosschop", "hiddenpowerghost", "rest", "rockslide", "sleeptalk"]
+                "movepool": ["crosschop", "hiddenpowerghost", "rest", "rockslide", "sleeptalk"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -2036,7 +2324,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "rockslide", "thunderwave", "toxic"]
+                "movepool": ["earthquake", "explosion", "rockslide", "thunderwave", "toxic"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -2045,15 +2334,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"]
+                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["bodyslam", "healbell", "protect", "wish"]
+                "movepool": ["bodyslam", "healbell", "protect", "wish"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "icebeam", "thunderbolt"]
+                "movepool": ["batonpass", "calmmind", "icebeam", "thunderbolt"],
+                "abilities": ["Cute Charm"]
             }
         ]
     },
@@ -2062,11 +2354,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "recover", "seismictoss", "toxic"]
+                "movepool": ["knockoff", "recover", "seismictoss", "toxic"],
+                "abilities": ["Keen Eye"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["recover", "seismictoss", "shadowball", "toxic"]
+                "movepool": ["recover", "seismictoss", "shadowball", "toxic"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -2076,11 +2370,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["batonpass", "brickbreak", "hiddenpowersteel", "rockslide", "substitute", "swordsdance"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["focuspunch", "hiddenpowersteel", "rockslide", "substitute", "toxic"]
+                "movepool": ["focuspunch", "hiddenpowersteel", "rockslide", "substitute", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -2090,11 +2386,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "irontail", "rockslide", "thunderwave", "toxic"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["doubleedge", "earthquake", "focuspunch", "irontail", "rockslide", "substitute"]
+                "movepool": ["doubleedge", "earthquake", "focuspunch", "irontail", "rockslide", "substitute"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -2104,11 +2402,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["brickbreak", "bulkup", "recover", "rockslide", "shadowball", "substitute"],
+                "abilities": ["Pure Power"],
                 "preferredTypes": ["Ghost"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["bulkup", "reversal", "shadowball", "substitute"]
+                "movepool": ["bulkup", "reversal", "shadowball", "substitute"],
+                "abilities": ["Pure Power"]
             }
         ]
     },
@@ -2117,7 +2417,8 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["crunch", "hiddenpowerice", "substitute", "thunderbolt"]
+                "movepool": ["crunch", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -2126,15 +2427,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["batonpass", "encore", "hiddenpowerice", "substitute", "thunderbolt", "toxic"]
+                "movepool": ["batonpass", "encore", "hiddenpowerice", "substitute", "thunderbolt", "toxic"],
+                "abilities": ["Plus"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"]
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Plus"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic", "wish"]
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic", "wish"],
+                "abilities": ["Plus"]
             }
         ]
     },
@@ -2143,15 +2447,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["batonpass", "encore", "hiddenpowerice", "substitute", "thunderbolt", "toxic"]
+                "movepool": ["batonpass", "encore", "hiddenpowerice", "substitute", "thunderbolt", "toxic"],
+                "abilities": ["Minus"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"]
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Minus"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic", "wish"]
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic", "wish"],
+                "abilities": ["Minus"]
             }
         ]
     },
@@ -2160,7 +2467,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "icepunch", "tailglow", "thunderbolt"]
+                "movepool": ["batonpass", "icepunch", "tailglow", "thunderbolt"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -2169,11 +2477,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "moonlight", "seismictoss", "thunderwave", "toxic"]
+                "movepool": ["encore", "moonlight", "seismictoss", "thunderwave", "toxic"],
+                "abilities": ["Oblivious"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["batonpass", "encore", "seismictoss", "substitute", "thunderwave", "toxic"]
+                "movepool": ["batonpass", "encore", "seismictoss", "substitute", "thunderwave", "toxic"],
+                "abilities": ["Oblivious"]
             }
         ]
     },
@@ -2182,11 +2492,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aromatherapy", "hiddenpowerfire", "magicalleaf", "spikes", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "hiddenpowerfire", "magicalleaf", "spikes", "synthesis", "toxic"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "hiddenpowergrass", "spikes", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "hiddenpowergrass", "spikes", "synthesis", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -2195,7 +2507,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["encore", "explosion", "hiddenpowerground", "icebeam", "painsplit", "shadowball", "sludgebomb", "toxic", "yawn"]
+                "movepool": ["encore", "explosion", "hiddenpowerground", "icebeam", "painsplit", "shadowball", "sludgebomb", "toxic", "yawn"],
+                "abilities": ["Liquid Ooze"]
             }
         ]
     },
@@ -2204,11 +2517,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "hiddenpowerflying", "hydropump"]
+                "movepool": ["doubleedge", "earthquake", "hiddenpowerflying", "hydropump"],
+                "abilities": ["Rough Skin"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["crunch", "hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "substitute"]
+                "movepool": ["crunch", "hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "substitute"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -2217,11 +2532,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Water Veil"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["hiddenpowergrass", "icebeam", "selfdestruct", "surf", "toxic"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2231,7 +2548,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "explosion", "fireblast", "rest", "rockslide", "sleeptalk", "toxic"]
+                "movepool": ["earthquake", "explosion", "fireblast", "rest", "rockslide", "sleeptalk", "toxic"],
+                "abilities": ["Magma Armor"]
             }
         ]
     },
@@ -2240,7 +2558,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["explosion", "fireblast", "flamethrower", "hiddenpowergrass", "rest", "toxic"]
+                "movepool": ["explosion", "fireblast", "flamethrower", "hiddenpowergrass", "rest", "toxic"],
+                "abilities": ["White Smoke"]
             }
         ]
     },
@@ -2250,6 +2569,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "firepunch", "psychic", "substitute", "thunderpunch"],
+                "abilities": ["Thick Fat"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -2259,11 +2579,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["encore", "protect", "seismictoss", "shadowball", "substitute", "toxic"]
+                "movepool": ["encore", "protect", "seismictoss", "shadowball", "substitute", "toxic"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -2273,15 +2595,18 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["dragonclaw", "earthquake", "fireblast", "hiddenpowerbug", "rockslide"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Bug", "Rock"]
             },
             {
                 "role": "Staller",
-                "movepool": ["dragonclaw", "earthquake", "fireblast", "protect", "toxic"]
+                "movepool": ["dragonclaw", "earthquake", "fireblast", "protect", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dragonclaw", "earthquake", "fireblast", "rockslide", "substitute", "toxic"]
+                "movepool": ["dragonclaw", "earthquake", "fireblast", "rockslide", "substitute", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2290,11 +2615,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["focuspunch", "hiddenpowerdark", "leechseed", "substitute"]
+                "movepool": ["focuspunch", "hiddenpowerdark", "leechseed", "substitute"],
+                "abilities": ["Sand Veil"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["hiddenpowerdark", "needlearm", "spikes", "thunderpunch"]
+                "movepool": ["hiddenpowerdark", "needlearm", "spikes", "thunderpunch"],
+                "abilities": ["Sand Veil"]
             }
         ]
     },
@@ -2303,11 +2630,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragonclaw", "earthquake", "flamethrower", "haze", "healbell", "rest", "toxic"]
+                "movepool": ["dragonclaw", "earthquake", "flamethrower", "haze", "healbell", "rest", "toxic"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "fireblast", "healbell", "hiddenpowerflying", "rest"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2318,6 +2647,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["brickbreak", "quickattack", "return", "shadowball", "swordsdance"],
+                "abilities": ["Immunity"],
                 "preferredTypes": ["Ghost"]
             }
         ]
@@ -2328,6 +2658,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crunch", "earthquake", "flamethrower", "hiddenpowergrass", "sludgebomb"],
+                "abilities": ["Shed Skin"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2337,11 +2668,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "hypnosis", "icebeam", "psychic"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "hypnosis", "icebeam", "psychic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["explosion", "hiddenpowerfire", "hypnosis", "icebeam", "psychic", "toxic"]
+                "movepool": ["explosion", "hiddenpowerfire", "hypnosis", "icebeam", "psychic", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2350,11 +2683,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "rockslide", "toxic"]
+                "movepool": ["earthquake", "protect", "rockslide", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "explosion", "overheat", "rockslide", "shadowball"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2364,11 +2699,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["earthquake", "icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Oblivious"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "icebeam", "protect", "toxic"]
+                "movepool": ["earthquake", "icebeam", "protect", "toxic"],
+                "abilities": ["Oblivious"]
             }
         ]
     },
@@ -2377,11 +2714,14 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["brickbreak", "crunch", "doubleedge", "hiddenpowerelectric", "hiddenpowergrass", "icebeam", "surf"]
+                "movepool": ["brickbreak", "crunch", "doubleedge", "hiddenpowerelectric", "hiddenpowergrass", "icebeam", "surf"],
+                "abilities": ["Hyper Cutter"],
+                "preferredTypes": ["Normal"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["brickbreak", "doubleedge", "hiddenpowerflying", "surf", "swordsdance"],
+                "abilities": ["Hyper Cutter"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2391,7 +2731,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "toxic"]
+                "movepool": ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2401,6 +2742,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "hiddenpowergrass", "recover", "rockslide", "toxic"],
+                "abilities": ["Suction Cups"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2411,6 +2753,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "hiddenpowerbug", "rapidspin", "rockslide", "swordsdance"],
+                "abilities": ["Battle Armor"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2420,7 +2763,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "recover", "refresh", "surf", "toxic"]
+                "movepool": ["icebeam", "recover", "refresh", "surf", "toxic"],
+                "abilities": ["Marvel Scale"]
             }
         ]
     },
@@ -2429,7 +2773,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "icebeam", "return", "thunderbolt", "thunderwave"]
+                "movepool": ["fireblast", "icebeam", "return", "thunderbolt", "thunderwave"],
+                "abilities": ["Forecast"]
             }
         ]
     },
@@ -2438,7 +2783,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["brickbreak", "return", "shadowball", "thunderwave", "trick"]
+                "movepool": ["brickbreak", "return", "shadowball", "thunderwave", "trick"],
+                "abilities": ["Color Change"]
             }
         ]
     },
@@ -2447,11 +2793,13 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["destinybond", "endure", "hiddenpowerfighting", "shadowball"]
+                "movepool": ["destinybond", "endure", "hiddenpowerfighting", "shadowball"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "hiddenpowerfighting", "knockoff", "shadowball", "willowisp"],
+                "abilities": ["Insomnia"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2461,15 +2809,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "seismictoss", "sleeptalk", "willowisp"]
+                "movepool": ["rest", "seismictoss", "sleeptalk", "willowisp"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["rest", "seismictoss", "shadowball", "sleeptalk"]
+                "movepool": ["rest", "seismictoss", "shadowball", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["focuspunch", "icebeam", "painsplit", "shadowball", "substitute", "willowisp"]
+                "movepool": ["focuspunch", "icebeam", "painsplit", "shadowball", "substitute", "willowisp"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2478,11 +2829,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "hiddenpowerflying", "swordsdance", "synthesis"]
+                "movepool": ["earthquake", "hiddenpowerflying", "swordsdance", "synthesis"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "hiddenpowerflying", "leechseed", "synthesis", "toxic"]
+                "movepool": ["earthquake", "hiddenpowerflying", "leechseed", "synthesis", "toxic"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -2491,7 +2844,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "healbell", "hiddenpowerfire", "psychic", "toxic"]
+                "movepool": ["calmmind", "healbell", "hiddenpowerfire", "psychic", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2501,11 +2855,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["batonpass", "doubleedge", "hiddenpowerfighting", "quickattack", "shadowball", "swordsdance"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fighting", "Ghost"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "hiddenpowerfighting", "quickattack", "shadowball"]
+                "movepool": ["doubleedge", "hiddenpowerfighting", "quickattack", "shadowball"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2514,7 +2870,8 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["earthquake", "explosion", "icebeam", "spikes", "toxic"]
+                "movepool": ["earthquake", "explosion", "icebeam", "spikes", "toxic"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -2523,11 +2880,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -2537,6 +2896,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2546,7 +2906,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"]
+                "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2556,6 +2917,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["doubleedge", "earthquake", "hiddenpowerflying", "rest", "rockslide", "sleeptalk", "toxic"],
+                "abilities": ["Rock Head", "Swift Swim"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2565,7 +2927,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "substitute", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "substitute", "surf", "toxic"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2575,11 +2938,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "fireblast", "hiddenpowerflying", "rockslide"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["brickbreak", "doubleedge", "earthquake", "fireblast", "hiddenpowerflying", "rockslide"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2589,11 +2954,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "explosion", "meteormash", "rockslide"]
+                "movepool": ["earthquake", "explosion", "meteormash", "rockslide"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["agility", "earthquake", "explosion", "meteormash", "psychic", "rockslide"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2604,11 +2971,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["curse", "earthquake", "explosion", "rest", "rockslide", "superpower"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "rest", "rockslide", "sleeptalk", "thunderwave", "toxic"]
+                "movepool": ["earthquake", "explosion", "rest", "rockslide", "sleeptalk", "thunderwave", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2617,11 +2986,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["explosion", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"]
+                "movepool": ["explosion", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"]
+                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2630,7 +3001,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"]
+                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2639,11 +3011,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "dragonclaw", "hiddenpowerfire", "psychic", "recover"]
+                "movepool": ["calmmind", "dragonclaw", "hiddenpowerfire", "psychic", "recover"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "dragonclaw", "recover", "refresh"]
+                "movepool": ["calmmind", "dragonclaw", "recover", "refresh"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2652,11 +3026,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "dragonclaw", "hiddenpowerfire", "psychic", "recover"]
+                "movepool": ["calmmind", "dragonclaw", "hiddenpowerfire", "psychic", "recover"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "dragonclaw", "recover", "refresh"]
+                "movepool": ["calmmind", "dragonclaw", "recover", "refresh"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2665,7 +3041,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"]
+                "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -2675,6 +3052,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "hiddenpowerbug", "overheat", "rockslide", "substitute", "swordsdance", "thunderwave"],
+                "abilities": ["Drought"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -2685,11 +3063,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "hiddenpowerflying", "overheat", "rockslide"],
+                "abilities": ["Air Lock"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "extremespeed", "hiddenpowerflying", "overheat", "rockslide"],
+                "abilities": ["Air Lock"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2699,11 +3079,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "firepunch", "protect", "psychic", "toxic", "wish"]
+                "movepool": ["bodyslam", "firepunch", "protect", "psychic", "toxic", "wish"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "firepunch", "icepunch", "psychic", "substitute", "thunderbolt"],
+                "abilities": ["Serene Grace"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -2714,6 +3096,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["extremespeed", "firepunch", "icebeam", "psychoboost", "shadowball", "spikes", "superpower"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fighting", "Ghost"]
             }
         ]
@@ -2724,6 +3107,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["extremespeed", "firepunch", "icebeam", "psychoboost", "shadowball", "superpower"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fighting", "Ghost"]
             }
         ]
@@ -2733,7 +3117,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["recover", "seismictoss", "spikes", "toxic"]
+                "movepool": ["recover", "seismictoss", "spikes", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2743,11 +3128,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "firepunch", "icebeam", "psychic", "recover", "substitute"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["psychoboost", "recover", "spikes", "superpower", "toxic"]
+                "movepool": ["psychoboost", "recover", "spikes", "superpower", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     }

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -1,5 +1,4 @@
 import RandomGen4Teams from '../gen4/teams';
-import {Utils} from '../../../lib';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
 import type {MoveCounter} from '../gen8/teams';
 
@@ -64,7 +63,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 	cullMovePool(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -165,7 +164,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 	// Generate random moveset for a given species, role, preferred type.
 	randomMoveset(
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -389,7 +388,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -398,26 +397,12 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		role: RandomTeamsTypes.Role
 	) {
 		switch (ability) {
-		case 'Rain Dish': case 'Sand Veil': case 'Soundproof': case 'Sticky Hold':
-			return true;
 		case 'Chlorophyll':
-			return !moves.has('sunnyday') && !teamDetails.sun;
-		case 'Hustle':
-			return !counter.get('Physical');
+			return !teamDetails.sun;
 		case 'Rock Head':
 			return !counter.get('recoil');
-		case 'Swarm':
-			return !counter.get('Bug');
 		case 'Swift Swim':
-			return (
-				// Relicanth always wants Swift Swim if it doesn't have Double-Edge
-				!moves.has('raindance') && !teamDetails.rain && !(species.id === 'relicanth' && !counter.get('recoil')) ||
-				!moves.has('raindance') && abilities.has('Water Absorb')
-			);
-		case 'Thick Fat':
-			return (species.id === 'snorlax' || (species.id === 'hariyama' && moves.has('sleeptalk')));
-		case 'Water Absorb':
-			return (species.id === 'mantine' && moves.has('raindance'));
+			return !teamDetails.rain;
 		}
 
 		return false;
@@ -427,7 +412,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 	getAbility(
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -435,47 +420,32 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		preferredType: string,
 		role: RandomTeamsTypes.Role,
 	): string {
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData.length <= 1) return abilityData[0].name;
+		if (abilities.length <= 1) return abilities[0];
 
 		// Hard-code abilities here
-		if (species.id === 'yanma' && counter.get('inaccurate')) return 'Compound Eyes';
-		if (moves.has('rest') && abilities.has('Early Bird')) return 'Early Bird';
-		if (species.id === 'arcanine') return 'Intimidate';
-		if (species.id === 'blissey') return 'Natural Cure';
-		if (species.id === 'heracross' && role === 'Berry Sweeper') return 'Swarm';
-		if (species.id === 'xatu') return 'Synchronize';
+		if (species.id === 'yanma') return counter.get('inaccurate') ? 'Compound Eyes' : 'Speed Boost';
 
-		let abilityAllowed: Ability[] = [];
+		const abilityAllowed: string[] = [];
 		// Obtain a list of abilities that are allowed (not culled)
-		for (const ability of abilityData) {
-			if (ability.rating >= 1 && !this.shouldCullAbility(
-				ability.name, types, moves, abilities, counter, movePool, teamDetails, species, preferredType, role
+		for (const ability of abilities) {
+			if (!this.shouldCullAbility(
+				ability, types, moves, abilities, counter, movePool, teamDetails, species, preferredType, role
 			)) {
 				abilityAllowed.push(ability);
 			}
 		}
 
-		// If all abilities are rejected, re-allow all abilities
+		// Pick a random allowed ability
+		if (abilityAllowed.length >= 1) return this.sample(abilityAllowed);
+
+		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
 		if (!abilityAllowed.length) {
-			for (const ability of abilityData) {
-				if (ability.rating > 0) abilityAllowed.push(ability);
-			}
-			if (!abilityAllowed.length) abilityAllowed = abilityData;
+			const weatherAbilities = abilities.filter(a => ['Chlorophyll', 'Swift Swim'].includes(a));
+			if (weatherAbilities.length) return this.sample(weatherAbilities);
 		}
 
-		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
-		// Sort abilities by rating with an element of randomness
-		if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-			if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-		} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
-			if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-		}
-
-		// After sorting, choose the first ability
-		return abilityAllowed[0].name;
+		// Pick a random ability
+		return this.sample(abilities);
 	}
 
 	getItem(
@@ -572,7 +542,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const types = species.types;
-		const abilities = new Set(Object.values(species.abilities));
+		const abilities = set.abilities!;
 
 		// Get moves
 		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, movePool,

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -4,11 +4,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["leechseed", "powerwhip", "sleeppowder", "sludgebomb", "substitute"]
+                "movepool": ["leechseed", "powerwhip", "sleeppowder", "sludgebomb", "substitute"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -17,7 +19,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "dragonpulse", "fireblast", "hiddenpowergrass", "roost"]
+                "movepool": ["airslash", "dragonpulse", "fireblast", "hiddenpowergrass", "roost"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -26,11 +29,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["icebeam", "rapidspin", "rest", "roar", "surf", "toxic"]
+                "movepool": ["icebeam", "rapidspin", "rest", "roar", "surf", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -39,7 +44,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbuzz", "sleeppowder", "stunspore", "uturn"]
+                "movepool": ["bugbuzz", "sleeppowder", "stunspore", "uturn"],
+                "abilities": ["Compound Eyes"]
             }
         ]
     },
@@ -48,11 +54,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["brickbreak", "poisonjab", "toxicspikes", "uturn"]
+                "movepool": ["brickbreak", "poisonjab", "toxicspikes", "uturn"],
+                "abilities": ["Swarm"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["brickbreak", "poisonjab", "swordsdance", "uturn", "xscissor"]
+                "movepool": ["brickbreak", "poisonjab", "swordsdance", "uturn", "xscissor"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -61,11 +69,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "heatwave", "return", "roost"]
+                "movepool": ["bravebird", "heatwave", "return", "roost"],
+                "abilities": ["Tangled Feet"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "doubleedge", "pursuit", "quickattack", "return", "roost", "uturn"]
+                "movepool": ["bravebird", "doubleedge", "pursuit", "quickattack", "return", "roost", "uturn"],
+                "abilities": ["Tangled Feet"]
             }
         ]
     },
@@ -74,7 +84,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "facade", "protect", "suckerpunch", "swordsdance", "uturn"]
+                "movepool": ["crunch", "facade", "protect", "suckerpunch", "swordsdance", "uturn"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -83,11 +94,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "drillpeck", "quickattack", "return", "uturn"]
+                "movepool": ["doubleedge", "drillpeck", "quickattack", "return", "uturn"],
+                "abilities": ["Keen Eye"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "pursuit", "return", "uturn"]
+                "movepool": ["doubleedge", "drillpeck", "pursuit", "return", "uturn"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -97,6 +110,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crunch", "earthquake", "glare", "gunkshot", "poisonjab", "seedbomb", "switcheroo"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -107,6 +121,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fakeout", "grassknot", "hiddenpowerice", "surf", "thunderbolt", "volttackle"],
+                "abilities": ["Static"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -116,7 +131,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "surf", "thunderbolt"]
+                "movepool": ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "surf", "thunderbolt"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -125,11 +141,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["earthquake", "nightslash", "rapidspin", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "nightslash", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Sand Veil"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["earthquake", "nightslash", "stoneedge", "substitute", "swordsdance", "xscissor"],
+                "abilities": ["Sand Veil"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -140,6 +158,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "fireblast", "icebeam", "roar", "stealthrock", "toxicspikes"],
+                "abilities": ["Poison Point"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -150,6 +169,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "stealthrock", "suckerpunch", "thunderbolt"],
+                "abilities": ["Poison Point"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -159,11 +179,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "doubleedge", "fireblast", "icebeam", "softboiled", "stealthrock", "thunderwave"]
+                "movepool": ["aromatherapy", "doubleedge", "fireblast", "icebeam", "softboiled", "stealthrock", "thunderwave"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"]
+                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"],
+                "abilities": ["Magic Guard"]
             }
         ]
     },
@@ -173,6 +195,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["energyball", "fireblast", "hiddenpowerrock", "hypnosis", "nastyplot"],
+                "abilities": ["Flash Fire"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -182,11 +205,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "doubleedge", "fireblast", "healbell", "protect", "stealthrock", "thunderwave", "toxic", "wish"]
+                "movepool": ["bodyslam", "doubleedge", "fireblast", "healbell", "protect", "stealthrock", "thunderwave", "toxic", "wish"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Cute Charm"]
             }
         ]
     },
@@ -195,11 +220,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfire", "sludgebomb", "solarbeam", "sunnyday"]
+                "movepool": ["hiddenpowerfire", "sludgebomb", "solarbeam", "sunnyday"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -208,11 +235,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "seedbomb", "spore", "stunspore", "synthesis", "xscissor"]
+                "movepool": ["aromatherapy", "seedbomb", "spore", "stunspore", "synthesis", "xscissor"],
+                "abilities": ["Dry Skin"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["pursuit", "seedbomb", "spore", "swordsdance", "xscissor"]
+                "movepool": ["pursuit", "seedbomb", "spore", "swordsdance", "xscissor"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -221,7 +250,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "roost", "sleeppowder", "toxicspikes", "uturn"]
+                "movepool": ["bugbuzz", "roost", "sleeppowder", "toxicspikes", "uturn"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -231,6 +261,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["earthquake", "nightslash", "stealthrock", "stoneedge", "suckerpunch"],
+                "abilities": ["Arena Trap"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -241,6 +272,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bite", "doubleedge", "fakeout", "hypnosis", "return", "seedbomb", "taunt", "uturn"],
+                "abilities": ["Technician"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -251,6 +283,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "encore", "focusblast", "hiddenpowergrass", "hydropump", "icebeam", "psychic", "surf"],
+                "abilities": ["Cloud Nine"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -261,6 +294,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "encore", "stoneedge", "uturn"],
+                "abilities": ["Vital Spirit"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -271,11 +305,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "morningsun", "roar", "thunderfang", "toxic", "willowisp"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Normal"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["crunch", "extremespeed", "flareblitz", "ironhead", "morningsun", "thunderfang"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -285,15 +321,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["brickbreak", "bulkup", "icepunch", "waterfall"]
+                "movepool": ["brickbreak", "bulkup", "icepunch", "waterfall"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["encore", "focuspunch", "icepunch", "substitute", "waterfall"]
+                "movepool": ["encore", "focuspunch", "icepunch", "substitute", "waterfall"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulkup", "rest", "sleeptalk", "toxic", "waterfall"]
+                "movepool": ["bulkup", "rest", "sleeptalk", "toxic", "waterfall"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -303,6 +342,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "encore", "focusblast", "psychic", "shadowball", "substitute", "trick"],
+                "abilities": ["Synchronize"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -312,7 +352,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "payback", "stoneedge"]
+                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "payback", "stoneedge"],
+                "abilities": ["No Guard"]
             }
         ]
     },
@@ -321,11 +362,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerground", "leafblade", "leafstorm", "sleeppowder", "sludgebomb", "suckerpunch"]
+                "movepool": ["hiddenpowerground", "leafblade", "leafstorm", "sleeppowder", "sludgebomb", "suckerpunch"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["sludgebomb", "solarbeam", "sunnyday", "weatherball"]
+                "movepool": ["sludgebomb", "solarbeam", "sunnyday", "weatherball"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -334,7 +377,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "hydropump", "icebeam", "rapidspin", "sludgebomb", "surf", "toxicspikes"]
+                "movepool": ["haze", "hydropump", "icebeam", "rapidspin", "sludgebomb", "surf", "toxicspikes"],
+                "abilities": ["Clear Body", "Liquid Ooze"]
             }
         ]
     },
@@ -343,7 +387,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -352,7 +397,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["flareblitz", "hypnosis", "megahorn", "morningsun", "willowisp"]
+                "movepool": ["flareblitz", "hypnosis", "megahorn", "morningsun", "willowisp"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -362,11 +408,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["fireblast", "icebeam", "psychic", "slackoff", "surf", "thunderwave", "toxic"],
+                "abilities": ["Own Tempo"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "psychic", "slackoff", "surf"]
+                "movepool": ["calmmind", "psychic", "slackoff", "surf"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -375,11 +423,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["heatwave", "leafblade", "nightslash", "return", "uturn"]
+                "movepool": ["heatwave", "leafblade", "nightslash", "return", "uturn"],
+                "abilities": ["Inner Focus"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "leafblade", "nightslash", "return", "swordsdance"]
+                "movepool": ["batonpass", "leafblade", "nightslash", "return", "swordsdance"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -388,7 +438,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "pursuit", "quickattack", "return", "roost"]
+                "movepool": ["bravebird", "pursuit", "quickattack", "return", "roost"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -397,15 +448,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["raindance", "rest", "surf", "toxic"]
+                "movepool": ["raindance", "rest", "surf", "toxic"],
+                "abilities": ["Hydration"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "raindance", "rest", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "raindance", "rest", "surf", "toxic"],
+                "abilities": ["Hydration", "Thick Fat"]
             }
         ]
     },
@@ -415,6 +469,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["brickbreak", "curse", "explosion", "gunkshot", "icepunch", "payback", "poisonjab", "rest", "shadowsneak"],
+                "abilities": ["Sticky Hold"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -424,7 +479,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["explosion", "iceshard", "rapidspin", "rockblast", "spikes", "surf", "toxicspikes"]
+                "movepool": ["explosion", "iceshard", "rapidspin", "rockblast", "spikes", "surf", "toxicspikes"],
+                "abilities": ["Shell Armor", "Skill Link"]
             }
         ]
     },
@@ -434,6 +490,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["explosion", "focusblast", "painsplit", "shadowball", "sludgebomb", "substitute", "trick", "willowisp"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -443,11 +500,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "psychic", "thunderwave", "toxic", "wish"]
+                "movepool": ["protect", "psychic", "thunderwave", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -456,11 +515,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crabhammer", "return", "superpower", "swordsdance", "xscissor"]
+                "movepool": ["crabhammer", "return", "superpower", "swordsdance", "xscissor"],
+                "abilities": ["Hyper Cutter"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["agility", "crabhammer", "return", "swordsdance"]
+                "movepool": ["agility", "crabhammer", "return", "swordsdance"],
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },
@@ -470,6 +531,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["explosion", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt"],
+                "abilities": ["Static"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -480,6 +542,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["explosion", "hiddenpowerfire", "leafstorm", "psychic", "sleeppowder", "synthesis"],
+                "abilities": ["Chlorophyll"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -490,6 +553,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "firepunch", "stealthrock", "stoneedge", "swordsdance"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -500,11 +564,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "machpunch", "rapidspin", "stoneedge", "suckerpunch"],
+                "abilities": ["Limber"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["bulkup", "closecombat", "earthquake", "machpunch", "stoneedge", "suckerpunch"],
+                "abilities": ["Limber"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -514,11 +580,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["closecombat", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"]
+                "movepool": ["closecombat", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
+                "abilities": ["Iron Fist"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "closecombat", "drainpunch", "icepunch", "machpunch", "stoneedge"]
+                "movepool": ["bulkup", "closecombat", "drainpunch", "icepunch", "machpunch", "stoneedge"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -527,11 +595,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"]
+                "movepool": ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "rest", "sleeptalk", "sludgebomb"]
+                "movepool": ["fireblast", "rest", "sleeptalk", "sludgebomb"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -540,11 +610,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["doubleedge", "earthquake", "fakeout", "hammerarm", "return", "suckerpunch"]
+                "movepool": ["doubleedge", "earthquake", "fakeout", "hammerarm", "return", "suckerpunch"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "earthquake", "protect", "return", "wish"]
+                "movepool": ["bodyslam", "earthquake", "protect", "return", "wish"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -553,7 +625,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["icebeam", "megahorn", "raindance", "return", "waterfall"]
+                "movepool": ["icebeam", "megahorn", "raindance", "return", "waterfall"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -562,11 +635,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hydropump", "icebeam", "psychic", "recover", "thunderbolt"]
+                "movepool": ["hydropump", "icebeam", "psychic", "recover", "thunderbolt"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "psychic", "rapidspin", "recover", "surf", "thunderwave"]
+                "movepool": ["icebeam", "psychic", "rapidspin", "recover", "surf", "thunderwave"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -576,6 +651,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["batonpass", "encore", "focusblast", "nastyplot", "psychic", "shadowball", "substitute"],
+                "abilities": ["Filter"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -585,11 +661,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aerialace", "brickbreak", "bugbite", "roost", "swordsdance"]
+                "movepool": ["aerialace", "brickbreak", "bugbite", "roost", "swordsdance"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["aerialace", "brickbreak", "pursuit", "uturn"]
+                "movepool": ["aerialace", "brickbreak", "pursuit", "uturn"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -598,11 +676,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "psychic", "trick"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "psychic", "trick"],
+                "abilities": ["Forewarn"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psychic", "substitute"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psychic", "substitute"],
+                "abilities": ["Forewarn"]
             }
         ]
     },
@@ -612,6 +692,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Mold Breaker"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -621,7 +702,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "payback", "pursuit", "return", "stoneedge"]
+                "movepool": ["doubleedge", "earthquake", "payback", "pursuit", "return", "stoneedge"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -630,11 +712,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "stoneedge", "substitute", "waterfall"]
+                "movepool": ["dragondance", "earthquake", "stoneedge", "substitute", "waterfall"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["dragondance", "rest", "sleeptalk", "waterfall"]
+                "movepool": ["dragondance", "rest", "sleeptalk", "waterfall"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -643,11 +727,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hydropump", "icebeam", "thunderbolt", "toxic"]
+                "movepool": ["healbell", "hydropump", "icebeam", "thunderbolt", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hydropump", "icebeam", "protect", "toxic"]
+                "movepool": ["hydropump", "icebeam", "protect", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -656,7 +742,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["transform"]
+                "movepool": ["transform"],
+                "abilities": ["Limber"]
             }
         ]
     },
@@ -665,11 +752,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "icebeam", "protect", "surf", "wish"]
+                "movepool": ["healbell", "icebeam", "protect", "surf", "wish"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "surf", "toxic", "wish"]
+                "movepool": ["protect", "surf", "toxic", "wish"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -678,11 +767,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["batonpass", "hiddenpowerice", "substitute", "thunderbolt", "toxic"]
+                "movepool": ["batonpass", "hiddenpowerice", "substitute", "thunderbolt", "toxic"],
+                "abilities": ["Volt Absorb"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "shadowball", "signalbeam", "thunderbolt"]
+                "movepool": ["hiddenpowerice", "shadowball", "signalbeam", "thunderbolt"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -691,11 +782,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "hiddenpowergrass", "lavaplume", "protect", "superpower", "wish"]
+                "movepool": ["fireblast", "hiddenpowergrass", "lavaplume", "protect", "superpower", "wish"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Staller",
-                "movepool": ["fireblast", "lavaplume", "protect", "toxic", "wish"]
+                "movepool": ["fireblast", "lavaplume", "protect", "toxic", "wish"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -704,11 +797,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["earthpower", "icebeam", "spikes", "stealthrock", "surf", "toxicspikes"],
+                "abilities": ["Shell Armor", "Swift Swim"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -718,11 +813,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "waterfall"]
+                "movepool": ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "waterfall"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"]
+                "movepool": ["aquajet", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             }
         ]
     },
@@ -731,11 +828,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"]
+                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["aquatail", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "movepool": ["aerialace", "aquatail", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -746,15 +845,18 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bodyslam", "crunch", "earthquake", "pursuit", "return", "selfdestruct"],
+                "abilities": ["Thick Fat"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "curse", "rest", "sleeptalk"]
+                "movepool": ["bodyslam", "curse", "rest", "sleeptalk"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "earthquake", "rest"]
+                "movepool": ["bodyslam", "curse", "earthquake", "rest"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -763,7 +865,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["healbell", "icebeam", "roost", "substitute", "toxic"]
+                "movepool": ["healbell", "icebeam", "roost", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -772,11 +875,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["heatwave", "hiddenpowerice", "roost", "substitute", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["heatwave", "hiddenpowerice", "roost", "substitute", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["heatwave", "hiddenpowerice", "roost", "thunderbolt", "uturn"]
+                "movepool": ["heatwave", "hiddenpowerice", "roost", "thunderbolt", "uturn"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -785,7 +890,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "fireblast", "hiddenpowergrass", "roost", "substitute", "toxic", "uturn"]
+                "movepool": ["airslash", "fireblast", "hiddenpowergrass", "roost", "substitute", "toxic", "uturn"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -794,11 +900,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "extremespeed", "outrage", "superpower"]
+                "movepool": ["earthquake", "extremespeed", "outrage", "superpower"],
+                "abilities": ["Inner Focus"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "firepunch", "outrage", "roost"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -808,7 +916,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "calmmind", "fireblast", "psychic", "recover", "shadowball"]
+                "movepool": ["aurasphere", "calmmind", "fireblast", "psychic", "recover", "shadowball"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -817,15 +926,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"]
+                "movepool": ["psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "batonpass", "earthpower", "fireblast", "nastyplot", "psychic", "softboiled"]
+                "movepool": ["aurasphere", "batonpass", "earthpower", "fireblast", "nastyplot", "psychic", "softboiled"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["batonpass", "earthquake", "explosion", "suckerpunch", "superpower", "swordsdance", "zenheadbutt"],
+                "abilities": ["Synchronize"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -835,7 +947,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "earthquake", "energyball", "leechseed", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "earthquake", "energyball", "leechseed", "synthesis", "toxic"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -844,7 +957,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"]
+                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -854,11 +968,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "icepunch", "return", "waterfall"],
+                "abilities": ["Torrent"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "earthquake", "icepunch", "return", "swordsdance", "waterfall"]
+                "movepool": ["aquajet", "earthquake", "icepunch", "return", "swordsdance", "waterfall"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -867,7 +983,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["aquatail", "doubleedge", "firepunch", "shadowclaw", "trick", "uturn"]
+                "movepool": ["aquatail", "doubleedge", "firepunch", "shadowclaw", "trick", "uturn"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -876,7 +993,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "nightshade", "roost", "toxic", "whirlwind"]
+                "movepool": ["airslash", "nightshade", "roost", "toxic", "whirlwind"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -885,11 +1003,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["encore", "focusblast", "hiddenpowerflying", "knockoff", "roost", "toxic"]
+                "movepool": ["encore", "focusblast", "hiddenpowerflying", "knockoff", "roost", "toxic"],
+                "abilities": ["Early Bird"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["agility", "batonpass", "encore", "swordsdance"]
+                "movepool": ["agility", "batonpass", "encore", "swordsdance"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -898,7 +1018,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbite", "poisonjab", "suckerpunch", "toxicspikes"]
+                "movepool": ["bugbite", "poisonjab", "suckerpunch", "toxicspikes"],
+                "abilities": ["Insomnia", "Swarm"]
             }
         ]
     },
@@ -907,7 +1028,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "heatwave", "roost", "superfang", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "heatwave", "roost", "superfang", "taunt", "toxic", "uturn"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -916,7 +1038,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["discharge", "healbell", "hydropump", "icebeam", "surf", "thunderbolt", "thunderwave", "toxic"]
+                "movepool": ["discharge", "healbell", "hydropump", "icebeam", "surf", "thunderbolt", "thunderwave", "toxic"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -926,11 +1049,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "grassknot", "heatwave", "hiddenpowerfighting", "psychic", "roost", "trick", "uturn"],
+                "abilities": ["Synchronize"],
                 "preferredTypes": ["Fire"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["heatwave", "hiddenpowerfighting", "psychic", "roost", "thunderwave", "toxic"]
+                "movepool": ["heatwave", "hiddenpowerfighting", "psychic", "roost", "thunderwave", "toxic"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -939,7 +1064,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["discharge", "focusblast", "healbell", "hiddenpowerice", "signalbeam", "thunderbolt", "toxic"]
+                "movepool": ["discharge", "focusblast", "healbell", "hiddenpowerice", "signalbeam", "thunderbolt", "toxic"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -948,7 +1074,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["energyball", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"]
+                "movepool": ["energyball", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -958,11 +1085,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aquajet", "doubleedge", "icepunch", "superpower", "waterfall"],
+                "abilities": ["Huge Power"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["aquajet", "bellydrum", "return", "waterfall"]
+                "movepool": ["aquajet", "bellydrum", "return", "waterfall"],
+                "abilities": ["Huge Power"]
             }
         ]
     },
@@ -971,7 +1100,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"]
+                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -981,11 +1111,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["encore", "focusblast", "hiddenpowergrass", "hydropump", "icebeam", "rest", "surf", "toxic"],
+                "abilities": ["Water Absorb"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Staller",
-                "movepool": ["encore", "icebeam", "protect", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -994,11 +1126,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "energyball", "sleeppowder", "stunspore", "toxic", "uturn"]
+                "movepool": ["encore", "energyball", "sleeppowder", "stunspore", "toxic", "uturn"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["hiddenpowerflying", "leechseed", "protect", "substitute", "toxic"]
+                "movepool": ["hiddenpowerflying", "leechseed", "protect", "substitute", "toxic"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1007,7 +1141,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"]
+                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1016,7 +1151,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "encore", "icebeam", "recover", "toxic", "waterfall"]
+                "movepool": ["earthquake", "encore", "icebeam", "recover", "toxic", "waterfall"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -1025,11 +1161,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "hiddenpowerfighting", "morningsun", "psychic", "signalbeam", "trick"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "morningsun", "psychic", "signalbeam", "trick"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "morningsun", "psychic", "substitute"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "morningsun", "psychic", "substitute"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1038,11 +1176,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["healbell", "moonlight", "payback", "toxic"]
+                "movepool": ["healbell", "moonlight", "payback", "toxic"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["curse", "payback", "protect", "toxic", "wish"]
+                "movepool": ["curse", "payback", "protect", "toxic", "wish"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1052,11 +1192,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["fireblast", "icebeam", "psychic", "slackoff", "surf", "thunderwave", "toxic"],
+                "abilities": ["Own Tempo"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["fireblast", "icebeam", "psychic", "slackoff", "surf", "trick", "trickroom"],
+                "abilities": ["Own Tempo"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -1066,7 +1208,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"]
+                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1075,7 +1218,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"]
+                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"],
+                "abilities": ["Shadow Tag"]
             }
         ]
     },
@@ -1084,7 +1228,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "psychic", "substitute", "thunderbolt"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "psychic", "substitute", "thunderbolt"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -1093,7 +1238,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["explosion", "payback", "rapidspin", "spikes", "stealthrock", "toxicspikes"]
+                "movepool": ["explosion", "payback", "rapidspin", "spikes", "stealthrock", "toxicspikes"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1102,11 +1248,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headbutt", "roost", "thunderwave"]
+                "movepool": ["earthquake", "headbutt", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["bite", "bodyslam", "earthquake", "roost", "stealthrock"],
+                "abilities": ["Serene Grace"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -1116,11 +1264,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "ironhead", "roar", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "explosion", "ironhead", "roar", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "ironhead", "protect", "toxic"]
+                "movepool": ["earthquake", "ironhead", "protect", "toxic"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -1129,7 +1279,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "crunch", "healbell", "return", "thunderwave"]
+                "movepool": ["closecombat", "crunch", "healbell", "return", "thunderwave"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1138,7 +1289,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "explosion", "spikes", "thunderwave", "toxicspikes", "waterfall"]
+                "movepool": ["destinybond", "explosion", "spikes", "thunderwave", "toxicspikes", "waterfall"],
+                "abilities": ["Poison Point", "Swift Swim"]
             }
         ]
     },
@@ -1147,11 +1299,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbite", "bulletpunch", "roost", "superpower", "swordsdance"]
+                "movepool": ["bugbite", "bulletpunch", "roost", "superpower", "swordsdance"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletpunch", "pursuit", "superpower", "uturn"]
+                "movepool": ["bulletpunch", "pursuit", "superpower", "uturn"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -1160,7 +1314,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "knockoff", "protect", "stealthrock", "toxic"]
+                "movepool": ["encore", "knockoff", "protect", "stealthrock", "toxic"],
+                "abilities": ["Gluttony"]
             }
         ]
     },
@@ -1169,11 +1324,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "facade", "megahorn", "nightslash"]
+                "movepool": ["closecombat", "facade", "megahorn", "nightslash"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "megahorn", "nightslash", "stoneedge", "swordsdance"]
+                "movepool": ["closecombat", "earthquake", "megahorn", "nightslash", "stoneedge", "swordsdance"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -1182,7 +1339,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"]
+                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
+                "abilities": ["Guts", "Quick Feet"]
             }
         ]
     },
@@ -1191,7 +1349,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic"]
+                "movepool": ["hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic"],
+                "abilities": ["Flame Body"]
             }
         ]
     },
@@ -1200,7 +1359,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["explosion", "powergem", "recover", "stealthrock", "surf", "toxic"]
+                "movepool": ["explosion", "powergem", "recover", "stealthrock", "surf", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1209,7 +1369,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["energyball", "fireblast", "icebeam", "surf", "thunderwave"]
+                "movepool": ["energyball", "fireblast", "icebeam", "surf", "thunderwave"],
+                "abilities": ["Sniper"]
             }
         ]
     },
@@ -1218,7 +1379,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"]
+                "movepool": ["icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"],
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -1227,11 +1389,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerflying", "protect", "surf", "toxic"]
+                "movepool": ["hiddenpowerflying", "protect", "surf", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -1240,11 +1404,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+                "abilities": ["Keen Eye"]
             },
             {
                 "role": "Staller",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"]
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -1253,7 +1419,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"]
+                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -1262,15 +1429,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["dragondance", "outrage", "rest", "substitute", "waterfall"]
+                "movepool": ["dragondance", "outrage", "rest", "substitute", "waterfall"],
+                "abilities": ["Sniper", "Swift Swim"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"]
+                "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["dragondance", "outrage", "rest", "sleeptalk"]
+                "movepool": ["dragondance", "outrage", "rest", "sleeptalk"],
+                "abilities": ["Sniper", "Swift Swim"]
             }
         ]
     },
@@ -1280,11 +1450,13 @@
             {
                 "role": "Spinner",
                 "movepool": ["earthquake", "iceshard", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Sturdy"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "gunkshot", "iceshard", "stealthrock", "stoneedge"],
+                "abilities": ["Sturdy"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -1294,7 +1466,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["discharge", "icebeam", "recover", "toxic", "triattack"]
+                "movepool": ["discharge", "icebeam", "recover", "toxic", "triattack"],
+                "abilities": ["Download", "Trace"]
             }
         ]
     },
@@ -1304,6 +1477,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "hypnosis", "megahorn", "return", "suckerpunch", "thunderbolt"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1313,7 +1487,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["explosion", "spikes", "spore", "stealthrock", "whirlwind"]
+                "movepool": ["explosion", "spikes", "spore", "stealthrock", "whirlwind"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -1322,7 +1497,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1330,12 +1506,9 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["bodyslam", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "earthquake", "milkdrink"]
+                "role": "Bulky Attacker",
+                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -1344,11 +1517,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1357,11 +1532,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aurasphere", "hiddenpowerice", "shadowball", "thunderbolt"]
+                "movepool": ["aurasphere", "hiddenpowerice", "shadowball", "thunderbolt"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1371,11 +1548,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "flareblitz", "ironhead", "stoneedge"]
+                "movepool": ["extremespeed", "flareblitz", "ironhead", "stoneedge"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge"]
+                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1384,11 +1563,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "rest", "sleeptalk", "surf"]
+                "movepool": ["calmmind", "rest", "sleeptalk", "surf"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "icebeam", "rest", "substitute", "surf"]
+                "movepool": ["calmmind", "hydropump", "icebeam", "rest", "substitute", "surf"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1397,11 +1578,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge", "superpower"],
+                "abilities": ["Sand Stream"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -1410,11 +1593,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"]
+                "movepool": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["aeroblast", "calmmind", "earthpower", "roost"]
+                "movepool": ["aeroblast", "calmmind", "earthpower", "roost"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1423,7 +1608,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "earthquake", "roost", "sacredfire", "substitute", "toxic"]
+                "movepool": ["bravebird", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1433,15 +1619,18 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthpower", "energyball", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
+                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "energyball", "nastyplot", "psychic", "recover"]
+                "movepool": ["batonpass", "energyball", "nastyplot", "psychic", "recover"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1450,11 +1639,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "focusblast", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"]
+                "movepool": ["earthquake", "focusblast", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Staller",
-                "movepool": ["energyball", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"]
+                "movepool": ["energyball", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -1463,11 +1654,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["agility", "fireblast", "stoneedge", "superpower", "thunderpunch", "vacuumwave"]
+                "movepool": ["agility", "fireblast", "stoneedge", "superpower", "thunderpunch", "vacuumwave"],
+                "abilities": ["Blaze"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["flareblitz", "stoneedge", "superpower", "swordsdance", "thunderpunch"]
+                "movepool": ["flareblitz", "stoneedge", "superpower", "swordsdance", "thunderpunch"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -1476,15 +1669,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "roar", "stealthrock", "toxic", "waterfall"]
+                "movepool": ["earthquake", "icebeam", "roar", "stealthrock", "toxic", "waterfall"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "toxic", "waterfall"]
+                "movepool": ["earthquake", "protect", "toxic", "waterfall"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "icepunch", "stoneedge", "waterfall"]
+                "movepool": ["earthquake", "icepunch", "stoneedge", "waterfall"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -1493,7 +1689,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["crunch", "doubleedge", "firefang", "suckerpunch", "superfang", "taunt", "toxic"]
+                "movepool": ["crunch", "doubleedge", "firefang", "suckerpunch", "superfang", "taunt", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1502,7 +1699,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"]
+                "movepool": ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"],
+                "abilities": ["Gluttony"]
             }
         ]
     },
@@ -1511,7 +1709,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bugbuzz", "hiddenpowerground", "psychic", "uturn"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "psychic", "uturn"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1520,7 +1719,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["bugbuzz", "hiddenpowerground", "roost", "toxic", "uturn", "whirlwind"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "roost", "toxic", "uturn", "whirlwind"],
+                "abilities": ["Shield Dust"]
             }
         ]
     },
@@ -1529,11 +1729,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["energyball", "hydropump", "icebeam", "raindance"]
+                "movepool": ["energyball", "hydropump", "icebeam", "raindance"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["energyball", "hydropump", "icebeam", "surf"]
+                "movepool": ["energyball", "hydropump", "icebeam", "surf"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1542,11 +1744,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "explosion", "hiddenpowerfire", "leafstorm", "lowkick", "suckerpunch"]
+                "movepool": ["darkpulse", "explosion", "hiddenpowerfire", "leafstorm", "lowkick", "suckerpunch"],
+                "abilities": ["Chlorophyll", "Early Bird"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["lowkick", "seedbomb", "suckerpunch", "swordsdance"]
+                "movepool": ["lowkick", "seedbomb", "suckerpunch", "swordsdance"],
+                "abilities": ["Chlorophyll", "Early Bird"]
             }
         ]
     },
@@ -1555,11 +1759,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "facade", "protect", "uturn"]
+                "movepool": ["bravebird", "facade", "protect", "uturn"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "facade", "quickattack", "uturn"]
+                "movepool": ["bravebird", "facade", "quickattack", "uturn"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -1568,7 +1774,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "hiddenpowergrass", "hydropump", "icebeam", "roost", "surf", "toxic", "uturn"]
+                "movepool": ["airslash", "hiddenpowergrass", "hydropump", "icebeam", "roost", "surf", "toxic", "uturn"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -1578,11 +1785,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["focusblast", "healingwish", "psychic", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Trace"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "focusblast", "psychic", "shadowball", "substitute", "willowisp"],
+                "abilities": ["Trace"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -1592,11 +1801,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "airslash", "batonpass", "bugbuzz", "hydropump", "roost"]
+                "movepool": ["agility", "airslash", "batonpass", "bugbuzz", "hydropump", "roost"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "bugbuzz", "hydropump", "roost", "stunspore", "toxic"]
+                "movepool": ["airslash", "bugbuzz", "hydropump", "roost", "stunspore", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1605,11 +1816,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["facade", "machpunch", "seedbomb", "spore", "stoneedge", "superpower", "swordsdance"]
+                "movepool": ["facade", "machpunch", "seedbomb", "spore", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Poison Heal"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focuspunch", "spore", "stoneedge", "substitute"]
+                "movepool": ["focuspunch", "spore", "stoneedge", "substitute"],
+                "abilities": ["Poison Heal"]
             }
         ]
     },
@@ -1618,15 +1831,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "earthquake", "encore", "nightslash", "return", "slackoff", "suckerpunch"]
+                "movepool": ["bodyslam", "earthquake", "encore", "nightslash", "return", "slackoff", "suckerpunch"],
+                "abilities": ["Vital Spirit"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "bulkup", "earthquake", "nightslash", "return", "slackoff"]
+                "movepool": ["bodyslam", "bulkup", "earthquake", "nightslash", "return", "slackoff"],
+                "abilities": ["Vital Spirit"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bodyslam", "bulkup", "earthquake", "nightslash", "return", "suckerpunch"]
+                "movepool": ["bodyslam", "bulkup", "earthquake", "nightslash", "return", "suckerpunch"],
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -1635,7 +1851,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "gigaimpact", "nightslash", "return"]
+                "movepool": ["doubleedge", "earthquake", "gigaimpact", "nightslash", "return"],
+                "abilities": ["Truant"]
             }
         ]
     },
@@ -1644,11 +1861,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "substitute", "swordsdance", "xscissor"]
+                "movepool": ["batonpass", "substitute", "swordsdance", "xscissor"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "protect", "swordsdance", "xscissor"]
+                "movepool": ["batonpass", "protect", "swordsdance", "xscissor"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -1657,7 +1876,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"]
+                "movepool": ["batonpass", "shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+                "abilities": ["Wonder Guard"]
             }
         ]
     },
@@ -1666,7 +1886,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "return", "surf"]
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "return", "surf"],
+                "abilities": ["Soundproof"]
             }
         ]
     },
@@ -1676,11 +1897,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["bulletpunch", "closecombat", "facade", "fakeout", "payback", "stoneedge"],
+                "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "bulletpunch", "closecombat", "payback", "stoneedge"]
+                "movepool": ["bulkup", "bulletpunch", "closecombat", "payback", "stoneedge"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -1689,15 +1912,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"]
+                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "toxic"]
+                "movepool": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "toxic"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "icebeam", "thunderbolt"]
+                "movepool": ["batonpass", "calmmind", "icebeam", "thunderbolt"],
+                "abilities": ["Cute Charm"]
             }
         ]
     },
@@ -1706,7 +1932,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["payback", "recover", "seismictoss", "toxic", "willowisp"]
+                "movepool": ["payback", "recover", "seismictoss", "toxic", "willowisp"],
+                "abilities": ["Keen Eye"]
             }
         ]
     },
@@ -1715,11 +1942,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "ironhead", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["batonpass", "ironhead", "substitute", "suckerpunch", "swordsdance"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focuspunch", "ironhead", "substitute", "suckerpunch"]
+                "movepool": ["focuspunch", "ironhead", "substitute", "suckerpunch"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1729,6 +1958,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquatail", "earthquake", "headsmash", "icepunch", "rockpolish", "stealthrock"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1738,7 +1968,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletpunch", "highjumpkick", "icepunch", "trick", "zenheadbutt"]
+                "movepool": ["bulletpunch", "highjumpkick", "icepunch", "trick", "zenheadbutt"],
+                "abilities": ["Pure Power"]
             }
         ]
     },
@@ -1747,7 +1978,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt"]
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -1756,11 +1988,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Plus"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Plus"]
             }
         ]
     },
@@ -1769,11 +2003,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Minus"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Minus"]
             }
         ]
     },
@@ -1782,15 +2018,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "bugbuzz", "substitute", "tailglow"]
+                "movepool": ["batonpass", "bugbuzz", "substitute", "tailglow"],
+                "abilities": ["Swarm"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["batonpass", "bugbuzz", "encore", "tailglow"]
+                "movepool": ["batonpass", "bugbuzz", "encore", "tailglow"],
+                "abilities": ["Swarm"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "bugbuzz", "roost", "tailglow"]
+                "movepool": ["batonpass", "bugbuzz", "roost", "tailglow"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1799,7 +2038,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbuzz", "encore", "roost", "thunderwave", "toxic", "uturn"]
+                "movepool": ["bugbuzz", "encore", "roost", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -1808,11 +2048,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "encore", "explosion", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"]
+                "movepool": ["earthquake", "encore", "explosion", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
+                "abilities": ["Liquid Ooze"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"]
+                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"],
+                "abilities": ["Liquid Ooze"]
             }
         ]
     },
@@ -1821,11 +2063,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["aquajet", "crunch", "earthquake", "hydropump", "icebeam"]
+                "movepool": ["aquajet", "crunch", "earthquake", "hydropump", "icebeam"],
+                "abilities": ["Rough Skin"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "crunch", "earthquake", "icebeam", "waterfall"]
+                "movepool": ["aquajet", "crunch", "earthquake", "icebeam", "waterfall"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -1835,6 +2079,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "selfdestruct", "surf", "waterspout"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1844,11 +2089,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "lavaplume", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "explosion", "lavaplume", "stealthrock", "toxic"],
+                "abilities": ["Solid Rock"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "explosion", "fireblast", "rockpolish", "stoneedge"]
+                "movepool": ["earthquake", "explosion", "fireblast", "rockpolish", "stoneedge"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -1857,7 +2104,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "lavaplume", "rapidspin", "stealthrock", "yawn"]
+                "movepool": ["earthquake", "explosion", "lavaplume", "rapidspin", "stealthrock", "yawn"],
+                "abilities": ["White Smoke"]
             }
         ]
     },
@@ -1866,11 +2114,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic"]
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "psychic", "shadowball", "trick"]
+                "movepool": ["calmmind", "focusblast", "psychic", "shadowball", "trick"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -1879,15 +2129,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["encore", "protect", "seismictoss", "shadowball", "substitute", "toxic"]
+                "movepool": ["encore", "protect", "seismictoss", "shadowball", "substitute", "toxic"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["doubleedge", "fakeout", "lowkick", "shadowball", "suckerpunch"],
+                "abilities": ["Own Tempo"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -1897,11 +2150,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "fireblast", "outrage", "roost", "stoneedge", "uturn"]
+                "movepool": ["earthquake", "fireblast", "outrage", "roost", "stoneedge", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "roost", "uturn"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "roost", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1910,15 +2165,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "encore", "lowkick", "seedbomb", "spikes", "suckerpunch"]
+                "movepool": ["darkpulse", "encore", "lowkick", "seedbomb", "spikes", "suckerpunch"],
+                "abilities": ["Sand Veil"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["lowkick", "seedbomb", "suckerpunch", "swordsdance"]
+                "movepool": ["lowkick", "seedbomb", "suckerpunch", "swordsdance"],
+                "abilities": ["Sand Veil"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focuspunch", "seedbomb", "substitute", "suckerpunch"]
+                "movepool": ["focuspunch", "seedbomb", "substitute", "suckerpunch"],
+                "abilities": ["Sand Veil"]
             }
         ]
     },
@@ -1927,11 +2185,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
+                "movepool": ["dragondance", "earthquake", "outrage", "roost"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "haze", "healbell", "roost", "toxic"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "haze", "healbell", "roost", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1941,6 +2201,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["closecombat", "nightslash", "quickattack", "return", "swordsdance"],
+                "abilities": ["Immunity"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -1951,6 +2212,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquatail", "darkpulse", "earthquake", "flamethrower", "sludgebomb", "suckerpunch", "switcheroo"],
+                "abilities": ["Shed Skin"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1960,11 +2222,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "earthpower", "psychic", "shadowball", "substitute"]
+                "movepool": ["batonpass", "calmmind", "earthpower", "psychic", "shadowball", "substitute"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthpower", "explosion", "psychic", "stealthrock", "toxic"]
+                "movepool": ["earthpower", "explosion", "psychic", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1974,6 +2238,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "explosion", "rockpolish", "stealthrock", "stoneedge", "zenheadbutt"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1983,7 +2248,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "stoneedge", "waterfall"]
+                "movepool": ["dragondance", "earthquake", "stoneedge", "waterfall"],
+                "abilities": ["Anticipation"]
             }
         ]
     },
@@ -1992,7 +2258,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "dragondance", "superpower", "waterfall", "xscissor"]
+                "movepool": ["crunch", "dragondance", "superpower", "waterfall", "xscissor"],
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },
@@ -2001,7 +2268,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2010,11 +2278,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["recover", "seedbomb", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["recover", "seedbomb", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Suction Cups"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"]
+                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"],
+                "abilities": ["Suction Cups"]
             }
         ]
     },
@@ -2023,11 +2293,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"]
+                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"],
+                "abilities": ["Battle Armor"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquatail", "earthquake", "rockpolish", "stealthrock", "stoneedge", "swordsdance", "xscissor"]
+                "movepool": ["aquatail", "earthquake", "rockpolish", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Battle Armor"]
             }
         ]
     },
@@ -2036,11 +2308,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["haze", "icebeam", "recover", "surf", "toxic"]
+                "movepool": ["haze", "icebeam", "recover", "surf", "toxic"],
+                "abilities": ["Marvel Scale"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Marvel Scale"]
             }
         ]
     },
@@ -2049,7 +2323,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "icebeam", "return", "thunderbolt", "thunderwave"]
+                "movepool": ["fireblast", "icebeam", "return", "thunderbolt", "thunderwave"],
+                "abilities": ["Forecast"]
             }
         ]
     },
@@ -2058,7 +2333,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["recover", "return", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["recover", "return", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Color Change"]
             }
         ]
     },
@@ -2067,7 +2343,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "shadowclaw", "shadowsneak", "thunderwave", "willowisp"]
+                "movepool": ["hiddenpowerfighting", "shadowclaw", "shadowsneak", "thunderwave", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -2076,11 +2353,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "earthquake", "leechseed", "roost", "toxic"]
+                "movepool": ["airslash", "earthquake", "leechseed", "roost", "toxic"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["aerialace", "dragondance", "earthquake", "leafblade", "roost"],
+                "abilities": ["Chlorophyll"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2090,11 +2369,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerfighting", "psychic", "recover", "thunderwave", "toxic"]
+                "movepool": ["healbell", "hiddenpowerfighting", "psychic", "recover", "thunderwave", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "recover", "signalbeam"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "recover", "signalbeam"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2104,11 +2385,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["nightslash", "psychocut", "pursuit", "suckerpunch", "superpower"],
+                "abilities": ["Super Luck"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["nightslash", "suckerpunch", "superpower", "swordsdance"]
+                "movepool": ["nightslash", "suckerpunch", "superpower", "swordsdance"],
+                "abilities": ["Super Luck"]
             }
         ]
     },
@@ -2117,7 +2400,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "explosion", "icebeam", "spikes", "taunt"]
+                "movepool": ["earthquake", "explosion", "icebeam", "spikes", "taunt"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -2126,11 +2410,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "roar", "superfang", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "roar", "superfang", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "protect", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -2140,11 +2426,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["doubleedge", "hiddenpowergrass", "hydropump", "icebeam", "suckerpunch", "surf"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2154,7 +2442,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2163,11 +2452,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"]
+                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "headsmash", "rockpolish", "waterfall"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2177,7 +2468,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "substitute", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "substitute", "surf", "toxic"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2187,6 +2479,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "fireblast", "outrage", "roost"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2197,11 +2490,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["agility", "earthquake", "explosion", "icepunch", "meteormash", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "stealthrock", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2211,15 +2506,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "rest", "stealthrock", "stoneedge", "thunderwave", "toxic"]
+                "movepool": ["earthquake", "explosion", "rest", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["curse", "earthquake", "rest", "sleeptalk", "stoneedge"]
+                "movepool": ["curse", "earthquake", "rest", "sleeptalk", "stoneedge"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "rockslide", "toxic"]
+                "movepool": ["earthquake", "protect", "rockslide", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2229,16 +2527,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["explosion", "focusblast", "icebeam", "rockpolish", "thunderbolt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"]
+                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2247,15 +2548,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "ironhead", "rest", "sleeptalk"]
+                "movepool": ["curse", "ironhead", "rest", "sleeptalk"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"]
+                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2264,7 +2568,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psychic", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psychic", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2273,7 +2578,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psychic", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psychic", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2282,11 +2588,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "surf", "thunder", "waterspout"]
+                "movepool": ["icebeam", "surf", "thunder", "waterspout"],
+                "abilities": ["Drizzle"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"]
+                "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -2295,11 +2603,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "stoneedge", "thunderwave"]
+                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "stoneedge", "thunderwave"],
+                "abilities": ["Drought"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "firepunch", "rockpolish", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "firepunch", "rockpolish", "stoneedge", "swordsdance"],
+                "abilities": ["Drought"]
             }
         ]
     },
@@ -2308,16 +2618,19 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "earthquake", "extremespeed", "fireblast", "outrage"]
+                "movepool": ["dracometeor", "earthquake", "extremespeed", "fireblast", "outrage"],
+                "abilities": ["Air Lock"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "overheat"],
+                "abilities": ["Air Lock"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragonclaw", "earthquake", "extremespeed", "swordsdance"]
+                "movepool": ["dragonclaw", "earthquake", "extremespeed", "swordsdance"],
+                "abilities": ["Air Lock"]
             }
         ]
     },
@@ -2326,11 +2639,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"]
+                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["calmmind", "hiddenpowerfire", "psychic", "substitute", "thunderbolt", "wish"],
+                "abilities": ["Serene Grace"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -2340,11 +2655,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "psychoboost", "shadowball", "superpower"]
+                "movepool": ["extremespeed", "psychoboost", "shadowball", "superpower"],
+                "abilities": ["Pressure"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["icebeam", "psychoboost", "shadowball", "superpower"]
+                "role": "Fast Support",
+                "movepool": ["icebeam", "psychoboost", "shadowball", "superpower"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2353,11 +2670,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "psychoboost", "shadowball", "superpower"]
+                "movepool": ["extremespeed", "psychoboost", "shadowball", "superpower"],
+                "abilities": ["Pressure"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["icebeam", "psychoboost", "shadowball", "superpower"]
+                "role": "Fast Support",
+                "movepool": ["icebeam", "psychoboost", "shadowball", "superpower"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2366,7 +2685,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"]
+                "movepool": ["recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2375,7 +2695,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["psychoboost", "spikes", "stealthrock", "superpower", "taunt"]
+                "movepool": ["psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2384,11 +2705,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"]
+                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"]
+                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -2397,11 +2720,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"]
+                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"],
+                "abilities": ["Blaze"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"]
+                "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -2410,15 +2735,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "stealthrock", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "stealthrock", "surf", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "roar", "stealthrock", "surf", "toxic"]
+                "movepool": ["icebeam", "roar", "stealthrock", "surf", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "grassknot", "hydropump", "icebeam"]
+                "movepool": ["agility", "grassknot", "hydropump", "icebeam"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -2428,11 +2756,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bravebird", "closecombat", "doubleedge", "pursuit", "quickattack", "return", "uturn"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bravebird", "closecombat", "return", "roost", "uturn"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2442,7 +2772,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["curse", "quickattack", "return", "waterfall"]
+                "movepool": ["curse", "quickattack", "return", "waterfall"],
+                "abilities": ["Simple"]
             }
         ]
     },
@@ -2451,7 +2782,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["brickbreak", "nightslash", "return", "swordsdance", "xscissor"]
+                "movepool": ["brickbreak", "nightslash", "return", "swordsdance", "xscissor"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -2461,11 +2793,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["crunch", "icefang", "roar", "superpower", "thunderbolt", "toxic"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "superpower", "thunderbolt", "toxic"]
+                "movepool": ["protect", "superpower", "thunderbolt", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -2474,7 +2808,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["energyball", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
+                "movepool": ["energyball", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -2484,11 +2819,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "firepunch", "rockpolish", "stoneedge", "zenheadbutt"],
+                "abilities": ["Mold Breaker"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "headsmash", "stoneedge", "superpower"]
+                "movepool": ["earthquake", "headsmash", "stoneedge", "superpower"],
+                "abilities": ["Mold Breaker"]
             }
         ]
     },
@@ -2497,11 +2834,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["metalburst", "roar", "rockslide", "stealthrock", "toxic"]
+                "movepool": ["metalburst", "roar", "rockslide", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"]
+                "movepool": ["metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -2510,7 +2849,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerground", "hiddenpowerrock", "leafstorm", "psychic", "signalbeam"]
+                "movepool": ["hiddenpowerground", "hiddenpowerrock", "leafstorm", "psychic", "signalbeam"],
+                "abilities": ["Anticipation"]
             }
         ]
     },
@@ -2519,7 +2859,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "rest", "sleeptalk", "toxic"]
+                "movepool": ["earthquake", "rest", "sleeptalk", "toxic"],
+                "abilities": ["Anticipation"]
             }
         ]
     },
@@ -2528,7 +2869,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"]
+                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"],
+                "abilities": ["Anticipation"]
             }
         ]
     },
@@ -2538,6 +2880,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["airslash", "bugbuzz", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "uturn"],
+                "abilities": ["Swarm"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -2547,7 +2890,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerflying", "roost", "toxic", "uturn"]
+                "movepool": ["hiddenpowerflying", "roost", "toxic", "uturn"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2556,11 +2900,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["discharge", "superfang", "thunderbolt", "thunderwave", "toxic", "uturn"]
+                "movepool": ["discharge", "superfang", "thunderbolt", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Pickup", "Run Away"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["protect", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Pickup", "Run Away"]
             }
         ]
     },
@@ -2570,11 +2916,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquajet", "crunch", "icepunch", "return", "waterfall"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "bulkup", "icepunch", "return", "substitute", "waterfall"]
+                "movepool": ["aquajet", "bulkup", "icepunch", "return", "substitute", "waterfall"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2583,7 +2931,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "leechseed", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "leechseed", "synthesis", "toxic"],
+                "abilities": ["Flower Gift"]
             }
         ]
     },
@@ -2592,7 +2941,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icebeam", "recover", "surf", "toxic"]
+                "movepool": ["earthquake", "icebeam", "recover", "surf", "toxic"],
+                "abilities": ["Sticky Hold"]
             }
         ]
     },
@@ -2601,7 +2951,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "lowkick", "payback", "pursuit", "return", "uturn"]
+                "movepool": ["fakeout", "lowkick", "payback", "pursuit", "return", "uturn"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -2610,7 +2961,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "rest", "shadowball", "substitute", "thunderbolt"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "rest", "shadowball", "substitute", "thunderbolt"],
+                "abilities": ["Unburden"]
             }
         ]
     },
@@ -2619,11 +2971,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["batonpass", "encore", "return", "substitute", "thunderwave", "toxic"]
+                "movepool": ["batonpass", "encore", "return", "substitute", "thunderwave", "toxic"],
+                "abilities": ["Cute Charm"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["healingwish", "icepunch", "return", "skyuppercut", "switcheroo"]
+                "movepool": ["healingwish", "icepunch", "return", "skyuppercut", "switcheroo"],
+                "abilities": ["Cute Charm"]
             }
         ]
     },
@@ -2632,11 +2986,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["destinybond", "hiddenpowerfighting", "painsplit", "shadowball", "substitute", "taunt", "willowisp"]
+                "movepool": ["destinybond", "hiddenpowerfighting", "painsplit", "shadowball", "substitute", "taunt", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "thunderbolt", "trick"]
+                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2645,7 +3001,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"]
+                "movepool": ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -2654,7 +3011,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "irontail", "return", "shadowclaw", "uturn"]
+                "movepool": ["fakeout", "irontail", "return", "shadowclaw", "uturn"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -2663,7 +3021,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "explosion", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"]
+                "movepool": ["crunch", "explosion", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"],
+                "abilities": ["Aftermath"]
             }
         ]
     },
@@ -2672,11 +3031,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "ironhead", "payback", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "explosion", "ironhead", "payback", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "psychic", "toxic"]
+                "movepool": ["earthquake", "protect", "psychic", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2685,11 +3046,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["chatter", "encore", "heatwave", "hiddenpowergrass", "hypervoice", "nastyplot"]
+                "movepool": ["chatter", "encore", "heatwave", "hiddenpowergrass", "hypervoice", "nastyplot"],
+                "abilities": ["Tangled Feet"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["chatter", "heatwave", "hiddenpowergrass", "hypervoice", "uturn"]
+                "movepool": ["chatter", "heatwave", "hiddenpowergrass", "hypervoice", "uturn"],
+                "abilities": ["Tangled Feet"]
             }
         ]
     },
@@ -2698,11 +3061,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "darkpulse", "rest", "sleeptalk"]
+                "movepool": ["calmmind", "darkpulse", "rest", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "shadowsneak", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "shadowsneak", "suckerpunch", "willowisp"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2711,15 +3076,18 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "fireblast", "outrage", "stealthrock", "stoneedge"]
+                "movepool": ["earthquake", "fireblast", "outrage", "stealthrock", "stoneedge"],
+                "abilities": ["Sand Veil"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"],
+                "abilities": ["Sand Veil"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["dragonclaw", "earthquake", "substitute", "swordsdance"]
+                "movepool": ["dragonclaw", "earthquake", "substitute", "swordsdance"],
+                "abilities": ["Sand Veil"]
             }
         ]
     },
@@ -2729,6 +3097,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "crunch", "extremespeed", "stoneedge", "swordsdance"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2738,7 +3107,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "roar", "slackoff", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "roar", "slackoff", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -2748,11 +3118,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquatail", "crunch", "earthquake", "poisonjab", "pursuit", "swordsdance"],
+                "abilities": ["Battle Armor"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["crunch", "earthquake", "poisonjab", "taunt", "toxicspikes", "whirlwind"]
+                "movepool": ["crunch", "earthquake", "poisonjab", "taunt", "toxicspikes", "whirlwind"],
+                "abilities": ["Battle Armor"]
             }
         ]
     },
@@ -2761,7 +3133,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crosschop", "earthquake", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["crosschop", "earthquake", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -2770,11 +3143,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "powerwhip", "sleeppowder", "synthesis"]
+                "movepool": ["knockoff", "powerwhip", "sleeppowder", "synthesis"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["powerwhip", "return", "sleeppowder", "swordsdance", "synthesis"]
+                "movepool": ["powerwhip", "return", "sleeppowder", "swordsdance", "synthesis"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2783,7 +3158,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "icebeam", "raindance", "surf", "uturn"]
+                "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "icebeam", "raindance", "surf", "uturn"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2792,7 +3168,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "earthquake", "iceshard", "woodhammer"]
+                "movepool": ["blizzard", "earthquake", "iceshard", "woodhammer"],
+                "abilities": ["Snow Warning"]
             }
         ]
     },
@@ -2801,7 +3178,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["icepunch", "iceshard", "lowkick", "nightslash", "pursuit", "swordsdance"]
+                "movepool": ["icepunch", "iceshard", "lowkick", "nightslash", "pursuit", "swordsdance"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2810,11 +3188,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["explosion", "flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt"]
+                "movepool": ["explosion", "flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt"],
+                "abilities": ["Magnet Pull"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"]
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -2823,11 +3203,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "healbell", "protect", "toxic", "wish"]
+                "movepool": ["bodyslam", "healbell", "protect", "toxic", "wish"],
+                "abilities": ["Own Tempo"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bodyslam", "earthquake", "explosion", "powerwhip", "return", "swordsdance"],
+                "abilities": ["Own Tempo"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2837,7 +3219,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stealthrock", "stoneedge"]
+                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stealthrock", "stoneedge"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -2846,11 +3229,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hiddenpowerfire", "leafstorm", "powerwhip", "rockslide", "sleeppowder", "synthesis"]
+                "movepool": ["earthquake", "hiddenpowerfire", "leafstorm", "powerwhip", "rockslide", "sleeppowder", "synthesis"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "powerwhip", "rockslide", "swordsdance"]
+                "movepool": ["earthquake", "powerwhip", "rockslide", "swordsdance"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -2860,6 +3245,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crosschop", "earthquake", "flamethrower", "hiddenpowergrass", "icepunch", "thunderbolt"],
+                "abilities": ["Motor Drive"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2870,6 +3256,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -2879,15 +3266,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["airslash", "aurasphere", "batonpass", "nastyplot", "roost", "thunderwave"]
+                "movepool": ["airslash", "aurasphere", "batonpass", "nastyplot", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "healbell", "roost", "thunderwave"]
+                "movepool": ["airslash", "healbell", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "aurasphere", "fireblast", "trick"]
+                "movepool": ["airslash", "aurasphere", "fireblast", "trick"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -2896,11 +3286,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "bugbuzz", "hiddenpowerfire", "hiddenpowerground", "protect"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerfire", "hiddenpowerground", "protect"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["airslash", "bugbuzz", "hiddenpowerfire", "hiddenpowerground", "uturn"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerfire", "hiddenpowerground", "uturn"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -2909,11 +3301,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "leafblade", "synthesis", "toxic"]
+                "movepool": ["healbell", "leafblade", "synthesis", "toxic"],
+                "abilities": ["Leaf Guard"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["batonpass", "doubleedge", "leafblade", "substitute", "swordsdance", "synthesis", "xscissor"],
+                "abilities": ["Leaf Guard"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2923,11 +3317,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerground", "icebeam", "protect", "wish"]
+                "movepool": ["healbell", "hiddenpowerground", "icebeam", "protect", "wish"],
+                "abilities": ["Snow Cloak"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "toxic", "wish"]
+                "movepool": ["icebeam", "protect", "toxic", "wish"],
+                "abilities": ["Snow Cloak"]
             }
         ]
     },
@@ -2936,11 +3332,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic", "uturn"]
+                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic", "uturn"],
+                "abilities": ["Hyper Cutter"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "roost", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "roost", "stoneedge", "swordsdance"],
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },
@@ -2949,7 +3347,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "iceshard", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["earthquake", "iceshard", "stealthrock", "stoneedge", "superpower"],
+                "abilities": ["Snow Cloak"]
             }
         ]
     },
@@ -2958,7 +3357,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "hiddenpowerfighting", "icebeam", "nastyplot", "thunderbolt", "triattack", "trick"]
+                "movepool": ["darkpulse", "hiddenpowerfighting", "icebeam", "nastyplot", "thunderbolt", "triattack", "trick"],
+                "abilities": ["Adaptability", "Download"]
             }
         ]
     },
@@ -2967,7 +3367,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "nightslash", "shadowsneak", "swordsdance", "trick", "zenheadbutt"]
+                "movepool": ["closecombat", "nightslash", "shadowsneak", "swordsdance", "trick", "zenheadbutt"],
+                "abilities": ["Steadfast"]
             }
         ]
     },
@@ -2976,7 +3377,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "explosion", "powergem", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["earthpower", "explosion", "powergem", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -2986,15 +3388,18 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "toxic", "trick", "willowisp"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"]
+                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focuspunch", "painsplit", "shadowsneak", "substitute"]
+                "movepool": ["focuspunch", "painsplit", "shadowsneak", "substitute"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3003,7 +3408,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"]
+                "movepool": ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"],
+                "abilities": ["Snow Cloak"]
             }
         ]
     },
@@ -3012,7 +3418,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerice", "shadowball", "thunderbolt", "trick"]
+                "movepool": ["hiddenpowerfighting", "hiddenpowerice", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3022,11 +3429,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["overheat", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Fire"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"]
+                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3036,11 +3445,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["hydropump", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Water"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"]
+                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3050,11 +3461,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["blizzard", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"]
+                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3063,11 +3476,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["painsplit", "shadowball", "thunderbolt", "willowisp"]
+                "movepool": ["painsplit", "shadowball", "thunderbolt", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"]
+                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3077,11 +3492,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["leafstorm", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Grass"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"]
+                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3090,7 +3507,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"]
+                "movepool": ["healbell", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3099,11 +3517,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "healingwish", "hiddenpowerfighting", "icebeam", "psychic", "thunderbolt", "trick", "uturn"]
+                "movepool": ["calmmind", "healingwish", "hiddenpowerfighting", "icebeam", "psychic", "thunderbolt", "trick", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfighting", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"]
+                "movepool": ["hiddenpowerfighting", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3113,11 +3533,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fireblast", "nastyplot", "psychic", "signalbeam", "thunderbolt", "trick", "uturn"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Fire"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["explosion", "fireblast", "psychic", "stealthrock", "taunt", "uturn"]
+                "movepool": ["explosion", "fireblast", "psychic", "stealthrock", "taunt", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3127,15 +3549,18 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aurasphere", "dracometeor", "fireblast", "roar", "stealthrock", "thunderbolt", "toxic"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulkup", "outrage", "rest", "sleeptalk"]
+                "movepool": ["bulkup", "outrage", "rest", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bulkup", "dragonclaw", "earthquake", "fireblast", "rest"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3146,6 +3571,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "fireblast", "hydropump", "spacialrend", "thunderwave"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -3155,16 +3581,19 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "eruption", "explosion", "fireblast"]
+                "movepool": ["earthpower", "eruption", "explosion", "fireblast"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["dragonpulse", "earthpower", "explosion", "fireblast", "hiddenpowergrass", "lavaplume", "roar", "stealthrock", "toxic"],
+                "abilities": ["Flash Fire"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthpower", "fireblast", "lavaplume", "protect", "substitute", "toxic"]
+                "movepool": ["earthpower", "fireblast", "lavaplume", "protect", "substitute", "toxic"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -3173,7 +3602,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "return", "substitute", "thunderwave"]
+                "movepool": ["earthquake", "return", "substitute", "thunderwave"],
+                "abilities": ["Slow Start"]
             }
         ]
     },
@@ -3182,7 +3612,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"]
+                "movepool": ["dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3191,7 +3622,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"]
+                "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3200,11 +3632,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psychic", "signalbeam"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psychic", "signalbeam"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfighting", "moonlight", "psychic", "thunderwave", "toxic"]
+                "movepool": ["hiddenpowerfighting", "moonlight", "psychic", "thunderwave", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3213,11 +3647,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["raindance", "rest", "surf", "toxic"]
+                "movepool": ["raindance", "rest", "surf", "toxic"],
+                "abilities": ["Hydration"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "icebeam", "surf", "toxic", "uturn"]
+                "movepool": ["healbell", "icebeam", "surf", "toxic", "uturn"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -3226,7 +3662,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["energyball", "icebeam", "surf", "tailglow"]
+                "movepool": ["energyball", "icebeam", "surf", "tailglow"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -3235,11 +3672,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["darkpulse", "darkvoid", "focusblast", "nastyplot"]
+                "movepool": ["darkpulse", "darkvoid", "focusblast", "nastyplot"],
+                "abilities": ["Bad Dreams"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["darkpulse", "darkvoid", "nastyplot", "substitute"]
+                "movepool": ["darkpulse", "darkvoid", "nastyplot", "substitute"],
+                "abilities": ["Bad Dreams"]
             }
         ]
     },
@@ -3249,6 +3688,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -3258,7 +3698,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"]
+                "movepool": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -3268,6 +3709,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3277,11 +3719,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3290,7 +3734,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "focusblast", "judgment", "recover", "refresh"]
+                "movepool": ["calmmind", "focusblast", "judgment", "recover", "refresh"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3300,11 +3745,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "outrage", "recover", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover", "refresh"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover", "refresh"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3313,7 +3760,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3322,7 +3770,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "darkpulse", "icebeam", "judgment", "recover"]
+                "movepool": ["calmmind", "darkpulse", "icebeam", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3331,7 +3780,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment", "recover", "thunderbolt"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment", "recover", "thunderbolt"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3340,7 +3790,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover", "refresh"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover", "refresh"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3349,7 +3800,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "judgment", "recover", "willowisp"]
+                "movepool": ["calmmind", "focusblast", "judgment", "recover", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3358,11 +3810,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3372,11 +3826,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3385,7 +3841,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3395,11 +3852,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3409,11 +3868,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "darkpulse", "focusblast", "judgment"]
+                "movepool": ["calmmind", "darkpulse", "focusblast", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3423,11 +3884,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3436,11 +3899,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3449,7 +3914,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover", "willowisp"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     }

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -1,5 +1,4 @@
 import RandomGen5Teams from '../gen5/teams';
-import {Utils} from '../../../lib';
 import {PRNG} from '../../../sim';
 import type {MoveCounter} from '../gen8/teams';
 
@@ -52,14 +51,14 @@ export class RandomGen4Teams extends RandomGen5Teams {
 
 		this.moveEnforcementCheckers = {
 			Bug: (movePool, moves, abilities, types, counter) => (
-				!counter.get('Bug') && (movePool.includes('megahorn') || abilities.has('Tinted Lens'))
+				!counter.get('Bug') && movePool.includes('megahorn')
 			),
 			Dark: (movePool, moves, abilities, types, counter) => !counter.get('Dark'),
 			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
 			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting'),
 			Fire: (movePool, moves, abilities, types, counter) => !counter.get('Fire'),
-			Flying: (movePool, moves, abilities, types, counter, species) => !counter.get('Flying'),
+			Flying: (movePool, moves, abilities, types, counter, species) => !counter.get('Flying') && species.id !== 'aerodactyl',
 			Ghost: (movePool, moves, abilities, types, counter) => !counter.get('Ghost'),
 			Grass: (movePool, moves, abilities, types, counter, species) => (
 				!counter.get('Grass') &&
@@ -72,7 +71,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!counter.get('Psychic') && (types.has('Fighting') || movePool.includes('calmmind'))
 			),
 			Rock: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Rock') && (species.baseStats.atk >= 95 || abilities.has('Rock Head'))
+				!counter.get('Rock') && (species.baseStats.atk >= 95 || abilities.includes('Rock Head'))
 			),
 			Steel: (movePool, moves, abilities, types, counter, species) => (!counter.get('Steel') && species.id === 'metagross'),
 			Water: (movePool, moves, abilities, types, counter) => !counter.get('Water'),
@@ -82,7 +81,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 	cullMovePool(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -233,7 +232,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 	// Generate random moveset for a given species, role, preferred type.
 	randomMoveset(
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -274,7 +273,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		// Add other moves you really want to have, e.g. STAB, recovery, setup.
 
 		// Enforce Facade if Guts is a possible ability
-		if (movePool.includes('facade') && abilities.has('Guts')) {
+		if (movePool.includes('facade') && abilities.includes('Guts')) {
 			counter = this.addMove('facade', moves, types, abilities, teamDetails, species, isLead,
 				movePool, preferredType, role);
 		}
@@ -470,7 +469,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -479,28 +478,14 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		role: RandomTeamsTypes.Role
 	): boolean {
 		switch (ability) {
-		case 'Hustle': case 'Ice Body': case 'Rain Dish': case 'Sand Veil': case 'Sniper': case 'Snow Cloak':
-		case 'Solar Power': case 'Steadfast': case 'Sticky Hold': case 'Unaware':
-			return true;
 		case 'Chlorophyll':
-			return !moves.has('sunnyday') && !teamDetails.sun;
-		case 'Guts':
-			return !moves.has('facade') && species.id !== 'heracross';
-		case 'Hydration': case 'Swift Swim':
-			return (
-				!moves.has('raindance') && !teamDetails.rain ||
-				!moves.has('raindance') && ['Rock Head', 'Water Absorb'].some(abil => abilities.has(abil))
-			);
-		case 'Reckless': case 'Rock Head':
+			return !teamDetails.sun;
+		case 'Swift Swim':
+			return !teamDetails.rain;
+		case 'Rock Head':
 			return !counter.get('recoil');
-		case 'Shed Skin':
-			return !moves.has('rest');
 		case 'Skill Link':
 			return !counter.get('skilllink');
-		case 'Swarm':
-			return !counter.get('Bug') && !moves.has('uturn');
-		case 'Technician':
-			return !counter.get('technician');
 		}
 
 		return false;
@@ -510,7 +495,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 	getAbility(
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -518,51 +503,33 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		preferredType: string,
 		role: RandomTeamsTypes.Role,
 	): string {
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData.length <= 1) return abilityData[0].name;
+		if (abilities.length <= 1) return abilities[0];
 
 		// Hard-code abilities here
-		if (species.id === 'jynx') return 'Forewarn';
-		if (species.id === 'arcanine') return 'Intimidate';
-		if (species.id === 'blissey') return 'Natural Cure';
-		if (species.id === 'octillery') return 'Sniper';
-		if (species.id === 'yanmega') return (role === 'Fast Attacker') ? 'Speed Boost' : 'Tinted Lens';
-		if (species.id === 'absol') return 'Super Luck';
-		if (species.id === 'lanturn') return 'Volt Absorb';
+		if (species.id === 'dewgong') return moves.has('raindance') ? 'Hydration' : 'Thick Fat';
+		if (species.id === 'cloyster' && counter.get('skilllink')) return 'Skill Link';
 
-		if (abilities.has('Guts') && !abilities.has('Quick Feet') && moves.has('facade')) return 'Guts';
-		if (abilities.has('Hydration') && moves.has('raindance') && moves.has('rest')) return 'Hydration';
-
-		let abilityAllowed: Ability[] = [];
+		const abilityAllowed: string[] = [];
 		// Obtain a list of abilities that are allowed (not culled)
-		for (const ability of abilityData) {
-			if (ability.rating >= 1 && !this.shouldCullAbility(
-				ability.name, types, moves, abilities, counter, movePool, teamDetails, species, preferredType, role
+		for (const ability of abilities) {
+			if (!this.shouldCullAbility(
+				ability, types, moves, abilities, counter, movePool, teamDetails, species, preferredType, role
 			)) {
 				abilityAllowed.push(ability);
 			}
 		}
 
-		// If all abilities are rejected, re-allow all abilities
+		// Pick a random allowed ability
+		if (abilityAllowed.length >= 1) return this.sample(abilityAllowed);
+
+		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
 		if (!abilityAllowed.length) {
-			for (const ability of abilityData) {
-				if (ability.rating > 0) abilityAllowed.push(ability);
-			}
-			if (!abilityAllowed.length) abilityAllowed = abilityData;
+			const weatherAbilities = abilities.filter(a => ['Chlorophyll', 'Swift Swim'].includes(a));
+			if (weatherAbilities.length) return this.sample(weatherAbilities);
 		}
 
-		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
-		// Sort abilities by rating with an element of randomness
-		if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-			if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-		} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
-			if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-		}
-
-		// After sorting, choose the first ability
-		return abilityAllowed[0].name;
+		// Pick a random ability
+		return this.sample(abilities);
 	}
 
 	getPriorityItem(
@@ -715,8 +682,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const types = species.types;
-		const abilities = new Set(Object.values(species.abilities));
-		if (species.unreleasedHidden) abilities.delete(species.abilities.H);
+		const abilities = set.abilities!;
 
 		// Get moves
 		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, movePool,

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -4,11 +4,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"]
+                "movepool": ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
+                "abilities": ["Chlorophyll", "Overgrow"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Chlorophyll", "Overgrow"]
             }
         ]
     },
@@ -17,15 +19,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "dragonpulse", "fireblast", "focusblast", "hiddenpowergrass", "roost"]
+                "movepool": ["airslash", "dragonpulse", "fireblast", "focusblast", "hiddenpowergrass", "roost"],
+                "abilities": ["Blaze",  "Solar Power"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "earthquake", "fireblast", "roost", "willowisp"]
+                "movepool": ["airslash", "earthquake", "fireblast", "roost", "willowisp"],
+                "abilities": ["Blaze",  "Solar Power"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["acrobatics", "dragondance", "earthquake", "flareblitz", "swordsdance"]
+                "movepool": ["acrobatics", "dragondance", "earthquake", "flareblitz", "swordsdance"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -34,11 +39,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["icebeam", "rapidspin", "roar", "scald", "toxic"]
+                "movepool": ["icebeam", "rapidspin", "roar", "scald", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["haze", "icebeam", "protect", "scald", "toxic"]
+                "movepool": ["haze", "icebeam", "protect", "scald", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -47,11 +54,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "substitute"]
+                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "substitute"],
+                "abilities": ["Tinted Lens"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "quiverdance", "roost", "sleeppowder"]
+                "movepool": ["bugbuzz", "quiverdance", "roost", "sleeppowder"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -60,7 +69,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["drillrun", "poisonjab", "toxicspikes", "uturn"]
+                "movepool": ["drillrun", "poisonjab", "toxicspikes", "uturn"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -69,11 +79,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "heatwave", "return", "roost", "uturn", "workup"]
+                "movepool": ["bravebird", "heatwave", "return", "roost", "uturn", "workup"],
+                "abilities": ["Big Pecks"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "quickattack", "return", "uturn"]
+                "movepool": ["bravebird", "quickattack", "return", "uturn"],
+                "abilities": ["Big Pecks"]
             }
         ]
     },
@@ -83,6 +95,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["crunch", "facade", "flamewheel", "protect", "suckerpunch", "swordsdance", "uturn"],
+                "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -92,11 +105,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"]
+                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"],
+                "abilities": ["Sniper"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "roost"]
+                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "roost"],
+                "abilities": ["Sniper"]
             }
         ]
     },
@@ -105,11 +120,19 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["coil", "earthquake", "glare", "gunkshot", "suckerpunch"]
+                "movepool": ["coil", "earthquake", "glare", "gunkshot", "suckerpunch"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["coil", "earthquake", "gunkshot", "suckerpunch"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["coil", "earthquake", "gunkshot", "rest", "suckerpunch"],
+                "movepool": ["coil", "earthquake", "gunkshot", "rest"],
+                "abilities": ["Shed Skin"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -119,7 +142,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["extremespeed", "grassknot", "hiddenpowerice", "voltswitch", "volttackle"]
+                "movepool": ["extremespeed", "grassknot", "hiddenpowerice", "voltswitch", "volttackle"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -128,7 +152,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"]
+                "movepool": ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -137,11 +162,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Sand Rush"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "stoneedge", "swordsdance", "xscissor"]
+                "movepool": ["earthquake", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Sand Rush"]
             }
         ]
     },
@@ -151,6 +178,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -161,6 +189,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "substitute", "superpower"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -170,11 +199,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "doubleedge", "fireblast", "softboiled", "stealthrock", "thunderwave"]
+                "movepool": ["aromatherapy", "doubleedge", "fireblast", "softboiled", "stealthrock", "thunderwave"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"]
+                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"],
+                "abilities": ["Magic Guard", "Unaware"]
             }
         ]
     },
@@ -184,11 +215,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["fireblast", "hypnosis", "nastyplot", "solarbeam", "willowisp"],
+                "abilities": ["Drought"],
                 "preferredTypes": ["Grass"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam", "substitute"],
+                "abilities": ["Drought"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -198,11 +231,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "doubleedge", "fireblast", "healbell", "protect", "stealthrock", "thunderwave", "toxic", "wish"]
+                "movepool": ["bodyslam", "doubleedge", "fireblast", "healbell", "protect", "stealthrock", "thunderwave", "toxic", "wish"],
+                "abilities": ["Frisk"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -211,7 +246,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "leechseed", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "leechseed", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Effect Spore"]
             }
         ]
     },
@@ -221,15 +257,18 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["aromatherapy", "leechseed", "seedbomb", "spore", "stunspore", "synthesis", "xscissor"],
+                "abilities": ["Dry Skin"],
                 "preferredTypes": ["Bug"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aromatherapy", "leechseed", "seedbomb", "spore", "stunspore", "xscissor"]
+                "movepool": ["aromatherapy", "leechseed", "seedbomb", "spore", "stunspore", "xscissor"],
+                "abilities": ["Dry Skin"]
             },
             {
                 "role": "Staller",
-                "movepool": ["leechseed", "protect", "spore", "xscissor"]
+                "movepool": ["leechseed", "protect", "spore", "xscissor"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -238,11 +277,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "quiverdance", "roost", "sleeppowder"]
+                "movepool": ["bugbuzz", "quiverdance", "roost", "sleeppowder"],
+                "abilities": ["Tinted Lens"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "substitute"]
+                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "substitute"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -251,7 +292,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"]
+                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"],
+                "abilities": ["Arena Trap"]
             }
         ]
     },
@@ -261,6 +303,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bite", "doubleedge", "fakeout", "hypnosis", "return", "seedbomb", "taunt", "uturn"],
+                "abilities": ["Technician"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -271,6 +314,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "encore", "focusblast", "hydropump", "icebeam", "psyshock", "scald"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -280,7 +324,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "honeclaws", "stoneedge", "uturn"]
+                "movepool": ["closecombat", "earthquake", "honeclaws", "stoneedge", "uturn"],
+                "abilities": ["Defiant", "Vital Spirit"]
             }
         ]
     },
@@ -289,11 +334,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"]
+                "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "wildcharge"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -303,11 +350,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hydropump", "icepunch", "raindance"]
+                "movepool": ["focusblast", "hydropump", "icepunch", "raindance"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["circlethrow", "rest", "scald", "sleeptalk"]
+                "movepool": ["circlethrow", "rest", "scald", "sleeptalk"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -316,11 +365,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"]
+                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+                "abilities": ["Magic Guard"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -331,6 +382,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "payback", "stoneedge"],
+                "abilities": ["No Guard"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -340,11 +392,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerground", "powerwhip", "sleeppowder", "sludgebomb", "suckerpunch"]
+                "movepool": ["hiddenpowerground", "powerwhip", "sleeppowder", "sludgebomb", "suckerpunch"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["powerwhip", "sludgebomb", "sunnyday", "weatherball"]
+                "movepool": ["powerwhip", "sludgebomb", "sunnyday", "weatherball"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -353,7 +407,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "icebeam", "rapidspin", "scald", "sludgebomb", "toxicspikes"]
+                "movepool": ["haze", "icebeam", "rapidspin", "scald", "sludgebomb", "toxicspikes"],
+                "abilities": ["Clear Body", "Liquid Ooze"]
             }
         ]
     },
@@ -362,7 +417,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -371,11 +427,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"]
+                "movepool": ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["drillrun", "flareblitz", "megahorn", "morningsun", "wildcharge"]
+                "movepool": ["drillrun", "flareblitz", "megahorn", "morningsun", "wildcharge"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -384,15 +442,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Staller",
-                "movepool": ["calmmind", "psyshock", "scald", "slackoff"]
+                "movepool": ["calmmind", "psyshock", "scald", "slackoff"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["fireblast", "icebeam", "psyshock", "surf", "trick", "trickroom"],
+                "abilities": ["Regenerator"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -402,7 +463,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bravebird", "leafblade", "quickattack", "return", "swordsdance"]
+                "movepool": ["bravebird", "leafblade", "quickattack", "return", "swordsdance"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -411,7 +473,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "pursuit", "quickattack", "return", "roost"]
+                "movepool": ["bravebird", "pursuit", "quickattack", "return", "roost"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -420,11 +483,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -434,6 +499,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["brickbreak", "curse", "icepunch", "poisonjab", "rest", "shadowsneak"],
+                "abilities": ["Poison Touch"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -443,7 +509,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hydropump", "iciclespear", "rockblast", "shellsmash"]
+                "movepool": ["hydropump", "iciclespear", "rockblast", "shellsmash"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -453,6 +520,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["focusblast", "painsplit", "shadowball", "sludgewave", "substitute", "trick", "willowisp"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -462,11 +530,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "foulplay", "protect", "psychic", "thunderwave", "toxic", "wish"]
+                "movepool": ["focusblast", "foulplay", "protect", "psychic", "thunderwave", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -475,11 +545,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bodyslam", "crabhammer", "rockslide", "superpower", "swordsdance", "xscissor"]
+                "movepool": ["bodyslam", "crabhammer", "rockslide", "superpower", "swordsdance", "xscissor"],
+                "abilities": ["Hyper Cutter", "Sheer Force"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["agility", "crabhammer", "return", "swordsdance"]
+                "movepool": ["agility", "crabhammer", "return", "swordsdance"],
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },
@@ -489,11 +561,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["foulplay", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"],
+                "abilities": ["Aftermath", "Static"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["hiddenpowerice", "thunderbolt", "thunderwave", "toxic", "voltswitch"]
+                "movepool": ["hiddenpowerice", "thunderbolt", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Aftermath", "Static"]
             }
         ]
     },
@@ -503,6 +577,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["gigadrain", "hiddenpowerfire", "leechseed", "psychic", "sleeppowder", "substitute"],
+                "abilities": ["Harvest"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -513,6 +588,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "firepunch", "stealthrock", "stoneedge", "swordsdance"],
+                "abilities": ["Battle Armor", "Rock Head"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -522,11 +598,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "fakeout", "rapidspin", "stoneedge", "suckerpunch"]
+                "movepool": ["closecombat", "earthquake", "fakeout", "rapidspin", "stoneedge", "suckerpunch"],
+                "abilities": ["Unburden"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "highjumpkick", "machpunch", "stoneedge", "suckerpunch"]
+                "movepool": ["earthquake", "highjumpkick", "machpunch", "stoneedge", "suckerpunch"],
+                "abilities": ["Reckless"]
             }
         ]
     },
@@ -535,11 +613,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"]
+                "movepool": ["drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
+                "abilities": ["Iron Fist"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "stoneedge"]
+                "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "stoneedge"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -548,7 +628,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"]
+                "movepool": ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -557,7 +638,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"]
+                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -566,7 +648,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -575,11 +658,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["doubleedge", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
+                "movepool": ["doubleedge", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "drainpunch", "protect", "return", "wish"]
+                "movepool": ["bodyslam", "drainpunch", "protect", "return", "wish"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -588,7 +673,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["drillrun", "icebeam", "megahorn", "raindance", "return", "waterfall"]
+                "movepool": ["drillrun", "icebeam", "megahorn", "return", "waterfall"],
+                "abilities": ["Lightning Rod"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["drillrun", "icebeam", "megahorn", "raindance", "return", "waterfall"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -597,11 +688,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hydropump", "icebeam", "psyshock", "recover", "thunderbolt"]
+                "movepool": ["hydropump", "icebeam", "psyshock", "recover", "thunderbolt"],
+                "abilities": ["Analytic"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "psyshock", "rapidspin", "recover", "scald", "thunderwave"]
+                "movepool": ["icebeam", "psyshock", "rapidspin", "recover", "scald", "thunderwave"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -611,6 +704,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["encore", "focusblast", "nastyplot", "psychic", "shadowball", "substitute"],
+                "abilities": ["Filter"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -620,7 +714,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aerialace", "brickbreak", "bugbite", "roost", "swordsdance"]
+                "movepool": ["aerialace", "brickbreak", "bugbite", "roost", "swordsdance"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -629,11 +724,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "psychic", "psyshock", "trick"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "psychic", "psyshock", "trick"],
+                "abilities": ["Dry Skin"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -643,6 +740,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Mold Breaker", "Moxie"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -653,11 +751,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["bodyslam", "earthquake", "fireblast", "rockslide", "zenheadbutt"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "stoneedge", "zenheadbutt"]
+                "movepool": ["doubleedge", "earthquake", "stoneedge", "zenheadbutt"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -666,7 +766,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "stoneedge", "substitute", "waterfall"]
+                "movepool": ["dragondance", "earthquake", "stoneedge", "substitute", "waterfall"],
+                "abilities": ["Intimidate", "Moxie"]
             }
         ]
     },
@@ -675,11 +776,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hydropump", "icebeam", "thunderbolt", "toxic"]
+                "movepool": ["healbell", "hydropump", "icebeam", "thunderbolt", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hydropump", "icebeam", "protect", "toxic"]
+                "movepool": ["hydropump", "icebeam", "protect", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -688,7 +791,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["transform"]
+                "movepool": ["transform"],
+                "abilities": ["Imposter"]
             }
         ]
     },
@@ -697,11 +801,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "icebeam", "protect", "scald", "wish"]
+                "movepool": ["healbell", "icebeam", "protect", "scald", "wish"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "scald", "toxic", "wish"]
+                "movepool": ["protect", "scald", "toxic", "wish"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -710,7 +816,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -719,11 +826,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["facade", "flamecharge", "rest", "sleeptalk"]
+                "movepool": ["facade", "flamecharge", "rest", "sleeptalk"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["facade", "flamecharge", "protect", "superpower"]
+                "movepool": ["facade", "flamecharge", "protect", "superpower"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -732,7 +841,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash", "surf"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash", "surf"],
+                "abilities": ["Shell Armor", "Swift Swim"]
             }
         ]
     },
@@ -741,11 +851,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "waterfall"]
+                "movepool": ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "waterfall"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"]
+                "movepool": ["aquajet", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             }
         ]
     },
@@ -754,11 +866,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"]
+                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"],
+                "abilities": ["Unnerve"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["aquatail", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "movepool": ["aerialace", "aquatail", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -768,15 +882,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "crunch", "earthquake", "rest", "sleeptalk"]
+                "movepool": ["bodyslam", "crunch", "earthquake", "rest", "sleeptalk"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "rest", "sleeptalk"]
+                "movepool": ["bodyslam", "curse", "rest", "sleeptalk"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "curse", "earthquake", "rest"]
+                "movepool": ["bodyslam", "curse", "earthquake", "rest"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -785,11 +902,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "roost", "substitute", "toxic"]
+                "movepool": ["icebeam", "roost", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hurricane", "icebeam", "roost", "substitute", "toxic"]
+                "movepool": ["hurricane", "icebeam", "roost", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -798,7 +917,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["heatwave", "hiddenpowerice", "roost", "substitute", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["heatwave", "hiddenpowerice", "roost", "substitute", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -807,7 +927,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "hiddenpowergrass", "hurricane", "roost", "substitute", "toxic", "uturn", "willowisp"]
+                "movepool": ["fireblast", "hiddenpowergrass", "hurricane", "roost", "substitute", "toxic", "uturn", "willowisp"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -816,11 +937,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "outrage", "rest", "waterfall"]
+                "movepool": ["dragondance", "outrage", "rest", "waterfall"],
+                "abilities": ["Shed Skin"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["dragondance", "outrage", "rest", "sleeptalk"]
+                "movepool": ["dragondance", "outrage", "rest", "sleeptalk"],
+                "abilities": ["Marvel Scale", "Shed Skin"]
             }
         ]
     },
@@ -829,11 +952,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "extremespeed", "outrage", "superpower"]
+                "movepool": ["earthquake", "extremespeed", "outrage", "superpower"],
+                "abilities": ["Multiscale"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "firepunch", "outrage", "roost"],
+                "abilities": ["Multiscale"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -843,7 +968,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"]
+                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"],
+                "abilities": ["Unnerve"]
             }
         ]
     },
@@ -852,11 +978,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"]
+                "movepool": ["psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "psyshock", "softboiled"]
+                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "psyshock", "softboiled"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -865,7 +993,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "dragontail", "earthquake", "gigadrain", "leechseed", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "dragontail", "earthquake", "gigadrain", "leechseed", "synthesis", "toxic"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -874,7 +1003,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"]
+                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -884,11 +1014,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "icepunch", "superpower", "waterfall"],
+                "abilities": ["Torrent"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "earthquake", "icepunch", "superpower", "swordsdance", "waterfall"]
+                "movepool": ["aquajet", "earthquake", "icepunch", "superpower", "swordsdance", "waterfall"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -897,7 +1029,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["aquatail", "doubleedge", "firepunch", "shadowclaw", "trick", "uturn"]
+                "movepool": ["aquatail", "doubleedge", "firepunch", "shadowclaw", "trick", "uturn"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -907,6 +1040,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["airslash", "heatwave", "hypervoice", "roost", "toxic", "whirlwind"],
+                "abilities": ["Tinted Lens"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -916,7 +1050,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["acrobatics", "encore", "focusblast", "knockoff", "roost", "toxic"]
+                "movepool": ["acrobatics", "encore", "focusblast", "knockoff", "roost", "toxic"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -925,7 +1060,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["poisonjab", "suckerpunch", "toxicspikes", "xscissor"]
+                "movepool": ["poisonjab", "suckerpunch", "toxicspikes", "xscissor"],
+                "abilities": ["Insomnia", "Swarm"]
             }
         ]
     },
@@ -934,7 +1070,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "heatwave", "hypnosis", "roost", "superfang", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "heatwave", "hypnosis", "roost", "superfang", "taunt", "toxic", "uturn"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -943,7 +1080,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["healbell", "icebeam", "scald", "thunderbolt", "thunderwave", "toxic", "voltswitch"]
+                "movepool": ["healbell", "icebeam", "scald", "thunderbolt", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -952,11 +1090,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "heatwave", "psychic", "roost"]
+                "movepool": ["calmmind", "heatwave", "psychic", "roost"],
+                "abilities": ["Magic Bounce"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"]
+                "movepool": ["heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Magic Bounce"]
             }
         ]
     },
@@ -965,11 +1105,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["agility", "focusblast", "hiddenpowerice", "thunderbolt", "voltswitch"]
+                "movepool": ["agility", "focusblast", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "abilities": ["Static"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focusblast", "healbell", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"]
+                "movepool": ["focusblast", "healbell", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -978,7 +1120,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -988,11 +1131,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aquajet", "doubleedge", "icepunch", "superpower", "waterfall"],
+                "abilities": ["Huge Power"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["aquajet", "bellydrum", "return", "waterfall"]
+                "movepool": ["aquajet", "bellydrum", "return", "waterfall"],
+                "abilities": ["Huge Power"]
             }
         ]
     },
@@ -1002,6 +1147,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -1012,11 +1158,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["encore", "focusblast", "hiddenpowergrass", "hypnosis", "icebeam", "rest", "scald"],
+                "abilities": ["Drizzle"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Staller",
-                "movepool": ["encore", "icebeam", "protect", "scald", "toxic"]
+                "movepool": ["encore", "icebeam", "protect", "scald", "toxic"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -1025,11 +1173,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["acrobatics", "encore", "sleeppowder", "uturn"]
+                "movepool": ["acrobatics", "encore", "sleeppowder", "uturn"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Staller",
-                "movepool": ["acrobatics", "leechseed", "sleeppowder", "substitute"]
+                "movepool": ["acrobatics", "leechseed", "sleeppowder", "substitute"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1038,11 +1188,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"]
+                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"],
+                "abilities": ["Chlorophyll", "Early Bird"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthpower", "hiddenpowerfire", "solarbeam", "sunnyday"]
+                "movepool": ["earthpower", "hiddenpowerfire", "solarbeam", "sunnyday"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1051,7 +1203,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["earthquake", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Unaware"]
             }
         ]
     },
@@ -1060,7 +1213,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "hiddenpowerfighting", "morningsun", "psychic", "psyshock", "signalbeam", "trick"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "morningsun", "psychic", "psyshock", "signalbeam", "trick"],
+                "abilities": ["Magic Bounce"]
             }
         ]
     },
@@ -1069,11 +1223,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["foulplay", "protect", "toxic", "wish"]
+                "movepool": ["foulplay", "protect", "toxic", "wish"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "healbell", "moonlight", "toxic"]
+                "movepool": ["foulplay", "healbell", "moonlight", "toxic"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1082,7 +1238,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "foulplay", "haze", "roost", "taunt", "thunderwave"]
+                "movepool": ["bravebird", "foulplay", "haze", "roost", "taunt", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -1091,11 +1248,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["fireblast", "icebeam", "psyshock", "surf", "trick", "trickroom"],
+                "abilities": ["Regenerator"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -1105,7 +1264,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerpsychic"]
+                "movepool": ["hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1114,7 +1274,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"]
+                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"],
+                "abilities": ["Shadow Tag"]
             }
         ]
     },
@@ -1123,7 +1284,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerfighting", "hypervoice", "psychic", "psyshock", "substitute", "thunderbolt"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "hypervoice", "psychic", "psyshock", "substitute", "thunderbolt"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },
@@ -1132,7 +1294,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"]
+                "movepool": ["earthquake", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1141,11 +1304,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "glare", "headbutt", "roost"]
+                "movepool": ["earthquake", "glare", "headbutt", "roost"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "coil", "earthquake", "roost"]
+                "movepool": ["bodyslam", "coil", "earthquake", "roost"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -1154,7 +1319,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "roost", "stealthrock", "taunt", "toxic", "uturn"]
+                "movepool": ["earthquake", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+                "abilities": ["Immunity"]
             }
         ]
     },
@@ -1164,15 +1330,18 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "ironhead", "roar", "rockslide", "stealthrock", "toxic"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Steel"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "heavyslam", "protect", "toxic"]
+                "movepool": ["earthquake", "heavyslam", "protect", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1181,7 +1350,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "crunch", "healbell", "return", "thunderwave"]
+                "movepool": ["closecombat", "crunch", "healbell", "return", "thunderwave"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1190,7 +1360,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"]
+                "movepool": ["destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1199,11 +1370,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbite", "bulletpunch", "roost", "superpower", "swordsdance"]
+                "movepool": ["bugbite", "bulletpunch", "roost", "superpower", "swordsdance"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletpunch", "pursuit", "superpower", "uturn"]
+                "movepool": ["bulletpunch", "pursuit", "superpower", "uturn"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -1212,7 +1385,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "knockoff", "protect", "stealthrock", "toxic"]
+                "movepool": ["encore", "knockoff", "protect", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1221,11 +1395,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "facade", "megahorn", "nightslash"]
+                "movepool": ["closecombat", "facade", "megahorn", "nightslash"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "megahorn", "nightslash", "stoneedge"],
+                "abilities": ["Moxie"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -1235,7 +1411,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"]
+                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
+                "abilities": ["Guts", "Quick Feet"]
             }
         ]
     },
@@ -1244,7 +1421,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic"]
+                "movepool": ["hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic"],
+                "abilities": ["Flame Body"]
             }
         ]
     },
@@ -1253,7 +1431,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["powergem", "recover", "scald", "stealthrock", "toxic"]
+                "movepool": ["powergem", "recover", "scald", "stealthrock", "toxic"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -1262,7 +1441,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["energyball", "fireblast", "hydropump", "icebeam", "thunderwave"]
+                "movepool": ["energyball", "fireblast", "hydropump", "icebeam", "thunderwave"],
+                "abilities": ["Sniper"]
             }
         ]
     },
@@ -1271,7 +1451,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"]
+                "movepool": ["icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"],
+                "abilities": ["Insomnia", "Vital Spirit"]
             }
         ]
     },
@@ -1280,11 +1461,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "rest", "scald", "sleeptalk", "toxic"]
+                "movepool": ["airslash", "rest", "scald", "sleeptalk", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "hydropump", "icebeam", "raindance"]
+                "movepool": ["airslash", "hydropump", "icebeam", "raindance"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1293,11 +1476,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"]
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1306,7 +1491,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"]
+                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -1315,11 +1501,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["dragondance", "outrage", "rest", "substitute", "waterfall"]
+                "movepool": ["dragondance", "outrage", "rest", "substitute", "waterfall"],
+                "abilities": ["Sniper", "Swift Swim"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"]
+                "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1329,11 +1517,13 @@
             {
                 "role": "Spinner",
                 "movepool": ["earthquake", "iceshard", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Sturdy"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "gunkshot", "iceshard", "stealthrock", "stoneedge"],
+                "abilities": ["Sturdy"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -1343,7 +1533,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["discharge", "icebeam", "recover", "toxic", "triattack"]
+                "movepool": ["discharge", "icebeam", "recover", "toxic", "triattack"],
+                "abilities": ["Download", "Trace"]
             }
         ]
     },
@@ -1353,6 +1544,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "hypnosis", "jumpkick", "megahorn", "suckerpunch", "thunderwave"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1362,7 +1554,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["memento", "spikes", "spore", "stealthrock", "whirlwind"]
+                "movepool": ["memento", "spikes", "spore", "stealthrock", "whirlwind"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -1371,7 +1564,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1379,12 +1573,9 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["bodyslam", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "earthquake", "milkdrink"]
+                "role": "Bulky Attacker",
+                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+                "abilities": ["Sap Sipper", "Thick Fat"]
             }
         ]
     },
@@ -1393,11 +1584,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1406,11 +1599,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"]
+                "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1420,11 +1615,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulldoze", "extremespeed", "flareblitz", "stoneedge"]
+                "movepool": ["bulldoze", "extremespeed", "flareblitz", "stoneedge"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge"]
+                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1433,15 +1630,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "rest", "scald", "sleeptalk"]
+                "movepool": ["calmmind", "rest", "scald", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "icebeam", "rest", "scald", "substitute"]
+                "movepool": ["calmmind", "hydropump", "icebeam", "rest", "scald", "substitute"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Staller",
-                "movepool": ["calmmind", "protect", "scald", "substitute"]
+                "movepool": ["calmmind", "protect", "scald", "substitute"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1450,11 +1650,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge", "superpower"],
+                "abilities": ["Sand Stream"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -1463,7 +1665,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"]
+                "movepool": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"],
+                "abilities": ["Multiscale"]
             }
         ]
     },
@@ -1472,7 +1675,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "earthquake", "roost", "sacredfire", "substitute", "toxic"]
+                "movepool": ["bravebird", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -1482,15 +1686,18 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
+                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["leafstorm", "nastyplot", "psychic", "recover"]
+                "movepool": ["leafstorm", "nastyplot", "psychic", "recover"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1499,15 +1706,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["acrobatics", "earthquake", "leafblade", "swordsdance"]
+                "movepool": ["acrobatics", "earthquake", "leafblade", "swordsdance"],
+                "abilities": ["Unburden"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"]
+                "movepool": ["earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -1516,11 +1726,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flareblitz", "highjumpkick", "protect", "stoneedge", "swordsdance"]
+                "movepool": ["flareblitz", "highjumpkick", "protect", "stoneedge", "swordsdance"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "highjumpkick", "protect", "stoneedge"]
+                "movepool": ["fireblast", "highjumpkick", "protect", "stoneedge"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -1529,11 +1741,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "roar", "scald", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "icebeam", "roar", "scald", "stealthrock", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "scald", "toxic"]
+                "movepool": ["earthquake", "protect", "scald", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -1543,6 +1757,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crunch", "doubleedge", "firefang", "suckerpunch", "taunt"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -1552,7 +1767,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"]
+                "movepool": ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"],
+                "abilities": ["Quick Feet"]
             }
         ]
     },
@@ -1561,7 +1777,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "hiddenpowerground", "psychic", "quiverdance"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "psychic", "quiverdance"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1570,7 +1787,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "hiddenpowerground", "quiverdance", "roost", "sludgebomb"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "quiverdance", "roost", "sludgebomb"],
+                "abilities": ["Shield Dust"]
             }
         ]
     },
@@ -1579,11 +1797,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["gigadrain", "hydropump", "icebeam", "raindance"]
+                "movepool": ["gigadrain", "hydropump", "icebeam", "raindance"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["gigadrain", "hydropump", "icebeam", "scald"]
+                "movepool": ["gigadrain", "hydropump", "icebeam", "scald"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1592,11 +1812,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "hiddenpowerfire", "leafstorm", "naturepower", "suckerpunch"]
+                "movepool": ["darkpulse", "hiddenpowerfire", "leafstorm", "naturepower", "suckerpunch"],
+                "abilities": ["Chlorophyll", "Early Bird"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["naturepower", "seedbomb", "suckerpunch", "swordsdance"]
+                "movepool": ["naturepower", "seedbomb", "suckerpunch", "swordsdance"],
+                "abilities": ["Chlorophyll", "Early Bird"]
             }
         ]
     },
@@ -1605,11 +1827,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "facade", "protect", "uturn"]
+                "movepool": ["bravebird", "facade", "protect", "uturn"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "facade", "quickattack", "uturn"]
+                "movepool": ["bravebird", "facade", "quickattack", "uturn"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -1618,7 +1842,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hurricane", "roost", "scald", "toxic", "uturn"]
+                "movepool": ["hurricane", "roost", "scald", "toxic", "uturn"],
+                "abilities": ["Rain Dish"]
             }
         ]
     },
@@ -1628,11 +1853,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["focusblast", "healingwish", "psychic", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Trace"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "shadowball", "substitute", "willowisp"],
+                "abilities": ["Trace"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -1642,7 +1869,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "hydropump", "quiverdance", "roost"]
+                "movepool": ["airslash", "bugbuzz", "hydropump", "quiverdance", "roost"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1651,11 +1879,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletseed", "machpunch", "spore", "stoneedge", "swordsdance"]
+                "movepool": ["bulletseed", "machpunch", "spore", "stoneedge", "swordsdance"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focuspunch", "spore", "stoneedge", "substitute"]
+                "movepool": ["focuspunch", "spore", "stoneedge", "substitute"],
+                "abilities": ["Poison Heal"]
             }
         ]
     },
@@ -1664,7 +1894,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "bulkup", "earthquake", "nightslash", "return", "slackoff"]
+                "movepool": ["bodyslam", "bulkup", "earthquake", "nightslash", "return", "slackoff"],
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -1673,7 +1904,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"]
+                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"],
+                "abilities": ["Truant"]
             }
         ]
     },
@@ -1682,11 +1914,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "nightslash", "swordsdance", "uturn", "xscissor"]
+                "movepool": ["aerialace", "nightslash", "swordsdance", "uturn", "xscissor"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aerialace", "substitute", "swordsdance", "xscissor"]
+                "movepool": ["aerialace", "substitute", "swordsdance", "xscissor"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -1695,7 +1929,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"]
+                "movepool": ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+                "abilities": ["Wonder Guard"]
             }
         ]
     },
@@ -1704,15 +1939,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "focusblast", "hypervoice", "icebeam", "surf"]
+                "movepool": ["fireblast", "focusblast", "hypervoice", "icebeam", "surf"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "earthquake", "facade", "lowkick"]
+                "movepool": ["doubleedge", "earthquake", "facade", "lowkick"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "fireblast", "focusblast", "return", "surf", "workup"]
+                "movepool": ["earthquake", "fireblast", "focusblast", "return", "surf", "workup"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -1721,11 +1959,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulletpunch", "closecombat", "facade", "fakeout", "stoneedge"]
+                "movepool": ["bulletpunch", "closecombat", "facade", "fakeout", "stoneedge"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bulkup", "bulletpunch", "closecombat", "earthquake", "stoneedge"],
+                "abilities": ["Thick Fat"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -1735,7 +1975,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "toxic"]
+                "movepool": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "toxic"],
+                "abilities": ["Wonder Skin"]
             }
         ]
     },
@@ -1744,11 +1985,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["foulplay", "recover", "taunt", "willowisp"]
+                "movepool": ["foulplay", "recover", "taunt", "willowisp"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["recover", "seismictoss", "taunt", "toxic", "willowisp"]
+                "movepool": ["recover", "seismictoss", "taunt", "toxic", "willowisp"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -1758,11 +2001,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["firefang", "ironhead", "suckerpunch", "swordsdance", "thunderpunch"],
+                "abilities": ["Intimidate", "Sheer Force"],
                 "preferredTypes": ["Fire"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["fireblast", "ironhead", "stealthrock", "suckerpunch", "thunderpunch"],
+                "abilities": ["Intimidate", "Sheer Force"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -1773,6 +2018,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquatail", "earthquake", "headsmash", "heavyslam", "rockpolish", "stealthrock", "thunderwave"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1782,7 +2028,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletpunch", "highjumpkick", "icepunch", "trick", "zenheadbutt"]
+                "movepool": ["bulletpunch", "highjumpkick", "icepunch", "trick", "zenheadbutt"],
+                "abilities": ["Pure Power"]
             }
         ]
     },
@@ -1791,7 +2038,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -1801,11 +2049,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Plus"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Plus"]
             }
         ]
     },
@@ -1815,11 +2065,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Minus"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Minus"]
             }
         ]
     },
@@ -1828,7 +2080,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "roost", "thunderwave", "uturn"]
+                "movepool": ["encore", "roost", "thunderwave", "uturn"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -1837,7 +2090,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbuzz", "encore", "roost", "thunderwave"]
+                "movepool": ["bugbuzz", "encore", "roost", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -1846,11 +2100,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"]
+                "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
+                "abilities": ["Liquid Ooze"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"]
+                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"],
+                "abilities": ["Liquid Ooze"]
             }
         ]
     },
@@ -1859,7 +2115,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["crunch", "earthquake", "hydropump", "icebeam", "protect"]
+                "movepool": ["crunch", "earthquake", "hydropump", "icebeam", "protect"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -1868,7 +2125,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
+                "abilities": ["Water Veil"]
             }
         ]
     },
@@ -1877,7 +2135,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "toxic"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -1886,7 +2145,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "rapidspin", "stealthrock", "yawn"]
+                "movepool": ["earthquake", "lavaplume", "rapidspin", "stealthrock", "yawn"],
+                "abilities": ["White Smoke"]
             }
         ]
     },
@@ -1895,11 +2155,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"]
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "shadowball", "trick"]
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "shadowball", "trick"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -1909,6 +2171,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["feintattack", "rapidspin", "return", "suckerpunch", "superpower"],
+                "abilities": ["Contrary"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -1918,11 +2181,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "outrage", "stoneedge", "uturn"]
+                "movepool": ["earthquake", "outrage", "stoneedge", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "roost", "uturn"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "roost", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1931,11 +2196,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"]
+                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "seedbomb", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "seedbomb", "suckerpunch", "swordsdance"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -1944,11 +2211,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
+                "movepool": ["dragondance", "earthquake", "outrage", "roost"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "haze", "healbell", "roost", "toxic"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "haze", "healbell", "roost", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1958,6 +2227,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["closecombat", "facade", "nightslash", "quickattack", "swordsdance"],
+                "abilities": ["Toxic Boost"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -1968,6 +2238,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "flamethrower", "gigadrain", "sludgebomb", "suckerpunch", "switcheroo"],
+                "abilities": ["Shed Skin"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1978,16 +2249,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "icebeam", "moonlight", "psychic", "rockpolish"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["earthpower", "hiddenpowerrock", "moonlight", "psychic", "stealthrock", "toxic"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "moonlight", "psychic"]
+                "movepool": ["calmmind", "earthpower", "moonlight", "psychic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1996,7 +2270,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "morningsun", "stealthrock", "stoneedge", "willowisp"]
+                "movepool": ["earthquake", "morningsun", "stealthrock", "stoneedge", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2005,7 +2280,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "stoneedge", "waterfall"]
+                "movepool": ["dragondance", "earthquake", "stoneedge", "waterfall"],
+                "abilities": ["Anticipation", "Hydration"]
             }
         ]
     },
@@ -2014,7 +2290,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "superpower", "waterfall"]
+                "movepool": ["crunch", "dragondance", "superpower", "waterfall"],
+                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -2023,7 +2300,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2032,11 +2310,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"]
+                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"],
+                "abilities": ["Storm Drain"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -2045,11 +2325,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"]
+                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquatail", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"]
+                "movepool": ["aquatail", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             }
         ]
     },
@@ -2058,7 +2340,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["dragontail", "haze", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["dragontail", "haze", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Marvel Scale"]
             }
         ]
     },
@@ -2067,7 +2350,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "icebeam", "return", "scald", "thunderbolt", "thunderwave"]
+                "movepool": ["fireblast", "icebeam", "return", "scald", "thunderbolt", "thunderwave"],
+                "abilities": ["Forecast"]
             }
         ]
     },
@@ -2076,7 +2360,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "recover", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["foulplay", "recover", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Color Change"]
             }
         ]
     },
@@ -2085,7 +2370,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "shadowclaw", "shadowsneak", "thunderwave", "willowisp"]
+                "movepool": ["hiddenpowerfighting", "shadowclaw", "shadowsneak", "thunderwave", "willowisp"],
+                "abilities": ["Cursed Body", "Frisk", "Insomnia"]
             }
         ]
     },
@@ -2094,7 +2380,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "seismictoss", "sleeptalk", "willowisp"]
+                "movepool": ["rest", "seismictoss", "sleeptalk", "willowisp"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2103,7 +2390,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "leechseed", "protect", "substitute"]
+                "movepool": ["airslash", "leechseed", "protect", "substitute"],
+                "abilities": ["Harvest"]
             }
         ]
     },
@@ -2112,11 +2400,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerfighting", "psychic", "recover", "thunderwave", "toxic"]
+                "movepool": ["healbell", "hiddenpowerfighting", "psychic", "recover", "thunderwave", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "recover", "signalbeam"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "recover", "signalbeam"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2126,11 +2416,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["nightslash", "pursuit", "suckerpunch", "superpower", "zenheadbutt"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["nightslash", "suckerpunch", "superpower", "swordsdance"]
+                "movepool": ["nightslash", "suckerpunch", "superpower", "swordsdance"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -2140,6 +2432,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["earthquake", "icebeam", "spikes", "superfang", "taunt"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2149,11 +2442,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "roar", "superfang", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "roar", "superfang", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -2163,6 +2458,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["icebeam", "return", "shellsmash", "suckerpunch", "waterfall"],
+                "abilities": ["Swift Swim", "Water Veil"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2172,7 +2468,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2181,11 +2478,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall", "yawn"]
+                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall", "yawn"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "headsmash", "rockpolish", "waterfall"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2195,7 +2494,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"]
+                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2205,6 +2505,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "fireblast", "outrage", "roost"],
+                "abilities": ["Intimidate", "Moxie"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2215,11 +2516,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["agility", "earthquake", "meteormash", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "stealthrock", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2229,15 +2532,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "drainpunch", "rest", "stoneedge"]
+                "movepool": ["curse", "drainpunch", "rest", "stoneedge"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "earthquake", "stealthrock", "stoneedge", "thunderwave", "toxic"]
+                "movepool": ["drainpunch", "earthquake", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["drainpunch", "earthquake", "protect", "rockslide", "toxic"]
+                "movepool": ["drainpunch", "earthquake", "protect", "rockslide", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2246,16 +2552,19 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"]
+                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icebeam", "rockpolish", "thunderbolt"]
+                "movepool": ["focusblast", "icebeam", "rockpolish", "thunderbolt"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2264,15 +2573,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "ironhead", "rest", "sleeptalk"]
+                "movepool": ["curse", "ironhead", "rest", "sleeptalk"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"]
+                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2281,7 +2593,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2290,7 +2603,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2299,11 +2613,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "surf", "thunder", "waterspout"]
+                "movepool": ["icebeam", "surf", "thunder", "waterspout"],
+                "abilities": ["Drizzle"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"]
+                "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -2312,11 +2628,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "earthquake", "lavaplume", "stealthrock", "stoneedge", "thunderwave"]
+                "movepool": ["dragontail", "earthquake", "lavaplume", "stealthrock", "stoneedge", "thunderwave"],
+                "abilities": ["Drought"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "firepunch", "rockpolish", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "firepunch", "rockpolish", "stoneedge", "swordsdance"],
+                "abilities": ["Drought"]
             }
         ]
     },
@@ -2325,15 +2643,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "earthquake", "extremespeed", "outrage", "vcreate"]
+                "movepool": ["dracometeor", "earthquake", "extremespeed", "outrage", "vcreate"],
+                "abilities": ["Air Lock"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"]
+                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
+                "abilities": ["Air Lock"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "extremespeed", "outrage", "swordsdance", "vcreate"],
+                "abilities": ["Air Lock"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2343,7 +2664,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"]
+                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -2352,11 +2674,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "extremespeed", "psychoboost", "superpower"]
+                "movepool": ["darkpulse", "extremespeed", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["darkpulse", "icebeam", "psychoboost", "superpower"]
+                "role": "Fast Support",
+                "movepool": ["darkpulse", "icebeam", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2365,11 +2689,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "extremespeed", "psychoboost", "superpower"]
+                "movepool": ["darkpulse", "extremespeed", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["darkpulse", "icebeam", "psychoboost", "superpower"]
+                "role": "Fast Support",
+                "movepool": ["darkpulse", "icebeam", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2378,7 +2704,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"]
+                "movepool": ["recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2387,7 +2714,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["psychoboost", "spikes", "stealthrock", "superpower", "taunt"]
+                "movepool": ["psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2396,11 +2724,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"]
+                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"]
+                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -2409,11 +2739,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"]
+                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"],
+                "abilities": ["Blaze", "Iron Fist"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"]
+                "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"],
+                "abilities": ["Blaze", "Iron Fist"]
             }
         ]
     },
@@ -2422,15 +2754,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "scald", "stealthrock", "toxic"]
+                "movepool": ["icebeam", "protect", "scald", "stealthrock", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "roar", "scald", "stealthrock", "toxic"]
+                "movepool": ["icebeam", "roar", "scald", "stealthrock", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "grassknot", "hydropump", "icebeam"]
+                "movepool": ["agility", "grassknot", "hydropump", "icebeam"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -2440,6 +2775,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bravebird", "closecombat", "doubleedge", "quickattack", "uturn"],
+                "abilities": ["Reckless"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2449,7 +2785,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["curse", "quickattack", "return", "waterfall"]
+                "movepool": ["curse", "quickattack", "return", "waterfall"],
+                "abilities": ["Simple"]
             }
         ]
     },
@@ -2458,7 +2795,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aerialace", "brickbreak", "bugbite", "nightslash", "swordsdance"]
+                "movepool": ["aerialace", "brickbreak", "bugbite", "nightslash", "swordsdance"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -2467,11 +2805,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "facade", "superpower", "wildcharge"]
+                "movepool": ["crunch", "facade", "superpower", "wildcharge"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["crunch", "icefang", "superpower", "voltswitch", "wildcharge"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2481,7 +2821,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
+                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -2490,11 +2831,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"]
+                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"],
+                "abilities": ["Sheer Force"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"]
+                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -2503,11 +2846,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["metalburst", "roar", "rockblast", "stealthrock", "toxic"]
+                "movepool": ["metalburst", "roar", "rockblast", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"]
+                "movepool": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -2516,11 +2861,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerground", "hiddenpowerrock", "leafstorm", "signalbeam", "synthesis", "toxic"]
+                "movepool": ["hiddenpowerground", "hiddenpowerrock", "leafstorm", "signalbeam", "synthesis", "toxic"],
+                "abilities": ["Anticipation", "Overcoat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "protect", "signalbeam", "synthesis", "toxic"]
+                "movepool": ["gigadrain", "protect", "signalbeam", "synthesis", "toxic"],
+                "abilities": ["Anticipation", "Overcoat"]
             }
         ]
     },
@@ -2529,7 +2876,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "stealthrock", "suckerpunch", "toxic"]
+                "movepool": ["earthquake", "protect", "stealthrock", "suckerpunch", "toxic"],
+                "abilities": ["Anticipation"]
             }
         ]
     },
@@ -2538,7 +2886,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"]
+                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"],
+                "abilities": ["Anticipation"]
             }
         ]
     },
@@ -2547,7 +2896,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "quiverdance", "substitute"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "quiverdance", "substitute"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -2556,7 +2906,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["acrobatics", "roost", "toxic", "uturn"]
+                "movepool": ["acrobatics", "roost", "toxic", "uturn"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2565,11 +2916,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["superfang", "thunderbolt", "thunderwave", "toxic", "uturn"]
+                "movepool": ["superfang", "thunderbolt", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Volt Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["protect", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -2579,11 +2932,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquajet", "crunch", "icepunch", "lowkick", "switcheroo", "waterfall"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["aquajet", "bulkup", "crunch", "icepunch", "lowkick", "substitute", "waterfall"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2593,11 +2948,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["gigadrain", "healingwish", "hiddenpowerfire", "hiddenpowerrock", "morningsun", "naturepower"]
+                "movepool": ["gigadrain", "healingwish", "hiddenpowerfire", "hiddenpowerrock", "morningsun", "naturepower"],
+                "abilities": ["Flower Gift"]
             },
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "gigadrain", "leechseed", "morningsun", "naturepower", "toxic"]
+                "movepool": ["aromatherapy", "gigadrain", "leechseed", "morningsun", "naturepower", "toxic"],
+                "abilities": ["Flower Gift"]
             }
         ]
     },
@@ -2606,7 +2963,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -2615,7 +2973,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "lowkick", "payback", "pursuit", "return", "uturn"]
+                "movepool": ["fakeout", "lowkick", "payback", "pursuit", "return", "uturn"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -2624,7 +2983,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["acrobatics", "destinybond", "disable", "shadowball", "substitute", "willowisp"]
+                "movepool": ["acrobatics", "destinybond", "disable", "shadowball", "substitute", "willowisp"],
+                "abilities": ["Unburden"]
             }
         ]
     },
@@ -2633,7 +2993,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["healingwish", "icepunch", "jumpkick", "return", "switcheroo"]
+                "movepool": ["healingwish", "icepunch", "jumpkick", "return", "switcheroo"],
+                "abilities": ["Limber"]
             }
         ]
     },
@@ -2642,11 +3003,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["destinybond", "hiddenpowerfighting", "painsplit", "shadowball", "substitute", "taunt", "willowisp"]
+                "movepool": ["destinybond", "hiddenpowerfighting", "painsplit", "shadowball", "substitute", "taunt", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "thunderbolt", "trick"]
+                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2655,7 +3018,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"]
+                "movepool": ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"],
+                "abilities": ["Moxie"]
             }
         ]
     },
@@ -2664,11 +3028,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["fakeout", "hypnosis", "return", "shadowclaw", "uturn"]
+                "movepool": ["fakeout", "hypnosis", "return", "shadowclaw", "uturn"],
+                "abilities": ["Defiant", "Thick Fat"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["honeclaws", "hypnosis", "irontail", "return"]
+                "movepool": ["honeclaws", "hypnosis", "irontail", "return"],
+                "abilities": ["Defiant", "Thick Fat"]
             }
         ]
     },
@@ -2677,7 +3043,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"]
+                "movepool": ["crunch", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"],
+                "abilities": ["Aftermath"]
             }
         ]
     },
@@ -2686,11 +3053,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "hypnosis", "psychic", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "hypnosis", "psychic", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "psychic", "toxic"]
+                "movepool": ["earthquake", "protect", "psychic", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2699,11 +3068,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["chatter", "heatwave", "hiddenpowerground", "hypervoice", "nastyplot", "uturn"]
+                "movepool": ["chatter", "heatwave", "hiddenpowerground", "hypervoice", "nastyplot", "uturn"],
+                "abilities": ["Tangled Feet"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["chatter", "heatwave", "hiddenpowerground", "hypervoice", "nastyplot", "substitute"]
+                "movepool": ["chatter", "heatwave", "hiddenpowerground", "hypervoice", "nastyplot", "substitute"],
+                "abilities": ["Tangled Feet"]
             }
         ]
     },
@@ -2712,11 +3083,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "darkpulse", "rest", "sleeptalk"]
+                "movepool": ["calmmind", "darkpulse", "rest", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2725,11 +3098,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "fireblast", "outrage", "stealthrock", "stoneedge"]
+                "movepool": ["earthquake", "fireblast", "outrage", "stealthrock", "stoneedge"],
+                "abilities": ["Rough Skin"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -2739,11 +3114,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "crunch", "extremespeed", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Normal"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"]
+                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -2752,7 +3129,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"]
+                "movepool": ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -2762,11 +3140,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquatail", "crunch", "earthquake", "poisonjab", "pursuit", "swordsdance"],
+                "abilities": ["Battle Armor"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["crunch", "earthquake", "poisonjab", "taunt", "toxicspikes", "whirlwind"]
+                "movepool": ["crunch", "earthquake", "poisonjab", "taunt", "toxicspikes", "whirlwind"],
+                "abilities": ["Battle Armor"]
             }
         ]
     },
@@ -2775,7 +3155,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "earthquake", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "earthquake", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -2784,7 +3165,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "powerwhip", "sleeppowder", "synthesis"]
+                "movepool": ["knockoff", "powerwhip", "sleeppowder", "synthesis"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2793,15 +3175,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "scald", "toxic", "uturn"]
+                "movepool": ["icebeam", "scald", "toxic", "uturn"],
+                "abilities": ["Storm Drain"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "scald", "toxic", "uturn"]
+                "movepool": ["icebeam", "protect", "scald", "toxic", "uturn"],
+                "abilities": ["Storm Drain"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowergrass", "icebeam", "scald", "toxic"]
+                "movepool": ["hiddenpowergrass", "icebeam", "scald", "toxic"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -2810,7 +3195,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "earthquake", "iceshard", "woodhammer"]
+                "movepool": ["blizzard", "earthquake", "iceshard", "woodhammer"],
+                "abilities": ["Snow Warning"]
             }
         ]
     },
@@ -2819,7 +3205,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["icepunch", "iceshard", "lowkick", "nightslash", "pursuit", "swordsdance"]
+                "movepool": ["icepunch", "iceshard", "lowkick", "nightslash", "pursuit", "swordsdance"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2828,7 +3215,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"]
+                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -2837,11 +3225,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "healbell", "protect", "toxic", "wish"]
+                "movepool": ["bodyslam", "healbell", "protect", "toxic", "wish"],
+                "abilities": ["Cloud Nine"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bodyslam", "earthquake", "explosion", "powerwhip", "return", "swordsdance"],
+                "abilities": ["Cloud Nine"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2851,7 +3241,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge", "swordsdance"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -2860,11 +3251,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hiddenpowerfire", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "synthesis"]
+                "movepool": ["earthquake", "hiddenpowerfire", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "synthesis"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "hiddenpowerfire", "leafstorm", "powerwhip", "rockslide", "sleeppowder"]
+                "movepool": ["earthquake", "hiddenpowerfire", "leafstorm", "powerwhip", "rockslide", "sleeppowder"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -2874,6 +3267,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+                "abilities": ["Motor Drive"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2884,6 +3278,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Flame Body", "Vital Spirit"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -2893,15 +3288,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["airslash", "aurasphere", "nastyplot", "roost", "thunderwave"]
+                "movepool": ["airslash", "aurasphere", "nastyplot", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "healbell", "roost", "thunderwave"]
+                "movepool": ["airslash", "healbell", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "aurasphere", "fireblast", "trick"]
+                "movepool": ["airslash", "aurasphere", "fireblast", "trick"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -2910,11 +3308,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "protect"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "protect"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "uturn"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "uturn"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -2924,6 +3324,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "leafblade", "swordsdance", "synthesis", "xscissor"],
+                "abilities": ["Chlorophyll"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2933,11 +3334,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerground", "icebeam", "protect", "wish"]
+                "movepool": ["healbell", "hiddenpowerground", "icebeam", "protect", "wish"],
+                "abilities": ["Ice Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "toxic", "wish"]
+                "movepool": ["icebeam", "protect", "toxic", "wish"],
+                "abilities": ["Ice Body"]
             }
         ]
     },
@@ -2946,15 +3349,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "substitute", "toxic"]
+                "movepool": ["earthquake", "protect", "substitute", "toxic"],
+                "abilities": ["Poison Heal"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "facade", "roost", "stealthrock", "stoneedge", "taunt", "toxic", "uturn"]
+                "movepool": ["earthquake", "facade", "roost", "stealthrock", "stoneedge", "taunt", "toxic", "uturn"],
+                "abilities": ["Poison Heal"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "facade", "roost", "swordsdance"]
+                "movepool": ["earthquake", "facade", "roost", "swordsdance"],
+                "abilities": ["Poison Heal"]
             }
         ]
     },
@@ -2963,11 +3369,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "stealthrock"]
+                "movepool": ["earthquake", "iceshard", "iciclecrash", "stealthrock"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "stoneedge", "superpower"]
+                "movepool": ["earthquake", "iceshard", "iciclecrash", "stoneedge", "superpower"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -2976,7 +3384,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "hiddenpowerfighting", "icebeam", "nastyplot", "thunderbolt", "triattack", "trick"]
+                "movepool": ["darkpulse", "hiddenpowerfighting", "icebeam", "nastyplot", "thunderbolt", "triattack", "trick"],
+                "abilities": ["Adaptability", "Download"]
             }
         ]
     },
@@ -2985,7 +3394,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "nightslash", "shadowsneak", "swordsdance", "trick", "zenheadbutt"]
+                "movepool": ["closecombat", "nightslash", "shadowsneak", "swordsdance", "trick", "zenheadbutt"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -2994,7 +3404,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "powergem", "stealthrock", "thunderwave", "toxic", "voltswitch"]
+                "movepool": ["earthpower", "powergem", "stealthrock", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -3004,11 +3415,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "toxic", "trick", "willowisp"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"]
+                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3017,7 +3430,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"]
+                "movepool": ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"],
+                "abilities": ["Cursed Body"]
             }
         ]
     },
@@ -3026,7 +3440,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "painsplit", "shadowball", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["hiddenpowerice", "painsplit", "shadowball", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3035,7 +3450,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"]
+                "movepool": ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3044,7 +3460,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hydropump", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"]
+                "movepool": ["hydropump", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3053,7 +3470,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["blizzard", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3062,7 +3480,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["airslash", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3071,7 +3490,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerice", "leafstorm", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"]
+                "movepool": ["hiddenpowerice", "leafstorm", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3080,7 +3500,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"]
+                "movepool": ["healbell", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3089,11 +3510,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "healingwish", "hiddenpowerfighting", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "uturn"]
+                "movepool": ["calmmind", "healingwish", "hiddenpowerfighting", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfighting", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"]
+                "movepool": ["hiddenpowerfighting", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3103,11 +3526,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fireblast", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "uturn"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Fire"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["explosion", "fireblast", "psychic", "stealthrock", "taunt", "uturn"]
+                "movepool": ["explosion", "fireblast", "psychic", "stealthrock", "taunt", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3117,6 +3542,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aurasphere", "dracometeor", "dragontail", "fireblast", "stealthrock", "thunderbolt", "toxic"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -3127,6 +3553,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "fireblast", "hydropump", "spacialrend", "thunderwave"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -3136,16 +3563,19 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "eruption", "fireblast", "hiddenpowerice"]
+                "movepool": ["earthpower", "eruption", "fireblast", "hiddenpowerice"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthpower", "fireblast", "hiddenpowerice", "lavaplume", "roar", "stealthrock", "toxic"],
+                "abilities": ["Flash Fire"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthpower", "magmastorm", "protect", "toxic"]
+                "movepool": ["earthpower", "magmastorm", "protect", "toxic"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -3154,7 +3584,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "return", "substitute", "thunderwave"]
+                "movepool": ["earthquake", "return", "substitute", "thunderwave"],
+                "abilities": ["Slow Start"]
             }
         ]
     },
@@ -3163,11 +3594,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["dragonpulse", "dragontail", "rest", "sleeptalk", "willowisp"]
+                "movepool": ["dragonpulse", "dragontail", "rest", "sleeptalk", "willowisp"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"]
+                "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3176,7 +3609,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"]
+                "movepool": ["dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3185,11 +3619,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "signalbeam"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "signalbeam"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfighting", "moonlight", "psychic", "thunderwave", "toxic"]
+                "movepool": ["hiddenpowerfighting", "moonlight", "psychic", "thunderwave", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3198,11 +3634,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["raindance", "rest", "scald", "toxic"]
+                "movepool": ["raindance", "rest", "scald", "toxic"],
+                "abilities": ["Hydration"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "icebeam", "scald", "toxic", "uturn"]
+                "movepool": ["healbell", "icebeam", "scald", "toxic", "uturn"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -3211,7 +3649,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["energyball", "icebeam", "surf", "tailglow"]
+                "movepool": ["energyball", "icebeam", "surf", "tailglow"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -3220,11 +3659,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["darkpulse", "darkvoid", "focusblast", "nastyplot"]
+                "movepool": ["darkpulse", "darkvoid", "focusblast", "nastyplot"],
+                "abilities": ["Bad Dreams"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["darkpulse", "darkvoid", "nastyplot", "substitute"]
+                "movepool": ["darkpulse", "darkvoid", "nastyplot", "substitute"],
+                "abilities": ["Bad Dreams"]
             }
         ]
     },
@@ -3234,6 +3675,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -3243,7 +3685,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"]
+                "movepool": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -3253,6 +3696,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3262,11 +3706,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3275,7 +3721,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "focusblast", "judgment", "recover", "refresh"]
+                "movepool": ["calmmind", "focusblast", "judgment", "recover", "refresh"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3285,11 +3732,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "outrage", "recover", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover", "refresh"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover", "refresh"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3298,7 +3747,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3307,7 +3757,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "darkpulse", "icebeam", "judgment", "recover"]
+                "movepool": ["calmmind", "darkpulse", "icebeam", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3316,7 +3767,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment", "recover", "thunderbolt"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment", "recover", "thunderbolt"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3325,7 +3777,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover", "refresh"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover", "refresh"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3334,7 +3787,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "judgment", "recover", "willowisp"]
+                "movepool": ["calmmind", "focusblast", "judgment", "recover", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3343,11 +3797,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3357,11 +3813,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3370,7 +3828,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3380,11 +3839,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3394,11 +3855,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "darkpulse", "focusblast", "judgment"]
+                "movepool": ["calmmind", "darkpulse", "focusblast", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3408,6 +3871,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3417,11 +3881,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3430,7 +3896,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover", "willowisp"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3439,11 +3906,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["boltstrike", "uturn", "vcreate", "zenheadbutt"]
+                "movepool": ["boltstrike", "uturn", "vcreate", "zenheadbutt"],
+                "abilities": ["Victory Star"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["boltstrike", "energyball", "focusblast", "psychic", "trick", "uturn", "vcreate"],
+                "abilities": ["Victory Star"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -3453,15 +3922,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aromatherapy", "dragonpulse", "gigadrain", "glare", "hiddenpowerfire", "leechseed", "substitute"]
+                "movepool": ["aromatherapy", "dragonpulse", "gigadrain", "glare", "hiddenpowerfire", "leechseed", "substitute"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "dragonpulse", "gigadrain", "hiddenpowerfire", "substitute"]
+                "movepool": ["calmmind", "dragonpulse", "gigadrain", "hiddenpowerfire", "substitute"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["aquatail", "leafblade", "return", "swordsdance"]
+                "movepool": ["aquatail", "leafblade", "return", "swordsdance"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -3470,11 +3942,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "flareblitz", "headsmash", "superpower", "wildcharge"]
+                "movepool": ["earthquake", "flareblitz", "headsmash", "superpower", "wildcharge"],
+                "abilities": ["Blaze"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "fireblast", "grassknot", "superpower", "wildcharge"]
+                "movepool": ["earthquake", "fireblast", "grassknot", "superpower", "wildcharge"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -3483,11 +3957,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "megahorn", "superpower"]
+                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "megahorn", "superpower"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["aquajet", "megahorn", "superpower", "swordsdance", "waterfall"]
+                "movepool": ["aquajet", "megahorn", "superpower", "swordsdance", "waterfall"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -3496,11 +3972,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "hypnosis", "return", "superfang"]
+                "movepool": ["crunch", "hypnosis", "return", "superfang"],
+                "abilities": ["Analytic"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["crunch", "hypnosis", "lowkick", "return", "substitute", "swordsdance"],
+                "abilities": ["Analytic"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3511,6 +3989,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["crunch", "return", "superpower", "thunderwave", "wildcharge"],
+                "abilities": ["Scrappy"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -3520,7 +3999,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["darkpulse", "encore", "hiddenpowerfighting", "nastyplot", "thunderwave"]
+                "movepool": ["darkpulse", "encore", "hiddenpowerfighting", "nastyplot", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -3529,11 +4009,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "leafstorm", "rockslide", "superpower"]
+                "movepool": ["hiddenpowerice", "leafstorm", "rockslide", "superpower"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "gigadrain", "hiddenpowerrock", "nastyplot", "substitute"]
+                "movepool": ["focusblast", "gigadrain", "hiddenpowerrock", "nastyplot", "substitute"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -3542,7 +4024,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"]
+                "movepool": ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -3552,6 +4035,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["grassknot", "hydropump", "icebeam", "nastyplot", "substitute"],
+                "abilities": ["Torrent"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -3561,11 +4045,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerfighting", "moonlight", "psychic", "signalbeam", "thunderwave", "toxic"]
+                "movepool": ["healbell", "hiddenpowerfighting", "moonlight", "psychic", "signalbeam", "thunderwave", "toxic"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "signalbeam"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "signalbeam"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -3574,7 +4060,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["hypnosis", "pluck", "return", "roost", "toxic", "uturn"]
+                "movepool": ["hypnosis", "pluck", "return", "roost", "toxic", "uturn"],
+                "abilities": ["Super Luck"]
             }
         ]
     },
@@ -3583,7 +4070,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
+                "movepool": ["hiddenpowerice", "overheat", "voltswitch", "wildcharge"],
+                "abilities": ["Sap Sipper"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -3593,6 +4086,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower", "toxic"],
+                "abilities": ["Sturdy"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3602,11 +4096,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "heatwave", "roost", "storedpower"]
+                "movepool": ["calmmind", "heatwave", "roost", "storedpower"],
+                "abilities": ["Simple"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "calmmind", "heatwave", "roost", "storedpower"]
+                "movepool": ["airslash", "calmmind", "heatwave", "roost", "storedpower"],
+                "abilities": ["Simple"]
             }
         ]
     },
@@ -3615,11 +4111,13 @@
         "sets": [
             {
                 "role": "Spinner",
-                "movepool": ["earthquake", "ironhead", "rapidspin", "swordsdance"]
+                "movepool": ["earthquake", "ironhead", "rapidspin", "swordsdance"],
+                "abilities": ["Mold Breaker", "Sand Rush"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "ironhead", "rockslide", "swordsdance"]
+                "movepool": ["earthquake", "ironhead", "rockslide", "swordsdance"],
+                "abilities": ["Mold Breaker", "Sand Rush"]
             }
         ]
     },
@@ -3628,7 +4126,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["doubleedge", "healbell", "protect", "toxic", "wish"]
+                "movepool": ["doubleedge", "healbell", "protect", "toxic", "wish"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -3637,7 +4136,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "thunderpunch"]
+                "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "thunderpunch"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -3646,15 +4146,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "hydropump", "raindance", "sludgewave"]
+                "movepool": ["earthquake", "hydropump", "raindance", "sludgewave"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "scald", "sludgebomb", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "scald", "sludgebomb", "stealthrock", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "scald", "toxic"]
+                "movepool": ["earthquake", "protect", "scald", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -3663,7 +4166,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bulkup", "circlethrow", "payback", "rest", "sleeptalk"]
+                "movepool": ["bulkup", "circlethrow", "payback", "rest", "sleeptalk"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -3672,7 +4176,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "closecombat", "earthquake", "icepunch", "stoneedge"]
+                "movepool": ["bulkup", "closecombat", "earthquake", "icepunch", "stoneedge"],
+                "abilities": ["Mold Breaker", "Sturdy"]
             }
         ]
     },
@@ -3681,7 +4186,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["leafblade", "return", "swordsdance", "xscissor"]
+                "movepool": ["leafblade", "return", "swordsdance", "xscissor"],
+                "abilities": ["Chlorophyll", "Swarm"]
             }
         ]
     },
@@ -3691,6 +4197,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "megahorn", "rockslide", "spikes", "swordsdance", "toxicspikes"],
+                "abilities": ["Swarm"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3700,11 +4207,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["encore", "gigadrain", "stunspore", "taunt", "toxic", "uturn"]
+                "movepool": ["encore", "gigadrain", "stunspore", "taunt", "toxic", "uturn"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Staller",
-                "movepool": ["hurricane", "leechseed", "protect", "substitute"]
+                "movepool": ["hurricane", "leechseed", "protect", "substitute"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -3713,7 +4222,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "quiverdance", "sleeppowder"],
+                "abilities": ["Chlorophyll"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -3722,7 +4237,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"]
+                "movepool": ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"],
+                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -3731,7 +4247,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "earthquake", "pursuit", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["crunch", "earthquake", "pursuit", "stealthrock", "stoneedge", "superpower"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -3740,7 +4257,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"]
+                "movepool": ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -3749,11 +4267,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "spikes", "suckerpunch", "synthesis", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "spikes", "suckerpunch", "synthesis", "toxic"],
+                "abilities": ["Storm Drain", "Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "protect"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "protect"],
+                "abilities": ["Storm Drain", "Water Absorb"]
             }
         ]
     },
@@ -3762,7 +4282,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "shellsmash", "stoneedge", "xscissor"]
+                "movepool": ["earthquake", "shellsmash", "stoneedge", "xscissor"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -3771,11 +4292,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "highjumpkick", "icepunch", "zenheadbutt"]
+                "movepool": ["crunch", "dragondance", "highjumpkick", "icepunch", "zenheadbutt"],
+                "abilities": ["Intimidate", "Moxie"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "crunch", "drainpunch", "rest"]
+                "movepool": ["bulkup", "crunch", "drainpunch", "rest"],
+                "abilities": ["Shed Skin"]
             }
         ]
     },
@@ -3784,16 +4307,19 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "calmmind", "heatwave", "psyshock", "roost"]
+                "movepool": ["airslash", "calmmind", "heatwave", "psyshock", "roost"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"],
+                "abilities": ["Tinted Lens"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Staller",
-                "movepool": ["cosmicpower", "psychoshift", "roost", "storedpower"]
+                "movepool": ["cosmicpower", "psychoshift", "roost", "storedpower"],
+                "abilities": ["Magic Guard"]
             }
         ]
     },
@@ -3802,11 +4328,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "hiddenpowerfighting", "painsplit", "shadowball", "willowisp"]
+                "movepool": ["haze", "hiddenpowerfighting", "painsplit", "shadowball", "willowisp"],
+                "abilities": ["Mummy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "trickroom"]
+                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "trickroom"],
+                "abilities": ["Mummy"]
             }
         ]
     },
@@ -3815,7 +4343,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "earthquake", "icebeam", "shellsmash", "stoneedge", "waterfall"]
+                "movepool": ["aquajet", "earthquake", "icebeam", "shellsmash", "stoneedge", "waterfall"],
+                "abilities": ["Solid Rock", "Sturdy", "Swift Swim"]
             }
         ]
     },
@@ -3825,6 +4354,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["acrobatics", "earthquake", "roost", "stealthrock", "stoneedge", "uturn"],
+                "abilities": ["Defeatist"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3834,7 +4364,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drainpunch", "gunkshot", "haze", "painsplit", "spikes", "toxicspikes"]
+                "movepool": ["drainpunch", "gunkshot", "haze", "painsplit", "spikes", "toxicspikes"],
+                "abilities": ["Aftermath"]
             }
         ]
     },
@@ -3843,7 +4374,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "flamethrower", "focusblast", "nastyplot", "trick", "uturn"]
+                "movepool": ["darkpulse", "flamethrower", "focusblast", "nastyplot", "trick", "uturn"],
+                "abilities": ["Illusion"]
             }
         ]
     },
@@ -3852,7 +4384,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletseed", "rockblast", "tailslap", "uturn"]
+                "movepool": ["bulletseed", "rockblast", "tailslap", "uturn"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -3861,7 +4394,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "signalbeam", "thunderbolt", "trick"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "signalbeam", "thunderbolt", "trick"],
+                "abilities": ["Shadow Tag"]
             }
         ]
     },
@@ -3870,11 +4404,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "signalbeam", "trickroom"]
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "signalbeam", "trickroom"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"]
+                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"],
+                "abilities": ["Magic Guard"]
             }
         ]
     },
@@ -3883,11 +4419,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "icebeam", "roost", "scald", "toxic"]
+                "movepool": ["bravebird", "icebeam", "roost", "scald", "toxic"],
+                "abilities": ["Hydration"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hurricane", "raindance", "rest", "surf"]
+                "movepool": ["hurricane", "raindance", "rest", "surf"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -3897,6 +4435,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["autotomize", "explosion", "flashcannon", "hiddenpowerground", "icebeam"],
+                "abilities": ["Weak Armor"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3907,6 +4446,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "hornleech", "naturepower", "return", "substitute", "swordsdance"],
+                "abilities": ["Sap Sipper"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -3916,7 +4456,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["acrobatics", "encore", "roost", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["acrobatics", "encore", "roost", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Motor Drive"]
             }
         ]
     },
@@ -3925,7 +4466,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["ironhead", "megahorn", "pursuit", "return", "swordsdance"]
+                "movepool": ["ironhead", "megahorn", "pursuit", "return", "swordsdance"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -3934,11 +4476,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerground", "sludgebomb", "spore", "stunspore", "toxic"]
+                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerground", "sludgebomb", "spore", "stunspore", "toxic"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["gigadrain", "sludgebomb", "spore", "synthesis"]
+                "movepool": ["gigadrain", "sludgebomb", "spore", "synthesis"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -3947,7 +4491,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "recover", "scald", "shadowball", "toxic", "willowisp"]
+                "movepool": ["icebeam", "recover", "scald", "shadowball", "toxic", "willowisp"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -3956,7 +4501,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "scald", "toxic", "wish"]
+                "movepool": ["protect", "scald", "toxic", "wish"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -3966,6 +4512,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["bugbuzz", "gigadrain", "hiddenpowerice", "thunder", "voltswitch"],
+                "abilities": ["Compound Eyes"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -3975,11 +4522,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gyroball", "leechseed", "powerwhip", "spikes", "stealthrock"]
+                "movepool": ["gyroball", "leechseed", "powerwhip", "spikes", "stealthrock"],
+                "abilities": ["Iron Barbs"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["powerwhip", "spikes", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["powerwhip", "spikes", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Iron Barbs"]
             }
         ]
     },
@@ -3988,7 +4537,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["geargrind", "return", "shiftgear", "substitute", "wildcharge"]
+                "movepool": ["geargrind", "return", "shiftgear", "substitute", "wildcharge"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -3997,11 +4547,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["flamethrower", "gigadrain", "hiddenpowerice", "superpower", "thunderbolt", "uturn"]
+                "movepool": ["flamethrower", "gigadrain", "hiddenpowerice", "superpower", "thunderbolt", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["aquatail", "coil", "drainpunch", "firepunch", "wildcharge"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4011,7 +4563,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "psychic", "signalbeam", "thunderbolt", "trick", "trickroom"]
+                "movepool": ["hiddenpowerfighting", "psychic", "signalbeam", "thunderbolt", "trick", "trickroom"],
+                "abilities": ["Analytic"]
             }
         ]
     },
@@ -4021,11 +4574,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["energyball", "fireblast", "hiddenpowerfighting", "shadowball", "trick"],
+                "abilities": ["Flash Fire"],
                 "preferredTypes": ["Grass"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"]
+                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"],
+                "abilities": ["Flame Body", "Flash Fire"]
             }
         ]
     },
@@ -4034,7 +4589,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "outrage", "superpower"]
+                "movepool": ["dragondance", "earthquake", "outrage", "superpower"],
+                "abilities": ["Mold Breaker"]
             }
         ]
     },
@@ -4044,6 +4600,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquajet", "iciclecrash", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4053,7 +4610,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "hiddenpowerground", "icebeam", "rapidspin", "recover", "toxic"]
+                "movepool": ["haze", "hiddenpowerground", "icebeam", "rapidspin", "recover", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -4062,7 +4620,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "uturn"]
+                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "uturn"],
+                "abilities": ["Hydration", "Sticky Hold"]
             }
         ]
     },
@@ -4071,7 +4630,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["discharge", "earthpower", "rest", "scald", "sleeptalk", "stealthrock", "toxic"]
+                "movepool": ["discharge", "earthpower", "rest", "scald", "sleeptalk", "stealthrock", "toxic"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -4081,15 +4641,18 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["acrobatics", "highjumpkick", "stoneedge", "substitute", "swordsdance"],
+                "abilities": ["Reckless"],
                 "preferredTypes": ["Flying"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "highjumpkick", "stoneedge", "uturn"]
+                "movepool": ["fakeout", "highjumpkick", "stoneedge", "uturn"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["drainpunch", "highjumpkick", "stoneedge", "uturn"]
+                "movepool": ["drainpunch", "highjumpkick", "stoneedge", "uturn"],
+                "abilities": ["Reckless"]
             }
         ]
     },
@@ -4098,7 +4661,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "earthquake", "glare", "outrage", "stealthrock", "suckerpunch", "superpower"]
+                "movepool": ["dragontail", "earthquake", "glare", "outrage", "stealthrock", "suckerpunch", "superpower"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -4108,6 +4672,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["dynamicpunch", "earthquake", "icepunch", "rockpolish", "stealthrock", "stoneedge"],
+                "abilities": ["No Guard"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4117,11 +4682,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["ironhead", "nightslash", "pursuit", "suckerpunch"]
+                "movepool": ["ironhead", "nightslash", "pursuit", "suckerpunch"],
+                "abilities": ["Defiant"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["ironhead", "lowkick", "nightslash", "suckerpunch", "swordsdance"],
+                "abilities": ["Defiant"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4131,7 +4698,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headcharge", "stoneedge", "superpower", "swordsdance"]
+                "movepool": ["earthquake", "headcharge", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Reckless", "Sap Sipper"]
             }
         ]
     },
@@ -4140,11 +4708,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "bulkup", "roost", "superpower"]
+                "movepool": ["bravebird", "bulkup", "roost", "superpower"],
+                "abilities": ["Defiant"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "return", "superpower", "uturn"]
+                "movepool": ["bravebird", "return", "superpower", "uturn"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -4153,11 +4723,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "foulplay", "roost", "taunt", "toxic", "whirlwind"]
+                "movepool": ["bravebird", "foulplay", "roost", "taunt", "toxic", "whirlwind"],
+                "abilities": ["Overcoat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["foulplay", "roost", "taunt", "toxic", "whirlwind"]
+                "movepool": ["foulplay", "roost", "taunt", "toxic", "whirlwind"],
+                "abilities": ["Overcoat"]
             }
         ]
     },
@@ -4166,7 +4738,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "gigadrain", "suckerpunch", "superpower"]
+                "movepool": ["fireblast", "gigadrain", "suckerpunch", "superpower"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -4176,6 +4749,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
+                "abilities": ["Hustle"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4185,7 +4759,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "dracometeor", "fireblast", "focusblast", "roost", "uturn"]
+                "movepool": ["darkpulse", "dracometeor", "fireblast", "focusblast", "roost", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -4194,7 +4769,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerrock", "quiverdance", "roost"]
+                "movepool": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerrock", "quiverdance", "roost"],
+                "abilities": ["Flame Body"]
             }
         ]
     },
@@ -4204,11 +4780,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "taunt", "thunderwave", "toxic"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Steel"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["closecombat", "ironhead", "stoneedge", "swordsdance"]
+                "movepool": ["closecombat", "ironhead", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -4218,6 +4796,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4227,7 +4806,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "leafblade", "stoneedge", "swordsdance"]
+                "movepool": ["closecombat", "leafblade", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -4236,11 +4816,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["acrobatics", "bulkup", "superpower", "taunt"]
+                "movepool": ["acrobatics", "bulkup", "superpower", "taunt"],
+                "abilities": ["Defiant"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "heatwave", "hurricane", "uturn"]
+                "movepool": ["focusblast", "heatwave", "hurricane", "uturn"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -4249,7 +4831,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "heatwave", "hurricane", "superpower", "uturn"]
+                "movepool": ["focusblast", "heatwave", "hurricane", "superpower", "uturn"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4258,11 +4841,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["hiddenpowerflying", "hiddenpowerice", "superpower", "taunt", "thunderbolt", "thunderwave"]
+                "movepool": ["hiddenpowerflying", "hiddenpowerice", "superpower", "taunt", "thunderbolt", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -4271,7 +4856,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"]
+                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -4280,7 +4866,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blueflare", "dracometeor", "flamecharge", "roost", "toxic"]
+                "movepool": ["blueflare", "dracometeor", "flamecharge", "roost", "toxic"],
+                "abilities": ["Turboblaze"]
             }
         ]
     },
@@ -4289,11 +4876,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["boltstrike", "dracometeor", "outrage", "roost", "voltswitch"]
+                "movepool": ["boltstrike", "dracometeor", "outrage", "roost", "voltswitch"],
+                "abilities": ["Teravolt"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["boltstrike", "honeclaws", "outrage", "roost", "substitute"]
+                "movepool": ["boltstrike", "honeclaws", "outrage", "roost", "substitute"],
+                "abilities": ["Teravolt"]
             }
         ]
     },
@@ -4303,11 +4892,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "focusblast", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "focusblast", "psychic", "rockpolish", "sludgewave"]
+                "movepool": ["calmmind", "earthpower", "focusblast", "psychic", "rockpolish", "sludgewave"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -4316,11 +4907,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "toxic", "uturn"]
+                "movepool": ["earthquake", "stealthrock", "stoneedge", "toxic", "uturn"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "rockpolish", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -4330,11 +4923,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthpower", "icebeam", "roost", "substitute"]
+                "movepool": ["earthpower", "icebeam", "roost", "substitute"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage", "roost", "substitute"]
+                "movepool": ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage", "roost", "substitute"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -4343,7 +4938,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"]
+                "movepool": ["earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"],
+                "abilities": ["Teravolt"]
             }
         ]
     },
@@ -4352,7 +4948,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthpower", "fusionflare", "icebeam", "roost"]
+                "movepool": ["dracometeor", "earthpower", "fusionflare", "icebeam", "roost"],
+                "abilities": ["Turboblaze"]
             }
         ]
     },
@@ -4361,15 +4958,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hiddenpowerice", "hydropump", "scald", "secretsword"]
+                "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hiddenpowerice", "hydropump", "scald", "secretsword"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "scald", "secretsword", "substitute"]
+                "movepool": ["calmmind", "scald", "secretsword", "substitute"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "hydropump", "scald", "secretsword"]
+                "movepool": ["focusblast", "hydropump", "scald", "secretsword"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -4378,11 +4978,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"]
+                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "relicsong", "return", "shadowclaw"]
+                "movepool": ["closecombat", "relicsong", "return", "shadowclaw"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -4391,15 +4993,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["blazekick", "ironhead", "shiftgear", "thunderbolt", "xscissor"]
+                "movepool": ["blazekick", "ironhead", "shiftgear", "thunderbolt", "xscissor"],
+                "abilities": ["Download"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["blazekick", "extremespeed", "ironhead", "uturn"]
+                "movepool": ["blazekick", "extremespeed", "ironhead", "uturn"],
+                "abilities": ["Download"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["bugbuzz", "flamethrower", "flashcannon", "icebeam", "thunderbolt", "uturn"],
+                "abilities": ["Download"],
                 "preferredTypes": ["Bug"]
             }
         ]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -4,11 +4,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"]
+                "movepool": ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
+                "abilities": ["Chlorophyll", "Overgrow"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "energyball", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "energyball", "knockoff", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Chlorophyll", "Overgrow"]
             }
         ]
     },
@@ -17,7 +19,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "gigadrain", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "gigadrain", "knockoff", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -26,7 +29,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "earthquake", "fireblast", "roost", "willowisp"]
+                "movepool": ["airslash", "earthquake", "fireblast", "roost", "willowisp"],
+                "abilities": ["Blaze", "Solar Power"]
             }
         ]
     },
@@ -35,7 +39,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragonclaw", "dragondance", "earthquake", "flareblitz", "roost"]
+                "movepool": ["dragonclaw", "dragondance", "earthquake", "flareblitz", "roost"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -44,11 +49,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "fireblast", "roost", "solarbeam"]
+                "movepool": ["airslash", "fireblast", "roost", "solarbeam"],
+                "abilities": ["Blaze"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dragonpulse", "fireblast", "roost", "solarbeam"]
+                "movepool": ["dragonpulse", "fireblast", "roost", "solarbeam"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -57,11 +64,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "rapidspin", "roar", "scald", "toxic"]
+                "movepool": ["icebeam", "rapidspin", "roar", "scald", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["haze", "icebeam", "protect", "rapidspin", "scald", "toxic"]
+                "movepool": ["haze", "icebeam", "protect", "rapidspin", "scald", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -70,7 +79,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aurasphere", "darkpulse", "icebeam", "rapidspin", "scald"]
+                "movepool": ["aurasphere", "darkpulse", "icebeam", "rapidspin", "scald"],
+                "abilities": ["Rain Dish"]
             }
         ]
     },
@@ -79,7 +89,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "psychic", "quiverdance", "sleeppowder"]
+                "movepool": ["bugbuzz", "psychic", "quiverdance", "sleeppowder"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -88,7 +99,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "knockoff", "poisonjab", "toxicspikes", "uturn"]
+                "movepool": ["defog", "knockoff", "poisonjab", "toxicspikes", "uturn"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -97,7 +109,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["drillrun", "knockoff", "poisonjab", "protect", "uturn"]
+                "movepool": ["drillrun", "knockoff", "poisonjab", "protect", "uturn"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -106,7 +119,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "heatwave", "return", "roost", "uturn"]
+                "movepool": ["bravebird", "defog", "heatwave", "return", "roost", "uturn"],
+                "abilities": ["Big Pecks"]
             }
         ]
     },
@@ -115,7 +129,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "heatwave", "hurricane", "roost", "uturn", "workup"]
+                "movepool": ["defog", "heatwave", "hurricane", "roost", "uturn", "workup"],
+                "abilities": ["Big Pecks"]
             }
         ]
     },
@@ -125,6 +140,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["crunch", "facade", "flamewheel", "protect", "suckerpunch", "swordsdance", "uturn"],
+                "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -134,7 +150,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"]
+                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"],
+                "abilities": ["Sniper"]
             }
         ]
     },
@@ -143,8 +160,14 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquatail", "coil", "earthquake", "gunkshot", "rest", "suckerpunch"],
+                "movepool": ["aquatail", "coil", "earthquake", "gunkshot", "suckerpunch"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["coil", "earthquake", "gunkshot", "rest"],
+                "abilities": ["Shed Skin"]
             }
         ]
     },
@@ -153,7 +176,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "surf", "voltswitch", "volttackle"]
+                "movepool": ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "surf", "voltswitch", "volttackle"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -163,11 +187,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["encore", "hiddenpowerice", "knockoff", "nastyplot", "nuzzle", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "grassknot", "nastyplot", "surf", "thunderbolt", "voltswitch"]
+                "movepool": ["focusblast", "grassknot", "nastyplot", "surf", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -176,7 +202,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "toxic"]
+                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+                "abilities": ["Sand Rush"]
             }
         ]
     },
@@ -186,6 +213,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -196,6 +224,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "substitute", "superpower"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -205,11 +234,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "knockoff", "moonblast", "softboiled", "stealthrock", "thunderwave"]
+                "movepool": ["aromatherapy", "knockoff", "moonblast", "softboiled", "stealthrock", "thunderwave"],
+                "abilities": ["Magic Guard", "Unaware"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "moonblast", "softboiled"]
+                "movepool": ["calmmind", "fireblast", "moonblast", "softboiled"],
+                "abilities": ["Magic Guard", "Unaware"]
             }
         ]
     },
@@ -218,11 +249,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam"]
+                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam"],
+                "abilities": ["Drought"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["fireblast", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "abilities": ["Drought"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -232,7 +265,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "fireblast", "healbell", "knockoff", "protect", "stealthrock", "thunderwave", "wish"]
+                "movepool": ["dazzlinggleam", "fireblast", "healbell", "knockoff", "protect", "stealthrock", "thunderwave", "wish"],
+                "abilities": ["Competitive"]
             }
         ]
     },
@@ -241,7 +275,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Effect Spore"]
             }
         ]
     },
@@ -251,6 +286,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aromatherapy", "knockoff", "seedbomb", "spore", "stunspore", "xscissor"],
+                "abilities": ["Dry Skin"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -260,7 +296,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb"]
+                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -269,7 +306,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"]
+                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"],
+                "abilities": ["Arena Trap"]
             }
         ]
     },
@@ -278,12 +316,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "fakeout", "gunkshot", "knockoff", "return", "seedbomb", "taunt", "uturn"],
-                "preferredTypes": ["Dark"]
+                "movepool": ["doubleedge", "knockoff", "return", "seedbomb", "uturn"],
+                "abilities": ["Limber"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["doubleedge", "fakeout", "knockoff", "return", "uturn"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfighting", "hypervoice", "nastyplot", "shadowball"]
+                "movepool": ["hiddenpowerfighting", "hypervoice", "nastyplot", "shadowball"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -293,6 +337,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "encore", "focusblast", "hydropump", "icebeam", "psyshock", "scald"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -302,7 +347,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "gunkshot", "honeclaws", "stoneedge", "uturn"]
+                "movepool": ["closecombat", "earthquake", "gunkshot", "honeclaws", "stoneedge", "uturn"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -311,11 +357,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"]
+                "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "wildcharge"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -325,11 +373,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icepunch", "raindance", "waterfall"]
+                "movepool": ["focusblast", "icepunch", "raindance", "waterfall"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["circlethrow", "rest", "scald", "sleeptalk"]
+                "movepool": ["circlethrow", "rest", "scald", "sleeptalk"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -338,11 +388,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"]
+                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+                "abilities": ["Magic Guard"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -353,6 +405,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+                "abilities": ["Magic Guard"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -363,11 +416,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "knockoff", "stoneedge"],
+                "abilities": ["No Guard"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bulletpunch", "dynamicpunch", "knockoff", "stoneedge"]
+                "movepool": ["bulletpunch", "dynamicpunch", "knockoff", "stoneedge"],
+                "abilities": ["No Guard"]
             }
         ]
     },
@@ -376,11 +431,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerground", "knockoff", "powerwhip", "sleeppowder", "sludgebomb", "suckerpunch"]
+                "movepool": ["hiddenpowerground", "knockoff", "powerwhip", "sleeppowder", "sludgebomb", "suckerpunch"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["powerwhip", "sludgebomb", "sunnyday", "weatherball"]
+                "movepool": ["powerwhip", "sludgebomb", "sunnyday", "weatherball"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -389,7 +446,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "knockoff", "rapidspin", "scald", "sludgebomb", "toxicspikes"]
+                "movepool": ["haze", "knockoff", "rapidspin", "scald", "sludgebomb", "toxicspikes"],
+                "abilities": ["Clear Body", "Liquid Ooze"]
             }
         ]
     },
@@ -398,11 +456,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge", "suckerpunch"]
+                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge", "suckerpunch"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -411,11 +471,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"]
+                "movepool": ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["drillrun", "flareblitz", "megahorn", "morningsun", "wildcharge"]
+                "movepool": ["drillrun", "flareblitz", "megahorn", "morningsun", "wildcharge"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -424,11 +486,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["fireblast", "futuresight", "icebeam", "psyshock", "scald"]
+                "movepool": ["fireblast", "futuresight", "icebeam", "psyshock", "scald"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -437,7 +501,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "fireblast", "psyshock", "scald", "slackoff"]
+                "movepool": ["calmmind", "fireblast", "psyshock", "scald", "slackoff"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -446,7 +511,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"]
+                "movepool": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -455,11 +521,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "doubleedge", "knockoff", "quickattack", "return"]
+                "movepool": ["bravebird", "doubleedge", "knockoff", "quickattack", "return"],
+                "abilities": ["Early Bird"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "knockoff", "return", "roost"]
+                "movepool": ["bravebird", "knockoff", "return", "roost"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -468,11 +536,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -482,6 +552,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["brickbreak", "curse", "gunkshot", "haze", "icepunch", "poisonjab", "shadowsneak"],
+                "abilities": ["Poison Touch"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -491,7 +562,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hydropump", "iciclespear", "rockblast", "shellsmash"]
+                "movepool": ["hydropump", "iciclespear", "rockblast", "shellsmash"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -500,7 +572,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "painsplit", "shadowball", "sludgewave", "substitute", "trick", "willowisp"]
+                "movepool": ["focusblast", "painsplit", "shadowball", "sludgewave", "substitute", "trick", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -509,11 +582,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["disable", "perishsong", "protect", "shadowball", "substitute"]
+                "movepool": ["disable", "perishsong", "protect", "shadowball", "substitute"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["destinybond", "disable", "focusblast", "shadowball", "sludgewave", "taunt"]
+                "movepool": ["destinybond", "disable", "focusblast", "shadowball", "sludgewave", "taunt"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -522,11 +597,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "foulplay", "protect", "psychic", "thunderwave", "toxic", "wish"]
+                "movepool": ["focusblast", "foulplay", "protect", "psychic", "thunderwave", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -535,7 +612,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "crabhammer", "knockoff", "rockslide", "superpower", "swordsdance", "xscissor"]
+                "movepool": ["agility", "crabhammer", "knockoff", "rockslide", "superpower", "swordsdance", "xscissor"],
+                "abilities": ["Hyper Cutter", "Sheer Force"]
             }
         ]
     },
@@ -545,11 +623,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["foulplay", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"],
+                "abilities": ["Aftermath", "Static"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["hiddenpowerice", "thunderbolt", "thunderwave", "toxic", "voltswitch"]
+                "movepool": ["hiddenpowerice", "thunderbolt", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Aftermath", "Static"]
             }
         ]
     },
@@ -559,6 +639,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["gigadrain", "hiddenpowerfire", "leechseed", "psychic", "sleeppowder", "substitute"],
+                "abilities": ["Harvest"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -569,6 +650,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "knockoff", "stealthrock", "stoneedge", "swordsdance"],
+                "abilities": ["Battle Armor", "Rock Head"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -579,11 +661,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["highjumpkick", "knockoff", "machpunch", "poisonjab", "rapidspin", "stoneedge"],
+                "abilities": ["Reckless"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["bulkup", "closecombat", "knockoff", "poisonjab", "stoneedge"],
+                "abilities": ["Unburden"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -593,7 +677,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"]
+                "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -602,7 +687,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "painsplit", "sludgebomb", "toxicspikes", "willowisp"]
+                "movepool": ["fireblast", "painsplit", "sludgebomb", "toxicspikes", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -611,7 +697,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"]
+                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -620,7 +707,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -629,11 +717,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["doubleedge", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
+                "movepool": ["doubleedge", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
+                "movepool": ["drainpunch", "earthquake", "fakeout", "return", "suckerpunch"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -642,11 +732,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bodyslam", "crunch", "fakeout", "seismictoss", "suckerpunch"]
+                "movepool": ["bodyslam", "crunch", "fakeout", "seismictoss", "suckerpunch"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["bodyslam", "crunch", "earthquake", "poweruppunch", "return", "suckerpunch"],
+                "abilities": ["Scrappy"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -656,7 +748,14 @@
         "sets": [
             {
                 "role": "Fast Attacker",
+                "movepool": ["drillrun", "icebeam", "knockoff", "megahorn", "waterfall"],
+                "abilities": ["Lightning Rod"],
+                "preferredTypes": ["Dark"]
+            },
+            {
+                "role": "Setup Sweeper",
                 "movepool": ["drillrun", "icebeam", "knockoff", "megahorn", "raindance", "waterfall"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -666,11 +765,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hydropump", "icebeam", "psyshock", "recover", "thunderbolt"]
+                "movepool": ["hydropump", "icebeam", "psyshock", "recover", "thunderbolt"],
+                "abilities": ["Analytic"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["psyshock", "rapidspin", "recover", "scald", "thunderwave", "toxic"]
+                "movepool": ["psyshock", "rapidspin", "recover", "scald", "thunderwave", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -680,6 +781,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["dazzlinggleam", "encore", "focusblast", "healingwish", "nastyplot", "psychic", "psyshock", "shadowball"],
+                "abilities": ["Filter"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -689,11 +791,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "brickbreak", "knockoff", "pursuit", "uturn"]
+                "movepool": ["aerialace", "brickbreak", "knockoff", "pursuit", "uturn"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aerialace", "brickbreak", "bugbite", "knockoff", "roost", "swordsdance"]
+                "movepool": ["aerialace", "brickbreak", "bugbite", "knockoff", "roost", "swordsdance"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -702,11 +806,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "psychic", "psyshock", "trick"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "psychic", "psyshock", "trick"],
+                "abilities": ["Dry Skin"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -716,6 +822,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "knockoff", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Mold Breaker", "Moxie"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -725,7 +832,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["closecombat", "earthquake", "quickattack", "return", "swordsdance"]
+                "movepool": ["closecombat", "earthquake", "quickattack", "return", "swordsdance"],
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },
@@ -735,11 +843,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["bodyslam", "earthquake", "fireblast", "rockslide", "zenheadbutt"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "stoneedge", "zenheadbutt"]
+                "movepool": ["doubleedge", "earthquake", "stoneedge", "zenheadbutt"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -748,7 +858,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "stoneedge", "substitute", "waterfall"]
+                "movepool": ["dragondance", "earthquake", "stoneedge", "substitute", "waterfall"],
+                "abilities": ["Intimidate", "Moxie"]
             }
         ]
     },
@@ -757,7 +868,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "substitute", "waterfall"]
+                "movepool": ["crunch", "dragondance", "earthquake", "substitute", "waterfall"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -766,11 +878,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["freezedry", "healbell", "hydropump", "icebeam", "toxic"]
+                "movepool": ["freezedry", "healbell", "hydropump", "icebeam", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["freezedry", "hydropump", "protect", "toxic"]
+                "movepool": ["freezedry", "hydropump", "protect", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -779,7 +893,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["transform"]
+                "movepool": ["transform"],
+                "abilities": ["Imposter"]
             }
         ]
     },
@@ -788,11 +903,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "icebeam", "protect", "scald", "wish"]
+                "movepool": ["healbell", "icebeam", "protect", "scald", "wish"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "scald", "toxic", "wish"]
+                "movepool": ["protect", "scald", "toxic", "wish"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -801,11 +918,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "shadowball", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "shadowball", "thunderbolt", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -814,7 +933,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"]
+                "movepool": ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -823,7 +943,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
+                "abilities": ["Shell Armor", "Swift Swim"]
             }
         ]
     },
@@ -832,7 +953,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["aquajet", "knockoff", "rapidspin", "stoneedge", "swordsdance", "waterfall"]
+                "movepool": ["aquajet", "knockoff", "rapidspin", "stoneedge", "swordsdance", "waterfall"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             }
         ]
     },
@@ -841,11 +963,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"]
+                "movepool": ["defog", "earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"],
+                "abilities": ["Unnerve"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "movepool": ["aerialace", "aquatail", "defog", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -856,6 +980,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aerialace", "aquatail", "earthquake", "honeclaws", "roost", "stoneedge"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -865,11 +990,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "crunch", "curse", "earthquake", "rest", "sleeptalk"]
+                "movepool": ["bodyslam", "crunch", "curse", "earthquake", "rest", "sleeptalk"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit"]
+                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -878,11 +1005,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["freezedry", "roost", "substitute", "toxic"]
+                "movepool": ["freezedry", "roost", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["freezedry", "hurricane", "roost", "substitute", "toxic"]
+                "movepool": ["freezedry", "hurricane", "roost", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -891,7 +1020,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "discharge", "heatwave", "hiddenpowerice", "roost", "toxic", "uturn"]
+                "movepool": ["defog", "discharge", "heatwave", "hiddenpowerice", "roost", "toxic", "uturn"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -900,7 +1030,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "fireblast", "hurricane", "roost", "toxic", "uturn", "willowisp"]
+                "movepool": ["defog", "fireblast", "hurricane", "roost", "toxic", "uturn", "willowisp"],
+                "abilities": ["Flame Body"]
             }
         ]
     },
@@ -910,6 +1041,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "ironhead", "outrage", "roost"],
+                "abilities": ["Multiscale"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -919,7 +1051,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"]
+                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"],
+                "abilities": ["Unnerve"]
             }
         ]
     },
@@ -928,7 +1061,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bulkup", "drainpunch", "stoneedge", "taunt", "zenheadbutt"]
+                "movepool": ["bulkup", "drainpunch", "stoneedge", "taunt", "zenheadbutt"],
+                "abilities": ["Unnerve"]
             }
         ]
     },
@@ -937,7 +1071,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"]
+                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"],
+                "abilities": ["Unnerve"]
             }
         ]
     },
@@ -946,15 +1081,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["defog", "knockoff", "psychic", "roost", "stealthrock", "taunt", "uturn", "willowisp"]
+                "movepool": ["defog", "knockoff", "psychic", "roost", "stealthrock", "taunt", "uturn", "willowisp"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "psyshock", "roost"]
+                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "psyshock", "roost"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "psyshock", "roost"]
+                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "psyshock", "roost"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -963,7 +1101,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "dragontail", "earthquake", "energyball", "leechseed", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "dragontail", "earthquake", "energyball", "leechseed", "synthesis", "toxic"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -972,7 +1111,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"]
+                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -982,6 +1122,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["crunch", "dragondance", "earthquake", "icepunch", "waterfall"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -992,6 +1133,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquatail", "doubleedge", "firepunch", "knockoff", "trick", "uturn"],
+                "abilities": ["Frisk"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -1002,6 +1144,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["airslash", "defog", "hypervoice", "roost", "toxic"],
+                "abilities": ["Tinted Lens"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -1012,6 +1155,7 @@
             {
                 "role": "Staller",
                 "movepool": ["encore", "focusblast", "knockoff", "roost", "toxic"],
+                "abilities": ["Early Bird"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -1021,7 +1165,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["megahorn", "poisonjab", "stickyweb", "suckerpunch", "toxicspikes"]
+                "movepool": ["megahorn", "poisonjab", "stickyweb", "suckerpunch", "toxicspikes"],
+                "abilities": ["Insomnia", "Swarm"]
             }
         ]
     },
@@ -1030,7 +1175,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "roost", "superfang", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "defog", "roost", "superfang", "taunt", "toxic", "uturn"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -1039,7 +1185,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["healbell", "icebeam", "scald", "thunderbolt", "toxic", "voltswitch"]
+                "movepool": ["healbell", "icebeam", "scald", "thunderbolt", "toxic", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -1048,11 +1195,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "heatwave", "psychic", "roost"]
+                "movepool": ["calmmind", "heatwave", "psychic", "roost"],
+                "abilities": ["Magic Bounce"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"]
+                "movepool": ["heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Magic Bounce"]
             }
         ]
     },
@@ -1061,7 +1210,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focusblast", "healbell", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"]
+                "movepool": ["focusblast", "healbell", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -1070,7 +1220,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["agility", "dragonpulse", "focusblast", "healbell", "thunderbolt", "voltswitch"]
+                "movepool": ["agility", "dragonpulse", "focusblast", "healbell", "thunderbolt", "voltswitch"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -1079,7 +1230,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "moonblast", "sleeppowder", "synthesis", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "moonblast", "sleeppowder", "synthesis", "toxic"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1088,7 +1240,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "bellydrum", "knockoff", "playrough", "superpower", "waterfall"]
+                "movepool": ["aquajet", "bellydrum", "knockoff", "playrough", "superpower", "waterfall"],
+                "abilities": ["Huge Power"]
             }
         ]
     },
@@ -1098,6 +1251,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -1107,11 +1261,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["encore", "icebeam", "protect", "scald", "toxic"]
+                "movepool": ["encore", "icebeam", "protect", "scald", "toxic"],
+                "abilities": ["Drizzle"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "rest", "scald", "toxic"]
+                "movepool": ["encore", "icebeam", "rest", "scald", "toxic"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -1120,11 +1276,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["acrobatics", "leechseed", "protect", "substitute"]
+                "movepool": ["acrobatics", "leechseed", "protect", "substitute"],
+                "abilities": ["Infiltrator"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["acrobatics", "encore", "sleeppowder", "toxic", "uturn"]
+                "movepool": ["acrobatics", "encore", "sleeppowder", "toxic", "uturn"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -1133,11 +1291,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"]
+                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthpower", "hiddenpowerfire", "solarbeam", "sunnyday"]
+                "movepool": ["earthpower", "hiddenpowerfire", "solarbeam", "sunnyday"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1146,7 +1306,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["earthquake", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Unaware"]
             }
         ]
     },
@@ -1155,7 +1316,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "dazzlinggleam", "morningsun", "psychic", "psyshock", "shadowball", "trick"]
+                "movepool": ["calmmind", "dazzlinggleam", "morningsun", "psychic", "psyshock", "shadowball", "trick"],
+                "abilities": ["Magic Bounce"]
             }
         ]
     },
@@ -1164,11 +1326,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["foulplay", "protect", "toxic", "wish"]
+                "movepool": ["foulplay", "protect", "toxic", "wish"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "healbell", "moonlight", "toxic"]
+                "movepool": ["foulplay", "healbell", "moonlight", "toxic"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1177,7 +1341,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["bravebird", "defog", "foulplay", "haze", "roost", "thunderwave"]
+                "movepool": ["bravebird", "defog", "foulplay", "haze", "roost", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -1186,11 +1351,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["dragontail", "fireblast", "futuresight", "icebeam", "psyshock", "scald"]
+                "movepool": ["dragontail", "fireblast", "futuresight", "icebeam", "psyshock", "scald"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -1199,7 +1366,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerpsychic"]
+                "movepool": ["hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1208,7 +1376,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"]
+                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"],
+                "abilities": ["Shadow Tag"]
             }
         ]
     },
@@ -1218,6 +1387,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dazzlinggleam", "hypervoice", "nastyplot", "psychic", "psyshock", "substitute", "thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -1227,7 +1397,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"]
+                "movepool": ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1236,11 +1407,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "glare", "headbutt", "roost"]
+                "movepool": ["earthquake", "glare", "headbutt", "roost"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "coil", "earthquake", "roost"]
+                "movepool": ["bodyslam", "coil", "earthquake", "roost"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -1249,7 +1422,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["defog", "earthquake", "knockoff", "roost", "stealthrock", "toxic", "uturn"]
+                "movepool": ["defog", "earthquake", "knockoff", "roost", "stealthrock", "toxic", "uturn"],
+                "abilities": ["Immunity"]
             }
         ]
     },
@@ -1259,15 +1433,18 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "ironhead", "roar", "rockslide", "stealthrock", "toxic"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Steel"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "heavyslam", "protect", "toxic"]
+                "movepool": ["earthquake", "heavyslam", "protect", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1276,7 +1453,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "earthquake", "heavyslam", "stealthrock", "toxic"]
+                "movepool": ["dragontail", "earthquake", "heavyslam", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1285,7 +1463,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "healbell", "playrough", "thunderwave", "toxic"]
+                "movepool": ["earthquake", "healbell", "playrough", "thunderwave", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1294,7 +1473,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"]
+                "movepool": ["destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1303,15 +1483,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbite", "bulletpunch", "knockoff", "roost", "superpower", "swordsdance"]
+                "movepool": ["bugbite", "bulletpunch", "knockoff", "roost", "superpower", "swordsdance"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulletpunch", "defog", "knockoff", "roost", "superpower", "uturn"]
+                "movepool": ["bulletpunch", "defog", "knockoff", "roost", "superpower", "uturn"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletpunch", "knockoff", "pursuit", "superpower", "uturn"]
+                "movepool": ["bulletpunch", "knockoff", "pursuit", "superpower", "uturn"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -1320,11 +1503,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbite", "bulletpunch", "knockoff", "roost", "superpower", "swordsdance"]
+                "movepool": ["bugbite", "bulletpunch", "knockoff", "roost", "superpower", "swordsdance"],
+                "abilities": ["Light Metal"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulletpunch", "defog", "knockoff", "roost", "superpower", "uturn"]
+                "movepool": ["bulletpunch", "defog", "knockoff", "roost", "superpower", "uturn"],
+                "abilities": ["Light Metal"]
             }
         ]
     },
@@ -1333,7 +1518,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "knockoff", "stealthrock", "stickyweb", "toxic"]
+                "movepool": ["encore", "knockoff", "stealthrock", "stickyweb", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1342,11 +1528,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "facade", "knockoff", "megahorn"]
+                "movepool": ["closecombat", "facade", "knockoff", "megahorn"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "knockoff", "megahorn", "stoneedge"]
+                "movepool": ["closecombat", "knockoff", "megahorn", "stoneedge"],
+                "abilities": ["Moxie"]
             }
         ]
     },
@@ -1356,6 +1544,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["closecombat", "pinmissile", "rockblast", "substitute", "swordsdance"],
+                "abilities": ["Moxie"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -1365,7 +1554,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"]
+                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
+                "abilities": ["Guts", "Quick Feet"]
             }
         ]
     },
@@ -1374,7 +1564,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"]
+                "movepool": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"],
+                "abilities": ["Flame Body"]
             }
         ]
     },
@@ -1383,7 +1574,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["powergem", "recover", "scald", "stealthrock", "toxic"]
+                "movepool": ["powergem", "recover", "scald", "stealthrock", "toxic"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -1392,11 +1584,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "scald"]
+                "movepool": ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "scald"],
+                "abilities": ["Sniper"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["energyball", "fireblast", "gunkshot", "icebeam", "scald", "thunderwave"]
+                "movepool": ["energyball", "fireblast", "gunkshot", "icebeam", "scald", "thunderwave"],
+                "abilities": ["Sniper"]
             }
         ]
     },
@@ -1405,7 +1599,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "freezedry", "rapidspin", "spikes"]
+                "movepool": ["destinybond", "freezedry", "rapidspin", "spikes"],
+                "abilities": ["Insomnia", "Vital Spirit"]
             }
         ]
     },
@@ -1414,11 +1609,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "defog", "haze", "rest", "scald", "toxic"]
+                "movepool": ["airslash", "defog", "haze", "rest", "scald", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["rest", "scald", "sleeptalk", "toxic"]
+                "movepool": ["rest", "scald", "sleeptalk", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -1427,11 +1624,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"]
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1440,7 +1639,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"]
+                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -1449,7 +1649,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"]
+                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -1458,7 +1659,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"]
+                "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1467,7 +1669,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1476,7 +1679,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["discharge", "icebeam", "recover", "toxic", "triattack"]
+                "movepool": ["discharge", "icebeam", "recover", "toxic", "triattack"],
+                "abilities": ["Download", "Trace"]
             }
         ]
     },
@@ -1486,6 +1690,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch", "thunderwave"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1495,7 +1700,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "nuzzle", "spore", "stealthrock", "stickyweb", "whirlwind"]
+                "movepool": ["destinybond", "nuzzle", "spore", "stealthrock", "stickyweb", "whirlwind"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -1504,7 +1710,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1512,12 +1719,9 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["bodyslam", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "earthquake", "milkdrink"]
+                "role": "Bulky Attacker",
+                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+                "abilities": ["Sap Sipper", "Thick Fat"]
             }
         ]
     },
@@ -1526,11 +1730,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1539,11 +1745,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"]
+                "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1553,11 +1761,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulldoze", "extremespeed", "flareblitz", "sacredfire"]
+                "movepool": ["bulldoze", "extremespeed", "flareblitz", "sacredfire"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stoneedge"]
+                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stoneedge"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1566,15 +1776,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "rest", "scald", "sleeptalk"]
+                "movepool": ["calmmind", "rest", "scald", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "rest", "scald", "substitute"]
+                "movepool": ["calmmind", "icebeam", "rest", "scald", "substitute"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Staller",
-                "movepool": ["calmmind", "protect", "scald", "substitute"]
+                "movepool": ["calmmind", "protect", "scald", "substitute"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1583,11 +1796,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge"]
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge"],
+                "abilities": ["Sand Stream"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -1596,7 +1811,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -1605,7 +1821,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"]
+                "movepool": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"],
+                "abilities": ["Multiscale"]
             }
         ]
     },
@@ -1614,7 +1831,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "earthquake", "roost", "sacredfire", "substitute", "toxic"]
+                "movepool": ["bravebird", "defog", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -1624,15 +1842,18 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
+                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["leafstorm", "nastyplot", "psychic", "recover"]
+                "movepool": ["leafstorm", "nastyplot", "psychic", "recover"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1641,11 +1862,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"]
+                "movepool": ["earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -1654,11 +1877,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragonpulse", "earthquake", "focusblast", "gigadrain", "leafstorm", "substitute"]
+                "movepool": ["dragonpulse", "earthquake", "focusblast", "gigadrain", "leafstorm", "substitute"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "leafblade", "outrage", "swordsdance"]
+                "movepool": ["earthquake", "leafblade", "outrage", "swordsdance"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -1667,11 +1892,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "highjumpkick", "knockoff", "protect", "stoneedge"]
+                "movepool": ["fireblast", "highjumpkick", "knockoff", "protect", "stoneedge"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flareblitz", "highjumpkick", "knockoff", "stoneedge", "swordsdance"]
+                "movepool": ["flareblitz", "highjumpkick", "knockoff", "stoneedge", "swordsdance"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -1680,7 +1907,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"]
+                "movepool": ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -1689,11 +1917,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "roar", "scald", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "icebeam", "roar", "scald", "stealthrock", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "scald", "toxic"]
+                "movepool": ["earthquake", "protect", "scald", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -1702,7 +1932,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "icepunch", "raindance", "superpower", "waterfall"]
+                "movepool": ["earthquake", "icepunch", "raindance", "superpower", "waterfall"],
+                "abilities": ["Damp"]
             }
         ]
     },
@@ -1712,6 +1943,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["crunch", "irontail", "playrough", "suckerpunch", "toxic"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fairy"]
             }
         ]
@@ -1721,7 +1953,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"]
+                "movepool": ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"],
+                "abilities": ["Quick Feet"]
             }
         ]
     },
@@ -1730,7 +1963,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aircutter", "bugbuzz", "hiddenpowerground", "quiverdance"]
+                "movepool": ["aircutter", "bugbuzz", "hiddenpowerground", "quiverdance"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1739,11 +1973,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "hiddenpowerground", "quiverdance", "roost", "sludgebomb"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "quiverdance", "roost", "sludgebomb"],
+                "abilities": ["Shield Dust"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbuzz", "defog", "roost", "sludgebomb", "toxic", "uturn"]
+                "movepool": ["bugbuzz", "defog", "roost", "sludgebomb", "toxic", "uturn"],
+                "abilities": ["Shield Dust"]
             }
         ]
     },
@@ -1752,11 +1988,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["gigadrain", "hydropump", "icebeam", "raindance"]
+                "movepool": ["gigadrain", "hydropump", "icebeam", "raindance"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["energyball", "hydropump", "icebeam", "scald"]
+                "movepool": ["energyball", "hydropump", "icebeam", "scald"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1765,11 +2003,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["defog", "knockoff", "leafstorm", "lowkick", "suckerpunch"]
+                "movepool": ["defog", "knockoff", "leafstorm", "lowkick", "suckerpunch"],
+                "abilities": ["Chlorophyll", "Pickpocket"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["knockoff", "leafblade", "lowkick", "suckerpunch", "swordsdance"]
+                "movepool": ["knockoff", "leafblade", "lowkick", "suckerpunch", "swordsdance"],
+                "abilities": ["Chlorophyll", "Pickpocket"]
             }
         ]
     },
@@ -1778,11 +2018,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "facade", "protect", "uturn"]
+                "movepool": ["bravebird", "facade", "protect", "uturn"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "facade", "quickattack", "uturn"]
+                "movepool": ["bravebird", "facade", "quickattack", "uturn"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -1791,11 +2033,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "hurricane", "knockoff", "roost", "scald", "toxic", "uturn"]
+                "movepool": ["defog", "hurricane", "knockoff", "roost", "scald", "toxic", "uturn"],
+                "abilities": ["Rain Dish"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "knockoff", "roost", "scald", "toxic", "uturn"]
+                "movepool": ["defog", "knockoff", "roost", "scald", "toxic", "uturn"],
+                "abilities": ["Rain Dish"]
             }
         ]
     },
@@ -1804,11 +2048,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "focusblast", "healingwish", "moonblast", "psychic", "shadowball", "thunderbolt", "trick"]
+                "movepool": ["calmmind", "focusblast", "healingwish", "moonblast", "psychic", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Trace"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "focusblast", "moonblast", "psyshock", "substitute", "willowisp"]
+                "movepool": ["calmmind", "focusblast", "moonblast", "psyshock", "substitute", "willowisp"],
+                "abilities": ["Trace"]
             }
         ]
     },
@@ -1817,7 +2063,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "substitute", "taunt", "willowisp"]
+                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "substitute", "taunt", "willowisp"],
+                "abilities": ["Trace"]
             }
         ]
     },
@@ -1826,11 +2073,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "hydropump", "quiverdance"]
+                "movepool": ["airslash", "bugbuzz", "hydropump", "quiverdance"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["airslash", "bugbuzz", "roost", "scald", "stickyweb", "stunspore", "uturn"]
+                "movepool": ["airslash", "bugbuzz", "roost", "scald", "stickyweb", "stunspore", "uturn"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1839,11 +2088,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletseed", "machpunch", "rocktomb", "spore", "swordsdance"]
+                "movepool": ["bulletseed", "machpunch", "rocktomb", "spore", "swordsdance"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bulletseed", "machpunch", "rocktomb", "swordsdance"]
+                "movepool": ["bulletseed", "machpunch", "rocktomb", "swordsdance"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -1852,7 +2103,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "bulkup", "earthquake", "return", "shadowclaw", "slackoff"]
+                "movepool": ["bodyslam", "bulkup", "earthquake", "return", "shadowclaw", "slackoff"],
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -1861,7 +2113,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"]
+                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"],
+                "abilities": ["Truant"]
             }
         ]
     },
@@ -1870,7 +2123,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "nightslash", "swordsdance", "uturn", "xscissor"]
+                "movepool": ["aerialace", "nightslash", "swordsdance", "uturn", "xscissor"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -1879,7 +2133,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"]
+                "movepool": ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+                "abilities": ["Wonder Guard"]
             }
         ]
     },
@@ -1888,7 +2143,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["boomburst", "fireblast", "focusblast", "icebeam", "surf"]
+                "movepool": ["boomburst", "fireblast", "focusblast", "icebeam", "surf"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -1898,11 +2154,13 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["bulletpunch", "closecombat", "heavyslam", "knockoff", "stoneedge"],
+                "abilities": ["Thick Fat"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["bulkup", "bulletpunch", "closecombat", "facade", "knockoff"],
+                "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -1912,7 +2170,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "toxic"]
+                "movepool": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "toxic"],
+                "abilities": ["Wonder Skin"]
             }
         ]
     },
@@ -1921,7 +2180,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "knockoff", "recover", "taunt", "willowisp"]
+                "movepool": ["foulplay", "knockoff", "recover", "taunt", "willowisp"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -1930,7 +2190,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "darkpulse", "recover", "willowisp"]
+                "movepool": ["calmmind", "darkpulse", "recover", "willowisp"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -1939,7 +2200,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["ironhead", "knockoff", "playrough", "stealthrock", "suckerpunch", "swordsdance"]
+                "movepool": ["ironhead", "knockoff", "playrough", "stealthrock", "suckerpunch", "swordsdance"],
+                "abilities": ["Intimidate", "Sheer Force"]
             }
         ]
     },
@@ -1948,7 +2210,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["ironhead", "knockoff", "playrough", "suckerpunch", "swordsdance"]
+                "movepool": ["ironhead", "knockoff", "playrough", "suckerpunch", "swordsdance"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1958,6 +2221,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquatail", "earthquake", "headsmash", "heavyslam", "rockpolish", "stealthrock"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1967,7 +2231,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "stoneedge", "thunderwave", "toxic"]
+                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1976,7 +2241,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletpunch", "highjumpkick", "icepunch", "poisonjab", "zenheadbutt"]
+                "movepool": ["bulletpunch", "highjumpkick", "icepunch", "poisonjab", "zenheadbutt"],
+                "abilities": ["Pure Power"]
             }
         ]
     },
@@ -1985,7 +2251,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "highjumpkick", "icepunch", "thunderpunch", "zenheadbutt"]
+                "movepool": ["fakeout", "highjumpkick", "icepunch", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Pure Power"]
             }
         ]
     },
@@ -1994,7 +2261,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -2003,7 +2271,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -2013,11 +2282,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -2027,11 +2298,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -2040,7 +2313,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "roost", "thunderwave", "uturn"]
+                "movepool": ["encore", "roost", "thunderwave", "uturn"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -2049,7 +2323,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbuzz", "encore", "roost", "thunderwave"]
+                "movepool": ["bugbuzz", "encore", "roost", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -2058,11 +2333,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"]
+                "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
+                "abilities": ["Liquid Ooze"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"]
+                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"],
+                "abilities": ["Liquid Ooze"]
             }
         ]
     },
@@ -2071,7 +2348,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "destinybond", "earthquake", "icebeam", "protect", "waterfall"]
+                "movepool": ["crunch", "destinybond", "earthquake", "icebeam", "protect", "waterfall"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -2080,7 +2358,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "icefang", "protect", "waterfall"]
+                "movepool": ["crunch", "icefang", "protect", "waterfall"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -2089,7 +2368,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
+                "abilities": ["Water Veil"]
             }
         ]
     },
@@ -2098,11 +2378,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "rockpolish", "stoneedge"]
+                "movepool": ["earthquake", "fireblast", "rockpolish", "stoneedge"],
+                "abilities": ["Solid Rock"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "toxic"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -2111,7 +2393,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["ancientpower", "earthpower", "fireblast", "stealthrock", "toxic", "willowisp"]
+                "movepool": ["ancientpower", "earthpower", "fireblast", "stealthrock", "toxic", "willowisp"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -2120,7 +2403,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "rapidspin", "stealthrock", "yawn"]
+                "movepool": ["earthquake", "lavaplume", "rapidspin", "stealthrock", "yawn"],
+                "abilities": ["White Smoke"]
             }
         ]
     },
@@ -2129,7 +2413,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"]
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -2139,6 +2424,7 @@
             {
                 "role": "Staller",
                 "movepool": ["feintattack", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
+                "abilities": ["Contrary"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2148,11 +2434,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "outrage", "stoneedge", "uturn"]
+                "movepool": ["earthquake", "outrage", "stoneedge", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "dracometeor", "earthquake", "roost", "uturn"]
+                "movepool": ["defog", "dracometeor", "earthquake", "roost", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2161,11 +2449,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"]
+                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "seedbomb", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "seedbomb", "suckerpunch", "swordsdance"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -2174,11 +2464,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
+                "movepool": ["dragondance", "earthquake", "outrage", "roost"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "healbell", "roost", "toxic"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "healbell", "roost", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -2187,11 +2479,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "return", "roost"]
+                "movepool": ["dragondance", "earthquake", "return", "roost"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "fireblast", "healbell", "return", "roost"]
+                "movepool": ["earthquake", "fireblast", "healbell", "return", "roost"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -2201,6 +2495,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"],
+                "abilities": ["Toxic Boost"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -2211,6 +2506,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "flamethrower", "gigadrain", "glare", "knockoff", "sludgewave", "suckerpunch", "switcheroo"],
+                "abilities": ["Infiltrator"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2221,11 +2517,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "icebeam", "moonblast", "moonlight", "psychic", "rockpolish"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthpower", "moonlight", "psychic", "stealthrock", "toxic"]
+                "movepool": ["earthpower", "moonlight", "psychic", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2234,7 +2532,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "morningsun", "stealthrock", "stoneedge", "willowisp"]
+                "movepool": ["earthquake", "morningsun", "stealthrock", "stoneedge", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2243,7 +2542,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "stoneedge", "waterfall"]
+                "movepool": ["dragondance", "earthquake", "stoneedge", "waterfall"],
+                "abilities": ["Hydration", "Oblivious"]
             }
         ]
     },
@@ -2252,11 +2552,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower"]
+                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower"],
+                "abilities": ["Adaptability"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "swordsdance"]
+                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "swordsdance"],
+                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -2265,7 +2567,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2274,11 +2577,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"]
+                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"],
+                "abilities": ["Storm Drain"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -2287,11 +2592,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"]
+                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "earthquake", "knockoff", "stoneedge", "swordsdance", "xscissor"]
+                "movepool": ["aquajet", "earthquake", "knockoff", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             }
         ]
     },
@@ -2300,7 +2607,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["dragontail", "haze", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["dragontail", "haze", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Competitive", "Marvel Scale"]
             }
         ]
     },
@@ -2309,7 +2617,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "icebeam", "return", "scald", "thunderbolt", "thunderwave"]
+                "movepool": ["fireblast", "icebeam", "return", "scald", "thunderbolt", "thunderwave"],
+                "abilities": ["Forecast"]
             }
         ]
     },
@@ -2319,11 +2628,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["drainpunch", "fakeout", "knockoff", "recover", "shadowsneak", "stealthrock", "suckerpunch"],
+                "abilities": ["Protean"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drainpunch", "knockoff", "recover", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["drainpunch", "knockoff", "recover", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Protean"]
             }
         ]
     },
@@ -2332,7 +2643,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["gunkshot", "knockoff", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"]
+                "movepool": ["gunkshot", "knockoff", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"],
+                "abilities": ["Cursed Body", "Frisk"]
             }
         ]
     },
@@ -2341,7 +2653,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "knockoff", "shadowclaw", "taunt", "willowisp"]
+                "movepool": ["destinybond", "knockoff", "shadowclaw", "taunt", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -2350,7 +2663,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "leechseed", "protect", "substitute"]
+                "movepool": ["airslash", "leechseed", "protect", "substitute"],
+                "abilities": ["Harvest"]
             }
         ]
     },
@@ -2359,11 +2673,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["healbell", "knockoff", "psychic", "recover", "toxic"]
+                "movepool": ["healbell", "knockoff", "psychic", "recover", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "psychic", "recover", "signalbeam"]
+                "movepool": ["calmmind", "psychic", "recover", "signalbeam"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2373,6 +2689,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             }
         ]
@@ -2383,11 +2700,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fireblast", "knockoff", "playrough", "protect", "pursuit", "suckerpunch", "superpower"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             }
         ]
@@ -2397,7 +2716,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "freezedry", "spikes", "superfang", "taunt"]
+                "movepool": ["earthquake", "freezedry", "spikes", "superfang", "taunt"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -2407,6 +2727,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "explosion", "freezedry", "iceshard", "return", "spikes"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2416,11 +2737,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "roar", "superfang", "surf", "toxic"]
+                "movepool": ["icebeam", "roar", "superfang", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -2430,6 +2753,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["icebeam", "return", "shellsmash", "suckerpunch", "waterfall"],
+                "abilities": ["Swift Swim", "Water Veil"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2439,7 +2763,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2448,11 +2773,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"]
+                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "headsmash", "rockpolish", "waterfall"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2462,7 +2789,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"]
+                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2471,7 +2799,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
+                "movepool": ["dragondance", "earthquake", "outrage", "roost"],
+                "abilities": ["Intimidate", "Moxie"]
             }
         ]
     },
@@ -2480,7 +2809,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["doubleedge", "dragondance", "earthquake", "return", "roost"]
+                "movepool": ["doubleedge", "dragondance", "earthquake", "return", "roost"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -2490,11 +2820,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["agility", "earthquake", "icepunch", "meteormash", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "stealthrock", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2505,6 +2837,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["agility", "earthquake", "hammerarm", "meteormash", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -2514,11 +2847,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "drainpunch", "rest", "stoneedge"]
+                "movepool": ["curse", "drainpunch", "rest", "stoneedge"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "earthquake", "stealthrock", "stoneedge", "thunderwave", "toxic"]
+                "movepool": ["drainpunch", "earthquake", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -2527,16 +2862,19 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"]
+                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["focusblast", "icebeam", "rockpolish", "thunderbolt"]
+                "movepool": ["focusblast", "icebeam", "rockpolish", "thunderbolt"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2545,15 +2883,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "ironhead", "rest", "sleeptalk"]
+                "movepool": ["curse", "ironhead", "rest", "sleeptalk"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"]
+                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2562,7 +2903,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2571,7 +2913,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2580,7 +2923,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2589,7 +2933,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2598,7 +2943,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "originpulse", "scald", "thunder", "waterspout"]
+                "movepool": ["icebeam", "originpulse", "scald", "thunder", "waterspout"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -2607,11 +2953,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "rest", "scald", "sleeptalk"]
+                "movepool": ["calmmind", "rest", "scald", "sleeptalk"],
+                "abilities": ["Drizzle"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "icebeam", "originpulse", "thunder"]
+                "movepool": ["calmmind", "icebeam", "originpulse", "thunder"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -2620,11 +2968,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "lavaplume", "precipiceblades", "stealthrock", "stoneedge", "thunderwave"]
+                "movepool": ["dragontail", "lavaplume", "precipiceblades", "stealthrock", "stoneedge", "thunderwave"],
+                "abilities": ["Drought"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["firepunch", "precipiceblades", "rockpolish", "stoneedge", "swordsdance"]
+                "movepool": ["firepunch", "precipiceblades", "rockpolish", "stoneedge", "swordsdance"],
+                "abilities": ["Drought"]
             }
         ]
     },
@@ -2633,11 +2983,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "lavaplume", "precipiceblades", "stealthrock", "thunderwave"]
+                "movepool": ["dragontail", "lavaplume", "precipiceblades", "stealthrock", "thunderwave"],
+                "abilities": ["Drought"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["firepunch", "precipiceblades", "rockpolish", "swordsdance"]
+                "movepool": ["firepunch", "precipiceblades", "rockpolish", "swordsdance"],
+                "abilities": ["Drought"]
             }
         ]
     },
@@ -2646,15 +2998,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "earthquake", "extremespeed", "outrage", "vcreate"]
+                "movepool": ["dracometeor", "earthquake", "extremespeed", "outrage", "vcreate"],
+                "abilities": ["Air Lock"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"]
+                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
+                "abilities": ["Air Lock"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "extremespeed", "outrage", "swordsdance", "vcreate"],
+                "abilities": ["Air Lock"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2664,7 +3019,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragonascent", "dragondance", "earthquake", "extremespeed", "vcreate"]
+                "movepool": ["dragonascent", "dragondance", "earthquake", "extremespeed", "vcreate"],
+                "abilities": ["Air Lock"]
             }
         ]
     },
@@ -2673,7 +3029,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"]
+                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -2682,11 +3039,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"]
+                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"]
+                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2695,11 +3054,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"]
+                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"]
+                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2708,7 +3069,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"]
+                "movepool": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2717,7 +3079,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["knockoff", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"]
+                "movepool": ["knockoff", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2726,11 +3089,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"]
+                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"]
+                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -2739,11 +3104,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"]
+                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"],
+                "abilities": ["Blaze", "Iron Fist"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"]
+                "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"],
+                "abilities": ["Blaze", "Iron Fist"]
             }
         ]
     },
@@ -2752,15 +3119,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["defog", "knockoff", "protect", "scald", "stealthrock", "toxic"]
+                "movepool": ["defog", "knockoff", "protect", "scald", "stealthrock", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "icebeam", "knockoff", "roar", "scald", "toxic"]
+                "movepool": ["defog", "icebeam", "knockoff", "roar", "scald", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["flashcannon", "grassknot", "hydropump", "icebeam", "knockoff", "scald"]
+                "movepool": ["flashcannon", "grassknot", "hydropump", "icebeam", "knockoff", "scald"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -2770,6 +3140,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bravebird", "closecombat", "doubleedge", "quickattack", "uturn"],
+                "abilities": ["Reckless"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2779,7 +3150,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["curse", "quickattack", "return", "waterfall"]
+                "movepool": ["curse", "quickattack", "return", "waterfall"],
+                "abilities": ["Simple"]
             }
         ]
     },
@@ -2788,7 +3160,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbite", "knockoff", "stickyweb", "taunt", "toxic"]
+                "movepool": ["bugbite", "knockoff", "stickyweb", "taunt", "toxic"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -2797,11 +3170,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "facade", "superpower", "wildcharge"]
+                "movepool": ["crunch", "facade", "superpower", "wildcharge"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["crunch", "icefang", "superpower", "voltswitch", "wildcharge"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2811,7 +3186,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
+                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"],
+                "abilities": ["Natural Cure", "Technician"]
             }
         ]
     },
@@ -2820,11 +3196,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"]
+                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"],
+                "abilities": ["Sheer Force"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"]
+                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -2833,11 +3211,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["metalburst", "roar", "rockblast", "stealthrock", "toxic"]
+                "movepool": ["metalburst", "roar", "rockblast", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"]
+                "movepool": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -2846,11 +3226,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerground", "hiddenpowerrock", "leafstorm", "signalbeam", "synthesis", "toxic"]
+                "movepool": ["hiddenpowerground", "hiddenpowerrock", "leafstorm", "signalbeam", "synthesis", "toxic"],
+                "abilities": ["Anticipation", "Overcoat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "protect", "signalbeam", "synthesis", "toxic"]
+                "movepool": ["gigadrain", "protect", "signalbeam", "synthesis", "toxic"],
+                "abilities": ["Anticipation", "Overcoat"]
             }
         ]
     },
@@ -2859,7 +3241,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "infestation", "protect", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "infestation", "protect", "stealthrock", "toxic"],
+                "abilities": ["Overcoat"]
             }
         ]
     },
@@ -2868,7 +3251,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "infestation", "protect", "stealthrock", "toxic"]
+                "movepool": ["flashcannon", "infestation", "protect", "stealthrock", "toxic"],
+                "abilities": ["Overcoat"]
             }
         ]
     },
@@ -2877,7 +3261,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance"]
+                "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -2886,7 +3271,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "defog", "roost", "toxic", "uturn"]
+                "movepool": ["airslash", "defog", "roost", "toxic", "uturn"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2895,7 +3281,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["nuzzle", "superfang", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["nuzzle", "superfang", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -2905,11 +3292,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["aquajet", "bulkup", "icepunch", "lowkick", "substitute", "waterfall"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquajet", "crunch", "icepunch", "lowkick", "waterfall"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2919,11 +3308,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock", "morningsun"]
+                "movepool": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock", "morningsun"],
+                "abilities": ["Flower Gift"]
             },
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "leechseed", "morningsun", "toxic"]
+                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "leechseed", "morningsun", "toxic"],
+                "abilities": ["Flower Gift"]
             }
         ]
     },
@@ -2932,7 +3323,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -2942,6 +3334,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fakeout", "knockoff", "lowkick", "return", "uturn"],
+                "abilities": ["Technician"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -2951,11 +3344,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["acrobatics", "defog", "destinybond", "shadowball", "substitute", "willowisp"]
+                "movepool": ["acrobatics", "defog", "destinybond", "shadowball", "substitute", "willowisp"],
+                "abilities": ["Unburden"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["acrobatics", "hex", "substitute", "willowisp"]
+                "movepool": ["acrobatics", "hex", "substitute", "willowisp"],
+                "abilities": ["Unburden"]
             }
         ]
     },
@@ -2964,7 +3359,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["healingwish", "highjumpkick", "icepunch", "return", "switcheroo"]
+                "movepool": ["healingwish", "highjumpkick", "icepunch", "return", "switcheroo"],
+                "abilities": ["Limber"]
             }
         ]
     },
@@ -2973,7 +3369,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["encore", "fakeout", "highjumpkick", "poweruppunch", "return", "substitute"]
+                "movepool": ["encore", "fakeout", "highjumpkick", "poweruppunch", "return", "substitute"],
+                "abilities": ["Limber"]
             }
         ]
     },
@@ -2982,11 +3379,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dazzlinggleam", "destinybond", "painsplit", "shadowball", "taunt", "willowisp"]
+                "movepool": ["dazzlinggleam", "destinybond", "painsplit", "shadowball", "taunt", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["dazzlinggleam", "nastyplot", "shadowball", "thunderbolt", "trick"]
+                "movepool": ["dazzlinggleam", "nastyplot", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2995,7 +3394,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"]
+                "movepool": ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"],
+                "abilities": ["Moxie"]
             }
         ]
     },
@@ -3005,6 +3405,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fakeout", "knockoff", "return", "uturn", "wakeupslap"],
+                "abilities": ["Defiant", "Thick Fat"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3014,7 +3415,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "defog", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"]
+                "movepool": ["crunch", "defog", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"],
+                "abilities": ["Aftermath"]
             }
         ]
     },
@@ -3024,11 +3426,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "ironhead", "psychic", "stealthrock", "toxic"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
                 "movepool": ["earthquake", "ironhead", "protect", "psychic", "toxic"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3038,11 +3442,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["boomburst", "chatter", "heatwave", "hiddenpowerground", "uturn"]
+                "movepool": ["boomburst", "chatter", "heatwave", "hiddenpowerground", "uturn"],
+                "abilities": ["Tangled Feet"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["boomburst", "chatter", "heatwave", "nastyplot", "substitute"]
+                "movepool": ["boomburst", "chatter", "heatwave", "nastyplot", "substitute"],
+                "abilities": ["Tangled Feet"]
             }
         ]
     },
@@ -3051,11 +3457,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "darkpulse", "rest", "sleeptalk"]
+                "movepool": ["calmmind", "darkpulse", "rest", "sleeptalk"],
+                "abilities": ["Infiltrator"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -3064,11 +3472,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["dragonclaw", "earthquake", "fireblast", "outrage", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["dragonclaw", "earthquake", "fireblast", "outrage", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Rough Skin"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -3077,11 +3487,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "stealthrock", "stoneedge"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "stealthrock", "stoneedge"],
+                "abilities": ["Rough Skin"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -3091,11 +3503,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bulletpunch", "closecombat", "crunch", "extremespeed", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Normal"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"]
+                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -3104,11 +3518,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulletpunch", "closecombat", "irontail", "swordsdance"]
+                "movepool": ["bulletpunch", "closecombat", "irontail", "swordsdance"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "flashcannon", "nastyplot", "vacuumwave"]
+                "movepool": ["aurasphere", "flashcannon", "nastyplot", "vacuumwave"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -3117,7 +3533,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"]
+                "movepool": ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -3127,11 +3544,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquatail", "earthquake", "knockoff", "poisonjab", "pursuit", "swordsdance"],
+                "abilities": ["Battle Armor"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "poisonjab", "taunt", "toxicspikes", "whirlwind"]
+                "movepool": ["earthquake", "knockoff", "poisonjab", "taunt", "toxicspikes", "whirlwind"],
+                "abilities": ["Battle Armor"]
             }
         ]
     },
@@ -3140,7 +3559,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "earthquake", "gunkshot", "knockoff", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "earthquake", "gunkshot", "knockoff", "substitute", "suckerpunch", "swordsdance"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -3149,7 +3569,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "powerwhip", "sleeppowder", "synthesis", "toxic"]
+                "movepool": ["knockoff", "powerwhip", "sleeppowder", "synthesis", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3158,7 +3579,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "icebeam", "scald", "toxic", "uturn"]
+                "movepool": ["defog", "icebeam", "scald", "toxic", "uturn"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -3168,6 +3590,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["blizzard", "earthquake", "gigadrain", "iceshard", "woodhammer"],
+                "abilities": ["Snow Warning"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3178,6 +3601,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["blizzard", "earthquake", "gigadrain", "iceshard", "woodhammer"],
+                "abilities": ["Snow Warning"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3187,7 +3611,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["iceshard", "iciclecrash", "knockoff", "lowkick", "pursuit", "swordsdance"]
+                "movepool": ["iceshard", "iciclecrash", "knockoff", "lowkick", "pursuit", "swordsdance"],
+                "abilities": ["Pickpocket"]
             }
         ]
     },
@@ -3196,7 +3621,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"]
+                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -3205,16 +3631,19 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "healbell", "knockoff", "protect", "wish"]
+                "movepool": ["bodyslam", "healbell", "knockoff", "protect", "wish"],
+                "abilities": ["Cloud Nine"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["bodyslam", "dragontail", "earthquake", "explosion", "knockoff", "powerwhip"],
+                "abilities": ["Cloud Nine"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bodyslam", "earthquake", "explosion", "knockoff", "powerwhip", "return", "swordsdance"],
+                "abilities": ["Cloud Nine"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3224,11 +3653,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dragontail", "earthquake", "icepunch", "megahorn", "stoneedge"]
+                "movepool": ["dragontail", "earthquake", "icepunch", "megahorn", "stoneedge"],
+                "abilities": ["Solid Rock"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge"]
+                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -3237,11 +3668,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["earthquake", "gigadrain", "knockoff", "powerwhip", "rockslide", "sludgebomb"]
+                "movepool": ["earthquake", "gigadrain", "knockoff", "powerwhip", "rockslide", "sludgebomb"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -3251,6 +3684,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+                "abilities": ["Motor Drive"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -3261,6 +3695,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -3270,15 +3705,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["airslash", "aurasphere", "nastyplot", "roost", "thunderwave"]
+                "movepool": ["airslash", "aurasphere", "nastyplot", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "defog", "healbell", "roost", "thunderwave"]
+                "movepool": ["airslash", "defog", "healbell", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "aurasphere", "dazzlinggleam", "trick"]
+                "movepool": ["airslash", "aurasphere", "dazzlinggleam", "trick"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -3287,11 +3725,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "protect"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "protect"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["airslash", "bugbuzz", "gigadrain", "uturn"]
+                "movepool": ["airslash", "bugbuzz", "gigadrain", "uturn"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -3301,6 +3741,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor"],
+                "abilities": ["Chlorophyll"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3310,11 +3751,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerground", "icebeam", "protect", "wish"]
+                "movepool": ["healbell", "hiddenpowerground", "icebeam", "protect", "wish"],
+                "abilities": ["Ice Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "toxic", "wish"]
+                "movepool": ["icebeam", "protect", "toxic", "wish"],
+                "abilities": ["Ice Body"]
             }
         ]
     },
@@ -3323,15 +3766,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "substitute", "toxic"]
+                "movepool": ["earthquake", "protect", "substitute", "toxic"],
+                "abilities": ["Poison Heal"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "roost", "stealthrock", "taunt", "toxic", "uturn"]
+                "movepool": ["earthquake", "knockoff", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+                "abilities": ["Poison Heal"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "facade", "roost", "swordsdance"]
+                "movepool": ["earthquake", "facade", "roost", "swordsdance"],
+                "abilities": ["Poison Heal"]
             }
         ]
     },
@@ -3340,7 +3786,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock"]
+                "movepool": ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -3349,7 +3796,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "nastyplot", "shadowball", "thunderbolt", "triattack", "trick"]
+                "movepool": ["icebeam", "nastyplot", "shadowball", "thunderbolt", "triattack", "trick"],
+                "abilities": ["Adaptability", "Download"]
             }
         ]
     },
@@ -3359,6 +3807,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "icepunch", "knockoff", "shadowsneak", "swordsdance", "zenheadbutt"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3368,7 +3817,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["closecombat", "knockoff", "swordsdance", "zenheadbutt"]
+                "movepool": ["closecombat", "knockoff", "swordsdance", "zenheadbutt"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -3377,7 +3827,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"]
+                "movepool": ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -3387,11 +3838,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "toxic", "willowisp"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"]
+                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3400,7 +3853,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"]
+                "movepool": ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"],
+                "abilities": ["Cursed Body"]
             }
         ]
     },
@@ -3409,7 +3863,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["hiddenpowerice", "painsplit", "shadowball", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["hiddenpowerice", "painsplit", "shadowball", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3418,7 +3873,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"]
+                "movepool": ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3427,7 +3883,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hydropump", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["hydropump", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3436,7 +3893,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["blizzard", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3445,7 +3903,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "painsplit", "thunderbolt", "voltswitch", "willowisp"]
+                "movepool": ["airslash", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3454,7 +3913,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["hiddenpowerice", "leafstorm", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["hiddenpowerice", "leafstorm", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3463,7 +3923,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn", "yawn"]
+                "movepool": ["healbell", "knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn", "yawn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3472,11 +3933,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "energyball", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"]
+                "movepool": ["calmmind", "energyball", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"]
+                "movepool": ["knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3485,11 +3948,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dazzlinggleam", "fireblast", "nastyplot", "psychic", "psyshock", "uturn"]
+                "movepool": ["dazzlinggleam", "fireblast", "nastyplot", "psychic", "psyshock", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["explosion", "fireblast", "knockoff", "psychic", "stealthrock", "taunt", "uturn"]
+                "movepool": ["explosion", "fireblast", "knockoff", "psychic", "stealthrock", "taunt", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3499,6 +3964,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -3509,6 +3975,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "fireblast", "hydropump", "spacialrend", "thunderwave"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -3518,11 +3985,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "flashcannon", "lavaplume", "magmastorm", "stealthrock", "taunt", "toxic"]
+                "movepool": ["earthpower", "flashcannon", "lavaplume", "magmastorm", "stealthrock", "taunt", "toxic"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthpower", "magmastorm", "protect", "toxic"]
+                "movepool": ["earthpower", "magmastorm", "protect", "toxic"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -3532,6 +4001,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["drainpunch", "knockoff", "return", "substitute", "thunderwave"],
+                "abilities": ["Slow Start"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3541,11 +4011,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "hex", "shadowsneak", "thunderwave", "willowisp"]
+                "movepool": ["dracometeor", "hex", "shadowsneak", "thunderwave", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["defog", "dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"]
+                "movepool": ["defog", "dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3554,15 +4026,18 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["dragontail", "rest", "shadowball", "sleeptalk", "willowisp"]
+                "movepool": ["dragontail", "rest", "shadowball", "sleeptalk", "willowisp"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"]
+                "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "dragontail", "rest", "shadowball", "willowisp"]
+                "movepool": ["defog", "dragontail", "rest", "shadowball", "willowisp"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3571,11 +4046,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "moonblast", "moonlight", "psyshock"]
+                "movepool": ["calmmind", "moonblast", "moonlight", "psyshock"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["moonblast", "moonlight", "psychic", "thunderwave", "toxic"]
+                "movepool": ["moonblast", "moonlight", "psychic", "thunderwave", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3584,7 +4061,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "icebeam", "knockoff", "scald", "toxic", "uturn"]
+                "movepool": ["healbell", "icebeam", "knockoff", "scald", "toxic", "uturn"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -3593,7 +4071,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["energyball", "icebeam", "surf", "tailglow"]
+                "movepool": ["energyball", "icebeam", "surf", "tailglow"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -3603,6 +4082,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["darkpulse", "darkvoid", "focusblast", "nastyplot", "sludgebomb", "substitute"],
+                "abilities": ["Bad Dreams"],
                 "preferredTypes": ["Poison"]
             }
         ]
@@ -3613,6 +4093,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -3622,7 +4103,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"]
+                "movepool": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -3631,7 +4113,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"]
+                "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3640,11 +4123,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3653,7 +4138,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "fireblast", "judgment", "recover", "sludgebomb", "toxic", "willowisp"]
+                "movepool": ["calmmind", "defog", "fireblast", "judgment", "recover", "sludgebomb", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3662,11 +4148,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "willowisp"]
+                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "outrage", "recover", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3676,7 +4164,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3685,11 +4174,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3698,7 +4189,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover", "shadowball"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "shadowball"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3707,7 +4199,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "energyball", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "energyball", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3716,11 +4209,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3729,11 +4224,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "focusblast", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["calmmind", "defog", "focusblast", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["brickbreak", "extremespeed", "shadowforce", "swordsdance"]
+                "movepool": ["brickbreak", "extremespeed", "shadowforce", "swordsdance"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3742,11 +4239,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3756,11 +4255,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3769,7 +4270,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3779,11 +4281,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["defog", "earthquake", "icebeam", "recover", "sludgebomb"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "earthpower", "icebeam", "recover", "sludgebomb"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3793,11 +4297,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3806,11 +4312,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3820,7 +4328,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3829,7 +4338,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3838,11 +4348,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["boltstrike", "uturn", "vcreate", "zenheadbutt"]
+                "movepool": ["boltstrike", "uturn", "vcreate", "zenheadbutt"],
+                "abilities": ["Victory Star"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["boltstrike", "energyball", "focusblast", "glaciate", "psychic", "uturn", "vcreate"],
+                "abilities": ["Victory Star"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -3852,7 +4364,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragonpulse", "glare", "hiddenpowerfire", "leafstorm", "leechseed", "substitute"]
+                "movepool": ["dragonpulse", "glare", "hiddenpowerfire", "leafstorm", "leechseed", "substitute"],
+                "abilities": ["Contrary"]
             }
         ]
     },
@@ -3861,11 +4374,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["flareblitz", "headsmash", "suckerpunch", "superpower", "wildcharge"]
+                "movepool": ["flareblitz", "headsmash", "suckerpunch", "superpower", "wildcharge"],
+                "abilities": ["Reckless"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["flareblitz", "grassknot", "suckerpunch", "superpower", "wildcharge"]
+                "movepool": ["flareblitz", "grassknot", "suckerpunch", "superpower", "wildcharge"],
+                "abilities": ["Reckless"]
             }
         ]
     },
@@ -3874,11 +4389,13 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "knockoff", "megahorn", "scald", "superpower"]
+                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "knockoff", "megahorn", "scald", "superpower"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "knockoff", "megahorn", "superpower", "swordsdance", "waterfall"]
+                "movepool": ["aquajet", "knockoff", "megahorn", "superpower", "swordsdance", "waterfall"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -3887,11 +4404,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hypnosis", "knockoff", "return", "superfang"]
+                "movepool": ["hypnosis", "knockoff", "return", "superfang"],
+                "abilities": ["Analytic"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hypnosis", "knockoff", "return", "substitute", "swordsdance"]
+                "movepool": ["hypnosis", "knockoff", "return", "substitute", "swordsdance"],
+                "abilities": ["Analytic"]
             }
         ]
     },
@@ -3901,6 +4420,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crunch", "playrough", "return", "superpower", "wildcharge"],
+                "abilities": ["Scrappy"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -3910,7 +4430,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["copycat", "encore", "knockoff", "substitute", "thunderwave", "uturn"]
+                "movepool": ["copycat", "encore", "knockoff", "substitute", "thunderwave", "uturn"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -3920,11 +4441,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["gunkshot", "hiddenpowerice", "knockoff", "leafstorm", "rockslide", "superpower"],
+                "abilities": ["Overgrow"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "gigadrain", "hiddenpowerice", "nastyplot", "substitute"]
+                "movepool": ["focusblast", "gigadrain", "hiddenpowerice", "nastyplot", "substitute"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -3933,7 +4456,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"]
+                "movepool": ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -3943,6 +4467,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["grassknot", "hydropump", "icebeam", "nastyplot", "substitute"],
+                "abilities": ["Torrent"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -3952,11 +4477,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "moonlight", "psyshock", "shadowball", "signalbeam"]
+                "movepool": ["calmmind", "moonlight", "psyshock", "shadowball", "signalbeam"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "moonlight", "psychic", "signalbeam", "thunderwave", "toxic"]
+                "movepool": ["healbell", "moonlight", "psychic", "signalbeam", "thunderwave", "toxic"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -3965,7 +4492,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["nightslash", "pluck", "return", "roost", "toxic", "uturn"]
+                "movepool": ["nightslash", "pluck", "return", "roost", "toxic", "uturn"],
+                "abilities": ["Super Luck"]
             }
         ]
     },
@@ -3974,7 +4502,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
+                "movepool": ["hiddenpowerice", "overheat", "voltswitch", "wildcharge"],
+                "abilities": ["Sap Sipper"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -3984,6 +4518,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower", "toxic"],
+                "abilities": ["Sturdy"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3993,11 +4528,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "heatwave", "roost", "storedpower"]
+                "movepool": ["calmmind", "heatwave", "roost", "storedpower"],
+                "abilities": ["Simple"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "calmmind", "heatwave", "roost", "storedpower"]
+                "movepool": ["airslash", "calmmind", "heatwave", "roost", "storedpower"],
+                "abilities": ["Simple"]
             }
         ]
     },
@@ -4006,7 +4543,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"]
+                "movepool": ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"],
+                "abilities": ["Mold Breaker"]
             }
         ]
     },
@@ -4015,7 +4553,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "protect", "toxic", "wish"]
+                "movepool": ["knockoff", "protect", "toxic", "wish"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4024,11 +4563,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["dazzlinggleam", "protect", "toxic", "wish"]
+                "movepool": ["dazzlinggleam", "protect", "toxic", "wish"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "protect", "wish"]
+                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "protect", "wish"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4037,11 +4578,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["drainpunch", "facade", "knockoff", "machpunch"]
+                "movepool": ["drainpunch", "facade", "knockoff", "machpunch"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bulkup", "drainpunch", "knockoff", "machpunch"]
+                "movepool": ["bulkup", "drainpunch", "knockoff", "machpunch"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -4050,15 +4593,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "hydropump", "knockoff", "raindance", "sludgewave"]
+                "movepool": ["earthquake", "hydropump", "knockoff", "raindance", "sludgewave"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "scald", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "knockoff", "scald", "stealthrock", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "scald", "toxic"]
+                "movepool": ["earthquake", "protect", "scald", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -4067,7 +4613,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bulkup", "circlethrow", "knockoff", "rest", "sleeptalk"]
+                "movepool": ["bulkup", "circlethrow", "knockoff", "rest", "sleeptalk"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -4077,6 +4624,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bulkup", "closecombat", "earthquake", "knockoff", "poisonjab", "stoneedge"],
+                "abilities": ["Mold Breaker", "Sturdy"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -4086,7 +4634,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["knockoff", "leafblade", "stickyweb", "toxic", "xscissor"]
+                "movepool": ["knockoff", "leafblade", "stickyweb", "toxic", "xscissor"],
+                "abilities": ["Chlorophyll", "Swarm"]
             }
         ]
     },
@@ -4095,11 +4644,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "megahorn", "poisonjab", "spikes", "toxicspikes"]
+                "movepool": ["earthquake", "megahorn", "poisonjab", "spikes", "toxicspikes"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "megahorn", "poisonjab", "protect", "swordsdance"]
+                "movepool": ["earthquake", "megahorn", "poisonjab", "protect", "swordsdance"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -4108,11 +4659,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["encore", "energyball", "moonblast", "stunspore", "taunt", "toxic", "uturn"]
+                "movepool": ["encore", "energyball", "moonblast", "stunspore", "taunt", "toxic", "uturn"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Staller",
-                "movepool": ["leechseed", "moonblast", "protect", "substitute"]
+                "movepool": ["leechseed", "moonblast", "protect", "substitute"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -4121,7 +4674,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "quiverdance", "sleeppowder"],
+                "abilities": ["Chlorophyll"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -4130,7 +4689,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"]
+                "movepool": ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"],
+                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -4139,7 +4699,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -4148,7 +4709,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"]
+                "movepool": ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -4157,11 +4719,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "synthesis", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "synthesis", "toxic"],
+                "abilities": ["Storm Drain", "Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "spikyshield"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "spikyshield"],
+                "abilities": ["Storm Drain", "Water Absorb"]
             }
         ]
     },
@@ -4171,6 +4735,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "knockoff", "shellsmash", "stoneedge", "xscissor"],
+                "abilities": ["Sturdy"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4180,11 +4745,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "highjumpkick", "ironhead", "knockoff"]
+                "movepool": ["dragondance", "highjumpkick", "ironhead", "knockoff"],
+                "abilities": ["Intimidate", "Moxie"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "drainpunch", "knockoff", "rest"]
+                "movepool": ["bulkup", "drainpunch", "knockoff", "rest"],
+                "abilities": ["Shed Skin"]
             }
         ]
     },
@@ -4193,16 +4760,19 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "calmmind", "heatwave", "psyshock", "roost"]
+                "movepool": ["airslash", "calmmind", "heatwave", "psyshock", "roost"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"],
+                "abilities": ["Tinted Lens"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Staller",
-                "movepool": ["cosmicpower", "psychoshift", "roost", "storedpower"]
+                "movepool": ["cosmicpower", "psychoshift", "roost", "storedpower"],
+                "abilities": ["Magic Guard"]
             }
         ]
     },
@@ -4211,11 +4781,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "painsplit", "shadowball", "toxicspikes", "willowisp"]
+                "movepool": ["haze", "painsplit", "shadowball", "toxicspikes", "willowisp"],
+                "abilities": ["Mummy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "trickroom"]
+                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "trickroom"],
+                "abilities": ["Mummy"]
             }
         ]
     },
@@ -4224,7 +4796,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "earthquake", "icebeam", "shellsmash", "stoneedge", "waterfall"]
+                "movepool": ["aquajet", "earthquake", "icebeam", "shellsmash", "stoneedge", "waterfall"],
+                "abilities": ["Solid Rock", "Sturdy", "Swift Swim"]
             }
         ]
     },
@@ -4233,11 +4806,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["acrobatics", "defog", "earthquake", "roost", "stoneedge", "uturn"]
+                "movepool": ["acrobatics", "defog", "earthquake", "roost", "stoneedge", "uturn"],
+                "abilities": ["Defeatist"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquatail", "earthquake", "headsmash", "knockoff", "stealthrock", "stoneedge", "uturn"],
+                "abilities": ["Defeatist"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4247,7 +4822,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "gunkshot", "haze", "painsplit", "spikes", "toxic", "toxicspikes"]
+                "movepool": ["drainpunch", "gunkshot", "haze", "painsplit", "spikes", "toxic", "toxicspikes"],
+                "abilities": ["Aftermath"]
             }
         ]
     },
@@ -4257,6 +4833,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["darkpulse", "flamethrower", "focusblast", "nastyplot", "sludgebomb", "trick", "uturn"],
+                "abilities": ["Illusion"],
                 "preferredTypes": ["Poison"]
             }
         ]
@@ -4266,7 +4843,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"]
+                "movepool": ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -4275,7 +4853,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "shadowball", "signalbeam", "thunderbolt", "trick"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "shadowball", "signalbeam", "thunderbolt", "trick"],
+                "abilities": ["Shadow Tag"]
             }
         ]
     },
@@ -4284,11 +4863,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trickroom"]
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trickroom"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"]
+                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"],
+                "abilities": ["Magic Guard"]
             }
         ]
     },
@@ -4297,7 +4878,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "roost", "scald", "toxic"]
+                "movepool": ["bravebird", "defog", "roost", "scald", "toxic"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -4307,11 +4889,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["autotomize", "explosion", "flashcannon", "freezedry", "hiddenpowerground", "icebeam", "toxic"],
+                "abilities": ["Weak Armor"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["explosion", "flashcannon", "freezedry", "hiddenpowerground", "icebeam"],
+                "abilities": ["Weak Armor"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4322,6 +4906,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["hornleech", "jumpkick", "return", "substitute", "swordsdance"],
+                "abilities": ["Sap Sipper"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -4331,7 +4916,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["acrobatics", "encore", "knockoff", "nuzzle", "roost", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["acrobatics", "encore", "knockoff", "nuzzle", "roost", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Motor Drive"]
             }
         ]
     },
@@ -4340,7 +4926,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"]
+                "movepool": ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"],
+                "abilities": ["Overcoat", "Swarm"]
             }
         ]
     },
@@ -4349,11 +4936,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerground", "sludgebomb", "spore"]
+                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerground", "sludgebomb", "spore"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["gigadrain", "sludgebomb", "spore", "synthesis"]
+                "movepool": ["gigadrain", "sludgebomb", "spore", "synthesis"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4362,11 +4951,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "recover", "scald", "shadowball", "taunt"]
+                "movepool": ["icebeam", "recover", "scald", "shadowball", "taunt"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hex", "recover", "scald", "toxic", "willowisp"]
+                "movepool": ["hex", "recover", "scald", "toxic", "willowisp"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -4375,7 +4966,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "protect", "scald", "toxic", "wish"]
+                "movepool": ["knockoff", "protect", "scald", "toxic", "wish"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4385,6 +4977,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["bugbuzz", "gigadrain", "stickyweb", "thunder", "voltswitch"],
+                "abilities": ["Compound Eyes"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -4394,11 +4987,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gyroball", "leechseed", "powerwhip", "spikes", "stealthrock"]
+                "movepool": ["gyroball", "leechseed", "powerwhip", "spikes", "stealthrock"],
+                "abilities": ["Iron Barbs"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "powerwhip", "spikes", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["knockoff", "powerwhip", "spikes", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Iron Barbs"]
             }
         ]
     },
@@ -4407,7 +5002,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["geargrind", "return", "shiftgear", "substitute", "wildcharge"]
+                "movepool": ["geargrind", "return", "shiftgear", "substitute", "wildcharge"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -4416,7 +5012,8 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["discharge", "flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "uturn"]
+                "movepool": ["discharge", "flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -4425,7 +5022,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"]
+                "movepool": ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"],
+                "abilities": ["Analytic"]
             }
         ]
     },
@@ -4434,11 +5032,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["energyball", "fireblast", "shadowball", "trick"]
+                "movepool": ["energyball", "fireblast", "shadowball", "trick"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"]
+                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"],
+                "abilities": ["Flame Body", "Flash Fire"]
             }
         ]
     },
@@ -4448,6 +5048,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "outrage", "poisonjab", "taunt"],
+                "abilities": ["Mold Breaker"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4458,6 +5059,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquajet", "iciclecrash", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4467,7 +5069,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["freezedry", "haze", "hiddenpowerground", "rapidspin", "recover", "toxic"]
+                "movepool": ["freezedry", "haze", "hiddenpowerground", "rapidspin", "recover", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -4476,7 +5079,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "uturn"]
+                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "uturn"],
+                "abilities": ["Hydration", "Sticky Hold"]
             }
         ]
     },
@@ -4485,11 +5089,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["discharge", "earthpower", "rest", "scald", "sleeptalk", "stealthrock", "toxic"]
+                "movepool": ["discharge", "earthpower", "rest", "scald", "sleeptalk", "stealthrock", "toxic"],
+                "abilities": ["Static"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["discharge", "earthpower", "foulplay", "scald", "sludgebomb"]
+                "movepool": ["discharge", "earthpower", "foulplay", "scald", "sludgebomb"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -4499,11 +5105,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["highjumpkick", "knockoff", "poisonjab", "stoneedge", "swordsdance", "uturn"],
+                "abilities": ["Reckless"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["fakeout", "highjumpkick", "knockoff", "uturn"]
+                "movepool": ["fakeout", "highjumpkick", "knockoff", "uturn"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4513,11 +5121,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["firepunch", "glare", "gunkshot", "outrage", "suckerpunch"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Poison"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "earthquake", "glare", "gunkshot", "outrage", "stealthrock", "suckerpunch"]
+                "movepool": ["dragontail", "earthquake", "glare", "gunkshot", "outrage", "stealthrock", "suckerpunch"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -4527,6 +5137,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["dynamicpunch", "earthquake", "icepunch", "rockpolish", "stealthrock", "stoneedge"],
+                "abilities": ["No Guard"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4536,7 +5147,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["ironhead", "knockoff", "pursuit", "suckerpunch", "swordsdance"]
+                "movepool": ["ironhead", "knockoff", "pursuit", "suckerpunch", "swordsdance"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -4545,7 +5157,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headcharge", "stoneedge", "superpower", "swordsdance"]
+                "movepool": ["earthquake", "headcharge", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Reckless", "Sap Sipper"]
             }
         ]
     },
@@ -4554,11 +5167,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "bulkup", "roost", "superpower"]
+                "movepool": ["bravebird", "bulkup", "roost", "superpower"],
+                "abilities": ["Defiant"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "return", "superpower", "uturn"]
+                "movepool": ["bravebird", "return", "superpower", "uturn"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -4567,11 +5182,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "foulplay", "knockoff", "roost", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "defog", "foulplay", "knockoff", "roost", "taunt", "toxic", "uturn"],
+                "abilities": ["Overcoat"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "foulplay", "roost", "taunt", "toxic", "uturn"]
+                "movepool": ["defog", "foulplay", "roost", "taunt", "toxic", "uturn"],
+                "abilities": ["Overcoat"]
             }
         ]
     },
@@ -4580,7 +5197,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "gigadrain", "knockoff", "suckerpunch", "superpower"]
+                "movepool": ["fireblast", "gigadrain", "knockoff", "suckerpunch", "superpower"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -4590,6 +5208,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
+                "abilities": ["Hustle"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4599,15 +5218,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "dracometeor", "earthpower", "fireblast", "flashcannon", "roost", "uturn"]
+                "movepool": ["darkpulse", "dracometeor", "earthpower", "fireblast", "flashcannon", "roost", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "dracometeor", "fireblast", "roost", "uturn"]
+                "movepool": ["darkpulse", "dracometeor", "fireblast", "roost", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["darkpulse", "dracometeor", "flashcannon", "superpower", "uturn"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4617,7 +5239,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerrock", "quiverdance", "roost"]
+                "movepool": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerrock", "quiverdance", "roost"],
+                "abilities": ["Flame Body", "Swarm"]
             }
         ]
     },
@@ -4626,7 +5249,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"]
+                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -4636,6 +5260,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4645,7 +5270,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "leafblade", "stoneedge", "swordsdance"]
+                "movepool": ["closecombat", "leafblade", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -4654,11 +5280,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"]
+                "movepool": ["heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"],
+                "abilities": ["Defiant", "Prankster"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["acrobatics", "bulkup", "knockoff", "superpower", "taunt"],
+                "abilities": ["Defiant"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4668,7 +5296,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"]
+                "movepool": ["heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4677,11 +5306,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerflying", "hiddenpowerice", "knockoff", "superpower", "taunt", "thunderbolt", "thunderwave"]
+                "movepool": ["hiddenpowerflying", "hiddenpowerice", "knockoff", "superpower", "taunt", "thunderbolt", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -4690,7 +5321,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"]
+                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -4699,7 +5331,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blueflare", "dracometeor", "roost", "toxic"]
+                "movepool": ["blueflare", "dracometeor", "roost", "toxic"],
+                "abilities": ["Turboblaze"]
             }
         ]
     },
@@ -4708,11 +5341,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["boltstrike", "honeclaws", "outrage", "roost", "substitute"]
+                "movepool": ["boltstrike", "honeclaws", "outrage", "roost", "substitute"],
+                "abilities": ["Teravolt"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["boltstrike", "dracometeor", "outrage", "voltswitch"]
+                "movepool": ["boltstrike", "dracometeor", "outrage", "voltswitch"],
+                "abilities": ["Teravolt"]
             }
         ]
     },
@@ -4721,11 +5356,14 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "focusblast", "knockoff", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"]
+                "movepool": ["earthpower", "focusblast", "knockoff", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"],
+                "abilities": ["Sheer Force"],
+                "preferredTypes": ["Rock"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "earthpower", "focusblast", "psychic", "rockpolish", "sludgewave"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Poison"]
             }
         ]
@@ -4735,11 +5373,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "stealthrock", "stoneedge", "toxic", "uturn"]
+                "movepool": ["earthquake", "knockoff", "stealthrock", "stoneedge", "toxic", "uturn"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "knockoff", "rockpolish", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -4749,15 +5389,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthpower", "icebeam", "roost", "substitute"]
+                "movepool": ["earthpower", "icebeam", "roost", "substitute"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["dracometeor", "earthpower", "icebeam", "outrage", "roost", "substitute"]
+                "movepool": ["dracometeor", "earthpower", "icebeam", "outrage", "roost", "substitute"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage"]
+                "movepool": ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -4766,7 +5409,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"]
+                "movepool": ["earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"],
+                "abilities": ["Teravolt"]
             }
         ]
     },
@@ -4775,7 +5419,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthpower", "fusionflare", "icebeam", "roost"]
+                "movepool": ["dracometeor", "earthpower", "fusionflare", "icebeam", "roost"],
+                "abilities": ["Turboblaze"]
             }
         ]
     },
@@ -4784,15 +5429,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword"]
+                "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "scald", "secretsword", "substitute"]
+                "movepool": ["calmmind", "scald", "secretsword", "substitute"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "hydropump", "scald", "secretsword"]
+                "movepool": ["focusblast", "hydropump", "scald", "secretsword"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -4801,11 +5449,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"]
+                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "knockoff", "relicsong", "return"]
+                "movepool": ["closecombat", "knockoff", "relicsong", "return"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -4814,15 +5464,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["blazekick", "ironhead", "shiftgear", "thunderbolt", "xscissor"]
+                "movepool": ["blazekick", "ironhead", "shiftgear", "thunderbolt", "xscissor"],
+                "abilities": ["Download"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["blazekick", "extremespeed", "ironhead", "uturn"]
+                "movepool": ["blazekick", "extremespeed", "ironhead", "uturn"],
+                "abilities": ["Download"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["bugbuzz", "flamethrower", "flashcannon", "icebeam", "thunderbolt", "uturn"],
+                "abilities": ["Download"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -4832,11 +5485,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bulkup", "drainpunch", "spikes", "synthesis", "toxic", "woodhammer"]
+                "movepool": ["bulkup", "drainpunch", "spikes", "synthesis", "toxic", "woodhammer"],
+                "abilities": ["Bulletproof"]
             },
             {
                 "role": "Staller",
-                "movepool": ["drainpunch", "leechseed", "spikyshield", "woodhammer"]
+                "movepool": ["drainpunch", "leechseed", "spikyshield", "woodhammer"],
+                "abilities": ["Bulletproof"]
             }
         ]
     },
@@ -4845,7 +5500,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "grassknot", "psyshock", "switcheroo"]
+                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "grassknot", "psyshock", "switcheroo"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -4854,7 +5510,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"]
+                "movepool": ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
+                "abilities": ["Protean"]
             }
         ]
     },
@@ -4864,11 +5521,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["agility", "earthquake", "knockoff", "quickattack", "return", "swordsdance"],
+                "abilities": ["Huge Power"],
                 "preferredTypes": ["Normal"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "foulplay", "quickattack", "return", "uturn"],
+                "abilities": ["Huge Power"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -4878,11 +5537,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "overheat", "roost", "uturn", "willowisp"]
+                "movepool": ["bravebird", "overheat", "roost", "uturn", "willowisp"],
+                "abilities": ["Gale Wings"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bravebird", "flareblitz", "roost", "swordsdance"]
+                "movepool": ["bravebird", "flareblitz", "roost", "swordsdance"],
+                "abilities": ["Gale Wings"]
             }
         ]
     },
@@ -4891,11 +5552,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["energyball", "hurricane", "quiverdance", "sleeppowder"]
+                "movepool": ["energyball", "hurricane", "quiverdance", "sleeppowder"],
+                "abilities": ["Compound Eyes"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bugbuzz", "hurricane", "quiverdance", "sleeppowder"]
+                "movepool": ["bugbuzz", "hurricane", "quiverdance", "sleeppowder"],
+                "abilities": ["Compound Eyes"]
             }
         ]
     },
@@ -4905,6 +5568,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp", "workup"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -4914,7 +5578,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerfire", "hiddenpowerground", "lightofruin", "moonblast", "psychic"]
+                "movepool": ["hiddenpowerfire", "hiddenpowerground", "lightofruin", "moonblast", "psychic"],
+                "abilities": ["Flower Veil"]
             }
         ]
     },
@@ -4923,15 +5588,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "moonblast", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "moonblast", "synthesis", "toxic"],
+                "abilities": ["Flower Veil"]
             },
             {
                 "role": "Staller",
-                "movepool": ["moonblast", "protect", "toxic", "wish"]
+                "movepool": ["moonblast", "protect", "toxic", "wish"],
+                "abilities": ["Flower Veil"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerground", "moonblast", "synthesis"]
+                "movepool": ["calmmind", "hiddenpowerground", "moonblast", "synthesis"],
+                "abilities": ["Flower Veil"]
             }
         ]
     },
@@ -4940,7 +5608,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "earthquake", "hornleech", "milkdrink", "toxic"]
+                "movepool": ["bulkup", "earthquake", "hornleech", "milkdrink", "toxic"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },
@@ -4950,6 +5619,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["drainpunch", "gunkshot", "icepunch", "knockoff", "partingshot", "superpower", "swordsdance"],
+                "abilities": ["Iron Fist", "Scrappy"],
                 "preferredTypes": ["Poison"]
             }
         ]
@@ -4959,11 +5629,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["darkpulse", "rest", "return", "thunderwave", "toxic", "uturn"]
+                "movepool": ["darkpulse", "rest", "return", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Fur Coat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["cottonguard", "rest", "return", "substitute", "toxic"]
+                "movepool": ["cottonguard", "rest", "return", "substitute", "toxic"],
+                "abilities": ["Fur Coat"]
             }
         ]
     },
@@ -4972,7 +5644,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "signalbeam", "thunderwave", "toxic", "yawn"]
+                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "signalbeam", "thunderwave", "toxic", "yawn"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -4981,7 +5654,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "darkpulse", "psychic", "psyshock", "signalbeam", "thunderbolt"]
+                "movepool": ["calmmind", "darkpulse", "psychic", "psyshock", "signalbeam", "thunderbolt"],
+                "abilities": ["Competitive"]
             }
         ]
     },
@@ -4990,7 +5664,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
+                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+                "abilities": ["No Guard"]
             }
         ]
     },
@@ -4999,11 +5674,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["ironhead", "kingsshield", "shadowball", "substitute", "toxic"]
+                "movepool": ["ironhead", "kingsshield", "shadowball", "substitute", "toxic"],
+                "abilities": ["Stance Change"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+                "abilities": ["Stance Change"],
                 "preferredTypes": ["Steel"]
             }
         ]
@@ -5013,7 +5690,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["calmmind", "moonblast", "protect", "toxic", "wish"]
+                "movepool": ["calmmind", "moonblast", "protect", "toxic", "wish"],
+                "abilities": ["Aroma Veil"]
             }
         ]
     },
@@ -5022,7 +5700,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "drainpunch", "playrough", "return"]
+                "movepool": ["bellydrum", "drainpunch", "playrough", "return"],
+                "abilities": ["Unburden"]
             }
         ]
     },
@@ -5031,11 +5710,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["knockoff", "rest", "sleeptalk", "superpower"]
+                "movepool": ["knockoff", "rest", "sleeptalk", "superpower"],
+                "abilities": ["Contrary"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["knockoff", "psychocut", "rest", "superpower"]
+                "movepool": ["knockoff", "psychocut", "rest", "superpower"],
+                "abilities": ["Contrary"]
             }
         ]
     },
@@ -5044,7 +5725,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "lowkick", "razorshell", "shellsmash", "stoneedge"]
+                "movepool": ["earthquake", "lowkick", "razorshell", "shellsmash", "stoneedge"],
+                "abilities": ["Tough Claws"]
             }
         ]
     },
@@ -5053,11 +5735,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "focusblast", "sludgewave", "toxicspikes"]
+                "movepool": ["dracometeor", "focusblast", "sludgewave", "toxicspikes"],
+                "abilities": ["Adaptability"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "dragonpulse", "focusblast", "sludgewave"]
+                "movepool": ["dracometeor", "dragonpulse", "focusblast", "sludgewave"],
+                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -5066,7 +5750,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["aurasphere", "darkpulse", "icebeam", "scald", "uturn", "waterpulse"]
+                "movepool": ["aurasphere", "darkpulse", "icebeam", "scald", "uturn", "waterpulse"],
+                "abilities": ["Mega Launcher"]
             }
         ]
     },
@@ -5076,11 +5761,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["darkpulse", "glare", "hypervoice", "surf", "thunderbolt", "voltswitch"],
+                "abilities": ["Dry Skin"],
                 "preferredTypes": ["Normal"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hypervoice", "raindance", "surf", "thunder"]
+                "movepool": ["hypervoice", "raindance", "surf", "thunder"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -5090,6 +5777,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["dragondance", "earthquake", "headsmash", "outrage", "stealthrock", "superpower"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -5100,11 +5788,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["ancientpower", "blizzard", "earthpower", "freezedry", "haze", "stealthrock", "thunderwave"],
+                "abilities": ["Snow Warning"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["ancientpower", "earthpower", "freezedry", "haze", "hypervoice", "stealthrock", "thunderwave"],
+                "abilities": ["Refrigerate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -5114,11 +5804,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "hiddenpowerground", "hypervoice", "protect", "psyshock", "wish"]
+                "movepool": ["calmmind", "hiddenpowerground", "hypervoice", "protect", "psyshock", "wish"],
+                "abilities": ["Pixilate"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hypervoice", "protect", "wish"]
+                "movepool": ["calmmind", "hypervoice", "protect", "wish"],
+                "abilities": ["Pixilate"]
             }
         ]
     },
@@ -5127,7 +5819,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["acrobatics", "highjumpkick", "skyattack", "substitute", "swordsdance"]
+                "movepool": ["acrobatics", "highjumpkick", "skyattack", "substitute", "swordsdance"],
+                "abilities": ["Unburden"]
             }
         ]
     },
@@ -5136,11 +5829,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "recycle", "thunderbolt", "toxic"]
+                "movepool": ["protect", "recycle", "thunderbolt", "toxic"],
+                "abilities": ["Cheek Pouch"]
             },
             {
                 "role": "Staller",
-                "movepool": ["recycle", "substitute", "superfang", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["recycle", "substitute", "superfang", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Cheek Pouch"]
             }
         ]
     },
@@ -5149,7 +5844,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["lightscreen", "moonblast", "powergem", "reflect", "stealthrock", "toxic"]
+                "movepool": ["lightscreen", "moonblast", "powergem", "reflect", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -5158,7 +5854,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"]
+                "movepool": ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },
@@ -5167,11 +5864,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "foulplay", "spikes", "thunderwave"]
+                "movepool": ["dazzlinggleam", "foulplay", "spikes", "thunderwave"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["magnetrise", "playrough", "spikes", "thunderwave"]
+                "movepool": ["magnetrise", "playrough", "spikes", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -5180,11 +5879,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"]
+                "movepool": ["earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "hornleech", "protect", "toxic"]
+                "movepool": ["earthquake", "hornleech", "protect", "toxic"],
+                "abilities": ["Harvest"]
             }
         ]
     },
@@ -5193,7 +5894,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
+                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -5202,7 +5904,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
+                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -5211,7 +5914,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
+                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -5220,7 +5924,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
+                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -5229,7 +5934,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["avalanche", "curse", "earthquake", "rapidspin", "recover"]
+                "movepool": ["avalanche", "curse", "earthquake", "rapidspin", "recover"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -5238,7 +5944,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["boomburst", "dracometeor", "flamethrower", "hurricane", "roost", "switcheroo", "uturn"]
+                "movepool": ["boomburst", "dracometeor", "flamethrower", "hurricane", "roost", "switcheroo", "uturn"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -5247,7 +5954,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "geomancy", "moonblast", "psyshock"]
+                "movepool": ["focusblast", "geomancy", "moonblast", "psyshock"],
+                "abilities": ["Fairy Aura"]
             }
         ]
     },
@@ -5256,7 +5964,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"]
+                "movepool": ["knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
+                "abilities": ["Dark Aura"]
             }
         ]
     },
@@ -5265,7 +5974,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "glare", "outrage", "substitute"]
+                "movepool": ["dragondance", "earthquake", "extremespeed", "glare", "outrage", "substitute"],
+                "abilities": ["Aura Break"]
             }
         ]
     },
@@ -5274,7 +5984,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["diamondstorm", "earthpower", "healbell", "moonblast", "stealthrock", "toxic"]
+                "movepool": ["diamondstorm", "earthpower", "healbell", "moonblast", "stealthrock", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -5284,6 +5995,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "diamondstorm", "earthpower", "moonblast", "protect"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -5293,7 +6005,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "nastyplot", "psychic", "psyshock", "shadowball", "trick"]
+                "movepool": ["focusblast", "nastyplot", "psychic", "psyshock", "shadowball", "trick"],
+                "abilities": ["Magician"]
             }
         ]
     },
@@ -5303,11 +6016,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["drainpunch", "gunkshot", "hyperspacefury", "trick", "zenheadbutt"],
+                "abilities": ["Magician"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["drainpunch", "gunkshot", "hyperspacefury", "psychic", "trick"],
+                "abilities": ["Magician"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -5317,7 +6032,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "fireblast", "sludgebomb", "steameruption", "superpower", "toxic"]
+                "movepool": ["earthpower", "fireblast", "sludgebomb", "steameruption", "superpower", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     }

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -1,7 +1,6 @@
 import {MoveCounter, TeamData} from '../gen8/teams';
 import RandomGen7Teams, {BattleFactorySpecies, ZeroAttackHPIVs} from '../gen7/teams';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
-import {Utils} from '../../../lib';
 import {toID} from '../../../sim/dex';
 
 // Moves that restore HP:
@@ -74,7 +73,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		this.moveEnforcementCheckers = {
 			Bug: (movePool, moves, abilities, types, counter) => (
 				['megahorn', 'pinmissile'].some(m => movePool.includes(m)) ||
-				!counter.get('Bug') && abilities.has('Tinted Lens')
+				!counter.get('Bug') && abilities.includes('Tinted Lens')
 			),
 			Dark: (movePool, moves, abilities, types, counter) => !counter.get('Dark'),
 			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
@@ -83,7 +82,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting'),
 			Fire: (movePool, moves, abilities, types, counter) => !counter.get('Fire'),
 			Flying: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Flying') && !['aerodactylmega', 'charizardmegay', 'mantine', 'murkrow'].includes(species.id) &&
+				!counter.get('Flying') && !['aerodactyl', 'aerodactylmega', 'mantine', 'murkrow'].includes(species.id) &&
 				!movePool.includes('hiddenpowerflying')
 			),
 			Ghost: (movePool, moves, abilities, types, counter) => !counter.get('Ghost'),
@@ -92,8 +91,8 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (
-				!counter.get('Ice') || (!moves.has('blizzard') && movePool.includes('freezedry')) ||
-				abilities.has('Refrigerate') && (movePool.includes('return') || movePool.includes('hypervoice'))
+				!counter.get('Ice') || (moves.has('icebeam') && movePool.includes('freezedry')) ||
+				abilities.includes('Refrigerate') && (movePool.includes('return') || movePool.includes('hypervoice'))
 			),
 			Normal: movePool => movePool.includes('boomburst'),
 			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
@@ -101,7 +100,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				!counter.get('Psychic') && (types.has('Fighting') || movePool.includes('calmmind'))
 			),
 			Rock: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Rock') && (species.baseStats.atk >= 95 || abilities.has('Rock Head'))
+				!counter.get('Rock') && (species.baseStats.atk >= 95 || abilities.includes('Rock Head'))
 			),
 			Steel: (movePool, moves, abilities, types, counter, species) => (
 				!counter.get('Steel') && species.baseStats.atk >= 100
@@ -113,7 +112,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 	cullMovePool(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -263,11 +262,11 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		}
 
 		const statusInflictingMoves = ['thunderwave', 'toxic', 'willowisp', 'yawn'];
-		if (!abilities.has('Prankster') && role !== 'Staller') {
+		if (!abilities.includes('Prankster') && role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}
 
-		if (abilities.has('Guts')) this.incompatibleMoves(moves, movePool, 'protect', 'swordsdance');
+		if (abilities.includes('Guts')) this.incompatibleMoves(moves, movePool, 'protect', 'swordsdance');
 
 		// Force Protect and U-turn on Beedrill-Mega
 		if (species.id === 'beedrillmega') {
@@ -290,7 +289,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 	// Generate random moveset for a given species, role, preferred type.
 	randomMoveset(
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -331,7 +330,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		// Add other moves you really want to have, e.g. STAB, recovery, setup.
 
 		// Enforce Facade if Guts is a possible ability
-		if (movePool.includes('facade') && abilities.has('Guts')) {
+		if (movePool.includes('facade') && abilities.includes('Guts')) {
 			counter = this.addMove('facade', moves, types, abilities, teamDetails, species, isLead,
 				movePool, preferredType, role);
 		}
@@ -345,7 +344,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		}
 
 		// Enforce Thunder Wave on Prankster users
-		if (movePool.includes('thunderwave') && abilities.has('Prankster')) {
+		if (movePool.includes('thunderwave') && abilities.includes('Prankster')) {
 			counter = this.addMove('thunderwave', moves, types, abilities, teamDetails, species, isLead,
 				movePool, preferredType, role);
 		}
@@ -535,7 +534,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -544,92 +543,22 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		role: RandomTeamsTypes.Role
 	): boolean {
 		switch (ability) {
-		case 'Flare Boost': case 'Gluttony': case 'Harvest': case 'Ice Body': case 'Magician':
-		case 'Moody': case 'Pressure': case 'Sand Veil': case 'Sniper': case 'Snow Cloak': case 'Steadfast':
-			return true;
-		case 'Aerilate': case 'Pixilate': case 'Refrigerate':
-			return ['doubleedge', 'hypervoice', 'return'].every(m => !moves.has(m));
-		case 'Chlorophyll':
-			// Petal Dance is for Lilligant
-			return (
-				species.baseStats.spe > 100 || moves.has('petaldance') ||
-				(!moves.has('sunnyday') && !teamDetails.sun)
-			);
-		case 'Competitive':
-			return !counter.get('Special');
-		case 'Compound Eyes': case 'No Guard':
-			return !counter.get('inaccurate');
-		case 'Contrary': case 'Skill Link': case 'Strong Jaw':
+		case 'Chlorophyll': case 'Solar Power':
+			return !teamDetails.sun;
+		case 'Hydration': case 'Swift Swim':
+			return !teamDetails.rain;
+		case 'Iron Fist': case 'Sheer Force': case 'Technician':
 			return !counter.get(toID(ability));
-		case 'Defiant': case 'Justified':
-			return !counter.get('Physical');
-		case 'Guts':
-			return (!moves.has('facade') && !moves.has('sleeptalk'));
-		case 'Hustle':
-			return counter.get('Physical') < 2;
-		case 'Hydration': case 'Rain Dish': case 'Swift Swim':
-			return (
-				species.baseStats.spe > 100 || !moves.has('raindance') && !teamDetails.rain ||
-				!moves.has('raindance') && ['Rock Head', 'Water Absorb'].some(abil => abilities.has(abil))
-			);
-		case 'Intimidate':
-			// Slam part is for Tauros
-			return (moves.has('bodyslam') || species.id === 'staraptor');
-		case 'Iron Fist':
-			return (!counter.get(toID(ability)) || species.id === 'golurk');
-		case 'Lightning Rod':
-			return (types.has('Ground') || ((!!teamDetails.rain || moves.has('raindance')) && species.id === 'seaking'));
-		case 'Magic Guard': case 'Speed Boost':
-			return (abilities.has('Tinted Lens') && role === 'Wallbreaker');
-		case 'Mold Breaker':
-			return (species.baseSpecies === 'Basculin' || species.id === 'pangoro' || abilities.has('Sheer Force'));
-		case 'Moxie':
-			return (!counter.get('Physical') || moves.has('stealthrock') || (!!species.isMega && abilities.has('Intimidate')));
-		case 'Oblivious': case 'Prankster':
-			return (!counter.get('Status') || (species.id === 'tornadus' && moves.has('bulkup')));
-		case 'Overcoat':
-			return types.has('Grass');
 		case 'Overgrow':
 			return !counter.get('Grass');
-		case 'Shed Skin':
-			return !moves.has('rest');
-		case 'Synchronize':
-			return (counter.get('Status') < 2 || !!counter.get('recoil') || !!species.isMega);
-		case 'Regenerator':
-			return species.id === 'mienshao' || species.id === 'reuniclus';
-		case 'Reckless': case 'Rock Head':
-			return (!counter.get('recoil') || !!species.isMega);
+		case 'Prankster':
+			return !counter.get('Status');
+		case 'Rock Head':
+			return !counter.get('recoil');
 		case 'Sand Force': case 'Sand Rush':
 			return !teamDetails.sand;
-		case 'Scrappy':
-			return !types.has('Normal');
-		case 'Serene Grace':
-			return !counter.get('serenegrace');
-		case 'Sheer Force':
-			return (!counter.get('sheerforce') || moves.has('doubleedge') || abilities.has('Guts') || !!species.isMega);
-		case 'Simple':
-			return !counter.get('setup');
-		case 'Snow Warning':
-			// Aurorus
-			return moves.has('hypervoice');
-		case 'Solar Power':
-			return (!counter.get('Special') || !teamDetails.sun || !!species.isMega);
-		case 'Sturdy':
-			return (!!counter.get('recoil') && !counter.get('recovery') || species.id === 'steelix' && !!counter.get('sheerforce'));
 		case 'Swarm':
-			return ((!counter.get('Bug') && !moves.has('uturn')) || !!species.isMega);
-		case 'Technician':
-			return (!counter.get('technician') || moves.has('tailslap') || !!species.isMega);
-		case 'Tinted Lens':
-			return (['illumise', 'sigilyph', 'yanmega'].some(m => species.id === (m)) && role !== 'Wallbreaker');
-		case 'Torrent':
-			return (!counter.get('Water') || !!species.isMega);
-		case 'Unaware':
-			return (!['Bulky Setup', 'Bulky Support', 'Staller'].includes(role));
-		case 'Unburden':
-			return (!!species.isMega || !counter.get('setup') && !moves.has('acrobatics'));
-		case 'Water Absorb':
-			return moves.has('raindance') || ['Drizzle', 'Unaware', 'Volt Absorb'].some(abil => abilities.has(abil));
+			return !counter.get('Bug');
 		}
 
 		return false;
@@ -639,7 +568,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 	getAbility(
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -647,93 +576,38 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		preferredType: string,
 		role: RandomTeamsTypes.Role,
 	): string {
-		if (species.battleOnly && !species.requiredAbility) {
-			abilities = new Set(Object.values(this.dex.species.get(species.battleOnly as string).abilities));
-		}
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData.length <= 1) return abilityData[0].name;
+		if (abilities.length <= 1) return abilities[0];
 
 		// Hard-code abilities here
-		if (
-			abilities.has('Guts') &&
-			!abilities.has('Quick Feet') &&
-			(moves.has('facade') || (moves.has('sleeptalk') && moves.has('rest')))
-		) return 'Guts';
+		if (species.id === 'pangoro' && counter.get('ironfist')) return 'Iron Fist';
+		if (species.id === 'tornadus' && counter.get('Status')) return 'Prankster';
+		if (species.id === 'marowak' && counter.get('recoil')) return 'Rock Head';
+		if (species.id === 'kingler' && counter.get('sheerforce')) return 'Sheer Force';
+		if (species.id === 'roserade' && counter.get('technician')) return 'Technician';
 
-		if (species.id === 'starmie') return role === 'Wallbreaker' ? 'Analytic' : 'Natural Cure';
-		if (species.id === 'beheeyem') return 'Analytic';
-		if (species.id === 'ninetales') return 'Drought';
-		if (species.baseSpecies === 'Gourgeist') return 'Frisk';
-		if (species.id === 'pinsirmega') return 'Hyper Cutter';
-		if (species.id === 'ninjask' || species.id === 'seviper') return 'Infiltrator';
-		if (species.id === 'gligar') return 'Immunity';
-		if (species.id === 'arcanine' || species.id === 'stantler') return 'Intimidate';
-		if (species.id === 'lucariomega') return 'Justified';
-		if (species.id === 'persian' && !counter.get('technician')) return 'Limber';
-		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
-		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
-		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
-		if (species.id === 'muk') return 'Poison Touch';
-		if (['dusknoir', 'vespiquen'].includes(species.id)) return 'Pressure';
-		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
-		if (species.id === 'zebstrika') return moves.has('wildcharge') ? 'Sap Sipper' : 'Lightning Rod';
-		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
-		if (species.id === 'octillery') return 'Sniper';
-		if (species.id === 'stunfisk') return 'Static';
-		if (species.id === 'breloom') return 'Technician';
-		if (species.id === 'zangoose') return 'Toxic Boost';
-
-		if (abilities.has('Harvest') && (role === 'Bulky Support' || role === 'Staller')) return 'Harvest';
-		if (abilities.has('Regenerator') && role === 'AV Pivot') return 'Regenerator';
-		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
-		if (abilities.has('Sniper') && moves.has('focusenergy')) return 'Sniper';
-		if (abilities.has('Unburden') && ['acrobatics', 'bellydrum'].some(m => moves.has(m))) return 'Unburden';
-
-		let abilityAllowed: Ability[] = [];
+		const abilityAllowed: string[] = [];
 		// Obtain a list of abilities that are allowed (not culled)
-		for (const ability of abilityData) {
-			if (ability.rating >= 1 && !this.shouldCullAbility(
-				ability.name, types, moves, abilities, counter, movePool, teamDetails, species, preferredType, role
+		for (const ability of abilities) {
+			if (!this.shouldCullAbility(
+				ability, types, moves, abilities, counter, movePool, teamDetails, species, preferredType, role
 			)) {
 				abilityAllowed.push(ability);
 			}
 		}
 
-		// If all abilities are rejected, re-allow all abilities
+		// Pick a random allowed ability
+		if (abilityAllowed.length >= 1) return this.sample(abilityAllowed);
+
+		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
 		if (!abilityAllowed.length) {
-			for (const ability of abilityData) {
-				if (ability.rating > 0) abilityAllowed.push(ability);
-			}
-			if (!abilityAllowed.length) abilityAllowed = abilityData;
+			const weatherAbilities = abilities.filter(
+				a => ['Chlorophyll', 'Hydration', 'Sand Force', 'Sand Rush', 'Solar Power', 'Swift Swim'].includes(a)
+			);
+			if (weatherAbilities.length) return this.sample(weatherAbilities);
 		}
 
-		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
-		// Sort abilities by rating with an element of randomness
-		// All three abilities can be chosen
-		if (abilityAllowed[2] && abilityAllowed[0].rating - 0.5 <= abilityAllowed[2].rating) {
-			if (abilityAllowed[1].rating <= abilityAllowed[2].rating) {
-				if (this.randomChance(1, 2)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
-			} else {
-				if (this.randomChance(1, 3)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
-			}
-			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-				if (this.randomChance(2, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			} else {
-				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			}
-		} else {
-			// Third ability cannot be chosen
-			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
-				if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			}
-		}
-
-		// After sorting, choose the first ability
-		return abilityAllowed[0].name;
+		// Pick a random ability
+		return this.sample(abilities);
 	}
 
 	getPriorityItem(
@@ -903,8 +777,9 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const types = species.types;
-		const abilities = new Set(Object.values(species.abilities));
-		if (species.unreleasedHidden) abilities.delete(species.abilities.H);
+		const baseAbilities = set.abilities!;
+		// Use the mega's ability for moveset generation
+		const abilities = (species.battleOnly && !species.requiredAbility) ? Object.values(species.abilities) : baseAbilities;
 
 		// Get moves
 		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, movePool,
@@ -912,7 +787,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		const counter = this.newQueryMoves(moves, species, preferredType, abilities);
 
 		// Get ability
-		ability = this.getAbility(new Set(types), moves, abilities, counter, movePool, teamDetails, species,
+		ability = this.getAbility(new Set(types), moves, baseAbilities, counter, movePool, teamDetails, species,
 			preferredType, role);
 
 		// Get items

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -4,11 +4,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"]
+                "movepool": ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
+                "abilities": ["Chlorophyll", "Overgrow"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "energyball", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "energyball", "knockoff", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Chlorophyll", "Overgrow"]
             }
         ]
     },
@@ -17,7 +19,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "gigadrain", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "gigadrain", "knockoff", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -27,11 +30,13 @@
             {
                 "role": "Z-Move user",
                 "movepool": ["airslash", "earthquake", "fireblast", "holdhands", "roost"],
+                "abilities": ["Blaze", "Solar Power"],
                 "preferredTypes": ["Normal"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "earthquake", "fireblast", "roost", "willowisp"]
+                "movepool": ["airslash", "earthquake", "fireblast", "roost", "willowisp"],
+                "abilities": ["Blaze", "Solar Power"]
             }
         ]
     },
@@ -40,7 +45,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragonclaw", "dragondance", "earthquake", "flareblitz", "roost"]
+                "movepool": ["dragonclaw", "dragondance", "earthquake", "flareblitz", "roost"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -49,11 +55,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "fireblast", "roost", "solarbeam"]
+                "movepool": ["airslash", "fireblast", "roost", "solarbeam"],
+                "abilities": ["Blaze"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dragonpulse", "fireblast", "roost", "solarbeam"]
+                "movepool": ["dragonpulse", "fireblast", "roost", "solarbeam"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -62,11 +70,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "rapidspin", "roar", "scald", "toxic"]
+                "movepool": ["icebeam", "rapidspin", "roar", "scald", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["haze", "icebeam", "protect", "rapidspin", "scald", "toxic"]
+                "movepool": ["haze", "icebeam", "protect", "rapidspin", "scald", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -75,7 +85,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aurasphere", "darkpulse", "icebeam", "rapidspin", "scald"]
+                "movepool": ["aurasphere", "darkpulse", "icebeam", "rapidspin", "scald"],
+                "abilities": ["Rain Dish"]
             }
         ]
     },
@@ -84,11 +95,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "quiverdance", "sleeppowder"]
+                "movepool": ["airslash", "bugbuzz", "quiverdance", "sleeppowder"],
+                "abilities": ["Tinted Lens"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["airslash", "bugbuzz", "quiverdance", "sleeppowder"],
+                "abilities": ["Tinted Lens"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -98,7 +111,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "knockoff", "poisonjab", "toxicspikes", "uturn"]
+                "movepool": ["defog", "knockoff", "poisonjab", "toxicspikes", "uturn"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -107,11 +121,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drillrun", "knockoff", "poisonjab", "swordsdance", "xscissor"]
+                "movepool": ["drillrun", "knockoff", "poisonjab", "swordsdance", "xscissor"],
+                "abilities": ["Swarm"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["drillrun", "knockoff", "poisonjab", "uturn"]
+                "movepool": ["drillrun", "knockoff", "poisonjab", "uturn"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -120,7 +136,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "heatwave", "return", "roost", "uturn"]
+                "movepool": ["bravebird", "defog", "heatwave", "return", "roost", "uturn"],
+                "abilities": ["Big Pecks"]
             }
         ]
     },
@@ -129,7 +146,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "heatwave", "hurricane", "roost", "uturn", "workup"]
+                "movepool": ["defog", "heatwave", "hurricane", "roost", "uturn", "workup"],
+                "abilities": ["Big Pecks"]
             }
         ]
     },
@@ -139,6 +157,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["crunch", "facade", "protect", "stompingtantrum", "suckerpunch", "swordsdance", "uturn"],
+                "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -148,11 +167,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "knockoff", "pursuit", "return", "suckerpunch", "swordsdance"]
+                "movepool": ["doubleedge", "knockoff", "pursuit", "return", "suckerpunch", "swordsdance"],
+                "abilities": ["Hustle"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["doubleedge", "knockoff", "suckerpunch", "swordsdance"],
+                "abilities": ["Hustle"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -162,11 +183,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"]
+                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"],
+                "abilities": ["Sniper"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drillpeck", "drillrun", "focusenergy", "return"]
+                "movepool": ["drillpeck", "drillrun", "focusenergy", "return"],
+                "abilities": ["Sniper"]
             }
         ]
     },
@@ -175,8 +198,14 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquatail", "coil", "earthquake", "gunkshot", "rest", "suckerpunch"],
+                "movepool": ["aquatail", "coil", "earthquake", "gunkshot", "suckerpunch"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["coil", "earthquake", "gunkshot", "rest"],
+                "abilities": ["Shed Skin"]
             }
         ]
     },
@@ -185,7 +214,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "surf", "voltswitch", "volttackle"]
+                "movepool": ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "surf", "voltswitch", "volttackle"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -195,11 +225,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["encore", "hiddenpowerice", "knockoff", "nastyplot", "nuzzle", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "grassknot", "nastyplot", "surf", "thunderbolt", "voltswitch"]
+                "movepool": ["focusblast", "grassknot", "nastyplot", "surf", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -209,16 +241,19 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["focusblast", "psyshock", "surf", "thunderbolt", "voltswitch"],
+                "abilities": ["Surge Surfer"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["focusblast", "nastyplot", "psyshock", "surf", "thunderbolt"],
+                "abilities": ["Surge Surfer"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["focusblast", "nastyplot", "psyshock", "surf", "thunderbolt"],
+                "abilities": ["Surge Surfer"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -228,7 +263,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "toxic"]
+                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+                "abilities": ["Sand Rush"]
             }
         ]
     },
@@ -237,7 +273,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "iciclecrash", "ironhead", "knockoff", "rapidspin", "stealthrock", "swordsdance"]
+                "movepool": ["earthquake", "iciclecrash", "ironhead", "knockoff", "rapidspin", "stealthrock", "swordsdance"],
+                "abilities": ["Slush Rush"]
             }
         ]
     },
@@ -247,6 +284,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -257,6 +295,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "substitute", "superpower"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -266,11 +305,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "knockoff", "moonblast", "softboiled", "stealthrock", "thunderwave"]
+                "movepool": ["aromatherapy", "knockoff", "moonblast", "softboiled", "stealthrock", "thunderwave"],
+                "abilities": ["Magic Guard", "Unaware"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "moonblast", "softboiled"]
+                "movepool": ["calmmind", "fireblast", "moonblast", "softboiled"],
+                "abilities": ["Magic Guard", "Unaware"]
             }
         ]
     },
@@ -279,11 +320,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam"]
+                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam"],
+                "abilities": ["Drought"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["fireblast", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "abilities": ["Drought"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -293,7 +336,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["auroraveil", "blizzard", "encore", "freezedry", "hiddenpowerground", "moonblast", "nastyplot"]
+                "movepool": ["auroraveil", "blizzard", "encore", "freezedry", "hiddenpowerground", "moonblast", "nastyplot"],
+                "abilities": ["Snow Warning"]
             }
         ]
     },
@@ -302,7 +346,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "fireblast", "healbell", "knockoff", "protect", "stealthrock", "thunderwave", "wish"]
+                "movepool": ["dazzlinggleam", "fireblast", "healbell", "knockoff", "protect", "stealthrock", "thunderwave", "wish"],
+                "abilities": ["Competitive"]
             }
         ]
     },
@@ -311,7 +356,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "sleeppowder", "sludgebomb", "strengthsap"]
+                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "sleeppowder", "sludgebomb", "strengthsap"],
+                "abilities": ["Effect Spore"]
             }
         ]
     },
@@ -321,6 +367,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aromatherapy", "knockoff", "leechlife", "seedbomb", "spore", "stunspore", "swordsdance"],
+                "abilities": ["Dry Skin"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -330,11 +377,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb"]
+                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb"],
+                "abilities": ["Tinted Lens"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["bugbuzz", "quiverdance", "roost", "sleeppowder", "sludgebomb"],
+                "abilities": ["Tinted Lens"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -344,7 +393,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"]
+                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"],
+                "abilities": ["Arena Trap"]
             }
         ]
     },
@@ -353,7 +403,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "ironhead", "stealthrock", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["earthquake", "ironhead", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Sand Force", "Tangling Hair"]
             }
         ]
     },
@@ -362,12 +413,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "fakeout", "gunkshot", "knockoff", "return", "seedbomb", "taunt", "uturn"],
-                "preferredTypes": ["Dark"]
+                "movepool": ["doubleedge", "knockoff", "return", "seedbomb", "uturn"],
+                "abilities": ["Limber"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["doubleedge", "fakeout", "knockoff", "return", "uturn"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfighting", "hypervoice", "nastyplot", "shadowball"]
+                "movepool": ["hiddenpowerfighting", "hypervoice", "nastyplot", "shadowball"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -376,11 +433,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["darkpulse", "hiddenpowerfighting", "hypnosis", "nastyplot", "powergem", "thunderbolt"]
+                "movepool": ["darkpulse", "hiddenpowerfighting", "hypnosis", "nastyplot", "powergem", "thunderbolt"],
+                "abilities": ["Fur Coat"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["darkpulse", "hiddenpowerfighting", "hypnosis", "nastyplot", "powergem", "thunderbolt"],
+                "abilities": ["Fur Coat"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -391,6 +450,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "encore", "focusblast", "hydropump", "icebeam", "psyshock", "scald"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -400,11 +460,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "gunkshot", "stoneedge", "throatchop", "uturn"]
+                "movepool": ["closecombat", "earthquake", "gunkshot", "stoneedge", "throatchop", "uturn"],
+                "abilities": ["Defiant"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["closecombat", "earthquake", "gunkshot", "honeclaws", "stoneedge", "throatchop"],
+                "abilities": ["Defiant"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -414,11 +476,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"]
+                "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "wildcharge"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -428,11 +492,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icepunch", "raindance", "waterfall"]
+                "movepool": ["focusblast", "icepunch", "raindance", "waterfall"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["circlethrow", "rest", "scald", "sleeptalk"]
+                "movepool": ["circlethrow", "rest", "scald", "sleeptalk"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -441,11 +507,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"]
+                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+                "abilities": ["Magic Guard"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -456,6 +524,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+                "abilities": ["Magic Guard"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -466,15 +535,18 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "knockoff", "stoneedge"],
+                "abilities": ["No Guard"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bulletpunch", "dynamicpunch", "knockoff", "stoneedge"]
+                "movepool": ["bulletpunch", "dynamicpunch", "knockoff", "stoneedge"],
+                "abilities": ["No Guard"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["bulkup", "bulletpunch", "closecombat", "facade", "knockoff"],
+                "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -484,15 +556,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["poisonjab", "powerwhip", "suckerpunch", "swordsdance"]
+                "movepool": ["poisonjab", "powerwhip", "suckerpunch", "swordsdance"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerground", "knockoff", "powerwhip", "sleeppowder", "sludgebomb", "strengthsap", "suckerpunch"]
+                "movepool": ["hiddenpowerground", "knockoff", "powerwhip", "sleeppowder", "sludgebomb", "strengthsap", "suckerpunch"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["powerwhip", "sludgebomb", "sunnyday", "weatherball"]
+                "movepool": ["powerwhip", "sludgebomb", "sunnyday", "weatherball"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -501,7 +576,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "knockoff", "rapidspin", "scald", "sludgebomb", "toxicspikes"]
+                "movepool": ["haze", "knockoff", "rapidspin", "scald", "sludgebomb", "toxicspikes"],
+                "abilities": ["Clear Body", "Liquid Ooze"]
             }
         ]
     },
@@ -510,11 +586,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge", "suckerpunch"]
+                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge", "suckerpunch"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -523,11 +601,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "firepunch", "stealthrock", "stoneedge", "wildcharge"]
+                "movepool": ["earthquake", "firepunch", "stealthrock", "stoneedge", "wildcharge"],
+                "abilities": ["Magnet Pull"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["autotomize", "earthquake", "explosion", "return", "stoneedge"],
+                "abilities": ["Galvanize"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -537,11 +617,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["flareblitz", "highhorsepower", "morningsun", "wildcharge", "willowisp"]
+                "movepool": ["flareblitz", "highhorsepower", "morningsun", "wildcharge", "willowisp"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["flareblitz", "highhorsepower", "megahorn", "morningsun", "wildcharge"]
+                "movepool": ["flareblitz", "highhorsepower", "megahorn", "morningsun", "wildcharge"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -550,11 +632,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["fireblast", "futuresight", "icebeam", "psyshock", "scald"]
+                "movepool": ["fireblast", "futuresight", "icebeam", "psyshock", "scald"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -563,7 +647,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "fireblast", "psyshock", "scald", "slackoff"]
+                "movepool": ["calmmind", "fireblast", "psyshock", "scald", "slackoff"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -572,7 +657,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"]
+                "movepool": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -582,11 +668,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bravebird", "jumpkick", "knockoff", "quickattack", "return", "swordsdance"],
+                "abilities": ["Early Bird"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["bravebird", "jumpkick", "knockoff", "return", "swordsdance"],
+                "abilities": ["Early Bird"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -596,11 +684,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "surf", "toxic"]
+                "movepool": ["encore", "icebeam", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -610,6 +700,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["brickbreak", "curse", "gunkshot", "haze", "icepunch", "poisonjab", "shadowsneak"],
+                "abilities": ["Poison Touch"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -619,11 +710,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "gunkshot", "knockoff", "recycle"]
+                "movepool": ["curse", "gunkshot", "knockoff", "recycle"],
+                "abilities": ["Gluttony"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["firepunch", "gunkshot", "icepunch", "knockoff", "poisonjab", "pursuit", "shadowsneak"]
+                "movepool": ["firepunch", "gunkshot", "icepunch", "knockoff", "poisonjab", "pursuit", "shadowsneak"],
+                "abilities": ["Poison Touch"]
             }
         ]
     },
@@ -632,7 +725,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hydropump", "iciclespear", "rockblast", "shellsmash"]
+                "movepool": ["hydropump", "iciclespear", "rockblast", "shellsmash"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -641,7 +735,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "painsplit", "shadowball", "sludgewave", "substitute", "trick", "willowisp"]
+                "movepool": ["focusblast", "painsplit", "shadowball", "sludgewave", "substitute", "trick", "willowisp"],
+                "abilities": ["Cursed Body"]
             }
         ]
     },
@@ -650,11 +745,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["disable", "perishsong", "protect", "shadowball", "substitute"]
+                "movepool": ["disable", "perishsong", "protect", "shadowball", "substitute"],
+                "abilities": ["Cursed Body"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["destinybond", "disable", "focusblast", "shadowball", "sludgewave", "taunt"]
+                "movepool": ["destinybond", "disable", "focusblast", "shadowball", "sludgewave", "taunt"],
+                "abilities": ["Cursed Body"]
             }
         ]
     },
@@ -663,11 +760,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "foulplay", "protect", "psychic", "thunderwave", "toxic", "wish"]
+                "movepool": ["focusblast", "foulplay", "protect", "psychic", "thunderwave", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -676,7 +775,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "knockoff", "liquidation", "rockslide", "superpower", "swordsdance", "xscissor"]
+                "movepool": ["agility", "knockoff", "liquidation", "rockslide", "superpower", "swordsdance", "xscissor"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -686,11 +786,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["foulplay", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"],
+                "abilities": ["Aftermath", "Static"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["hiddenpowerice", "lightscreen", "reflect", "thunderbolt", "thunderwave", "toxic", "voltswitch"]
+                "movepool": ["hiddenpowerice", "lightscreen", "reflect", "thunderbolt", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Aftermath", "Static"]
             }
         ]
     },
@@ -700,6 +802,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["gigadrain", "hiddenpowerfire", "leechseed", "psychic", "sleeppowder", "substitute"],
+                "abilities": ["Harvest"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -709,15 +812,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "flamethrower", "gigadrain", "leafstorm", "trickroom"]
+                "movepool": ["dracometeor", "flamethrower", "gigadrain", "leafstorm", "trickroom"],
+                "abilities": ["Frisk"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "flamethrower", "gigadrain", "leafstorm"]
+                "movepool": ["dracometeor", "flamethrower", "gigadrain", "leafstorm"],
+                "abilities": ["Frisk"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["dracometeor", "flamethrower", "gigadrain", "knockoff"]
+                "movepool": ["dracometeor", "flamethrower", "gigadrain", "knockoff"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -727,6 +833,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "knockoff", "stealthrock", "stoneedge", "swordsdance"],
+                "abilities": ["Battle Armor", "Rock Head"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -736,7 +843,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "flamecharge", "flareblitz", "shadowbone", "stealthrock", "stoneedge", "swordsdance", "willowisp"]
+                "movepool": ["earthquake", "flamecharge", "flareblitz", "shadowbone", "stealthrock", "stoneedge", "swordsdance", "willowisp"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -746,11 +854,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["highjumpkick", "knockoff", "machpunch", "poisonjab", "rapidspin", "stoneedge"],
+                "abilities": ["Reckless"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["closecombat", "curse", "knockoff", "poisonjab", "stoneedge"],
+                "abilities": ["Unburden"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -760,7 +870,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge", "throatchop"]
+                "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge", "throatchop"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -769,7 +880,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "painsplit", "sludgebomb", "toxicspikes", "willowisp"]
+                "movepool": ["fireblast", "painsplit", "sludgebomb", "toxicspikes", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -778,7 +890,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"]
+                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -787,7 +900,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -796,11 +910,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["doubleedge", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
+                "movepool": ["doubleedge", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
+                "movepool": ["drainpunch", "earthquake", "fakeout", "return", "suckerpunch"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -809,11 +925,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bodyslam", "crunch", "fakeout", "seismictoss", "suckerpunch"]
+                "movepool": ["bodyslam", "crunch", "fakeout", "seismictoss", "suckerpunch"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["bodyslam", "crunch", "earthquake", "poweruppunch", "return", "suckerpunch"],
+                "abilities": ["Scrappy"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -823,7 +941,14 @@
         "sets": [
             {
                 "role": "Fast Attacker",
+                "movepool": ["drillrun", "icebeam", "knockoff", "megahorn", "waterfall"],
+                "abilities": ["Lightning Rod"],
+                "preferredTypes": ["Dark"]
+            },
+            {
+                "role": "Setup Sweeper",
                 "movepool": ["drillrun", "icebeam", "knockoff", "megahorn", "raindance", "waterfall"],
+                "abilities": ["Swift Swim"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -833,11 +958,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hydropump", "icebeam", "psyshock", "recover", "thunderbolt"]
+                "movepool": ["hydropump", "icebeam", "psyshock", "recover", "thunderbolt"],
+                "abilities": ["Analytic"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["psyshock", "rapidspin", "recover", "scald", "thunderwave", "toxic"]
+                "movepool": ["psyshock", "rapidspin", "recover", "scald", "thunderwave", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -847,6 +974,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["dazzlinggleam", "encore", "focusblast", "healingwish", "nastyplot", "psychic", "psyshock", "shadowball"],
+                "abilities": ["Filter"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -856,11 +984,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "brickbreak", "knockoff", "pursuit", "uturn"]
+                "movepool": ["aerialace", "brickbreak", "knockoff", "pursuit", "uturn"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aerialace", "brickbreak", "bugbite", "knockoff", "roost", "swordsdance"]
+                "movepool": ["aerialace", "brickbreak", "bugbite", "knockoff", "roost", "swordsdance"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -869,11 +999,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "psychic", "psyshock", "trick"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "psychic", "psyshock", "trick"],
+                "abilities": ["Dry Skin"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -883,6 +1015,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "knockoff", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Mold Breaker", "Moxie"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -892,7 +1025,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["closecombat", "earthquake", "quickattack", "return", "swordsdance"]
+                "movepool": ["closecombat", "earthquake", "quickattack", "return", "swordsdance"],
+                "abilities": ["Moxie"]
             }
         ]
     },
@@ -902,11 +1036,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["bodyslam", "earthquake", "fireblast", "rockslide", "zenheadbutt"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "stoneedge", "zenheadbutt"]
+                "movepool": ["doubleedge", "earthquake", "stoneedge", "zenheadbutt"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -915,11 +1051,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "stoneedge", "substitute", "waterfall"]
+                "movepool": ["dragondance", "earthquake", "stoneedge", "substitute", "waterfall"],
+                "abilities": ["Intimidate", "Moxie"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["bounce", "dragondance", "earthquake", "waterfall"],
+                "abilities": ["Moxie"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -929,7 +1067,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "substitute", "waterfall"]
+                "movepool": ["crunch", "dragondance", "earthquake", "substitute", "waterfall"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -938,11 +1077,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["freezedry", "healbell", "hydropump", "icebeam", "toxic"]
+                "movepool": ["freezedry", "healbell", "hydropump", "icebeam", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["freezedry", "hydropump", "protect", "toxic"]
+                "movepool": ["freezedry", "hydropump", "protect", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -951,7 +1092,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["transform"]
+                "movepool": ["transform"],
+                "abilities": ["Imposter"]
             }
         ]
     },
@@ -960,11 +1102,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "icebeam", "protect", "scald", "wish"]
+                "movepool": ["healbell", "icebeam", "protect", "scald", "wish"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "scald", "toxic", "wish"]
+                "movepool": ["protect", "scald", "toxic", "wish"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -973,11 +1117,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "shadowball", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "shadowball", "thunderbolt", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -986,7 +1132,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"]
+                "movepool": ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -995,7 +1142,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
+                "abilities": ["Shell Armor", "Swift Swim"]
             }
         ]
     },
@@ -1004,11 +1152,18 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["aquajet", "knockoff", "liquidation", "rapidspin", "stoneedge", "swordsdance"]
+                "movepool": ["aquajet", "knockoff", "liquidation", "rapidspin", "stoneedge"],
+                "abilities": ["Battle Armor", "Swift Swim"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["aquajet", "knockoff", "liquidation", "stoneedge", "swordsdance"],
+                "abilities": ["Weak Armor"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["aquajet", "knockoff", "liquidation", "stoneedge", "swordsdance"],
+                "abilities": ["Weak Armor"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -1018,16 +1173,19 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"]
+                "movepool": ["defog", "earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"],
+                "abilities": ["Unnerve"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "movepool": ["aerialace", "aquatail", "defog", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["earthquake", "honeclaws", "skyattack", "stoneedge"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -1038,6 +1196,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aerialace", "aquatail", "earthquake", "honeclaws", "roost", "stoneedge"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1047,15 +1206,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "crunch", "curse", "earthquake", "rest", "return", "sleeptalk"]
+                "movepool": ["bodyslam", "crunch", "curse", "earthquake", "rest", "return", "sleeptalk"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit", "return"]
+                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit", "return"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "crunch", "curse", "earthquake", "recycle", "return"]
+                "movepool": ["bodyslam", "crunch", "curse", "earthquake", "recycle", "return"],
+                "abilities": ["Gluttony"]
             }
         ]
     },
@@ -1064,11 +1226,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["freezedry", "roost", "substitute", "toxic"]
+                "movepool": ["freezedry", "roost", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["freezedry", "hurricane", "roost", "substitute", "toxic"]
+                "movepool": ["freezedry", "hurricane", "roost", "substitute", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1077,7 +1241,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "discharge", "heatwave", "hiddenpowerice", "roost", "toxic", "uturn"]
+                "movepool": ["defog", "discharge", "heatwave", "hiddenpowerice", "roost", "toxic", "uturn"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -1086,7 +1251,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "fireblast", "hurricane", "roost", "toxic", "uturn", "willowisp"]
+                "movepool": ["defog", "fireblast", "hurricane", "roost", "toxic", "uturn", "willowisp"],
+                "abilities": ["Flame Body"]
             }
         ]
     },
@@ -1096,11 +1262,13 @@
             {
                 "role": "Z-Move user",
                 "movepool": ["dragondance", "earthquake", "fly", "outrage"],
+                "abilities": ["Multiscale"],
                 "preferredTypes": ["Flying"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "ironhead", "outrage", "roost"],
+                "abilities": ["Multiscale"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1110,7 +1278,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"]
+                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"],
+                "abilities": ["Unnerve"]
             }
         ]
     },
@@ -1119,7 +1288,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bulkup", "drainpunch", "stoneedge", "taunt", "zenheadbutt"]
+                "movepool": ["bulkup", "drainpunch", "stoneedge", "taunt", "zenheadbutt"],
+                "abilities": ["Unnerve"]
             }
         ]
     },
@@ -1128,7 +1298,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"]
+                "movepool": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"],
+                "abilities": ["Unnerve"]
             }
         ]
     },
@@ -1137,11 +1308,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["defog", "knockoff", "psychic", "roost", "stealthrock", "taunt", "uturn", "willowisp"]
+                "movepool": ["defog", "knockoff", "psychic", "roost", "stealthrock", "taunt", "uturn", "willowisp"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "roost"]
+                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "roost"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1150,7 +1323,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "dragontail", "earthquake", "energyball", "leechseed", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "dragontail", "earthquake", "energyball", "leechseed", "synthesis", "toxic"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -1159,7 +1333,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"]
+                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -1169,6 +1344,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["crunch", "dragondance", "earthquake", "icepunch", "liquidation"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1179,11 +1355,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquatail", "doubleedge", "firepunch", "knockoff", "trick", "uturn"],
+                "abilities": ["Frisk"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["coil", "irontail", "knockoff", "return"]
+                "movepool": ["coil", "irontail", "knockoff", "return"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -1192,7 +1370,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "hurricane", "hypervoice", "roost", "toxic"]
+                "movepool": ["defog", "hurricane", "hypervoice", "roost", "toxic"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -1201,7 +1380,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "defog", "encore", "focusblast", "knockoff", "roost", "toxic"]
+                "movepool": ["airslash", "defog", "encore", "focusblast", "knockoff", "roost", "toxic"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -1210,7 +1390,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["megahorn", "poisonjab", "stickyweb", "suckerpunch", "toxicspikes"]
+                "movepool": ["megahorn", "poisonjab", "stickyweb", "suckerpunch", "toxicspikes"],
+                "abilities": ["Insomnia", "Swarm"]
             }
         ]
     },
@@ -1219,7 +1400,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "roost", "superfang", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "defog", "roost", "superfang", "taunt", "toxic", "uturn"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -1228,7 +1410,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["healbell", "icebeam", "scald", "thunderbolt", "toxic", "voltswitch"]
+                "movepool": ["healbell", "icebeam", "scald", "thunderbolt", "toxic", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -1237,11 +1420,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "heatwave", "psychic", "roost"]
+                "movepool": ["calmmind", "heatwave", "psychic", "roost"],
+                "abilities": ["Magic Bounce"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"]
+                "movepool": ["heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Magic Bounce"]
             }
         ]
     },
@@ -1250,7 +1435,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focusblast", "healbell", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"]
+                "movepool": ["focusblast", "healbell", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -1259,7 +1445,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["agility", "dragonpulse", "focusblast", "healbell", "thunderbolt", "voltswitch"]
+                "movepool": ["agility", "dragonpulse", "focusblast", "healbell", "thunderbolt", "voltswitch"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -1268,15 +1455,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "moonblast", "quiverdance", "strengthsap"]
+                "movepool": ["gigadrain", "moonblast", "quiverdance", "strengthsap"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "quiverdance", "strengthsap"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "quiverdance", "strengthsap"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["gigadrain", "quiverdance", "sleeppowder", "strengthsap"],
+                "abilities": ["Chlorophyll"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -1286,7 +1476,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "bellydrum", "knockoff", "liquidation", "playrough", "superpower"]
+                "movepool": ["aquajet", "bellydrum", "knockoff", "liquidation", "playrough", "superpower"],
+                "abilities": ["Huge Power"]
             }
         ]
     },
@@ -1296,6 +1487,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "headsmash", "stealthrock", "suckerpunch", "toxic", "woodhammer"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -1305,11 +1497,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["encore", "icebeam", "protect", "scald", "toxic"]
+                "movepool": ["encore", "icebeam", "protect", "scald", "toxic"],
+                "abilities": ["Drizzle"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "rest", "scald", "toxic"]
+                "movepool": ["encore", "icebeam", "rest", "scald", "toxic"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -1318,11 +1512,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["acrobatics", "leechseed", "strengthsap", "substitute"]
+                "movepool": ["acrobatics", "leechseed", "strengthsap", "substitute"],
+                "abilities": ["Infiltrator"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["acrobatics", "encore", "sleeppowder", "strengthsap", "toxic", "uturn"]
+                "movepool": ["acrobatics", "encore", "sleeppowder", "strengthsap", "toxic", "uturn"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -1331,11 +1527,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"]
+                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"],
+                "abilities": ["Chlorophyll"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthpower", "hiddenpowerfire", "solarbeam", "sunnyday"]
+                "movepool": ["earthpower", "hiddenpowerfire", "solarbeam", "sunnyday"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -1344,7 +1542,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["earthquake", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Unaware"]
             }
         ]
     },
@@ -1353,7 +1552,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "dazzlinggleam", "morningsun", "psychic", "psyshock", "shadowball", "trick"]
+                "movepool": ["calmmind", "dazzlinggleam", "morningsun", "psychic", "psyshock", "shadowball", "trick"],
+                "abilities": ["Magic Bounce"]
             }
         ]
     },
@@ -1362,11 +1562,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["foulplay", "protect", "toxic", "wish"]
+                "movepool": ["foulplay", "protect", "toxic", "wish"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "healbell", "moonlight", "toxic"]
+                "movepool": ["foulplay", "healbell", "moonlight", "toxic"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1375,11 +1577,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic"]
+                "movepool": ["fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["dragontail", "fireblast", "futuresight", "icebeam", "psyshock", "scald"]
+                "movepool": ["dragontail", "fireblast", "futuresight", "icebeam", "psyshock", "scald"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -1388,7 +1592,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerpsychic"]
+                "movepool": ["hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -1397,7 +1602,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"]
+                "movepool": ["counter", "destinybond", "encore", "mirrorcoat"],
+                "abilities": ["Shadow Tag"]
             }
         ]
     },
@@ -1406,11 +1612,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dazzlinggleam", "nastyplot", "psychic", "psyshock", "substitute", "thunderbolt"]
+                "movepool": ["dazzlinggleam", "nastyplot", "psychic", "psyshock", "substitute", "thunderbolt"],
+                "abilities": ["Sap Sipper"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["hypervoice", "nastyplot", "psyshock", "thunderbolt"]
+                "movepool": ["hypervoice", "nastyplot", "psyshock", "thunderbolt"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },
@@ -1419,7 +1627,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"]
+                "movepool": ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1428,11 +1637,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "glare", "headbutt", "roost"]
+                "movepool": ["earthquake", "glare", "headbutt", "roost"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "coil", "earthquake", "roost"]
+                "movepool": ["bodyslam", "coil", "earthquake", "roost"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -1441,7 +1652,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["defog", "earthquake", "knockoff", "roost", "stealthrock", "toxic", "uturn"]
+                "movepool": ["defog", "earthquake", "knockoff", "roost", "stealthrock", "toxic", "uturn"],
+                "abilities": ["Immunity"]
             }
         ]
     },
@@ -1451,15 +1663,18 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "ironhead", "roar", "rockslide", "stealthrock", "toxic"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Steel"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "heavyslam", "protect", "toxic"]
+                "movepool": ["earthquake", "heavyslam", "protect", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1468,7 +1683,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "earthquake", "heavyslam", "stealthrock", "toxic"]
+                "movepool": ["dragontail", "earthquake", "heavyslam", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1477,7 +1693,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "healbell", "playrough", "thunderwave", "toxic"]
+                "movepool": ["earthquake", "healbell", "playrough", "thunderwave", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1486,7 +1703,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"]
+                "movepool": ["destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1495,15 +1713,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbite", "bulletpunch", "knockoff", "roost", "superpower", "swordsdance"]
+                "movepool": ["bugbite", "bulletpunch", "knockoff", "roost", "superpower", "swordsdance"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulletpunch", "defog", "knockoff", "roost", "superpower", "uturn"]
+                "movepool": ["bulletpunch", "defog", "knockoff", "roost", "superpower", "uturn"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletpunch", "knockoff", "pursuit", "superpower", "uturn"]
+                "movepool": ["bulletpunch", "knockoff", "pursuit", "superpower", "uturn"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -1512,11 +1733,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbite", "bulletpunch", "knockoff", "roost", "superpower", "swordsdance"]
+                "movepool": ["bugbite", "bulletpunch", "knockoff", "roost", "superpower", "swordsdance"],
+                "abilities": ["Light Metal"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulletpunch", "defog", "knockoff", "roost", "superpower", "uturn"]
+                "movepool": ["bulletpunch", "defog", "knockoff", "roost", "superpower", "uturn"],
+                "abilities": ["Light Metal"]
             }
         ]
     },
@@ -1525,7 +1748,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "knockoff", "stealthrock", "stickyweb", "toxic"]
+                "movepool": ["encore", "knockoff", "stealthrock", "stickyweb", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1534,11 +1758,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "facade", "knockoff", "swordsdance"]
+                "movepool": ["closecombat", "facade", "knockoff", "swordsdance"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "knockoff", "megahorn", "stoneedge"]
+                "movepool": ["closecombat", "knockoff", "megahorn", "stoneedge"],
+                "abilities": ["Moxie"]
             }
         ]
     },
@@ -1548,6 +1774,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["closecombat", "pinmissile", "rockblast", "substitute", "swordsdance"],
+                "abilities": ["Moxie"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -1557,7 +1784,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"]
+                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
+                "abilities": ["Guts", "Quick Feet"]
             }
         ]
     },
@@ -1566,11 +1794,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"]
+                "movepool": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"],
+                "abilities": ["Flame Body"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["ancientpower", "earthpower", "fireblast", "shellsmash"],
+                "abilities": ["Weak Armor"],
                 "preferredTypes": ["Fire", "Rock"]
             }
         ]
@@ -1580,7 +1810,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["powergem", "recover", "scald", "stealthrock", "toxic"]
+                "movepool": ["powergem", "recover", "scald", "stealthrock", "toxic"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -1589,7 +1820,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "scald"]
+                "movepool": ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "scald"],
+                "abilities": ["Sniper"]
             }
         ]
     },
@@ -1598,7 +1830,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "freezedry", "rapidspin", "spikes"]
+                "movepool": ["destinybond", "freezedry", "rapidspin", "spikes"],
+                "abilities": ["Insomnia", "Vital Spirit"]
             }
         ]
     },
@@ -1607,7 +1840,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "defog", "haze", "roost", "scald", "toxic"]
+                "movepool": ["airslash", "defog", "haze", "roost", "scald", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -1616,11 +1850,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"]
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1629,7 +1865,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"]
+                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -1638,7 +1875,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"]
+                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -1647,7 +1885,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"]
+                "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1656,7 +1895,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1665,7 +1905,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["discharge", "icebeam", "recover", "toxic", "triattack"]
+                "movepool": ["discharge", "icebeam", "recover", "toxic", "triattack"],
+                "abilities": ["Download", "Trace"]
             }
         ]
     },
@@ -1675,6 +1916,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch", "throatchop", "thunderwave"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1684,7 +1926,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "nuzzle", "spore", "stealthrock", "stickyweb", "whirlwind"]
+                "movepool": ["destinybond", "nuzzle", "spore", "stealthrock", "stickyweb", "whirlwind"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -1693,7 +1936,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1701,12 +1945,9 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["bodyslam", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["bodyslam", "curse", "earthquake", "milkdrink"]
+                "role": "Bulky Attacker",
+                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+                "abilities": ["Sap Sipper", "Thick Fat"]
             }
         ]
     },
@@ -1715,11 +1956,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["protect", "seismictoss", "toxic", "wish"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -1728,11 +1971,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"]
+                "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1742,11 +1987,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stompingtantrum"]
+                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stompingtantrum"],
+                "abilities": ["Inner Focus"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stoneedge"]
+                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stoneedge"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -1755,15 +2002,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "rest", "scald", "sleeptalk"]
+                "movepool": ["calmmind", "rest", "scald", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "rest", "scald", "substitute"]
+                "movepool": ["calmmind", "icebeam", "rest", "scald", "substitute"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Staller",
-                "movepool": ["calmmind", "protect", "scald", "substitute"]
+                "movepool": ["calmmind", "protect", "scald", "substitute"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -1772,11 +2022,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge"]
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge"],
+                "abilities": ["Sand Stream"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -1785,7 +2037,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -1794,7 +2047,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"]
+                "movepool": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"],
+                "abilities": ["Multiscale"]
             }
         ]
     },
@@ -1803,7 +2057,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "earthquake", "roost", "sacredfire", "substitute", "toxic"]
+                "movepool": ["bravebird", "defog", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -1813,15 +2068,18 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
+                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["leafstorm", "nastyplot", "psychic", "recover"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -1831,11 +2089,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"]
+                "movepool": ["earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -1844,11 +2104,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragonpulse", "earthquake", "focusblast", "gigadrain", "leafstorm", "substitute"]
+                "movepool": ["dragonpulse", "earthquake", "focusblast", "gigadrain", "leafstorm", "substitute"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "leafblade", "outrage", "swordsdance"]
+                "movepool": ["earthquake", "leafblade", "outrage", "swordsdance"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -1857,11 +2119,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "highjumpkick", "knockoff", "protect", "stoneedge"]
+                "movepool": ["fireblast", "highjumpkick", "knockoff", "protect", "stoneedge"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flareblitz", "highjumpkick", "knockoff", "stoneedge", "swordsdance"]
+                "movepool": ["flareblitz", "highjumpkick", "knockoff", "stoneedge", "swordsdance"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -1870,7 +2134,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"]
+                "movepool": ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -1879,11 +2144,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "roar", "scald", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "icebeam", "roar", "scald", "stealthrock", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "scald", "toxic"]
+                "movepool": ["earthquake", "protect", "scald", "toxic"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -1892,7 +2159,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "icepunch", "raindance", "superpower", "waterfall"]
+                "movepool": ["earthquake", "icepunch", "raindance", "superpower", "waterfall"],
+                "abilities": ["Damp"]
             }
         ]
     },
@@ -1902,6 +2170,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["crunch", "irontail", "playrough", "suckerpunch", "toxic"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fairy"]
             }
         ]
@@ -1911,7 +2180,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "extremespeed", "stompingtantrum", "throatchop"]
+                "movepool": ["bellydrum", "extremespeed", "stompingtantrum", "throatchop"],
+                "abilities": ["Gluttony"]
             }
         ]
     },
@@ -1920,7 +2190,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aircutter", "bugbuzz", "hiddenpowerground", "quiverdance"]
+                "movepool": ["aircutter", "bugbuzz", "hiddenpowerground", "quiverdance"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -1929,11 +2200,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "hiddenpowerground", "quiverdance", "roost", "sludgebomb"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "quiverdance", "roost", "sludgebomb"],
+                "abilities": ["Shield Dust"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbuzz", "defog", "roost", "sludgebomb", "toxic", "uturn"]
+                "movepool": ["bugbuzz", "defog", "roost", "sludgebomb", "toxic", "uturn"],
+                "abilities": ["Shield Dust"]
             }
         ]
     },
@@ -1942,11 +2215,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["gigadrain", "hydropump", "icebeam", "raindance"]
+                "movepool": ["gigadrain", "hydropump", "icebeam", "raindance"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["energyball", "hydropump", "icebeam", "scald"]
+                "movepool": ["energyball", "hydropump", "icebeam", "scald"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -1955,11 +2230,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["defog", "knockoff", "leafstorm", "lowkick", "suckerpunch"]
+                "movepool": ["defog", "knockoff", "leafstorm", "lowkick", "suckerpunch"],
+                "abilities": ["Chlorophyll", "Pickpocket"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["knockoff", "leafblade", "lowkick", "suckerpunch", "swordsdance"]
+                "movepool": ["knockoff", "leafblade", "lowkick", "suckerpunch", "swordsdance"],
+                "abilities": ["Chlorophyll", "Pickpocket"]
             }
         ]
     },
@@ -1968,11 +2245,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "facade", "protect", "quickattack", "uturn"]
+                "movepool": ["bravebird", "facade", "protect", "quickattack", "uturn"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["boomburst", "heatwave", "hurricane", "uturn"]
+                "movepool": ["boomburst", "heatwave", "hurricane", "uturn"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -1981,11 +2260,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "hurricane", "knockoff", "roost", "scald", "uturn"]
+                "movepool": ["defog", "hurricane", "knockoff", "roost", "scald", "uturn"],
+                "abilities": ["Drizzle"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hurricane", "hydropump", "scald", "uturn"]
+                "movepool": ["hurricane", "hydropump", "scald", "uturn"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -1994,11 +2275,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "focusblast", "healingwish", "moonblast", "psychic", "shadowball", "thunderbolt", "trick"]
+                "movepool": ["calmmind", "focusblast", "healingwish", "moonblast", "psychic", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Trace"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "focusblast", "moonblast", "psyshock", "substitute", "willowisp"]
+                "movepool": ["calmmind", "focusblast", "moonblast", "psyshock", "substitute", "willowisp"],
+                "abilities": ["Trace"]
             }
         ]
     },
@@ -2007,7 +2290,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "substitute", "taunt", "willowisp"]
+                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "substitute", "taunt", "willowisp"],
+                "abilities": ["Trace"]
             }
         ]
     },
@@ -2016,11 +2300,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "hydropump", "quiverdance"]
+                "movepool": ["airslash", "bugbuzz", "hydropump", "quiverdance"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["airslash", "bugbuzz", "roost", "scald", "stickyweb", "stunspore", "uturn"]
+                "movepool": ["airslash", "bugbuzz", "roost", "scald", "stickyweb", "stunspore", "uturn"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -2029,11 +2315,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletseed", "machpunch", "rocktomb", "spore", "swordsdance"]
+                "movepool": ["bulletseed", "machpunch", "rocktomb", "spore", "swordsdance"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bulletseed", "machpunch", "rocktomb", "swordsdance"]
+                "movepool": ["bulletseed", "machpunch", "rocktomb", "swordsdance"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -2042,7 +2330,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bodyslam", "bulkup", "earthquake", "return", "shadowclaw", "slackoff"]
+                "movepool": ["bodyslam", "bulkup", "earthquake", "return", "shadowclaw", "slackoff"],
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -2051,7 +2340,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"]
+                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"],
+                "abilities": ["Truant"]
             }
         ]
     },
@@ -2060,11 +2350,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "leechlife", "nightslash", "swordsdance", "uturn"]
+                "movepool": ["aerialace", "leechlife", "nightslash", "swordsdance", "uturn"],
+                "abilities": ["Infiltrator"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["aerialace", "dig", "leechlife", "swordsdance"],
+                "abilities": ["Infiltrator"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2074,7 +2366,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"]
+                "movepool": ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+                "abilities": ["Wonder Guard"]
             }
         ]
     },
@@ -2083,7 +2376,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["boomburst", "fireblast", "focusblast", "icebeam", "surf"]
+                "movepool": ["boomburst", "fireblast", "focusblast", "icebeam", "surf"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -2093,11 +2387,13 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["bulletpunch", "closecombat", "heavyslam", "knockoff", "stoneedge"],
+                "abilities": ["Thick Fat"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["bulkup", "bulletpunch", "closecombat", "facade", "knockoff"],
+                "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -2107,7 +2403,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["doubleedge", "fakeout", "healbell", "shadowball", "stompingtantrum", "thunderwave", "toxic"]
+                "movepool": ["doubleedge", "fakeout", "healbell", "shadowball", "stompingtantrum", "thunderwave", "toxic"],
+                "abilities": ["Wonder Skin"]
             }
         ]
     },
@@ -2116,7 +2413,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "knockoff", "recover", "taunt", "toxic", "willowisp"]
+                "movepool": ["foulplay", "knockoff", "recover", "taunt", "toxic", "willowisp"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -2125,7 +2423,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "darkpulse", "recover", "willowisp"]
+                "movepool": ["calmmind", "darkpulse", "recover", "willowisp"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -2134,7 +2433,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["ironhead", "knockoff", "playrough", "stealthrock", "suckerpunch", "swordsdance"]
+                "movepool": ["ironhead", "knockoff", "playrough", "stealthrock", "suckerpunch", "swordsdance"],
+                "abilities": ["Intimidate", "Sheer Force"]
             }
         ]
     },
@@ -2143,7 +2443,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["ironhead", "knockoff", "playrough", "suckerpunch", "swordsdance"]
+                "movepool": ["ironhead", "knockoff", "playrough", "suckerpunch", "swordsdance"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -2153,6 +2454,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquatail", "earthquake", "headsmash", "heavyslam", "rockpolish", "stealthrock"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2162,7 +2464,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "stoneedge", "thunderwave", "toxic"]
+                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -2171,7 +2474,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletpunch", "highjumpkick", "icepunch", "poisonjab", "zenheadbutt"]
+                "movepool": ["bulletpunch", "highjumpkick", "icepunch", "poisonjab", "zenheadbutt"],
+                "abilities": ["Pure Power"]
             }
         ]
     },
@@ -2180,7 +2484,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "highjumpkick", "icepunch", "thunderpunch", "zenheadbutt"]
+                "movepool": ["fakeout", "highjumpkick", "icepunch", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Pure Power"]
             }
         ]
     },
@@ -2189,7 +2494,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -2198,7 +2504,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -2208,11 +2515,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -2222,11 +2531,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -2235,11 +2546,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "encore", "roost", "thunderwave", "uturn"]
+                "movepool": ["defog", "encore", "roost", "thunderwave", "uturn"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Staller",
-                "movepool": ["defog", "encore", "lunge", "roost", "thunderwave"]
+                "movepool": ["defog", "encore", "lunge", "roost", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -2248,7 +2561,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bugbuzz", "defog", "encore", "roost", "thunderwave"]
+                "movepool": ["bugbuzz", "defog", "encore", "roost", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -2257,11 +2571,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"]
+                "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
+                "abilities": ["Liquid Ooze"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"]
+                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"],
+                "abilities": ["Liquid Ooze"]
             }
         ]
     },
@@ -2270,7 +2586,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "destinybond", "earthquake", "icebeam", "protect", "waterfall"]
+                "movepool": ["crunch", "destinybond", "earthquake", "icebeam", "protect", "waterfall"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -2279,7 +2596,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "icefang", "protect", "psychicfangs", "waterfall"]
+                "movepool": ["crunch", "icefang", "protect", "psychicfangs", "waterfall"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -2288,7 +2606,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
+                "abilities": ["Water Veil"]
             }
         ]
     },
@@ -2297,11 +2616,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "rockpolish", "stoneedge"]
+                "movepool": ["earthquake", "fireblast", "rockpolish", "stoneedge"],
+                "abilities": ["Solid Rock"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "toxic"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -2310,7 +2631,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["ancientpower", "earthpower", "fireblast", "stealthrock", "toxic", "willowisp"]
+                "movepool": ["ancientpower", "earthpower", "fireblast", "stealthrock", "toxic", "willowisp"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -2319,7 +2641,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "rapidspin", "solarbeam", "stealthrock", "yawn"]
+                "movepool": ["earthquake", "lavaplume", "rapidspin", "solarbeam", "stealthrock", "yawn"],
+                "abilities": ["Drought"]
             }
         ]
     },
@@ -2328,11 +2651,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"]
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recycle"]
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recycle"],
+                "abilities": ["Gluttony"]
             }
         ]
     },
@@ -2342,6 +2667,7 @@
             {
                 "role": "Staller",
                 "movepool": ["feintattack", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
+                "abilities": ["Contrary"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2351,15 +2677,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragondance", "earthquake", "outrage", "stoneedge", "uturn"]
+                "movepool": ["dragondance", "earthquake", "outrage", "stoneedge", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "dragondance", "earthquake", "outrage", "roost"]
+                "movepool": ["defog", "dragondance", "earthquake", "outrage", "roost"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["dragondance", "earthquake", "outrage", "roost", "stoneedge"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -2369,11 +2698,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"]
+                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "seedbomb", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "seedbomb", "suckerpunch", "swordsdance"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -2382,7 +2713,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "dracometeor", "earthquake", "fireblast", "healbell", "roost", "toxic"]
+                "movepool": ["defog", "dracometeor", "earthquake", "fireblast", "healbell", "roost", "toxic"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -2391,11 +2723,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "return", "roost"]
+                "movepool": ["dragondance", "earthquake", "return", "roost"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "earthquake", "fireblast", "healbell", "return", "roost"]
+                "movepool": ["defog", "earthquake", "fireblast", "healbell", "return", "roost"],
+                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -2405,6 +2739,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"],
+                "abilities": ["Toxic Boost"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -2415,11 +2750,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "flamethrower", "gigadrain", "glare", "knockoff", "sludgewave", "suckerpunch", "switcheroo"],
+                "abilities": ["Infiltrator"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "poisonjab", "suckerpunch", "swordsdance"]
+                "movepool": ["earthquake", "poisonjab", "suckerpunch", "swordsdance"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -2429,11 +2766,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthpower", "icebeam", "moonblast", "moonlight", "powergem", "psychic", "rockpolish"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthpower", "moonlight", "powergem", "psychic", "stealthrock", "toxic"]
+                "movepool": ["earthpower", "moonlight", "powergem", "psychic", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2442,7 +2781,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "morningsun", "stealthrock", "stoneedge", "willowisp"]
+                "movepool": ["earthquake", "morningsun", "stealthrock", "stoneedge", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2451,7 +2791,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "stoneedge", "waterfall"]
+                "movepool": ["dragondance", "earthquake", "stoneedge", "waterfall"],
+                "abilities": ["Hydration", "Oblivious"]
             }
         ]
     },
@@ -2460,11 +2801,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower"]
+                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower"],
+                "abilities": ["Adaptability"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "swordsdance"]
+                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "swordsdance"],
+                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -2473,7 +2816,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2482,11 +2826,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"]
+                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"],
+                "abilities": ["Storm Drain"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -2495,11 +2841,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"]
+                "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "earthquake", "knockoff", "liquidation", "stoneedge", "swordsdance", "xscissor"]
+                "movepool": ["aquajet", "earthquake", "knockoff", "liquidation", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Battle Armor", "Swift Swim"]
             }
         ]
     },
@@ -2508,7 +2856,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["dragontail", "haze", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["dragontail", "haze", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Competitive", "Marvel Scale"]
             }
         ]
     },
@@ -2517,7 +2866,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "icebeam", "return", "scald", "thunderbolt", "thunderwave"]
+                "movepool": ["fireblast", "icebeam", "return", "scald", "thunderbolt", "thunderwave"],
+                "abilities": ["Forecast"]
             }
         ]
     },
@@ -2527,11 +2877,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["drainpunch", "fakeout", "knockoff", "recover", "shadowsneak", "stealthrock", "suckerpunch"],
+                "abilities": ["Protean"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drainpunch", "knockoff", "recover", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["drainpunch", "knockoff", "recover", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Protean"]
             }
         ]
     },
@@ -2540,7 +2892,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["gunkshot", "knockoff", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"]
+                "movepool": ["gunkshot", "knockoff", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"],
+                "abilities": ["Cursed Body", "Frisk"]
             }
         ]
     },
@@ -2549,7 +2902,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "gunkshot", "knockoff", "shadowclaw", "shadowsneak", "taunt", "willowisp"]
+                "movepool": ["destinybond", "gunkshot", "knockoff", "shadowclaw", "shadowsneak", "taunt", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -2558,7 +2912,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "leechseed", "protect", "substitute"]
+                "movepool": ["airslash", "leechseed", "protect", "substitute"],
+                "abilities": ["Harvest"]
             }
         ]
     },
@@ -2567,11 +2922,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["defog", "healbell", "knockoff", "psychic", "recover", "toxic"]
+                "movepool": ["defog", "healbell", "knockoff", "psychic", "recover", "toxic"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "psychic", "recover", "signalbeam"]
+                "movepool": ["calmmind", "psychic", "recover", "signalbeam"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2581,6 +2938,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             }
         ]
@@ -2591,11 +2949,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fireblast", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             }
         ]
@@ -2605,7 +2965,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "freezedry", "spikes", "superfang", "taunt"]
+                "movepool": ["earthquake", "freezedry", "spikes", "superfang", "taunt"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -2615,6 +2976,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "explosion", "freezedry", "iceshard", "return", "spikes"],
+                "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2624,11 +2986,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "roar", "superfang", "surf", "toxic"]
+                "movepool": ["icebeam", "roar", "superfang", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -2638,6 +3002,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["icebeam", "return", "shellsmash", "suckerpunch", "waterfall"],
+                "abilities": ["Swift Swim", "Water Veil"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2647,7 +3012,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2656,11 +3022,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"]
+                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"],
+                "abilities": ["Rock Head"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "earthquake", "headsmash", "rockpolish", "waterfall"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2670,7 +3038,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"]
+                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"],
+                "abilities": ["Swift Swim"]
             }
         ]
     },
@@ -2679,11 +3048,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
+                "movepool": ["dragondance", "earthquake", "outrage", "roost"],
+                "abilities": ["Intimidate", "Moxie"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["dragondance", "earthquake", "fly", "outrage"],
+                "abilities": ["Moxie"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -2693,11 +3064,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["doubleedge", "dragondance", "earthquake", "return", "roost"]
+                "movepool": ["doubleedge", "dragondance", "earthquake", "return", "roost"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "dracometeor", "earthquake", "fireblast", "return", "roost"]
+                "movepool": ["doubleedge", "dracometeor", "earthquake", "fireblast", "return", "roost"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -2707,11 +3080,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["agility", "earthquake", "icepunch", "meteormash", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "stealthrock", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2722,6 +3097,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["agility", "earthquake", "hammerarm", "meteormash", "zenheadbutt"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -2731,11 +3107,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "drainpunch", "rest", "stoneedge"]
+                "movepool": ["curse", "drainpunch", "rest", "stoneedge"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "earthquake", "stealthrock", "stoneedge", "thunderwave", "toxic"]
+                "movepool": ["drainpunch", "earthquake", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -2744,16 +3122,19 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"]
+                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["focusblast", "icebeam", "rockpolish", "thunderbolt"]
+                "movepool": ["focusblast", "icebeam", "rockpolish", "thunderbolt"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2762,15 +3143,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "ironhead", "rest", "sleeptalk"]
+                "movepool": ["curse", "ironhead", "rest", "sleeptalk"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"]
+                "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2779,11 +3163,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["calmmind", "defog", "dracometeor", "healingwish", "hiddenpowerfire", "psyshock", "roost", "trick"]
+                "movepool": ["calmmind", "defog", "dracometeor", "healingwish", "hiddenpowerfire", "psyshock", "roost", "trick"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -2793,7 +3179,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2802,11 +3189,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost", "surf", "thunderbolt", "trick"]
+                "movepool": ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost", "surf", "thunderbolt", "trick"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -2816,7 +3205,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2825,7 +3215,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "originpulse", "scald", "thunder", "waterspout"]
+                "movepool": ["icebeam", "originpulse", "scald", "thunder", "waterspout"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -2834,11 +3225,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "rest", "scald", "sleeptalk"]
+                "movepool": ["calmmind", "rest", "scald", "sleeptalk"],
+                "abilities": ["Drizzle"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "icebeam", "originpulse", "thunder"]
+                "movepool": ["calmmind", "icebeam", "originpulse", "thunder"],
+                "abilities": ["Drizzle"]
             }
         ]
     },
@@ -2847,11 +3240,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "lavaplume", "precipiceblades", "stealthrock", "stoneedge", "thunderwave"]
+                "movepool": ["dragontail", "lavaplume", "precipiceblades", "stealthrock", "stoneedge", "thunderwave"],
+                "abilities": ["Drought"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["firepunch", "precipiceblades", "rockpolish", "stoneedge", "swordsdance"]
+                "movepool": ["firepunch", "precipiceblades", "rockpolish", "stoneedge", "swordsdance"],
+                "abilities": ["Drought"]
             }
         ]
     },
@@ -2860,11 +3255,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "lavaplume", "precipiceblades", "stealthrock", "thunderwave"]
+                "movepool": ["dragontail", "lavaplume", "precipiceblades", "stealthrock", "thunderwave"],
+                "abilities": ["Drought"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["firepunch", "precipiceblades", "rockpolish", "swordsdance"]
+                "movepool": ["firepunch", "precipiceblades", "rockpolish", "swordsdance"],
+                "abilities": ["Drought"]
             }
         ]
     },
@@ -2874,15 +3271,18 @@
             {
                 "role": "Z-Move user",
                 "movepool": ["dragonascent", "dragondance", "earthquake", "extremespeed", "vcreate"],
+                "abilities": ["Air Lock"],
                 "preferredTypes": ["Flying"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"]
+                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
+                "abilities": ["Air Lock"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["earthquake", "extremespeed", "outrage", "swordsdance", "vcreate"],
+                "abilities": ["Air Lock"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2892,7 +3292,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragonascent", "dragondance", "earthquake", "extremespeed", "vcreate"]
+                "movepool": ["dragonascent", "dragondance", "earthquake", "extremespeed", "vcreate"],
+                "abilities": ["Air Lock"]
             }
         ]
     },
@@ -2901,11 +3302,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"]
+                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["drainpunch", "happyhour", "ironhead", "psychic"],
+                "abilities": ["Serene Grace"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2915,11 +3318,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"]
+                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"]
+                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2928,11 +3333,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"]
+                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"]
+                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2941,7 +3348,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"]
+                "movepool": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2950,7 +3358,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["knockoff", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"]
+                "movepool": ["knockoff", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -2959,11 +3368,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"]
+                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"]
+                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -2972,16 +3383,19 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"]
+                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"],
+                "abilities": ["Blaze", "Iron Fist"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["fireblast", "focusblast", "grassknot", "nastyplot", "vacuumwave"],
+                "abilities": ["Blaze"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"]
+                "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"],
+                "abilities": ["Blaze", "Iron Fist"]
             }
         ]
     },
@@ -2990,15 +3404,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["defog", "knockoff", "protect", "scald", "stealthrock", "toxic"]
+                "movepool": ["defog", "knockoff", "protect", "scald", "stealthrock", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "icebeam", "knockoff", "roar", "scald", "toxic"]
+                "movepool": ["defog", "icebeam", "knockoff", "roar", "scald", "toxic"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["flashcannon", "grassknot", "hydropump", "icebeam", "knockoff", "scald"]
+                "movepool": ["flashcannon", "grassknot", "hydropump", "icebeam", "knockoff", "scald"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -3008,6 +3425,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bravebird", "closecombat", "doubleedge", "quickattack", "uturn"],
+                "abilities": ["Reckless"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -3017,7 +3435,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "liquidation", "quickattack", "return", "swordsdance"]
+                "movepool": ["aquajet", "liquidation", "quickattack", "return", "swordsdance"],
+                "abilities": ["Simple"]
             }
         ]
     },
@@ -3026,7 +3445,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["knockoff", "leechlife", "stickyweb", "taunt", "toxic"]
+                "movepool": ["knockoff", "leechlife", "stickyweb", "taunt", "toxic"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -3035,11 +3455,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "facade", "superpower", "wildcharge"]
+                "movepool": ["crunch", "facade", "superpower", "wildcharge"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["crunch", "icefang", "superpower", "voltswitch", "wildcharge"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -3049,7 +3471,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
+                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"],
+                "abilities": ["Natural Cure", "Technician"]
             }
         ]
     },
@@ -3058,11 +3481,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"]
+                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"],
+                "abilities": ["Sheer Force"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"]
+                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -3071,11 +3496,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["metalburst", "roar", "rockblast", "stealthrock", "toxic"]
+                "movepool": ["metalburst", "roar", "rockblast", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"]
+                "movepool": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -3084,7 +3511,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "energyball", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "quiverdance"]
+                "movepool": ["bugbuzz", "energyball", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "quiverdance"],
+                "abilities": ["Anticipation", "Overcoat"]
             }
         ]
     },
@@ -3093,7 +3521,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "infestation", "protect", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "infestation", "protect", "stealthrock", "toxic"],
+                "abilities": ["Overcoat"]
             }
         ]
     },
@@ -3102,7 +3531,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "infestation", "protect", "stealthrock", "toxic"]
+                "movepool": ["flashcannon", "infestation", "protect", "stealthrock", "toxic"],
+                "abilities": ["Overcoat"]
             }
         ]
     },
@@ -3111,11 +3541,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance"]
+                "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance"],
+                "abilities": ["Tinted Lens"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance"],
+                "abilities": ["Tinted Lens"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -3125,7 +3557,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "defog", "roost", "toxic", "uturn"]
+                "movepool": ["airslash", "defog", "roost", "toxic", "uturn"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3134,7 +3567,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["nuzzle", "superfang", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["nuzzle", "superfang", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -3144,16 +3578,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["aquajet", "bulkup", "icepunch", "liquidation", "lowkick", "substitute"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquajet", "crunch", "icepunch", "liquidation", "lowkick"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["bulkup", "icepunch", "liquidation", "lowkick"],
+                "abilities": ["Water Veil"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -3163,11 +3600,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock", "morningsun"]
+                "movepool": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock", "morningsun"],
+                "abilities": ["Flower Gift"]
             },
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "leechseed", "morningsun", "toxic"]
+                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "leechseed", "morningsun", "toxic"],
+                "abilities": ["Flower Gift"]
             }
         ]
     },
@@ -3176,7 +3615,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic"]
+                "movepool": ["clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -3186,6 +3626,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fakeout", "knockoff", "lowkick", "return", "uturn"],
+                "abilities": ["Technician"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3195,11 +3636,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["acrobatics", "defog", "destinybond", "shadowball", "substitute", "willowisp"]
+                "movepool": ["acrobatics", "defog", "destinybond", "shadowball", "substitute", "willowisp"],
+                "abilities": ["Unburden"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["acrobatics", "hex", "substitute", "willowisp"]
+                "movepool": ["acrobatics", "hex", "substitute", "willowisp"],
+                "abilities": ["Unburden"]
             }
         ]
     },
@@ -3208,11 +3651,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["brutalswing", "healingwish", "highjumpkick", "return", "switcheroo"]
+                "movepool": ["brutalswing", "healingwish", "highjumpkick", "return", "switcheroo"],
+                "abilities": ["Limber"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["brutalswing", "highjumpkick", "return", "splash"],
+                "abilities": ["Limber"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -3222,7 +3667,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["encore", "fakeout", "highjumpkick", "poweruppunch", "return", "substitute"]
+                "movepool": ["encore", "fakeout", "highjumpkick", "poweruppunch", "return", "substitute"],
+                "abilities": ["Limber"]
             }
         ]
     },
@@ -3231,11 +3677,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dazzlinggleam", "painsplit", "shadowball", "taunt", "willowisp"]
+                "movepool": ["dazzlinggleam", "painsplit", "shadowball", "taunt", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["dazzlinggleam", "mysticalfire", "nastyplot", "shadowball", "thunderbolt", "trick"]
+                "movepool": ["dazzlinggleam", "mysticalfire", "nastyplot", "shadowball", "thunderbolt", "trick"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3244,7 +3692,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"]
+                "movepool": ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"],
+                "abilities": ["Moxie"]
             }
         ]
     },
@@ -3254,6 +3703,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["fakeout", "knockoff", "return", "stompingtantrum", "uturn"],
+                "abilities": ["Defiant", "Thick Fat"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3263,7 +3713,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "defog", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"]
+                "movepool": ["crunch", "defog", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"],
+                "abilities": ["Aftermath"]
             }
         ]
     },
@@ -3273,11 +3724,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "ironhead", "psychic", "stealthrock", "toxic"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
                 "movepool": ["earthquake", "ironhead", "protect", "psychic", "toxic"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3287,11 +3740,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["boomburst", "chatter", "heatwave", "hiddenpowerground", "uturn"]
+                "movepool": ["boomburst", "chatter", "heatwave", "hiddenpowerground", "uturn"],
+                "abilities": ["Tangled Feet"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["boomburst", "chatter", "heatwave", "nastyplot", "substitute"]
+                "movepool": ["boomburst", "chatter", "heatwave", "nastyplot", "substitute"],
+                "abilities": ["Tangled Feet"]
             }
         ]
     },
@@ -3300,11 +3755,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "darkpulse", "rest", "sleeptalk"]
+                "movepool": ["calmmind", "darkpulse", "rest", "sleeptalk"],
+                "abilities": ["Infiltrator"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -3313,15 +3770,18 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["dragonclaw", "earthquake", "fireblast", "outrage", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["dragonclaw", "earthquake", "fireblast", "outrage", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Rough Skin"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"],
+                "abilities": ["Rough Skin"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"],
+                "abilities": ["Rough Skin"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -3331,11 +3791,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "stealthrock", "stoneedge"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "stealthrock", "stoneedge"],
+                "abilities": ["Rough Skin"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"]
+                "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -3345,11 +3807,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "crunch", "extremespeed", "meteormash", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Normal"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"]
+                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -3358,11 +3822,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["closecombat", "extremespeed", "meteormash", "swordsdance"]
+                "movepool": ["closecombat", "extremespeed", "meteormash", "swordsdance"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "flashcannon", "nastyplot", "vacuumwave"]
+                "movepool": ["aurasphere", "flashcannon", "nastyplot", "vacuumwave"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -3371,7 +3837,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"]
+                "movepool": ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
+                "abilities": ["Sand Stream"]
             }
         ]
     },
@@ -3381,11 +3848,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquatail", "earthquake", "knockoff", "poisonjab", "pursuit", "swordsdance"],
+                "abilities": ["Battle Armor"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "poisonjab", "taunt", "toxicspikes", "whirlwind"]
+                "movepool": ["earthquake", "knockoff", "poisonjab", "taunt", "toxicspikes", "whirlwind"],
+                "abilities": ["Battle Armor"]
             }
         ]
     },
@@ -3394,7 +3863,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "earthquake", "gunkshot", "knockoff", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "earthquake", "gunkshot", "knockoff", "substitute", "suckerpunch", "swordsdance"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -3403,7 +3873,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "knockoff", "powerwhip", "sleeppowder", "synthesis", "toxic"]
+                "movepool": ["defog", "knockoff", "powerwhip", "sleeppowder", "synthesis", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3412,7 +3883,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "icebeam", "scald", "toxic", "uturn"]
+                "movepool": ["defog", "icebeam", "scald", "toxic", "uturn"],
+                "abilities": ["Storm Drain"]
             }
         ]
     },
@@ -3422,6 +3894,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["blizzard", "earthquake", "gigadrain", "iceshard", "woodhammer"],
+                "abilities": ["Snow Warning"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3432,6 +3905,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["blizzard", "earthquake", "gigadrain", "iceshard", "woodhammer"],
+                "abilities": ["Snow Warning"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3441,7 +3915,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["iceshard", "iciclecrash", "knockoff", "lowkick", "pursuit", "swordsdance"]
+                "movepool": ["iceshard", "iciclecrash", "knockoff", "lowkick", "pursuit", "swordsdance"],
+                "abilities": ["Pickpocket"]
             }
         ]
     },
@@ -3450,7 +3925,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"]
+                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -3459,16 +3935,19 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "healbell", "knockoff", "protect", "wish"]
+                "movepool": ["bodyslam", "healbell", "knockoff", "protect", "wish"],
+                "abilities": ["Cloud Nine"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["bodyslam", "dragontail", "earthquake", "explosion", "knockoff", "powerwhip"],
+                "abilities": ["Cloud Nine"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bodyslam", "earthquake", "explosion", "knockoff", "powerwhip", "return", "swordsdance"],
+                "abilities": ["Cloud Nine"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3478,11 +3957,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dragontail", "earthquake", "icepunch", "megahorn", "stoneedge"]
+                "movepool": ["dragontail", "earthquake", "icepunch", "megahorn", "stoneedge"],
+                "abilities": ["Solid Rock"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge"]
+                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge"],
+                "abilities": ["Solid Rock"]
             }
         ]
     },
@@ -3491,11 +3972,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "sludgebomb", "synthesis"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["earthquake", "gigadrain", "knockoff", "powerwhip", "rockslide", "sludgebomb"]
+                "movepool": ["earthquake", "gigadrain", "knockoff", "powerwhip", "rockslide", "sludgebomb"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -3505,6 +3988,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+                "abilities": ["Motor Drive"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -3515,6 +3999,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -3524,15 +4009,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["airslash", "aurasphere", "nastyplot", "roost", "thunderwave"]
+                "movepool": ["airslash", "aurasphere", "nastyplot", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "defog", "healbell", "roost", "thunderwave"]
+                "movepool": ["airslash", "defog", "healbell", "roost", "thunderwave"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "aurasphere", "dazzlinggleam", "trick"]
+                "movepool": ["airslash", "aurasphere", "dazzlinggleam", "trick"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -3541,11 +4029,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "protect"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "protect"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["airslash", "bugbuzz", "gigadrain", "uturn"]
+                "movepool": ["airslash", "bugbuzz", "gigadrain", "uturn"],
+                "abilities": ["Tinted Lens"]
             }
         ]
     },
@@ -3555,6 +4045,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor"],
+                "abilities": ["Chlorophyll"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3564,15 +4055,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerground", "icebeam", "protect", "wish"]
+                "movepool": ["healbell", "hiddenpowerground", "icebeam", "protect", "wish"],
+                "abilities": ["Ice Body"]
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "toxic", "wish"]
+                "movepool": ["icebeam", "protect", "toxic", "wish"],
+                "abilities": ["Ice Body"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["celebrate", "hiddenpowerground", "icebeam", "storedpower"],
+                "abilities": ["Ice Body"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -3582,15 +4076,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "substitute", "toxic"]
+                "movepool": ["earthquake", "protect", "substitute", "toxic"],
+                "abilities": ["Poison Heal"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "roost", "stealthrock", "taunt", "toxic", "uturn"]
+                "movepool": ["earthquake", "knockoff", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+                "abilities": ["Poison Heal"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "facade", "roost", "swordsdance"]
+                "movepool": ["earthquake", "facade", "roost", "swordsdance"],
+                "abilities": ["Poison Heal"]
             }
         ]
     },
@@ -3599,7 +4096,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock"]
+                "movepool": ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock"],
+                "abilities": ["Thick Fat"]
             }
         ]
     },
@@ -3608,11 +4106,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["icebeam", "nastyplot", "shadowball", "thunderbolt", "triattack", "trick"]
+                "movepool": ["icebeam", "nastyplot", "shadowball", "thunderbolt", "triattack", "trick"],
+                "abilities": ["Adaptability", "Download"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["conversion", "icebeam", "recover", "shadowball", "thunderbolt"],
+                "abilities": ["Adaptability"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -3623,6 +4123,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "icepunch", "knockoff", "shadowsneak", "swordsdance", "zenheadbutt"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3632,7 +4133,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["closecombat", "knockoff", "swordsdance", "zenheadbutt"]
+                "movepool": ["closecombat", "knockoff", "swordsdance", "zenheadbutt"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -3641,7 +4143,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"]
+                "movepool": ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Magnet Pull"]
             }
         ]
     },
@@ -3651,11 +4154,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "toxic", "willowisp"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"]
+                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3664,7 +4169,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave", "willowisp"]
+                "movepool": ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave", "willowisp"],
+                "abilities": ["Cursed Body"]
             }
         ]
     },
@@ -3673,7 +4179,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "hiddenpowerice", "painsplit", "shadowball", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["defog", "hiddenpowerice", "painsplit", "shadowball", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3682,7 +4189,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"]
+                "movepool": ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3691,7 +4199,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "hydropump", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["defog", "hydropump", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3700,11 +4209,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["blizzard", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["blizzard", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -3714,7 +4225,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "defog", "painsplit", "thunderbolt", "voltswitch", "willowisp"]
+                "movepool": ["airslash", "defog", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3723,7 +4235,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "hiddenpowerice", "leafstorm", "thunderbolt", "trick", "voltswitch", "willowisp"]
+                "movepool": ["defog", "hiddenpowerice", "leafstorm", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3732,7 +4245,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn", "yawn"]
+                "movepool": ["healbell", "knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn", "yawn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3741,11 +4255,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "energyball", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"]
+                "movepool": ["calmmind", "energyball", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"]
+                "movepool": ["knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3754,11 +4270,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dazzlinggleam", "fireblast", "nastyplot", "psychic", "psyshock", "uturn"]
+                "movepool": ["dazzlinggleam", "fireblast", "nastyplot", "psychic", "psyshock", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["explosion", "fireblast", "knockoff", "psychic", "stealthrock", "taunt", "uturn"]
+                "movepool": ["explosion", "fireblast", "knockoff", "psychic", "stealthrock", "taunt", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3768,6 +4286,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -3778,6 +4297,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "fireblast", "hydropump", "spacialrend", "thunderwave"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -3787,11 +4307,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "flashcannon", "lavaplume", "magmastorm", "stealthrock", "taunt", "toxic"]
+                "movepool": ["earthpower", "flashcannon", "lavaplume", "magmastorm", "stealthrock", "taunt", "toxic"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthpower", "magmastorm", "protect", "toxic"]
+                "movepool": ["earthpower", "magmastorm", "protect", "toxic"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -3801,6 +4323,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["drainpunch", "knockoff", "return", "substitute", "thunderwave"],
+                "abilities": ["Slow Start"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3810,11 +4333,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "hex", "shadowsneak", "thunderwave", "willowisp"]
+                "movepool": ["dracometeor", "hex", "shadowsneak", "thunderwave", "willowisp"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["defog", "dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"]
+                "movepool": ["defog", "dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3823,15 +4348,18 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["dragontail", "rest", "shadowball", "sleeptalk", "willowisp"]
+                "movepool": ["dragontail", "rest", "shadowball", "sleeptalk", "willowisp"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"]
+                "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "dragontail", "rest", "shadowball", "willowisp"]
+                "movepool": ["defog", "dragontail", "rest", "shadowball", "willowisp"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3840,11 +4368,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "moonblast", "moonlight", "psyshock"]
+                "movepool": ["calmmind", "moonblast", "moonlight", "psyshock"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["moonblast", "moonlight", "psychic", "thunderwave", "toxic"]
+                "movepool": ["moonblast", "moonlight", "psychic", "thunderwave", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3853,7 +4383,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "icebeam", "knockoff", "scald", "toxic", "uturn"]
+                "movepool": ["healbell", "icebeam", "knockoff", "scald", "toxic", "uturn"],
+                "abilities": ["Hydration"]
             }
         ]
     },
@@ -3862,11 +4393,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["energyball", "icebeam", "surf", "tailglow"]
+                "movepool": ["energyball", "icebeam", "surf", "tailglow"],
+                "abilities": ["Hydration"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["energyball", "icebeam", "surf", "tailglow"],
+                "abilities": ["Hydration"],
                 "preferredTypes": ["Water"]
             }
         ]
@@ -3877,11 +4410,13 @@
             {
                 "role": "Z-Move user",
                 "movepool": ["darkpulse", "focusblast", "hypnosis", "nastyplot", "sludgebomb"],
+                "abilities": ["Bad Dreams"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["darkpulse", "focusblast", "hypnosis", "nastyplot", "sludgebomb", "substitute"],
+                "abilities": ["Bad Dreams"],
                 "preferredTypes": ["Poison"]
             }
         ]
@@ -3892,6 +4427,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
+                "abilities": ["Natural Cure"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -3901,7 +4437,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"]
+                "movepool": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -3910,7 +4447,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"]
+                "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3919,11 +4457,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3932,7 +4472,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "fireblast", "judgment", "recover", "sludgebomb", "toxic", "willowisp"]
+                "movepool": ["calmmind", "defog", "fireblast", "judgment", "recover", "sludgebomb", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3941,11 +4482,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "willowisp"]
+                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["earthquake", "extremespeed", "outrage", "recover", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3955,7 +4498,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3964,11 +4508,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3977,7 +4523,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover", "shadowball"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "shadowball"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3986,11 +4533,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "energyball", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "energyball", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["calmmind", "earthpower", "energyball", "fireblast", "recover"]
+                "movepool": ["calmmind", "earthpower", "energyball", "fireblast", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -3999,11 +4548,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4012,11 +4563,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "focusblast", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["calmmind", "defog", "focusblast", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["brickbreak", "extremespeed", "shadowforce", "swordsdance"]
+                "movepool": ["brickbreak", "extremespeed", "shadowforce", "swordsdance"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4025,11 +4578,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "judgment"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4039,11 +4594,13 @@
             {
                 "role": "Z-Move user",
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4052,7 +4609,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"]
+                "movepool": ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4062,16 +4620,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["defog", "earthquake", "icebeam", "recover", "sludgebomb"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "earthpower", "icebeam", "recover", "sludgebomb"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["calmmind", "earthpower", "icebeam", "recover", "sludgebomb"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4081,11 +4642,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4094,11 +4657,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4108,11 +4673,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["earthquake", "ironhead", "recover", "stoneedge", "swordsdance"],
+                "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4122,7 +4689,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4131,16 +4699,19 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["boltstrike", "uturn", "vcreate", "zenheadbutt"]
+                "movepool": ["boltstrike", "uturn", "vcreate", "zenheadbutt"],
+                "abilities": ["Victory Star"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["boltstrike", "energyball", "focusblast", "glaciate", "psychic", "uturn", "vcreate"],
+                "abilities": ["Victory Star"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["blueflare", "boltstrike", "celebrate", "storedpower"],
+                "abilities": ["Victory Star"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -4150,7 +4721,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "dragonpulse", "glare", "hiddenpowerfire", "leafstorm", "leechseed", "substitute"]
+                "movepool": ["defog", "dragonpulse", "glare", "hiddenpowerfire", "leafstorm", "leechseed", "substitute"],
+                "abilities": ["Contrary"]
             }
         ]
     },
@@ -4159,11 +4731,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["flareblitz", "headsmash", "suckerpunch", "superpower", "wildcharge"]
+                "movepool": ["flareblitz", "headsmash", "suckerpunch", "superpower", "wildcharge"],
+                "abilities": ["Reckless"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["flareblitz", "grassknot", "suckerpunch", "superpower", "wildcharge"]
+                "movepool": ["flareblitz", "grassknot", "suckerpunch", "superpower", "wildcharge"],
+                "abilities": ["Reckless"]
             }
         ]
     },
@@ -4172,11 +4746,13 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "knockoff", "megahorn", "sacredsword", "scald"]
+                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "knockoff", "megahorn", "sacredsword", "scald"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "knockoff", "liquidation", "megahorn", "sacredsword", "swordsdance"]
+                "movepool": ["aquajet", "knockoff", "liquidation", "megahorn", "sacredsword", "swordsdance"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -4185,11 +4761,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hypnosis", "knockoff", "return", "superfang"]
+                "movepool": ["hypnosis", "knockoff", "return", "superfang"],
+                "abilities": ["Analytic"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["hypnosis", "knockoff", "return", "stompingtantrum", "swordsdance"],
+                "abilities": ["Analytic"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -4200,6 +4778,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["crunch", "playrough", "return", "superpower", "wildcharge"],
+                "abilities": ["Scrappy"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4209,7 +4788,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["copycat", "encore", "knockoff", "substitute", "thunderwave", "uturn"]
+                "movepool": ["copycat", "encore", "knockoff", "substitute", "thunderwave", "uturn"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -4219,11 +4799,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["gunkshot", "hiddenpowerice", "knockoff", "leafstorm", "rockslide", "superpower"],
+                "abilities": ["Overgrow"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "gigadrain", "hiddenpowerice", "nastyplot", "substitute"]
+                "movepool": ["focusblast", "gigadrain", "hiddenpowerice", "nastyplot", "substitute"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -4232,7 +4814,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"]
+                "movepool": ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -4242,6 +4825,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["grassknot", "hydropump", "icebeam", "nastyplot", "substitute"],
+                "abilities": ["Torrent"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -4251,11 +4835,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "moonlight", "psyshock", "shadowball", "signalbeam"]
+                "movepool": ["calmmind", "moonlight", "psyshock", "shadowball", "signalbeam"],
+                "abilities": ["Synchronize"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "moonlight", "psychic", "signalbeam", "thunderwave", "toxic"]
+                "movepool": ["healbell", "moonlight", "psychic", "signalbeam", "thunderwave", "toxic"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -4264,7 +4850,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "nightslash", "pluck", "return", "roost", "toxic", "uturn"]
+                "movepool": ["defog", "nightslash", "pluck", "return", "roost", "toxic", "uturn"],
+                "abilities": ["Super Luck"]
             }
         ]
     },
@@ -4273,7 +4860,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
+                "movepool": ["hiddenpowerice", "overheat", "voltswitch", "wildcharge"],
+                "abilities": ["Sap Sipper"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -4283,6 +4876,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower", "toxic"],
+                "abilities": ["Sand Stream"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4292,11 +4886,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "heatwave", "roost", "storedpower"]
+                "movepool": ["calmmind", "heatwave", "roost", "storedpower"],
+                "abilities": ["Simple"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "calmmind", "heatwave", "roost", "storedpower"]
+                "movepool": ["airslash", "calmmind", "heatwave", "roost", "storedpower"],
+                "abilities": ["Simple"]
             }
         ]
     },
@@ -4305,7 +4901,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"]
+                "movepool": ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"],
+                "abilities": ["Mold Breaker", "Sand Rush"]
             }
         ]
     },
@@ -4314,7 +4911,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "protect", "toxic", "wish"]
+                "movepool": ["knockoff", "protect", "toxic", "wish"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4323,11 +4921,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["dazzlinggleam", "protect", "toxic", "wish"]
+                "movepool": ["dazzlinggleam", "protect", "toxic", "wish"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "protect", "wish"]
+                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "protect", "wish"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4336,7 +4936,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "drainpunch", "knockoff", "machpunch"]
+                "movepool": ["bulkup", "drainpunch", "knockoff", "machpunch"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -4345,7 +4946,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["drainpunch", "facade", "knockoff", "machpunch"]
+                "movepool": ["drainpunch", "facade", "knockoff", "machpunch"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -4354,15 +4956,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "hydropump", "knockoff", "raindance", "sludgewave"]
+                "movepool": ["earthquake", "hydropump", "knockoff", "raindance", "sludgewave"],
+                "abilities": ["Swift Swim"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "scald", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "knockoff", "scald", "stealthrock", "toxic"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "scald", "toxic"]
+                "movepool": ["earthquake", "protect", "scald", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -4371,11 +4976,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "facade", "knockoff", "stormthrow"]
+                "movepool": ["bulkup", "facade", "knockoff", "stormthrow"],
+                "abilities": ["Guts"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulkup", "circlethrow", "knockoff", "rest", "sleeptalk"]
+                "movepool": ["bulkup", "circlethrow", "knockoff", "rest", "sleeptalk"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -4385,6 +4992,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["bulkup", "closecombat", "earthquake", "knockoff", "poisonjab", "stoneedge"],
+                "abilities": ["Mold Breaker", "Sturdy"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -4394,7 +5002,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["knockoff", "leafblade", "stickyweb", "toxic", "xscissor"]
+                "movepool": ["knockoff", "leafblade", "stickyweb", "toxic", "xscissor"],
+                "abilities": ["Chlorophyll", "Swarm"]
             }
         ]
     },
@@ -4403,11 +5012,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "megahorn", "poisonjab", "spikes", "toxicspikes"]
+                "movepool": ["earthquake", "megahorn", "poisonjab", "spikes", "toxicspikes"],
+                "abilities": ["Speed Boost"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "megahorn", "poisonjab", "protect", "swordsdance"]
+                "movepool": ["earthquake", "megahorn", "poisonjab", "protect", "swordsdance"],
+                "abilities": ["Speed Boost"]
             }
         ]
     },
@@ -4416,11 +5027,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "encore", "energyball", "moonblast", "stunspore", "taunt", "toxic", "uturn"]
+                "movepool": ["defog", "encore", "energyball", "moonblast", "stunspore", "taunt", "toxic", "uturn"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Staller",
-                "movepool": ["leechseed", "moonblast", "protect", "substitute"]
+                "movepool": ["leechseed", "moonblast", "protect", "substitute"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -4429,7 +5042,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "quiverdance", "sleeppowder"],
+                "abilities": ["Chlorophyll"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"],
+                "abilities": ["Own Tempo"]
             }
         ]
     },
@@ -4438,7 +5057,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "crunch", "headsmash", "liquidation", "superpower"]
+                "movepool": ["aquajet", "crunch", "headsmash", "liquidation", "superpower"],
+                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -4447,7 +5067,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -4456,7 +5077,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"]
+                "movepool": ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -4465,11 +5087,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "synthesis", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "synthesis", "toxic"],
+                "abilities": ["Storm Drain", "Water Absorb"]
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "spikyshield"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "spikyshield"],
+                "abilities": ["Storm Drain", "Water Absorb"]
             }
         ]
     },
@@ -4479,6 +5103,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "knockoff", "shellsmash", "stoneedge", "xscissor"],
+                "abilities": ["Sturdy"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4488,11 +5113,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "highjumpkick", "ironhead", "knockoff"]
+                "movepool": ["dragondance", "highjumpkick", "ironhead", "knockoff"],
+                "abilities": ["Intimidate", "Moxie"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "drainpunch", "knockoff", "rest"]
+                "movepool": ["bulkup", "drainpunch", "knockoff", "rest"],
+                "abilities": ["Shed Skin"]
             }
         ]
     },
@@ -4501,11 +5128,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["airslash", "calmmind", "defog", "heatwave", "psyshock", "roost"]
+                "movepool": ["airslash", "calmmind", "defog", "heatwave", "psyshock", "roost"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"],
+                "abilities": ["Tinted Lens"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -4515,11 +5144,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "painsplit", "shadowball", "toxicspikes", "willowisp"]
+                "movepool": ["haze", "painsplit", "shadowball", "toxicspikes", "willowisp"],
+                "abilities": ["Mummy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "trickroom"]
+                "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "trickroom"],
+                "abilities": ["Mummy"]
             }
         ]
     },
@@ -4528,7 +5159,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "earthquake", "icebeam", "liquidation", "shellsmash", "stoneedge"]
+                "movepool": ["aquajet", "earthquake", "icebeam", "liquidation", "shellsmash", "stoneedge"],
+                "abilities": ["Solid Rock", "Sturdy", "Swift Swim"]
             }
         ]
     },
@@ -4537,11 +5169,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["acrobatics", "defog", "earthquake", "roost", "stoneedge", "uturn"]
+                "movepool": ["acrobatics", "defog", "earthquake", "roost", "stoneedge", "uturn"],
+                "abilities": ["Defeatist"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquatail", "earthquake", "headsmash", "knockoff", "stealthrock", "stoneedge", "uturn"],
+                "abilities": ["Defeatist"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4551,7 +5185,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["gunkshot", "haze", "painsplit", "spikes", "stompingtantrum", "toxic", "toxicspikes"]
+                "movepool": ["gunkshot", "haze", "painsplit", "spikes", "stompingtantrum", "toxic", "toxicspikes"],
+                "abilities": ["Aftermath"]
             }
         ]
     },
@@ -4561,6 +5196,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["darkpulse", "flamethrower", "focusblast", "nastyplot", "sludgebomb", "trick", "uturn"],
+                "abilities": ["Illusion"],
                 "preferredTypes": ["Poison"]
             }
         ]
@@ -4570,7 +5206,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"]
+                "movepool": ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -4579,7 +5216,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "shadowball", "signalbeam", "thunderbolt", "trick"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "shadowball", "signalbeam", "thunderbolt", "trick"],
+                "abilities": ["Shadow Tag"]
             }
         ]
     },
@@ -4588,11 +5226,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trickroom"]
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trickroom"],
+                "abilities": ["Magic Guard"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"]
+                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"],
+                "abilities": ["Magic Guard"]
             }
         ]
     },
@@ -4601,11 +5241,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "roost", "scald", "toxic"]
+                "movepool": ["bravebird", "defog", "roost", "scald", "toxic"],
+                "abilities": ["Hydration"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["hurricane", "raindance", "rest", "scald"],
+                "abilities": ["Hydration"],
                 "preferredTypes": ["Water"]
             }
         ]
@@ -4616,11 +5258,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["autotomize", "blizzard", "explosion", "flashcannon", "freezedry", "hiddenpowerground"],
+                "abilities": ["Snow Warning"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["blizzard", "explosion", "flashcannon", "freezedry", "hiddenpowerground"],
+                "abilities": ["Snow Warning"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4631,6 +5275,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["headbutt", "hornleech", "jumpkick", "return", "substitute", "swordsdance"],
+                "abilities": ["Sap Sipper", "Serene Grace"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -4640,7 +5285,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["acrobatics", "defog", "encore", "knockoff", "roost", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["acrobatics", "defog", "encore", "knockoff", "roost", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Motor Drive"]
             }
         ]
     },
@@ -4649,7 +5295,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"]
+                "movepool": ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"],
+                "abilities": ["Overcoat", "Swarm"]
             }
         ]
     },
@@ -4658,11 +5305,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["clearsmog", "foulplay", "gigadrain", "sludgebomb", "spore", "stompingtantrum"]
+                "movepool": ["clearsmog", "foulplay", "gigadrain", "sludgebomb", "spore", "stompingtantrum"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["gigadrain", "sludgebomb", "spore", "synthesis"]
+                "movepool": ["gigadrain", "sludgebomb", "spore", "synthesis"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4671,11 +5320,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "recover", "scald", "shadowball", "taunt"]
+                "movepool": ["icebeam", "recover", "scald", "shadowball", "taunt"],
+                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hex", "recover", "scald", "toxic", "willowisp"]
+                "movepool": ["hex", "recover", "scald", "toxic", "willowisp"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -4684,7 +5335,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "protect", "scald", "toxic", "wish"]
+                "movepool": ["knockoff", "protect", "scald", "toxic", "wish"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4694,6 +5346,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["bugbuzz", "gigadrain", "stickyweb", "thunder", "voltswitch"],
+                "abilities": ["Compound Eyes"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -4703,11 +5356,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gyroball", "leechseed", "powerwhip", "spikes", "stealthrock"]
+                "movepool": ["gyroball", "leechseed", "powerwhip", "spikes", "stealthrock"],
+                "abilities": ["Iron Barbs"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "powerwhip", "spikes", "stealthrock", "thunderwave", "toxic"]
+                "movepool": ["knockoff", "powerwhip", "spikes", "stealthrock", "thunderwave", "toxic"],
+                "abilities": ["Iron Barbs"]
             }
         ]
     },
@@ -4716,11 +5371,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["geargrind", "return", "shiftgear", "substitute", "wildcharge"]
+                "movepool": ["geargrind", "return", "shiftgear", "substitute", "wildcharge"],
+                "abilities": ["Clear Body"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["geargrind", "return", "shiftgear", "substitute", "wildcharge"],
+                "abilities": ["Clear Body"],
                 "preferredTypes": ["Electric", "Normal", "Steel"]
             }
         ]
@@ -4730,7 +5387,8 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["discharge", "flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "uturn"]
+                "movepool": ["discharge", "flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "uturn"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -4739,7 +5397,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"]
+                "movepool": ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"],
+                "abilities": ["Analytic"]
             }
         ]
     },
@@ -4748,11 +5407,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["energyball", "fireblast", "shadowball", "trick"]
+                "movepool": ["energyball", "fireblast", "shadowball", "trick"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"]
+                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"],
+                "abilities": ["Flame Body", "Flash Fire"]
             }
         ]
     },
@@ -4762,11 +5423,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dragondance", "earthquake", "outrage", "poisonjab", "taunt"],
+                "abilities": ["Mold Breaker"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["dragondance", "earthquake", "outrage", "poisonjab"],
+                "abilities": ["Mold Breaker"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -4777,6 +5440,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aquajet", "iciclecrash", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Slush Rush", "Swift Swim"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4786,7 +5450,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["freezedry", "haze", "hiddenpowerground", "rapidspin", "recover", "toxic"]
+                "movepool": ["freezedry", "haze", "hiddenpowerground", "rapidspin", "recover", "toxic"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -4795,7 +5460,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "toxicspikes", "uturn"]
+                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "toxicspikes", "uturn"],
+                "abilities": ["Hydration", "Sticky Hold"]
             }
         ]
     },
@@ -4804,11 +5470,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["discharge", "earthpower", "rest", "scald", "sleeptalk", "stealthrock", "toxic"]
+                "movepool": ["discharge", "earthpower", "rest", "scald", "sleeptalk", "stealthrock", "toxic"],
+                "abilities": ["Static"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["discharge", "earthpower", "foulplay", "scald", "sludgebomb"]
+                "movepool": ["discharge", "earthpower", "foulplay", "scald", "sludgebomb"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -4818,11 +5486,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["highjumpkick", "knockoff", "poisonjab", "stoneedge", "swordsdance", "uturn"],
+                "abilities": ["Reckless"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["fakeout", "highjumpkick", "knockoff", "uturn"]
+                "movepool": ["fakeout", "highjumpkick", "knockoff", "uturn"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -4832,11 +5502,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["firepunch", "glare", "gunkshot", "outrage", "suckerpunch"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Poison"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "earthquake", "glare", "gunkshot", "outrage", "stealthrock", "suckerpunch"]
+                "movepool": ["dragontail", "earthquake", "glare", "gunkshot", "outrage", "stealthrock", "suckerpunch"],
+                "abilities": ["Rough Skin"]
             }
         ]
     },
@@ -4846,11 +5518,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["dynamicpunch", "earthquake", "icepunch", "rockpolish", "stealthrock", "stoneedge"],
+                "abilities": ["No Guard"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "icepunch", "rockpolish", "shadowpunch"]
+                "movepool": ["earthquake", "icepunch", "rockpolish", "shadowpunch"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -4859,7 +5533,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["ironhead", "knockoff", "pursuit", "suckerpunch", "swordsdance"]
+                "movepool": ["ironhead", "knockoff", "pursuit", "suckerpunch", "swordsdance"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -4868,7 +5543,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headcharge", "stoneedge", "superpower", "swordsdance"]
+                "movepool": ["earthquake", "headcharge", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Reckless", "Sap Sipper"]
             }
         ]
     },
@@ -4877,11 +5553,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "bulkup", "roost", "superpower"]
+                "movepool": ["bravebird", "bulkup", "roost", "superpower"],
+                "abilities": ["Defiant"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "return", "superpower", "uturn"]
+                "movepool": ["bravebird", "return", "superpower", "uturn"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -4890,11 +5568,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "foulplay", "knockoff", "roost", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "defog", "foulplay", "knockoff", "roost", "taunt", "toxic", "uturn"],
+                "abilities": ["Overcoat"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "foulplay", "roost", "taunt", "toxic", "uturn"]
+                "movepool": ["defog", "foulplay", "roost", "taunt", "toxic", "uturn"],
+                "abilities": ["Overcoat"]
             }
         ]
     },
@@ -4903,7 +5583,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "firelash", "gigadrain", "knockoff", "suckerpunch", "superpower"]
+                "movepool": ["fireblast", "firelash", "gigadrain", "knockoff", "suckerpunch", "superpower"],
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -4913,6 +5594,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
+                "abilities": ["Hustle"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4922,15 +5604,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "dracometeor", "earthpower", "fireblast", "flashcannon", "roost", "uturn"]
+                "movepool": ["darkpulse", "dracometeor", "earthpower", "fireblast", "flashcannon", "roost", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "defog", "dracometeor", "fireblast", "roost", "uturn"]
+                "movepool": ["darkpulse", "defog", "dracometeor", "fireblast", "roost", "uturn"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["darkpulse", "dracometeor", "flashcannon", "superpower", "uturn"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -4940,11 +5625,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerrock", "quiverdance", "roost"]
+                "movepool": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerrock", "quiverdance", "roost"],
+                "abilities": ["Flame Body", "Swarm"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["bugbuzz", "fireblast", "gigadrain", "quiverdance", "roost"],
+                "abilities": ["Flame Body", "Swarm"],
                 "preferredTypes": ["Bug", "Fire"]
             }
         ]
@@ -4954,11 +5641,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"]
+                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["closecombat", "ironhead", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fighting", "Steel"]
             }
         ]
@@ -4969,15 +5658,18 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["closecombat", "earthquake", "stoneedge", "swordsdance"]
+                "movepool": ["closecombat", "earthquake", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["closecombat", "earthquake", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fighting", "Rock"]
             }
         ]
@@ -4987,11 +5679,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "leafblade", "stoneedge", "swordsdance"]
+                "movepool": ["closecombat", "leafblade", "stoneedge", "swordsdance"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["calmmind", "focusblast", "gigadrain", "hiddenpowerrock"],
+                "abilities": ["Justified"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -5001,11 +5695,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"]
+                "movepool": ["defog", "heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"],
+                "abilities": ["Defiant", "Prankster"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["acrobatics", "bulkup", "knockoff", "superpower", "taunt"],
+                "abilities": ["Defiant"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -5015,7 +5711,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"]
+                "movepool": ["defog", "heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -5024,11 +5721,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerflying", "hiddenpowerice", "knockoff", "superpower", "taunt", "thunderbolt", "thunderwave"]
+                "movepool": ["hiddenpowerflying", "hiddenpowerice", "knockoff", "superpower", "taunt", "thunderbolt", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -5037,7 +5736,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"]
+                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+                "abilities": ["Volt Absorb"]
             }
         ]
     },
@@ -5046,7 +5746,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blueflare", "defog", "dracometeor", "roost", "toxic"]
+                "movepool": ["blueflare", "defog", "dracometeor", "roost", "toxic"],
+                "abilities": ["Turboblaze"]
             }
         ]
     },
@@ -5055,15 +5756,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["boltstrike", "honeclaws", "outrage", "roost", "substitute"]
+                "movepool": ["boltstrike", "honeclaws", "outrage", "roost", "substitute"],
+                "abilities": ["Teravolt"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["boltstrike", "dracometeor", "outrage", "voltswitch"]
+                "movepool": ["boltstrike", "dracometeor", "outrage", "voltswitch"],
+                "abilities": ["Teravolt"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["boltstrike", "honeclaws", "outrage", "roost"],
+                "abilities": ["Teravolt"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -5073,11 +5777,14 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "focusblast", "knockoff", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"]
+                "movepool": ["earthpower", "focusblast", "knockoff", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"],
+                "abilities": ["Sheer Force"],
+                "preferredTypes": ["Rock"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "earthpower", "focusblast", "psychic", "rockpolish", "sludgewave"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Poison"]
             }
         ]
@@ -5087,16 +5794,19 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "knockoff", "stealthrock", "stoneedge", "toxic", "uturn"]
+                "movepool": ["defog", "earthquake", "knockoff", "stealthrock", "stoneedge", "toxic", "uturn"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "knockoff", "rockpolish", "stoneedge", "superpower", "swordsdance"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Rock"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["earthquake", "fly", "rockpolish", "stoneedge", "swordsdance"],
+                "abilities": ["Intimidate"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -5106,15 +5816,18 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthpower", "icebeam", "roost", "substitute"]
+                "movepool": ["earthpower", "icebeam", "roost", "substitute"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["dracometeor", "earthpower", "icebeam", "outrage", "roost", "substitute"]
+                "movepool": ["dracometeor", "earthpower", "icebeam", "outrage", "roost", "substitute"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage"]
+                "movepool": ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -5123,11 +5836,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"]
+                "movepool": ["earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"],
+                "abilities": ["Teravolt"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["freezeshock", "fusionbolt", "honeclaws", "outrage", "roost"],
+                "abilities": ["Teravolt"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -5137,7 +5852,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthpower", "fusionflare", "icebeam", "roost"]
+                "movepool": ["dracometeor", "earthpower", "fusionflare", "icebeam", "roost"],
+                "abilities": ["Turboblaze"]
             }
         ]
     },
@@ -5146,15 +5862,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword"]
+                "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "scald", "secretsword", "substitute"]
+                "movepool": ["calmmind", "scald", "secretsword", "substitute"],
+                "abilities": ["Justified"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "hydropump", "scald", "secretsword"]
+                "movepool": ["focusblast", "hydropump", "scald", "secretsword"],
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -5163,11 +5882,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"]
+                "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"],
+                "abilities": ["Serene Grace"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "knockoff", "relicsong", "return"]
+                "movepool": ["closecombat", "knockoff", "relicsong", "return"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },
@@ -5176,15 +5897,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["blazekick", "ironhead", "shiftgear", "thunderbolt", "xscissor"]
+                "movepool": ["blazekick", "ironhead", "shiftgear", "thunderbolt", "xscissor"],
+                "abilities": ["Download"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["blazekick", "extremespeed", "ironhead", "uturn"]
+                "movepool": ["blazekick", "extremespeed", "ironhead", "uturn"],
+                "abilities": ["Download"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["bugbuzz", "flamethrower", "flashcannon", "icebeam", "thunderbolt", "uturn"],
+                "abilities": ["Download"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -5194,11 +5918,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bulkup", "drainpunch", "spikes", "synthesis", "toxic", "woodhammer"]
+                "movepool": ["bulkup", "drainpunch", "spikes", "synthesis", "toxic", "woodhammer"],
+                "abilities": ["Bulletproof"]
             },
             {
                 "role": "Staller",
-                "movepool": ["drainpunch", "leechseed", "spikyshield", "woodhammer"]
+                "movepool": ["drainpunch", "leechseed", "spikyshield", "woodhammer"],
+                "abilities": ["Bulletproof"]
             }
         ]
     },
@@ -5207,7 +5933,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "grassknot", "psyshock", "switcheroo"]
+                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "grassknot", "psyshock", "switcheroo"],
+                "abilities": ["Blaze"]
             }
         ]
     },
@@ -5216,7 +5943,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"]
+                "movepool": ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
+                "abilities": ["Protean"]
             }
         ]
     },
@@ -5225,7 +5953,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "hydropump", "icebeam", "uturn", "watershuriken"]
+                "movepool": ["darkpulse", "hydropump", "icebeam", "uturn", "watershuriken"],
+                "abilities": ["Battle Bond"]
             }
         ]
     },
@@ -5235,11 +5964,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["agility", "earthquake", "knockoff", "quickattack", "return", "swordsdance"],
+                "abilities": ["Huge Power"],
                 "preferredTypes": ["Normal"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "foulplay", "quickattack", "return", "uturn"],
+                "abilities": ["Huge Power"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -5249,11 +5980,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "overheat", "roost", "uturn", "willowisp"]
+                "movepool": ["bravebird", "defog", "overheat", "roost", "uturn", "willowisp"],
+                "abilities": ["Flame Body"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["bravebird", "flareblitz", "roost", "swordsdance"],
+                "abilities": ["Gale Wings"],
                 "preferredTypes": ["Flying"]
             }
         ]
@@ -5263,11 +5996,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["energyball", "hurricane", "quiverdance", "sleeppowder"]
+                "movepool": ["energyball", "hurricane", "quiverdance", "sleeppowder"],
+                "abilities": ["Compound Eyes"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bugbuzz", "hurricane", "quiverdance", "sleeppowder"]
+                "movepool": ["bugbuzz", "hurricane", "quiverdance", "sleeppowder"],
+                "abilities": ["Compound Eyes"]
             }
         ]
     },
@@ -5276,11 +6011,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp", "workup"]
+                "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp", "workup"],
+                "abilities": ["Unnerve"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "willowisp"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -5290,7 +6027,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerfire", "hiddenpowerground", "lightofruin", "moonblast", "psychic"]
+                "movepool": ["hiddenpowerfire", "hiddenpowerground", "lightofruin", "moonblast", "psychic"],
+                "abilities": ["Flower Veil"]
             }
         ]
     },
@@ -5299,15 +6037,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "defog", "moonblast", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "defog", "moonblast", "synthesis", "toxic"],
+                "abilities": ["Flower Veil"]
             },
             {
                 "role": "Staller",
-                "movepool": ["moonblast", "protect", "toxic", "wish"]
+                "movepool": ["moonblast", "protect", "toxic", "wish"],
+                "abilities": ["Flower Veil"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerground", "moonblast", "synthesis"]
+                "movepool": ["calmmind", "hiddenpowerground", "moonblast", "synthesis"],
+                "abilities": ["Flower Veil"]
             }
         ]
     },
@@ -5316,7 +6057,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "earthquake", "hornleech", "milkdrink", "toxic"]
+                "movepool": ["bulkup", "earthquake", "hornleech", "milkdrink", "toxic"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },
@@ -5326,6 +6068,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["bulletpunch", "drainpunch", "gunkshot", "icepunch", "knockoff", "partingshot", "superpower", "swordsdance"],
+                "abilities": ["Iron Fist", "Scrappy"],
                 "preferredTypes": ["Poison"]
             }
         ]
@@ -5335,11 +6078,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["darkpulse", "rest", "return", "thunderwave", "toxic", "uturn"]
+                "movepool": ["darkpulse", "rest", "return", "thunderwave", "toxic", "uturn"],
+                "abilities": ["Fur Coat"]
             },
             {
                 "role": "Staller",
-                "movepool": ["cottonguard", "rest", "return", "substitute", "toxic"]
+                "movepool": ["cottonguard", "rest", "return", "substitute", "toxic"],
+                "abilities": ["Fur Coat"]
             }
         ]
     },
@@ -5348,7 +6093,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "signalbeam", "thunderwave", "toxic", "yawn"]
+                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "signalbeam", "thunderwave", "toxic", "yawn"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -5357,7 +6103,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "darkpulse", "psychic", "psyshock", "signalbeam", "thunderbolt"]
+                "movepool": ["calmmind", "darkpulse", "psychic", "psyshock", "signalbeam", "thunderbolt"],
+                "abilities": ["Competitive"]
             }
         ]
     },
@@ -5366,7 +6113,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
+                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+                "abilities": ["No Guard"]
             }
         ]
     },
@@ -5375,11 +6123,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["ironhead", "kingsshield", "shadowball", "substitute", "toxic"]
+                "movepool": ["ironhead", "kingsshield", "shadowball", "substitute", "toxic"],
+                "abilities": ["Stance Change"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+                "abilities": ["Stance Change"],
                 "preferredTypes": ["Steel"]
             }
         ]
@@ -5389,7 +6139,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["calmmind", "moonblast", "protect", "toxic", "wish"]
+                "movepool": ["calmmind", "moonblast", "protect", "toxic", "wish"],
+                "abilities": ["Aroma Veil"]
             }
         ]
     },
@@ -5398,7 +6149,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "drainpunch", "playrough", "return"]
+                "movepool": ["bellydrum", "drainpunch", "playrough", "return"],
+                "abilities": ["Unburden"]
             }
         ]
     },
@@ -5407,11 +6159,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["knockoff", "rest", "sleeptalk", "superpower"]
+                "movepool": ["knockoff", "rest", "sleeptalk", "superpower"],
+                "abilities": ["Contrary"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["happyhour", "knockoff", "psychocut", "superpower"],
+                "abilities": ["Contrary"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -5421,7 +6175,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "liquidation", "lowkick", "shellsmash", "stoneedge"]
+                "movepool": ["earthquake", "liquidation", "lowkick", "shellsmash", "stoneedge"],
+                "abilities": ["Tough Claws"]
             }
         ]
     },
@@ -5430,11 +6185,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "focusblast", "sludgewave", "toxicspikes"]
+                "movepool": ["dracometeor", "focusblast", "sludgewave", "toxicspikes"],
+                "abilities": ["Adaptability"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "dragonpulse", "focusblast", "sludgewave"]
+                "movepool": ["dracometeor", "dragonpulse", "focusblast", "sludgewave"],
+                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -5443,7 +6200,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["aurasphere", "darkpulse", "icebeam", "scald", "uturn", "waterpulse"]
+                "movepool": ["aurasphere", "darkpulse", "icebeam", "scald", "uturn", "waterpulse"],
+                "abilities": ["Mega Launcher"]
             }
         ]
     },
@@ -5452,11 +6210,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "glare", "hypervoice", "surf", "thunderbolt", "voltswitch"]
+                "movepool": ["darkpulse", "glare", "hypervoice", "surf", "thunderbolt", "voltswitch"],
+                "abilities": ["Dry Skin"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hypervoice", "raindance", "surf", "thunder"]
+                "movepool": ["hypervoice", "raindance", "surf", "thunder"],
+                "abilities": ["Dry Skin"]
             }
         ]
     },
@@ -5466,11 +6226,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["dragondance", "earthquake", "headsmash", "outrage", "stealthrock", "superpower"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["dragondance", "earthquake", "headsmash", "outrage"],
+                "abilities": ["Rock Head"],
                 "preferredTypes": ["Dragon", "Rock"]
             }
         ]
@@ -5481,6 +6243,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["ancientpower", "blizzard", "earthpower", "freezedry", "stealthrock", "thunderwave"],
+                "abilities": ["Snow Warning"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -5490,11 +6253,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "hiddenpowerground", "hypervoice", "protect", "psyshock", "wish"]
+                "movepool": ["calmmind", "hiddenpowerground", "hypervoice", "protect", "psyshock", "wish"],
+                "abilities": ["Pixilate"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hypervoice", "protect", "wish"]
+                "movepool": ["calmmind", "hypervoice", "protect", "wish"],
+                "abilities": ["Pixilate"]
             }
         ]
     },
@@ -5503,7 +6268,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["acrobatics", "highjumpkick", "skyattack", "substitute", "swordsdance"]
+                "movepool": ["acrobatics", "highjumpkick", "skyattack", "substitute", "swordsdance"],
+                "abilities": ["Unburden"]
             }
         ]
     },
@@ -5512,11 +6278,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "recycle", "thunderbolt", "toxic"]
+                "movepool": ["protect", "recycle", "thunderbolt", "toxic"],
+                "abilities": ["Cheek Pouch"]
             },
             {
                 "role": "Staller",
-                "movepool": ["recycle", "substitute", "superfang", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["recycle", "substitute", "superfang", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["Cheek Pouch"]
             }
         ]
     },
@@ -5525,7 +6293,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["lightscreen", "moonblast", "powergem", "reflect", "stealthrock", "toxic"]
+                "movepool": ["lightscreen", "moonblast", "powergem", "reflect", "stealthrock", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -5534,7 +6303,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"]
+                "movepool": ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },
@@ -5543,11 +6313,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "foulplay", "spikes", "thunderwave"]
+                "movepool": ["dazzlinggleam", "foulplay", "spikes", "thunderwave"],
+                "abilities": ["Prankster"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["magnetrise", "playrough", "spikes", "thunderwave"]
+                "movepool": ["magnetrise", "playrough", "spikes", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -5556,11 +6328,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"]
+                "movepool": ["earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
+                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "hornleech", "protect", "toxic"]
+                "movepool": ["earthquake", "hornleech", "protect", "toxic"],
+                "abilities": ["Harvest"]
             }
         ]
     },
@@ -5569,7 +6343,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
+                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -5578,7 +6353,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
+                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -5587,7 +6363,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
+                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -5596,7 +6373,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
+                "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"],
+                "abilities": ["Frisk"]
             }
         ]
     },
@@ -5605,7 +6383,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["avalanche", "curse", "earthquake", "rapidspin", "recover"]
+                "movepool": ["avalanche", "curse", "earthquake", "rapidspin", "recover"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -5614,11 +6393,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["boomburst", "dracometeor", "flamethrower", "hurricane", "roost", "switcheroo"]
+                "movepool": ["boomburst", "dracometeor", "flamethrower", "hurricane", "roost", "switcheroo"],
+                "abilities": ["Infiltrator"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "dracometeor", "flamethrower", "hurricane", "roost", "uturn"]
+                "movepool": ["defog", "dracometeor", "flamethrower", "hurricane", "roost", "uturn"],
+                "abilities": ["Infiltrator"]
             }
         ]
     },
@@ -5627,7 +6408,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "geomancy", "moonblast", "psyshock"]
+                "movepool": ["focusblast", "geomancy", "moonblast", "psyshock"],
+                "abilities": ["Fairy Aura"]
             }
         ]
     },
@@ -5636,7 +6418,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"]
+                "movepool": ["knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
+                "abilities": ["Dark Aura"]
             }
         ]
     },
@@ -5645,11 +6428,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "extremespeed", "outrage", "substitute", "thousandarrows"]
+                "movepool": ["dragondance", "extremespeed", "outrage", "substitute", "thousandarrows"],
+                "abilities": ["Power Construct"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["coil", "rest", "sleeptalk", "thousandarrows"]
+                "movepool": ["coil", "rest", "sleeptalk", "thousandarrows"],
+                "abilities": ["Power Construct"]
             }
         ]
     },
@@ -5658,15 +6443,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["extremespeed", "irontail", "outrage", "thousandarrows"]
+                "movepool": ["extremespeed", "irontail", "outrage", "thousandarrows"],
+                "abilities": ["Aura Break"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["coil", "extremespeed", "irontail", "outrage", "thousandarrows"]
+                "movepool": ["coil", "extremespeed", "irontail", "outrage", "thousandarrows"],
+                "abilities": ["Aura Break"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["coil", "extremespeed", "irontail", "outrage", "thousandarrows"],
+                "abilities": ["Aura Break"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -5676,7 +6464,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["diamondstorm", "earthpower", "healbell", "moonblast", "stealthrock", "toxic"]
+                "movepool": ["diamondstorm", "earthpower", "healbell", "moonblast", "stealthrock", "toxic"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -5685,7 +6474,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "diamondstorm", "earthpower", "moonblast", "stealthrock"]
+                "movepool": ["calmmind", "diamondstorm", "earthpower", "moonblast", "stealthrock"],
+                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -5694,7 +6484,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "nastyplot", "psychic", "psyshock", "shadowball", "trick"]
+                "movepool": ["focusblast", "nastyplot", "psychic", "psyshock", "shadowball", "trick"],
+                "abilities": ["Magician"]
             }
         ]
     },
@@ -5704,11 +6495,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["drainpunch", "gunkshot", "hyperspacefury", "trick", "zenheadbutt"],
+                "abilities": ["Magician"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["drainpunch", "gunkshot", "hyperspacefury", "psychic", "trick"],
+                "abilities": ["Magician"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -5718,7 +6511,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthpower", "fireblast", "sludgebomb", "steameruption", "superpower", "toxic"]
+                "movepool": ["defog", "earthpower", "fireblast", "sludgebomb", "steameruption", "superpower", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -5727,11 +6521,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "leafstorm", "roost", "spiritshackle", "uturn"]
+                "movepool": ["defog", "leafstorm", "roost", "spiritshackle", "uturn"],
+                "abilities": ["Overgrow"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["leafblade", "shadowsneak", "spiritshackle", "swordsdance"]
+                "movepool": ["leafblade", "shadowsneak", "spiritshackle", "swordsdance"],
+                "abilities": ["Overgrow"]
             }
         ]
     },
@@ -5740,7 +6536,8 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["darkestlariat", "earthquake", "fakeout", "flareblitz", "knockoff", "overheat", "uturn"]
+                "movepool": ["darkestlariat", "earthquake", "fakeout", "flareblitz", "knockoff", "overheat", "uturn"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -5749,7 +6546,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hydropump", "moonblast", "psychic", "scald"]
+                "movepool": ["hydropump", "moonblast", "psychic", "scald"],
+                "abilities": ["Torrent"]
             }
         ]
     },
@@ -5758,11 +6556,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["beakblast", "boomburst", "brickbreak", "bulletseed", "roost"]
+                "movepool": ["beakblast", "boomburst", "brickbreak", "bulletseed", "roost"],
+                "abilities": ["Keen Eye", "Skill Link"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "brickbreak", "bulletseed", "knockoff", "rockblast", "swordsdance", "uturn"]
+                "movepool": ["bravebird", "brickbreak", "bulletseed", "knockoff", "rockblast", "swordsdance", "uturn"],
+                "abilities": ["Keen Eye", "Skill Link"]
             }
         ]
     },
@@ -5771,7 +6571,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "earthquake", "return", "uturn"]
+                "movepool": ["crunch", "earthquake", "return", "uturn"],
+                "abilities": ["Adaptability", "Stakeout"]
             }
         ]
     },
@@ -5780,11 +6581,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["agility", "bugbuzz", "energyball", "thunderbolt", "voltswitch"]
+                "movepool": ["agility", "bugbuzz", "energyball", "thunderbolt", "voltswitch"],
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bugbuzz", "energyball", "roost", "thunderbolt", "voltswitch"],
+                "abilities": ["Levitate"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -5794,7 +6597,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "drainpunch", "earthquake", "icehammer", "stoneedge"]
+                "movepool": ["closecombat", "drainpunch", "earthquake", "icehammer", "stoneedge"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -5803,7 +6607,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "hurricane", "revelationdance", "roost", "toxic"]
+                "movepool": ["calmmind", "defog", "hurricane", "revelationdance", "roost", "toxic"],
+                "abilities": ["Dancer"]
             }
         ]
     },
@@ -5812,7 +6617,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "hurricane", "revelationdance", "roost", "toxic"]
+                "movepool": ["calmmind", "defog", "hurricane", "revelationdance", "roost", "toxic"],
+                "abilities": ["Dancer"]
             }
         ]
     },
@@ -5821,7 +6627,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "hurricane", "revelationdance", "roost", "toxic"]
+                "movepool": ["calmmind", "defog", "hurricane", "revelationdance", "roost", "toxic"],
+                "abilities": ["Dancer"]
             }
         ]
     },
@@ -5830,7 +6637,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "hurricane", "revelationdance", "roost", "toxic"]
+                "movepool": ["calmmind", "defog", "hurricane", "revelationdance", "roost", "toxic"],
+                "abilities": ["Dancer"]
             }
         ]
     },
@@ -5839,11 +6647,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "hiddenpowerground", "moonblast", "quiverdance", "roost"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "moonblast", "quiverdance", "roost"],
+                "abilities": ["Shield Dust"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["aromatherapy", "moonblast", "roost", "stickyweb", "stunspore", "uturn"]
+                "movepool": ["aromatherapy", "moonblast", "roost", "stickyweb", "stunspore", "uturn"],
+                "abilities": ["Shield Dust"]
             }
         ]
     },
@@ -5853,11 +6663,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["accelerock", "drillrun", "firefang", "stoneedge", "swordsdance"],
+                "abilities": ["Sand Rush"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["accelerock", "drillrun", "firefang", "stoneedge", "swordsdance"],
+                "abilities": ["Sand Rush"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -5867,11 +6679,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["stealthrock", "stompingtantrum", "stoneedge", "suckerpunch", "swordsdance"]
+                "movepool": ["stealthrock", "stompingtantrum", "stoneedge", "suckerpunch", "swordsdance"],
+                "abilities": ["No Guard"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["stompingtantrum", "stoneedge", "suckerpunch", "swordsdance"]
+                "movepool": ["stompingtantrum", "stoneedge", "suckerpunch", "swordsdance"],
+                "abilities": ["No Guard"]
             }
         ]
     },
@@ -5881,11 +6695,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["accelerock", "drillrun", "firefang", "return", "stoneedge", "swordsdance"],
+                "abilities": ["Tough Claws"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["accelerock", "drillrun", "firefang", "return", "stoneedge", "swordsdance"],
+                "abilities": ["Tough Claws"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -5896,11 +6712,13 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["earthquake", "hiddenpowergrass", "hydropump", "icebeam", "scald", "uturn"],
+                "abilities": ["Schooling"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "scald"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "scald"],
+                "abilities": ["Schooling"]
             }
         ]
     },
@@ -5909,11 +6727,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["haze", "recover", "scald", "toxic", "toxicspikes"]
+                "movepool": ["haze", "recover", "scald", "toxic", "toxicspikes"],
+                "abilities": ["Regenerator"]
             },
             {
                 "role": "Staller",
-                "movepool": ["banefulbunker", "recover", "scald", "toxic"]
+                "movepool": ["banefulbunker", "recover", "scald", "toxic"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -5923,6 +6743,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["closecombat", "earthquake", "heavyslam", "rockslide", "stealthrock", "toxic"],
+                "abilities": ["Stamina"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -5932,7 +6753,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["leechlife", "liquidation", "mirrorcoat", "stickyweb", "toxic"]
+                "movepool": ["leechlife", "liquidation", "mirrorcoat", "stickyweb", "toxic"],
+                "abilities": ["Water Bubble"]
             }
         ]
     },
@@ -5942,11 +6764,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["defog", "hiddenpowerice", "knockoff", "leafstorm", "superpower", "synthesis"],
+                "abilities": ["Contrary"],
                 "preferredTypes": ["Fighting"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["hiddenpowerice", "hiddenpowerrock", "knockoff", "leafstorm", "superpower"]
+                "movepool": ["hiddenpowerice", "hiddenpowerrock", "knockoff", "leafstorm", "superpower"],
+                "abilities": ["Contrary"]
             }
         ]
     },
@@ -5955,7 +6779,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["gigadrain", "hiddenpowerground", "leechseed", "moonblast", "spore", "strengthsap"]
+                "movepool": ["gigadrain", "hiddenpowerground", "leechseed", "moonblast", "spore", "strengthsap"],
+                "abilities": ["Effect Spore"]
             }
         ]
     },
@@ -5965,11 +6790,13 @@
             {
                 "role": "Z-Move user",
                 "movepool": ["dragonpulse", "fireblast", "hiddenpowergrass", "nastyplot", "sludgewave"],
+                "abilities": ["Corrosion"],
                 "preferredTypes": ["Dragon", "Fire"]
             },
             {
                 "role": "Staller",
-                "movepool": ["flamethrower", "protect", "substitute", "toxic"]
+                "movepool": ["flamethrower", "protect", "substitute", "toxic"],
+                "abilities": ["Corrosion"]
             }
         ]
     },
@@ -5978,15 +6805,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "return", "shadowclaw", "superpower", "swordsdance"]
+                "movepool": ["doubleedge", "return", "shadowclaw", "superpower", "swordsdance"],
+                "abilities": ["Fluffy"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "drainpunch", "shadowclaw", "superpower"]
+                "movepool": ["doubleedge", "drainpunch", "shadowclaw", "superpower"],
+                "abilities": ["Fluffy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "doubleedge", "drainpunch", "return", "shadowclaw"]
+                "movepool": ["bulkup", "doubleedge", "drainpunch", "return", "shadowclaw"],
+                "abilities": ["Fluffy"]
             }
         ]
     },
@@ -5996,6 +6826,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["highjumpkick", "knockoff", "powerwhip", "rapidspin", "synthesis", "uturn"],
+                "abilities": ["Queenly Majesty"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -6005,15 +6836,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "defog", "drainingkiss", "synthesis", "toxic", "uturn"]
+                "movepool": ["aromatherapy", "defog", "drainingkiss", "synthesis", "toxic", "uturn"],
+                "abilities": ["Triage"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "drainingkiss", "gigadrain", "hiddenpowerground"]
+                "movepool": ["calmmind", "drainingkiss", "gigadrain", "hiddenpowerground"],
+                "abilities": ["Triage"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "drainingkiss", "gigadrain", "hiddenpowerground", "synthesis"],
+                "abilities": ["Triage"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -6023,7 +6857,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["focusblast", "nastyplot", "naturepower", "psychic", "psyshock", "thunderbolt", "trick"]
+                "movepool": ["focusblast", "nastyplot", "naturepower", "psychic", "psyshock", "thunderbolt", "trick"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -6033,11 +6868,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "gunkshot", "knockoff", "rockslide", "uturn"],
+                "abilities": ["Defiant"],
                 "preferredTypes": ["Dark"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "drainpunch", "gunkshot", "knockoff"]
+                "movepool": ["bulkup", "drainpunch", "gunkshot", "knockoff"],
+                "abilities": ["Defiant"]
             }
         ]
     },
@@ -6046,7 +6883,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["firstimpression", "knockoff", "leechlife", "liquidation", "spikes"]
+                "movepool": ["firstimpression", "knockoff", "leechlife", "liquidation", "spikes"],
+                "abilities": ["Emergency Exit"]
             }
         ]
     },
@@ -6055,7 +6893,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "shadowball", "shoreup", "stealthrock", "toxic"]
+                "movepool": ["earthpower", "shadowball", "shoreup", "stealthrock", "toxic"],
+                "abilities": ["Water Compaction"]
             }
         ]
     },
@@ -6064,7 +6903,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["block", "recover", "soak", "toxic"]
+                "movepool": ["block", "recover", "soak", "toxic"],
+                "abilities": ["Unaware"]
             }
         ]
     },
@@ -6073,11 +6913,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["rest", "return", "sleeptalk", "swordsdance"]
+                "movepool": ["rest", "return", "sleeptalk", "swordsdance"],
+                "abilities": ["Battle Armor"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["payback", "rest", "return", "sleeptalk", "uturn"]
+                "movepool": ["payback", "rest", "return", "sleeptalk", "uturn"],
+                "abilities": ["Battle Armor"]
             }
         ]
     },
@@ -6087,6 +6929,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["crunch", "doubleedge", "explosion", "flamecharge", "ironhead", "return", "swordsdance"],
+                "abilities": ["RKS System"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -6096,7 +6939,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "icebeam", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6105,7 +6949,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flamecharge", "ironhead", "multiattack", "swordsdance"]
+                "movepool": ["flamecharge", "ironhead", "multiattack", "swordsdance"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6114,11 +6959,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "dracometeor", "flamethrower", "ironhead", "partingshot", "toxic", "uturn"]
+                "movepool": ["defog", "dracometeor", "flamethrower", "ironhead", "partingshot", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flamecharge", "ironhead", "outrage", "swordsdance"]
+                "movepool": ["flamecharge", "ironhead", "outrage", "swordsdance"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6128,6 +6975,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"],
+                "abilities": ["RKS System"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -6137,7 +6985,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "surf", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "surf", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6146,11 +6995,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "shadowball", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "shadowball", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["crunch", "flamecharge", "ironhead", "multiattack", "rockslide", "swordsdance"],
+                "abilities": ["RKS System"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -6160,7 +7011,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "icebeam", "multiattack", "partingshot", "surf", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["defog", "icebeam", "multiattack", "partingshot", "surf", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6169,7 +7021,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "ironhead", "multiattack", "partingshot", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "ironhead", "multiattack", "partingshot", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6178,11 +7031,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["explosion", "multiattack", "swordsdance", "xscissor"]
+                "movepool": ["explosion", "multiattack", "swordsdance", "xscissor"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6191,7 +7046,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6200,11 +7056,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flamecharge", "multiattack", "rockslide", "swordsdance"]
+                "movepool": ["flamecharge", "multiattack", "rockslide", "swordsdance"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6214,6 +7072,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["RKS System"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -6223,7 +7082,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "surf", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "surf", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6232,7 +7092,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6241,7 +7102,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6250,7 +7112,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6259,7 +7122,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "icebeam", "multiattack", "partingshot", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["defog", "icebeam", "multiattack", "partingshot", "thunderbolt", "toxic", "uturn"],
+                "abilities": ["RKS System"]
             }
         ]
     },
@@ -6268,7 +7132,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["acrobatics", "earthquake", "powergem", "shellsmash"]
+                "movepool": ["acrobatics", "earthquake", "powergem", "shellsmash"],
+                "abilities": ["Shields Down"]
             }
         ]
     },
@@ -6278,6 +7143,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "knockoff", "rapidspin", "return", "suckerpunch", "superpower", "uturn", "woodhammer"],
+                "abilities": ["Comatose"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -6287,11 +7153,13 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["dracometeor", "dragontail", "earthquake", "explosion", "fireblast"]
+                "movepool": ["dracometeor", "dragontail", "earthquake", "explosion", "fireblast"],
+                "abilities": ["Shell Armor"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dracometeor", "dragonpulse", "earthquake", "fireblast", "shellsmash"]
+                "movepool": ["dracometeor", "dragonpulse", "earthquake", "fireblast", "shellsmash"],
+                "abilities": ["Shell Armor"]
             }
         ]
     },
@@ -6300,15 +7168,18 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["ironhead", "nuzzle", "spikyshield", "uturn", "wish"]
+                "movepool": ["ironhead", "nuzzle", "spikyshield", "uturn", "wish"],
+                "abilities": ["Iron Barbs", "Lightning Rod", "Sturdy"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["ironhead", "spikyshield", "uturn", "wish", "zingzap"]
+                "movepool": ["ironhead", "spikyshield", "uturn", "wish", "zingzap"],
+                "abilities": ["Iron Barbs", "Lightning Rod", "Sturdy"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["ironhead", "nuzzle", "superfang", "uturn", "zingzap"],
+                "abilities": ["Iron Barbs", "Lightning Rod", "Sturdy"],
                 "preferredTypes": ["Steel"]
             }
         ]
@@ -6318,11 +7189,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "playrough", "shadowclaw", "shadowsneak", "swordsdance"]
+                "movepool": ["drainpunch", "playrough", "shadowclaw", "shadowsneak", "swordsdance"],
+                "abilities": ["Disguise"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["drainpunch", "playrough", "shadowclaw", "shadowsneak", "swordsdance"]
+                "movepool": ["drainpunch", "playrough", "shadowclaw", "shadowsneak", "swordsdance"],
+                "abilities": ["Disguise"]
             }
         ]
     },
@@ -6332,6 +7205,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquajet", "crunch", "icefang", "liquidation", "psychicfangs", "swordsdance"],
+                "abilities": ["Strong Jaw"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -6341,12 +7215,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "fireblast", "hypervoice", "roost", "thunderbolt"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["dracometeor", "fireblast", "hypervoice", "thunderbolt"],
+                "abilities": ["Sap Sipper"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["dracometeor", "fireblast", "hypervoice", "roost"],
+                "abilities": ["Berserk"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "fireblast", "glare", "hypervoice", "roost"]
+                "movepool": ["dracometeor", "fireblast", "glare", "hypervoice", "roost"],
+                "abilities": ["Berserk"]
             }
         ]
     },
@@ -6356,6 +7236,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["anchorshot", "earthquake", "knockoff", "powerwhip", "rapidspin", "synthesis"],
+                "abilities": ["Steelworker"],
                 "preferredTypes": ["Steel"]
             }
         ]
@@ -6366,11 +7247,13 @@
             {
                 "role": "Z-Move user",
                 "movepool": ["clangingscales", "closecombat", "dragondance", "ironhead"],
+                "abilities": ["Bulletproof", "Soundproof"],
                 "preferredTypes": ["Dragon"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["closecombat", "dragondance", "ironhead", "outrage"]
+                "movepool": ["closecombat", "dragondance", "ironhead", "outrage"],
+                "abilities": ["Bulletproof", "Soundproof"]
             }
         ]
     },
@@ -6379,11 +7262,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bravebird", "dazzlinggleam", "defog", "naturesmadness", "uturn", "wildcharge"]
+                "movepool": ["bravebird", "dazzlinggleam", "defog", "naturesmadness", "uturn", "wildcharge"],
+                "abilities": ["Electric Surge"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["calmmind", "dazzlinggleam", "grassknot", "roost", "thunderbolt"],
+                "abilities": ["Electric Surge"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -6393,11 +7278,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "moonblast", "psychic", "psyshock"]
+                "movepool": ["focusblast", "moonblast", "psychic", "psyshock"],
+                "abilities": ["Psychic Surge"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "focusblast", "moonblast", "psychic", "psyshock"]
+                "movepool": ["calmmind", "focusblast", "moonblast", "psychic", "psyshock"],
+                "abilities": ["Psychic Surge"]
             }
         ]
     },
@@ -6406,7 +7293,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "hornleech", "megahorn", "stoneedge", "superpower", "woodhammer"]
+                "movepool": ["bulkup", "hornleech", "megahorn", "stoneedge", "superpower", "woodhammer"],
+                "abilities": ["Grassy Surge"]
             }
         ]
     },
@@ -6415,7 +7303,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "icebeam", "moonblast", "surf", "taunt"]
+                "movepool": ["calmmind", "hydropump", "icebeam", "moonblast", "surf", "taunt"],
+                "abilities": ["Misty Surge"]
             }
         ]
     },
@@ -6424,15 +7313,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "flareblitz", "knockoff", "morningsun", "stoneedge", "sunsteelstrike", "zenheadbutt"]
+                "movepool": ["earthquake", "flareblitz", "knockoff", "morningsun", "stoneedge", "sunsteelstrike", "zenheadbutt"],
+                "abilities": ["Full Metal Body"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "flareblitz", "knockoff", "stoneedge", "sunsteelstrike", "zenheadbutt"]
+                "movepool": ["earthquake", "flareblitz", "knockoff", "stoneedge", "sunsteelstrike", "zenheadbutt"],
+                "abilities": ["Full Metal Body"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "flamecharge", "knockoff", "psychic", "sunsteelstrike"]
+                "movepool": ["earthquake", "flamecharge", "knockoff", "psychic", "sunsteelstrike"],
+                "abilities": ["Full Metal Body"]
             }
         ]
     },
@@ -6441,11 +7333,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "moonblast", "moongeistbeam", "psyshock", "roost"]
+                "movepool": ["calmmind", "moonblast", "moongeistbeam", "psyshock", "roost"],
+                "abilities": ["Shadow Shield"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["calmmind", "moonblast", "moongeistbeam", "psyshock", "roost"]
+                "movepool": ["calmmind", "moonblast", "moongeistbeam", "psyshock", "roost"],
+                "abilities": ["Shadow Shield"]
             }
         ]
     },
@@ -6455,6 +7349,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["grassknot", "hiddenpowerfire", "hiddenpowerground", "powergem", "sludgewave", "stealthrock", "thunderbolt", "toxicspikes"],
+                "abilities": ["Beast Boost"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -6464,11 +7359,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["drainpunch", "earthquake", "ironhead", "leechlife", "stoneedge", "superpower"]
+                "movepool": ["drainpunch", "earthquake", "ironhead", "leechlife", "stoneedge", "superpower"],
+                "abilities": ["Beast Boost"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "drainpunch", "leechlife", "roost", "stoneedge", "toxic"]
+                "movepool": ["bulkup", "drainpunch", "leechlife", "roost", "stoneedge", "toxic"],
+                "abilities": ["Beast Boost"]
             }
         ]
     },
@@ -6477,7 +7374,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["highjumpkick", "icebeam", "poisonjab", "throatchop", "uturn"]
+                "movepool": ["highjumpkick", "icebeam", "poisonjab", "throatchop", "uturn"],
+                "abilities": ["Beast Boost"]
             }
         ]
     },
@@ -6486,11 +7384,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dazzlinggleam", "energyball", "hiddenpowerice", "tailglow", "thunderbolt", "voltswitch"]
+                "movepool": ["dazzlinggleam", "energyball", "hiddenpowerice", "tailglow", "thunderbolt", "voltswitch"],
+                "abilities": ["Beast Boost"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["dazzlinggleam", "electricterrain", "energyball", "hiddenpowerice", "thunderbolt"],
+                "abilities": ["Beast Boost"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -6500,15 +7400,18 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["airslash", "earthquake", "fireblast", "heavyslam"]
+                "movepool": ["airslash", "earthquake", "fireblast", "heavyslam"],
+                "abilities": ["Beast Boost"]
             },
             {
                 "role": "Staller",
-                "movepool": ["airslash", "heavyslam", "leechseed", "protect"]
+                "movepool": ["airslash", "heavyslam", "leechseed", "protect"],
+                "abilities": ["Beast Boost"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["airslash", "autotomize", "earthquake", "fireblast", "heavyslam"]
+                "movepool": ["airslash", "autotomize", "earthquake", "fireblast", "heavyslam"],
+                "abilities": ["Beast Boost"]
             }
         ]
     },
@@ -6517,11 +7420,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["knockoff", "leafblade", "sacredsword", "smartstrike", "swordsdance"]
+                "movepool": ["knockoff", "leafblade", "sacredsword", "smartstrike", "swordsdance"],
+                "abilities": ["Beast Boost"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["knockoff", "leafblade", "sacredsword", "smartstrike", "swordsdance"],
+                "abilities": ["Beast Boost"],
                 "preferredTypes": ["Fighting", "Grass", "Steel"]
             }
         ]
@@ -6531,7 +7436,8 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "heavyslam", "knockoff"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "heavyslam", "knockoff"],
+                "abilities": ["Beast Boost"]
             }
         ]
     },
@@ -6540,16 +7446,19 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "heatwave", "moonlight", "photongeyser", "stealthrock"]
+                "movepool": ["calmmind", "heatwave", "moonlight", "photongeyser", "stealthrock"],
+                "abilities": ["Prism Armor"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["calmmind", "heatwave", "moonlight", "photongeyser"],
+                "abilities": ["Prism Armor"],
                 "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "knockoff", "photongeyser", "swordsdance"]
+                "movepool": ["earthquake", "knockoff", "photongeyser", "swordsdance"],
+                "abilities": ["Prism Armor"]
             }
         ]
     },
@@ -6559,11 +7468,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["autotomize", "earthquake", "knockoff", "photongeyser", "sunsteelstrike", "swordsdance"],
+                "abilities": ["Prism Armor"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["autotomize", "earthquake", "knockoff", "photongeyser", "sunsteelstrike", "swordsdance"],
+                "abilities": ["Prism Armor"],
                 "preferredTypes": ["Psychic"]
             }
         ]
@@ -6573,11 +7484,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "signalbeam"]
+                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "signalbeam"],
+                "abilities": ["Prism Armor"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "signalbeam"]
+                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "signalbeam"],
+                "abilities": ["Prism Armor"]
             }
         ]
     },
@@ -6586,15 +7499,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "flashcannon", "fleurcannon", "shiftgear"]
+                "movepool": ["calmmind", "flashcannon", "fleurcannon", "shiftgear"],
+                "abilities": ["Soul-Heart"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["aurasphere", "flashcannon", "fleurcannon", "healbell", "painsplit", "thunderwave", "voltswitch"]
+                "movepool": ["aurasphere", "flashcannon", "fleurcannon", "healbell", "painsplit", "thunderwave", "voltswitch"],
+                "abilities": ["Soul-Heart"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["aurasphere", "fleurcannon", "ironhead", "shiftgear"],
+                "abilities": ["Soul-Heart"],
                 "preferredTypes": ["Fairy", "Steel"]
             }
         ]
@@ -6604,11 +7520,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "closecombat", "rocktomb", "shadowsneak", "spectralthief"]
+                "movepool": ["bulkup", "closecombat", "rocktomb", "shadowsneak", "spectralthief"],
+                "abilities": ["Technician"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["bulkup", "closecombat", "rocktomb", "shadowsneak", "spectralthief"]
+                "movepool": ["bulkup", "closecombat", "rocktomb", "shadowsneak", "spectralthief"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -6617,15 +7535,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "fireblast", "sludgewave", "uturn"]
+                "movepool": ["dracometeor", "fireblast", "sludgewave", "uturn"],
+                "abilities": ["Beast Boost"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dracometeor", "fireblast", "nastyplot", "sludgewave"]
+                "movepool": ["dracometeor", "fireblast", "nastyplot", "sludgewave"],
+                "abilities": ["Beast Boost"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["dracometeor", "fireblast", "nastyplot", "sludgewave"],
+                "abilities": ["Beast Boost"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -6635,7 +7556,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "gyroball", "stoneedge", "superpower", "trickroom"]
+                "movepool": ["earthquake", "gyroball", "stoneedge", "superpower", "trickroom"],
+                "abilities": ["Beast Boost"]
             }
         ]
     },
@@ -6644,11 +7566,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "fireblast", "hiddenpowerice", "psyshock", "shadowball", "trick"]
+                "movepool": ["calmmind", "fireblast", "hiddenpowerice", "psyshock", "shadowball", "trick"],
+                "abilities": ["Beast Boost"]
             },
             {
                 "role": "Z-Move user",
                 "movepool": ["calmmind", "fireblast", "hiddenpowerice", "psyshock", "shadowball"],
+                "abilities": ["Beast Boost"],
                 "preferredTypes": ["Fire", "Ghost"]
             }
         ]
@@ -6658,11 +7582,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bulkup", "closecombat", "knockoff", "plasmafists"]
+                "movepool": ["bulkup", "closecombat", "knockoff", "plasmafists"],
+                "abilities": ["Volt Absorb"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["closecombat", "grassknot", "hiddenpowerice", "knockoff", "plasmafists", "voltswitch"],
+                "abilities": ["Volt Absorb"],
                 "preferredTypes": ["Fighting"]
             }
         ]

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -1,6 +1,5 @@
 import {MoveCounter, TeamData, RandomGen8Teams} from '../gen8/teams';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
-import {Utils} from '../../../lib';
 import {toID} from '../../../sim/dex';
 
 export interface BattleFactorySpecies {
@@ -110,16 +109,16 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		this.moveEnforcementCheckers = {
 			Bug: (movePool, moves, abilities, types, counter) => (
 				['megahorn', 'pinmissile'].some(m => movePool.includes(m)) ||
-				!counter.get('Bug') && (abilities.has('Tinted Lens') || abilities.has('Adaptability'))
+				!counter.get('Bug') && (abilities.includes('Tinted Lens') || abilities.includes('Adaptability'))
 			),
 			Dark: (movePool, moves, abilities, types, counter) => !counter.get('Dark'),
-			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon') && !abilities.has('Aerilate'),
+			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon') && !abilities.includes('Aerilate'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
 			Fairy: (movePool, moves, abilities, types, counter) => !counter.get('Fairy'),
 			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting'),
 			Fire: (movePool, moves, abilities, types, counter) => !counter.get('Fire'),
 			Flying: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Flying') && !['aerodactylmega', 'charizardmegay', 'mantine'].includes(species.id) &&
+				!counter.get('Flying') && !['aerodactyl', 'aerodactylmega', 'mantine'].includes(species.id) &&
 				!movePool.includes('hiddenpowerflying')
 			),
 			Ghost: (movePool, moves, abilities, types, counter) => !counter.get('Ghost'),
@@ -128,8 +127,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (
-				!counter.get('Ice') || (!moves.has('blizzard') && movePool.includes('freezedry')) ||
-				abilities.has('Refrigerate') && (movePool.includes('return') || movePool.includes('hypervoice'))
+				!counter.get('Ice') || (moves.has('icebeam') && movePool.includes('freezedry')) ||
+				(abilities.includes('Refrigerate') && movePool.includes('return'))
 			),
 			Normal: movePool => (movePool.includes('boomburst') || movePool.includes('hypervoice')),
 			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
@@ -139,7 +138,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				)
 			),
 			Rock: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Rock') && (species.baseStats.atk >= 100 || abilities.has('Rock Head'))
+				!counter.get('Rock') && (species.baseStats.atk >= 100 || abilities.includes('Rock Head'))
 			),
 			Steel: (movePool, moves, abilities, types, counter, species) => (
 				!counter.get('Steel') && species.baseStats.atk >= 100
@@ -152,7 +151,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		moves: Set<string> | null,
 		species: Species,
 		preferredType: string,
-		abilities: Set<string> = new Set(),
+		abilities: string[],
 	): MoveCounter {
 		// This is primarily a helper function for random setbuilder functions.
 		const counter = new MoveCounter();
@@ -196,9 +195,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				if (move.flags['bite']) counter.add('strongjaw');
 				if (move.flags['punch']) counter.add('ironfist');
 				if (move.flags['sound']) counter.add('sound');
-				if (move.priority > 0 || (moveid === 'grassyglide' && abilities.has('Grassy Surge'))) {
-					counter.add('priority');
-				}
+				if (move.priority > 0) counter.add('priority');
 			}
 			// Moves with secondary effects:
 			if (move.secondary || move.hasSheerForce) {
@@ -230,7 +227,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 	cullMovePool(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -382,11 +379,11 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		}
 
 		const statusInflictingMoves = ['thunderwave', 'toxic', 'willowisp', 'yawn'];
-		if (!abilities.has('Prankster') && role !== 'Staller') {
+		if (!abilities.includes('Prankster') && role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}
 
-		if (abilities.has('Guts')) this.incompatibleMoves(moves, movePool, 'protect', 'swordsdance');
+		if (abilities.includes('Guts')) this.incompatibleMoves(moves, movePool, 'protect', 'swordsdance');
 
 		// Z-Conversion Porygon-Z
 		if (species.id === 'porygonz') {
@@ -441,7 +438,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		move: string,
 		moves: Set<string>,
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -458,16 +455,16 @@ export class RandomGen7Teams extends RandomGen8Teams {
 	}
 
 	// Returns the type of a given move for STAB/coverage enforcement purposes
-	getMoveType(move: Move, species: Species, abilities: Set<string>, preferredType: string): string {
+	getMoveType(move: Move, species: Species, abilities: string[], preferredType: string): string {
 		if (['judgment', 'multiattack', 'revelationdance'].includes(move.id)) return species.types[0];
 		if (species.id === 'genesectdouse' && move.id === 'technoblast') return 'Water';
 
 		const moveType = move.type;
 		if (moveType === 'Normal') {
-			if (abilities.has('Aerilate')) return 'Flying';
-			if (abilities.has('Galvanize')) return 'Electric';
-			if (abilities.has('Pixilate')) return 'Fairy';
-			if (abilities.has('Refrigerate')) return 'Ice';
+			if (abilities.includes('Aerilate')) return 'Flying';
+			if (abilities.includes('Galvanize')) return 'Electric';
+			if (abilities.includes('Pixilate')) return 'Fairy';
+			if (abilities.includes('Refrigerate')) return 'Ice';
 		}
 		return moveType;
 	}
@@ -475,7 +472,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 	// Generate random moveset for a given species, role, preferred type.
 	randomMoveset(
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -516,7 +513,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		// Add other moves you really want to have, e.g. STAB, recovery, setup.
 
 		// Enforce Facade if Guts is a possible ability
-		if (movePool.includes('facade') && abilities.has('Guts')) {
+		if (movePool.includes('facade') && abilities.includes('Guts')) {
 			counter = this.addMove('facade', moves, types, abilities, teamDetails, species, isLead,
 				movePool, preferredType, role);
 		}
@@ -530,7 +527,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		}
 
 		// Enforce Thunder Wave on Prankster users
-		if (movePool.includes('thunderwave') && abilities.has('Prankster')) {
+		if (movePool.includes('thunderwave') && abilities.includes('Prankster')) {
 			counter = this.addMove('thunderwave', moves, types, abilities, teamDetails, species, isLead,
 				movePool, preferredType, role);
 		}
@@ -726,7 +723,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -735,107 +732,24 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		role: RandomTeamsTypes.Role
 	): boolean {
 		switch (ability) {
-		case 'Battle Bond': case 'Dazzling': case 'Flare Boost': case 'Gluttony': case 'Harvest': case 'Hyper Cutter':
-		case 'Ice Body': case 'Innards Out': case 'Liquid Voice': case 'Magician': case 'Moody': case 'Pressure':
-		case 'Sand Veil': case 'Sniper': case 'Snow Cloak': case 'Steadfast': case 'Weak Armor':
-			return true;
-		case 'Aerilate': case 'Galvanize': case 'Pixilate': case 'Refrigerate':
-			return ['doubleedge', 'hypervoice', 'return'].every(m => !moves.has(m));
-		case 'Chlorophyll':
-			// Petal Dance is for Lilligant
-			return (
-				species.baseStats.spe > 100 || moves.has('petaldance') ||
-				(!moves.has('sunnyday') && !teamDetails.sun)
-			);
-		case 'Competitive':
-			return !counter.get('Special');
-		case 'Compound Eyes': case 'No Guard':
-			// Shadow Punch bit is for Golurk
-			return (!counter.get('inaccurate') || moves.has('shadowpunch'));
-		case 'Contrary': case 'Skill Link': case 'Strong Jaw':
+		case 'Chlorophyll': case 'Solar Power':
+			return !teamDetails.sun;
+		case 'Hydration': case 'Swift Swim':
+			return !teamDetails.rain;
+		case 'Iron Fist': case 'Skill Link': case 'Technician':
 			return !counter.get(toID(ability));
-		case 'Defiant': case 'Justified':
-			return !counter.get('Physical');
-		case 'Guts':
-			return (!moves.has('facade') && !moves.has('sleeptalk'));
-		case 'Hustle':
-			return counter.get('Physical') < 2;
-		case 'Hydration': case 'Rain Dish': case 'Swift Swim':
-			return (
-				species.baseStats.spe > 100 || !moves.has('raindance') && !teamDetails.rain ||
-				!moves.has('raindance') && ['Rock Head', 'Water Absorb'].some(abil => abilities.has(abil))
-			);
-		case 'Intimidate':
-			// Slam part is for Tauros
-			return (moves.has('bodyslam') || species.id === 'staraptor');
-		case 'Iron Fist':
-			// Dynamic Punch bit is for Golurk
-			return (!counter.get(toID(ability)) || moves.has('dynamicpunch'));
-		case 'Lightning Rod':
-			return (
-				types.has('Ground') || species.id === 'marowakalola' ||
-				((!!teamDetails.rain || moves.has('raindance')) && species.id === 'seaking')
-			);
-		case 'Magic Guard': case 'Speed Boost':
-			return (abilities.has('Tinted Lens') && role === 'Wallbreaker');
-		case 'Mold Breaker':
-			return (
-				species.baseSpecies === 'Basculin' || species.id === 'pangoro' || species.id === 'pinsirmega' ||
-				abilities.has('Sheer Force')
-			);
-		case 'Moxie':
-			return (!counter.get('Physical') || moves.has('stealthrock') || (!!species.isMega && abilities.has('Intimidate')));
-		case 'Oblivious': case 'Prankster':
-			return (!counter.get('Status') || (species.id === 'tornadus' && moves.has('bulkup')));
-		case 'Overcoat':
-			return types.has('Grass');
 		case 'Overgrow':
 			return !counter.get('Grass');
-		case 'Power Construct':
-			return species.forme === '10%';
-		case 'Shed Skin':
-			return !moves.has('rest');
-		case 'Synchronize':
-			return (counter.get('Status') < 2 || !!counter.get('recoil') || !!species.isMega);
-		case 'Regenerator':
-			return species.id === 'mienshao' || species.id === 'reuniclus';
-		case 'Reckless': case 'Rock Head':
-			return (!counter.get('recoil') || !!species.isMega);
+		case 'Prankster':
+			return !counter.get('Status');
+		case 'Rock Head':
+			return !counter.get('recoil');
 		case 'Sand Force': case 'Sand Rush':
 			return !teamDetails.sand;
-		case 'Scrappy':
-			return !types.has('Normal');
-		case 'Serene Grace':
-			return !counter.get('serenegrace');
-		case 'Sheer Force':
-			return (
-				!counter.get('sheerforce') ||
-				moves.has('doubleedge') || abilities.has('Guts') ||
-				!!species.isMega
-			);
-		case 'Simple':
-			return !counter.get('setup');
 		case 'Slush Rush':
 			return !teamDetails.hail;
-		case 'Solar Power':
-			return (!counter.get('Special') || !teamDetails.sun || !!species.isMega);
-		case 'Sturdy':
-			return (!!counter.get('recoil') && !counter.get('recovery') ||
-				(species.id === 'steelix' && role === 'Wallbreaker'));
 		case 'Swarm':
-			return ((!counter.get('Bug') && !moves.has('uturn')) || !!species.isMega);
-		case 'Technician':
-			return (!counter.get('technician') || moves.has('tailslap') || !!species.isMega || species.id === 'persianalola');
-		case 'Tinted Lens':
-			return (['illumise', 'sigilyph', 'yanmega'].some(m => species.id === (m)) && role !== 'Wallbreaker');
-		case 'Torrent':
-			return (!counter.get('Water') || !!species.isMega);
-		case 'Unaware':
-			return (!['Bulky Setup', 'Bulky Support', 'Staller'].includes(role));
-		case 'Unburden':
-			return (!!species.isMega || !counter.get('setup') && !moves.has('acrobatics'));
-		case 'Water Absorb':
-			return moves.has('raindance') || ['Drizzle', 'Unaware', 'Volt Absorb'].some(abil => abilities.has(abil));
+			return !counter.get('Bug');
 		}
 
 		return false;
@@ -845,7 +759,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 	getAbility(
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -853,102 +767,39 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		preferredType: string,
 		role: RandomTeamsTypes.Role,
 	): string {
-		if (species.battleOnly && !species.requiredAbility) {
-			abilities = new Set(Object.values(this.dex.species.get(species.battleOnly as string).abilities));
-		}
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData.length <= 1) return abilityData[0].name;
+		if (abilities.length <= 1) return abilities[0];
 
 		// Hard-code abilities here
-		if (species.id === 'gurdurr' || (
-			abilities.has('Guts') &&
-			!abilities.has('Quick Feet') &&
-			(moves.has('facade') || (moves.has('sleeptalk') && moves.has('rest')))
-		)) return 'Guts';
+		if (species.id === 'pangoro' && counter.get('ironfist')) return 'Iron Fist';
+		if (species.id === 'tornadus' && counter.get('Status')) return 'Prankster';
+		if (species.id === 'marowak' && counter.get('recoil')) return 'Rock Head';
+		if (species.id === 'sawsbuck') return moves.has('headbutt') ? 'Serene Grace' : 'Sap Sipper';
+		if (species.id === 'toucannon' && counter.get('skilllink')) return 'Skill Link';
+		if (species.id === 'roserade' && counter.get('technician')) return 'Technician';
 
-		if (species.id === 'starmie') return role === 'Wallbreaker' ? 'Analytic' : 'Natural Cure';
-		if (species.id === 'beheeyem') return 'Analytic';
-		if (species.id === 'drampa' && moves.has('roost')) return 'Berserk';
-		if (species.id === 'ninetales') return 'Drought';
-		if (species.baseSpecies === 'Gourgeist') return 'Frisk';
-		if (species.id === 'talonflame' && role === 'Z-Move user') return 'Gale Wings';
-		if (species.id === 'golemalola' && moves.has('return')) return 'Galvanize';
-		if (species.id === 'raticatealola') return 'Hustle';
-		if (species.id === 'ninjask' || species.id === 'seviper') return 'Infiltrator';
-		if (species.id === 'arcanine' || species.id === 'stantler') return 'Intimidate';
-		if (species.id === 'lucariomega') return 'Justified';
-		if (species.id === 'toucannon' && !counter.get('sheerforce') && !counter.get('skilllink')) return 'Keen Eye';
-		if (species.id === 'persian' && !counter.get('technician')) return 'Limber';
-		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
-		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
-		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
-		if (species.id === 'muk') return 'Poison Touch';
-		if (['dusknoir', 'raikou', 'suicune', 'vespiquen'].includes(species.id)) return 'Pressure';
-		if (species.id === 'tsareena') return 'Queenly Majesty';
-		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
-		if (species.id === 'zebstrika') return moves.has('wildcharge') ? 'Sap Sipper' : 'Lightning Rod';
-		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
-		if (species.baseSpecies === 'Sawsbuck' && moves.has('headbutt')) return 'Serene Grace';
-		if (species.id === 'octillery') return 'Sniper';
-		if (species.id === 'kommoo' && role === 'Z-Move user') return 'Soundproof';
-		if (species.id === 'stunfisk') return 'Static';
-		if (species.id === 'breloom') return 'Technician';
-		if (species.id === 'zangoose') return 'Toxic Boost';
-		if (counter.get('setup') && (species.id === 'magcargo' || species.id === 'kabutops')) return 'Weak Armor';
-
-		if (abilities.has('Gluttony') && (moves.has('recycle') || moves.has('bellydrum'))) return 'Gluttony';
-		if (abilities.has('Harvest') && (role === 'Bulky Support' || role === 'Staller')) return 'Harvest';
-		if (abilities.has('Moxie') && (moves.has('bounce') || moves.has('fly'))) return 'Moxie';
-		if (abilities.has('Regenerator') && role === 'AV Pivot') return 'Regenerator';
-		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
-		if (abilities.has('Sniper') && moves.has('focusenergy')) return 'Sniper';
-		if (abilities.has('Unburden') && ['acrobatics', 'bellydrum', 'closecombat'].some(m => moves.has(m))) return 'Unburden';
-
-		let abilityAllowed: Ability[] = [];
+		const abilityAllowed: string[] = [];
 		// Obtain a list of abilities that are allowed (not culled)
-		for (const ability of abilityData) {
-			if (ability.rating >= 1 && !this.shouldCullAbility(
-				ability.name, types, moves, abilities, counter, movePool, teamDetails, species, preferredType, role
+		for (const ability of abilities) {
+			if (!this.shouldCullAbility(
+				ability, types, moves, abilities, counter, movePool, teamDetails, species, preferredType, role
 			)) {
 				abilityAllowed.push(ability);
 			}
 		}
 
-		// If all abilities are rejected, re-allow all abilities
+		// Pick a random allowed ability
+		if (abilityAllowed.length >= 1) return this.sample(abilityAllowed);
+
+		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
 		if (!abilityAllowed.length) {
-			for (const ability of abilityData) {
-				if (ability.rating > 0) abilityAllowed.push(ability);
-			}
-			if (!abilityAllowed.length) abilityAllowed = abilityData;
+			const weatherAbilities = abilities.filter(
+				a => ['Chlorophyll', 'Hydration', 'Sand Force', 'Sand Rush', 'Slush Rush', 'Solar Power', 'Swift Swim'].includes(a)
+			);
+			if (weatherAbilities.length) return this.sample(weatherAbilities);
 		}
 
-		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
-		// Sort abilities by rating with an element of randomness
-		// All three abilities can be chosen
-		if (abilityAllowed[2] && abilityAllowed[0].rating - 0.5 <= abilityAllowed[2].rating) {
-			if (abilityAllowed[1].rating <= abilityAllowed[2].rating) {
-				if (this.randomChance(1, 2)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
-			} else {
-				if (this.randomChance(1, 3)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
-			}
-			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-				if (this.randomChance(2, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			} else {
-				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			}
-		} else {
-			// Third ability cannot be chosen
-			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
-				if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			}
-		}
-
-		// After sorting, choose the first ability
-		return abilityAllowed[0].name;
+		// Pick a random ability
+		return this.sample(abilities);
 	}
 
 	getPriorityItem(
@@ -1192,8 +1043,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const types = species.types;
-		const abilities = new Set(Object.values(species.abilities));
-		if (species.unreleasedHidden) abilities.delete(species.abilities.H);
+		const baseAbilities = set.abilities!;
+		// Use the mega's ability for moveset generation
+		const abilities = (species.battleOnly && !species.requiredAbility) ? Object.values(species.abilities) : baseAbilities;
 
 		// Get moves
 		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, movePool,
@@ -1201,7 +1053,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		const counter = this.newQueryMoves(moves, species, preferredType, abilities);
 
 		// Get ability
-		ability = this.getAbility(new Set(types), moves, abilities, counter, movePool, teamDetails, species,
+		ability = this.getAbility(new Set(types), moves, baseAbilities, counter, movePool, teamDetails, species,
 			preferredType, role);
 
 		// Get items

--- a/data/random-battles/gen7letsgo/teams.ts
+++ b/data/random-battles/gen7letsgo/teams.ts
@@ -24,7 +24,7 @@ export class RandomLetsGoTeams extends RandomGen8Teams {
 		move: Move,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -140,13 +140,13 @@ export class RandomLetsGoTeams extends RandomGen8Teams {
 				moves.add(moveid);
 			}
 
-			counter = this.queryMoves(moves, species.types, new Set(), movePool);
+			counter = this.queryMoves(moves, species.types, [], movePool);
 
 			// Iterate through the moves again, this time to cull them:
 			for (const moveid of moves) {
 				const move = this.dex.moves.get(moveid);
 
-				let {cull, isSetup} = this.shouldCullMove(move, types, moves, new Set(), counter, movePool, teamDetails);
+				let {cull, isSetup} = this.shouldCullMove(move, types, moves, [], counter, movePool, teamDetails);
 
 				if (
 					!isSetup &&
@@ -184,7 +184,7 @@ export class RandomLetsGoTeams extends RandomGen8Teams {
 						cull = true;
 					} else {
 						for (const type of types) {
-							if (this.moveEnforcementCheckers[type]?.(movePool, moves, new Set(), types, counter, species, teamDetails)) cull = true;
+							if (this.moveEnforcementCheckers[type]?.(movePool, moves, [], types, counter, species, teamDetails)) cull = true;
 						}
 					}
 				}

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -50,7 +50,7 @@ export class MoveCounter extends Utils.Multiset<string> {
 }
 
 type MoveEnforcementChecker = (
-	movePool: string[], moves: Set<string>, abilities: Set<string>, types: Set<string>,
+	movePool: string[], moves: Set<string>, abilities: string[], types: Set<string>,
 	counter: MoveCounter, species: Species, teamDetails: RandomTeamsTypes.TeamDetails
 ) => boolean;
 
@@ -205,10 +205,11 @@ export class RandomGen8Teams {
 			Ice: (movePool, moves, abilities, types, counter) => {
 				if (!counter.get('Ice')) return true;
 				if (movePool.includes('iciclecrash')) return true;
-				return abilities.has('Snow Warning') && movePool.includes('blizzard');
+				return abilities.includes('Snow Warning') && movePool.includes('blizzard');
 			},
 			Normal: (movePool, moves, abilities, types, counter) => (
-				(abilities.has('Guts') && movePool.includes('facade')) || (abilities.has('Pixilate') && !counter.get('Normal'))
+				(abilities.includes('Guts') && movePool.includes('facade')) ||
+				(abilities.includes('Pixilate') && !counter.get('Normal'))
 			),
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (counter.get('Poison')) return false;
@@ -217,7 +218,7 @@ export class RandomGen8Teams {
 			Psychic: (movePool, moves, abilities, types, counter) => {
 				if (counter.get('Psychic')) return false;
 				if (types.has('Ghost') || types.has('Steel')) return false;
-				return abilities.has('Psychic Surge') || !!counter.setupType || movePool.includes('psychicfangs');
+				return abilities.includes('Psychic Surge') || !!counter.setupType || movePool.includes('psychicfangs');
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
 			Steel: (movePool, moves, abilities, types, counter, species) => {
@@ -228,7 +229,7 @@ export class RandomGen8Teams {
 			Water: (movePool, moves, abilities, types, counter, species) => {
 				if (!counter.get('Water') && !moves.has('hypervoice')) return true;
 				if (['hypervoice', 'liquidation', 'surgingstrikes'].some(m => movePool.includes(m))) return true;
-				return abilities.has('Huge Power') && movePool.includes('aquajet');
+				return abilities.includes('Huge Power') && movePool.includes('aquajet');
 			},
 		};
 	}
@@ -877,7 +878,7 @@ export class RandomGen8Teams {
 	queryMoves(
 		moves: Set<string> | null,
 		types: string[],
-		abilities: Set<string> = new Set(),
+		abilities: string[],
 		movePool: string[] = []
 	): MoveCounter {
 		// This is primarily a helper function for random setbuilder functions.
@@ -925,9 +926,9 @@ export class RandomGen8Teams {
 					}
 				} else if (
 					// Less obvious forms of STAB
-					(moveType === 'Normal' && (['Aerilate', 'Galvanize', 'Pixilate', 'Refrigerate'].some(abil => abilities.has(abil)))) ||
-					(move.priority === 0 && (abilities.has('Libero') || abilities.has('Protean')) && !this.noStab.includes(moveid)) ||
-					(moveType === 'Steel' && abilities.has('Steelworker'))
+					(moveType === 'Normal' && (['Aerilate', 'Galvanize', 'Pixilate', 'Refrigerate'].some(a => abilities.includes(a)))) ||
+					(move.priority === 0 && (['Libero', 'Protean'].some(a => abilities.includes(a))) && !this.noStab.includes(moveid)) ||
+					(moveType === 'Steel' && abilities.includes('Steelworker'))
 				) {
 					counter.add('stab');
 				}
@@ -935,7 +936,7 @@ export class RandomGen8Teams {
 				if (move.flags['bite']) counter.add('strongjaw');
 				if (move.flags['punch']) counter.add('ironfist');
 				if (move.flags['sound']) counter.add('sound');
-				if (move.priority !== 0 || (moveid === 'grassyglide' && abilities.has('Grassy Surge'))) {
+				if (move.priority !== 0 || (moveid === 'grassyglide' && abilities.includes('Grassy Surge'))) {
 					counter.add('priority');
 				}
 				counter.damagingMoves.add(move);
@@ -1019,7 +1020,7 @@ export class RandomGen8Teams {
 		move: Move,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -1056,7 +1057,7 @@ export class RandomGen8Teams {
 			return {cull: movePool.includes('protect') || movePool.includes('wish')};
 		case 'fireblast':
 			// Special case for Togekiss, which always wants Aura Sphere
-			return {cull: abilities.has('Serene Grace') && (!moves.has('trick') || counter.get('Status') > 1)};
+			return {cull: abilities.includes('Serene Grace') && (!moves.has('trick') || counter.get('Status') > 1)};
 		case 'firepunch':
 			// Special case for Darmanitan-Zen-Galar, which doesn't always want Fire Punch
 			return {cull: movePool.includes('bellydrum') || (moves.has('earthquake') && movePool.includes('substitute'))};
@@ -1074,7 +1075,7 @@ export class RandomGen8Teams {
 			return {cull: species.id !== 'registeel' && (movePool.includes('sleeptalk') || bulkySetup)};
 		case 'sleeptalk':
 			if (!moves.has('rest')) return {cull: true};
-			if (movePool.length > 1 && !abilities.has('Contrary')) {
+			if (movePool.length > 1 && !abilities.includes('Contrary')) {
 				const rest = movePool.indexOf('rest');
 				if (rest >= 0) this.fastPop(movePool, rest);
 			}
@@ -1163,7 +1164,7 @@ export class RandomGen8Teams {
 			if (
 				!isDoubles &&
 				counter.get('Status') < 2 &&
-				['Hunger Switch', 'Speed Boost'].every(m => !abilities.has(m))
+				['Hunger Switch', 'Speed Boost'].every(m => !abilities.includes(m))
 			) return {cull: true};
 			if (movePool.includes('leechseed') || (movePool.includes('toxic') && !moves.has('wish'))) return {cull: true};
 			if (isDoubles && (
@@ -1316,8 +1317,8 @@ export class RandomGen8Teams {
 			return {
 				cull: moves.has('hydropump') ||
 					(counter.get('Physical') >= 4 && movePool.includes('uturn')) ||
-					(moves.has('substitute') && !abilities.has('Contrary')),
-				isSetup: abilities.has('Contrary'),
+					(moves.has('substitute') && !abilities.includes('Contrary')),
+				isSetup: abilities.includes('Contrary'),
 			};
 		case 'poisonjab':
 			return {cull: !types.has('Poison') && counter.get('Status') >= 2};
@@ -1338,7 +1339,7 @@ export class RandomGen8Teams {
 			return {cull:
 				(species.id === 'naganadel' && moves.has('nastyplot')) ||
 				hasRestTalk ||
-				(abilities.has('Simple') && !!counter.get('recovery')) ||
+				(abilities.includes('Simple') && !!counter.get('recovery')) ||
 				counter.setupType === 'Physical',
 			};
 		case 'bravebird':
@@ -1359,7 +1360,7 @@ export class RandomGen8Teams {
 			return {cull: moves.has('rapidspin')};
 		case 'psyshock':
 			// Special case for Sylveon which only wants Psyshock if it gets a Choice item
-			const sylveonCase = abilities.has('Pixilate') && counter.get('Special') < 4;
+			const sylveonCase = abilities.includes('Pixilate') && counter.get('Special') < 4;
 			return {cull: moves.has('psychic') || (!counter.setupType && sylveonCase) || (isDoubles && moves.has('psychic'))};
 		case 'bugbuzz':
 			return {cull: moves.has('uturn') && !counter.setupType};
@@ -1370,7 +1371,7 @@ export class RandomGen8Teams {
 				movePool.includes('spikes'),
 			};
 		case 'stoneedge':
-			const gutsCullCondition = abilities.has('Guts') && (!moves.has('dynamicpunch') || moves.has('spikes'));
+			const gutsCullCondition = abilities.includes('Guts') && (!moves.has('dynamicpunch') || moves.has('spikes'));
 			const rockSlidePlusStatusPossible = counter.get('Status') && movePool.includes('rockslide');
 			const otherRockMove = moves.has('rockblast') || moves.has('rockslide');
 			const lucarioCull = species.id === 'lucario' && !!counter.setupType;
@@ -1382,7 +1383,7 @@ export class RandomGen8Teams {
 			return {cull:
 				(isDoubles && moves.has('phantomforce')) ||
 				// Special case for Sylveon, which never wants Shadow Ball as its only coverage move
-				(abilities.has('Pixilate') && (!!counter.setupType || counter.get('Status') > 1)) ||
+				(abilities.includes('Pixilate') && (!!counter.setupType || counter.get('Status') > 1)) ||
 				(!types.has('Ghost') && movePool.includes('focusblast')),
 			};
 		case 'shadowclaw':
@@ -1468,7 +1469,7 @@ export class RandomGen8Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -1490,7 +1491,7 @@ export class RandomGen8Teams {
 		case 'Analytic':
 			return (moves.has('rapidspin') || species.nfe || isDoubles);
 		case 'Blaze':
-			return (isDoubles && abilities.has('Solar Power')) || (!isDoubles && !isNoDynamax && species.id === 'charizard');
+			return (isDoubles && abilities.includes('Solar Power')) || (!isDoubles && !isNoDynamax && species.id === 'charizard');
 		// case 'Bulletproof': case 'Overcoat':
 		// 	return !!counter.setupType;
 		case 'Chlorophyll':
@@ -1502,7 +1503,7 @@ export class RandomGen8Teams {
 		case 'Compound Eyes': case 'No Guard':
 			return !counter.get('inaccurate');
 		case 'Cursed Body':
-			return abilities.has('Infiltrator');
+			return abilities.includes('Infiltrator');
 		case 'Defiant':
 			return !counter.get('Physical');
 		case 'Download':
@@ -1510,24 +1511,24 @@ export class RandomGen8Teams {
 		case 'Early Bird':
 			return (types.has('Grass') && isDoubles);
 		case 'Flash Fire':
-			return (this.dex.getEffectiveness('Fire', species) < -1 || abilities.has('Drought'));
+			return (this.dex.getEffectiveness('Fire', species) < -1 || abilities.includes('Drought'));
 		case 'Gluttony':
 			return !moves.has('bellydrum');
 		case 'Guts':
 			return (!moves.has('facade') && !moves.has('sleeptalk') && !species.nfe);
 		case 'Harvest':
-			return (abilities.has('Frisk') && !isDoubles);
+			return (abilities.includes('Frisk') && !isDoubles);
 		case 'Hustle': case 'Inner Focus':
-			return ((species.id !== 'glalie' && counter.get('Physical') < 2) || abilities.has('Iron Fist'));
+			return ((species.id !== 'glalie' && counter.get('Physical') < 2) || abilities.includes('Iron Fist'));
 		case 'Infiltrator':
-			return (moves.has('rest') && moves.has('sleeptalk')) || (isDoubles && abilities.has('Clear Body'));
+			return (moves.has('rest') && moves.has('sleeptalk')) || (isDoubles && abilities.includes('Clear Body'));
 		case 'Intimidate':
 			if (species.id === 'salamence' && moves.has('dragondance')) return true;
 			return ['bodyslam', 'bounce', 'tripleaxel'].some(m => moves.has(m));
 		case 'Iron Fist':
 			return (counter.get('ironfist') < 2 || moves.has('dynamicpunch'));
 		case 'Justified':
-			return (isDoubles && abilities.has('Inner Focus'));
+			return (isDoubles && abilities.includes('Inner Focus'));
 		case 'Lightning Rod':
 			return (species.types.includes('Ground') || (!isNoDynamax && counter.setupType === 'Physical'));
 		case 'Limber':
@@ -1536,11 +1537,11 @@ export class RandomGen8Teams {
 			return !moves.has('hypervoice');
 		case 'Magic Guard':
 			// For Sigilyph
-			return (abilities.has('Tinted Lens') && !counter.get('Status') && !isDoubles);
+			return (abilities.includes('Tinted Lens') && !counter.get('Status') && !isDoubles);
 		case 'Mold Breaker':
 			return (
-				abilities.has('Adaptability') || abilities.has('Scrappy') || (abilities.has('Unburden') && !!counter.setupType) ||
-				(abilities.has('Sheer Force') && !!counter.get('sheerforce'))
+				abilities.includes('Adaptability') || abilities.includes('Scrappy') || (abilities.includes('Unburden') && !!counter.setupType) ||
+				(abilities.includes('Sheer Force') && !!counter.get('sheerforce'))
 			);
 		case 'Moxie':
 			return (counter.get('Physical') < 2 || moves.has('stealthrock') || moves.has('defog'));
@@ -1558,7 +1559,7 @@ export class RandomGen8Teams {
 			return !counter.get('Normal');
 		case 'Regenerator':
 			// For Reuniclus
-			return abilities.has('Magic Guard');
+			return abilities.includes('Magic Guard');
 		case 'Reckless':
 			return !counter.get('recoil') || moves.has('curse');
 		case 'Rock Head':
@@ -1578,11 +1579,11 @@ export class RandomGen8Teams {
 			// For Scrafty
 			return moves.has('dragondance');
 		case 'Sheer Force':
-			return (!counter.get('sheerforce') || abilities.has('Guts') || (species.id === 'druddigon' && !isDoubles));
+			return (!counter.get('sheerforce') || abilities.includes('Guts') || (species.id === 'druddigon' && !isDoubles));
 		case 'Shell Armor':
 			return (species.id === 'omastar' && (moves.has('spikes') || moves.has('stealthrock')));
 		case 'Slush Rush':
-			return (!teamDetails.hail && !abilities.has('Swift Swim'));
+			return (!teamDetails.hail && !abilities.includes('Swift Swim'));
 		case 'Sniper':
 			// Inteleon wants Torrent unless it is Gmax
 			return (species.name === 'Inteleon' || (counter.get('Water') > 1 && !moves.has('focusenergy')));
@@ -1593,7 +1594,7 @@ export class RandomGen8Teams {
 		case 'Steely Spirit':
 			return (moves.has('fakeout') && !isDoubles);
 		case 'Sturdy':
-			return (moves.has('bulkup') || !!counter.get('recoil') || (!isNoDynamax && abilities.has('Solid Rock')));
+			return (moves.has('bulkup') || !!counter.get('recoil') || (!isNoDynamax && abilities.includes('Solid Rock')));
 		case 'Swarm':
 			return (!counter.get('Bug') || !!counter.get('recovery'));
 		case 'Sweet Veil':
@@ -1602,15 +1603,15 @@ export class RandomGen8Teams {
 			if (isNoDynamax) {
 				const neverWantsSwim = !moves.has('raindance') && [
 					'Intimidate', 'Rock Head', 'Water Absorb',
-				].some(m => abilities.has(m));
+				].some(m => abilities.includes(m));
 				const noSwimIfNoRain = !moves.has('raindance') && [
 					'Cloud Nine', 'Lightning Rod', 'Intimidate', 'Rock Head', 'Sturdy', 'Water Absorb', 'Weak Armor',
-				].some(m => abilities.has(m));
+				].some(m => abilities.includes(m));
 				return teamDetails.rain ? neverWantsSwim : noSwimIfNoRain;
 			}
 			return (!moves.has('raindance') && (
-				['Intimidate', 'Rock Head', 'Slush Rush', 'Water Absorb'].some(abil => abilities.has(abil)) ||
-				(abilities.has('Lightning Rod') && !counter.setupType)
+				['Intimidate', 'Rock Head', 'Slush Rush', 'Water Absorb'].some(abil => abilities.includes(abil)) ||
+				(abilities.includes('Lightning Rod') && !counter.setupType)
 			));
 		case 'Synchronize':
 			return counter.get('Status') < 3;
@@ -1618,7 +1619,7 @@ export class RandomGen8Teams {
 			return (
 				!counter.get('technician') ||
 				moves.has('tailslap') ||
-				abilities.has('Punk Rock') ||
+				abilities.includes('Punk Rock') ||
 				// For Doubles Alolan Persian
 				movePool.includes('snarl')
 			);
@@ -1627,7 +1628,7 @@ export class RandomGen8Teams {
 				// For Sigilyph
 				moves.has('defog') ||
 				// For Butterfree
-				(moves.has('hurricane') && abilities.has('Compound Eyes')) ||
+				(moves.has('hurricane') && abilities.includes('Compound Eyes')) ||
 				(counter.get('Status') > 2 && !counter.setupType)
 			);
 		case 'Torrent':
@@ -1640,13 +1641,13 @@ export class RandomGen8Teams {
 			// For Swoobat and Clefable
 			return (!!counter.setupType || moves.has('fireblast'));
 		case 'Unburden':
-			return (abilities.has('Prankster') || !counter.setupType && !isDoubles);
+			return (abilities.includes('Prankster') || !counter.setupType && !isDoubles);
 		case 'Volt Absorb':
 			return (this.dex.getEffectiveness('Electric', species) < -1);
 		case 'Water Absorb':
 			return (
 				moves.has('raindance') ||
-				['Drizzle', 'Strong Jaw', 'Unaware', 'Volt Absorb'].some(abil => abilities.has(abil))
+				['Drizzle', 'Strong Jaw', 'Unaware', 'Volt Absorb'].some(abil => abilities.includes(abil))
 			);
 		case 'Weak Armor':
 			// The Speed less than 50 case is intended for Cursola, but could apply to any slow Pokémon.
@@ -1664,7 +1665,7 @@ export class RandomGen8Teams {
 	getAbility(
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -1685,31 +1686,33 @@ export class RandomGen8Teams {
 		// since paralysis would arguably be good for them.
 		if (species.id === 'lopunny' && moves.has('facade')) return 'Cute Charm';
 		if (species.id === 'copperajahgmax') return 'Heavy Metal';
-		if (abilities.has('Guts') &&
+		if (abilities.includes('Guts') &&
 			// for Ursaring in BDSP
-			!abilities.has('Quick Feet') && (
+			!abilities.includes('Quick Feet') && (
 			species.id === 'gurdurr' || species.id === 'throh' ||
 			moves.has('facade') || (moves.has('rest') && moves.has('sleeptalk'))
 		)) return 'Guts';
-		if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce')) && !isDoubles) return 'Moxie';
+		if (abilities.includes('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce')) && !isDoubles) return 'Moxie';
 
 		if (isDoubles) {
-			if (abilities.has('Competitive') && !abilities.has('Shadow Tag') && !abilities.has('Strong Jaw')) return 'Competitive';
-			if (abilities.has('Friend Guard')) return 'Friend Guard';
-			if (abilities.has('Gluttony') && moves.has('recycle')) return 'Gluttony';
-			if (abilities.has('Guts')) return 'Guts';
-			if (abilities.has('Harvest')) return 'Harvest';
-			if (abilities.has('Healer') && (
-				abilities.has('Natural Cure') ||
-				(abilities.has('Aroma Veil') && this.randomChance(1, 2))
+			if (abilities.includes('Competitive') && species.id !== 'boltund' && species.id !== 'gothitelle') return 'Competitive';
+			if (abilities.includes('Friend Guard')) return 'Friend Guard';
+			if (abilities.includes('Gluttony') && moves.has('recycle')) return 'Gluttony';
+			if (abilities.includes('Guts')) return 'Guts';
+			if (abilities.includes('Harvest')) return 'Harvest';
+			if (abilities.includes('Healer') && (
+				abilities.includes('Natural Cure') ||
+				(abilities.includes('Aroma Veil') && this.randomChance(1, 2))
 			)) return 'Healer';
-			if (abilities.has('Intimidate')) return 'Intimidate';
+			if (abilities.includes('Intimidate')) return 'Intimidate';
 			if (species.id === 'lopunny') return 'Klutz';
-			if (abilities.has('Magic Guard') && !abilities.has('Unaware')) return 'Magic Guard';
-			if (abilities.has('Ripen')) return 'Ripen';
-			if (abilities.has('Stalwart')) return 'Stalwart';
-			if (abilities.has('Storm Drain')) return 'Storm Drain';
-			if (abilities.has('Telepathy') && (abilities.has('Pressure') || abilities.has('Analytic'))) return 'Telepathy';
+			if (abilities.includes('Magic Guard') && !abilities.includes('Unaware')) return 'Magic Guard';
+			if (abilities.includes('Ripen')) return 'Ripen';
+			if (abilities.includes('Stalwart')) return 'Stalwart';
+			if (abilities.includes('Storm Drain')) return 'Storm Drain';
+			if (abilities.includes('Telepathy') && (
+				abilities.includes('Pressure') || abilities.includes('Analytic')
+			)) return 'Telepathy';
 		}
 
 		let abilityAllowed: Ability[] = [];
@@ -1857,7 +1860,7 @@ export class RandomGen8Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
@@ -1875,7 +1878,7 @@ export class RandomGen8Teams {
 			moves.has('flipturn') || moves.has('uturn')
 		)) {
 			return (
-				!counter.get('priority') && !abilities.has('Speed Boost') &&
+				!counter.get('priority') && !abilities.includes('Speed Boost') &&
 				species.baseStats.spe >= 60 && species.baseStats.spe <= 100 &&
 				this.randomChance(1, 2)
 			) ? 'Choice Scarf' : 'Choice Band';
@@ -1987,7 +1990,7 @@ export class RandomGen8Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
@@ -2020,7 +2023,7 @@ export class RandomGen8Teams {
 
 		if (
 			!isDoubles && this.dex.getEffectiveness('Ground', species) >= 2 && !types.has('Poison') &&
-			ability !== 'Levitate' && !abilities.has('Iron Barbs')
+			ability !== 'Levitate' && !abilities.includes('Iron Barbs')
 		) return 'Air Balloon';
 		if (
 			!isDoubles &&
@@ -2179,8 +2182,9 @@ export class RandomGen8Teams {
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const types = new Set(species.types);
-		const abilities = new Set(Object.values(species.abilities));
-		if (species.unreleasedHidden) abilities.delete(species.abilities.H);
+		const abilitiesSet = new Set(Object.values(species.abilities));
+		if (species.unreleasedHidden) abilitiesSet.delete(species.abilities.H);
+		const abilities = Array.from(abilitiesSet);
 
 		const moves = new Set<string>();
 		let counter: MoveCounter;
@@ -2235,7 +2239,7 @@ export class RandomGen8Teams {
 					!(species.id === 'shuckle' && ['stealthrock', 'stickyweb'].includes(move.id)) && (
 						move.category === 'Status' ||
 						(!types.has(move.type) && move.id !== 'judgment') ||
-						(isLowBP && !move.multihit && !abilities.has('Technician'))
+						(isLowBP && !move.multihit && !abilities.includes('Technician'))
 					)
 				);
 				// Setup-supported moves should only be rejected under specific circumstances
@@ -2257,7 +2261,7 @@ export class RandomGen8Teams {
 						// Swords Dance Mew should have Brave Bird
 						(moves.has('swordsdance') && species.id === 'mew' && runEnforcementChecker('Flying')) ||
 						// Dhelmise should have Anchor Shot
-						(abilities.has('Steelworker') && runEnforcementChecker('Steel')) ||
+						(abilities.includes('Steelworker') && runEnforcementChecker('Steel')) ||
 						// Check for miscellaneous important moves
 						(!isDoubles && runEnforcementChecker('recovery') && move.id !== 'stickyweb') ||
 						runEnforcementChecker('screens') ||

--- a/data/random-battles/gen8bdsp/teams.ts
+++ b/data/random-battles/gen8bdsp/teams.ts
@@ -133,7 +133,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
@@ -181,7 +181,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		move: Move,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -213,7 +213,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return {cull: movePool.includes('protect') || movePool.includes('wish')};
 		case 'fireblast':
 			// Special case for Togekiss, which always wants Aura Sphere
-			return {cull: abilities.has('Serene Grace') && (!moves.has('trick') || counter.get('Status') > 1)};
+			return {cull: abilities.includes('Serene Grace') && (!moves.has('trick') || counter.get('Status') > 1)};
 		case 'firepunch':
 			// Special case for Darmanitan-Zen-Galar, which doesn't always want Fire Punch
 			return {cull: moves.has('earthquake') && movePool.includes('substitute')};
@@ -229,7 +229,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			// Milotic always wants RestTalk
 			if (species.id === 'milotic') return {cull: false};
 			if (moves.has('stealthrock') || !moves.has('rest')) return {cull: true};
-			if (movePool.length > 1 && !abilities.has('Contrary')) {
+			if (movePool.length > 1 && !abilities.includes('Contrary')) {
 				const rest = movePool.indexOf('rest');
 				if (rest >= 0) this.fastPop(movePool, rest);
 			}
@@ -313,7 +313,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			if (
 				!isDoubles &&
 				counter.get('Status') < 2 &&
-				['Guts', 'Quick Feet', 'Speed Boost', 'Moody'].every(m => !abilities.has(m))
+				['Guts', 'Quick Feet', 'Speed Boost', 'Moody'].every(m => !abilities.includes(m))
 			) return {cull: true};
 			if (movePool.includes('leechseed') || (movePool.includes('toxic') && !moves.has('wish'))) return {cull: true};
 			if (isDoubles && (
@@ -361,7 +361,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return {cull: (
 				!!counter.get('speedsetup') ||
 				(counter.setupType && !bugSwordsDanceCase) ||
-				(abilities.has('Speed Boost') && moves.has('protect')) ||
+				(abilities.includes('Speed Boost') && moves.has('protect')) ||
 				(isDoubles && moves.has('leechlife'))
 			)};
 
@@ -416,7 +416,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return {cull: moves.has('closecombat') || (!types.has('Fighting') && movePool.includes('swordsdance'))};
 		case 'facade':
 			// Prefer Dynamic Punch when it can be a guaranteed-hit STAB move (mostly for Machamp)
-			return {cull: moves.has('dynamicpunch') && species.types.includes('Fighting') && abilities.has('No Guard')};
+			return {cull: moves.has('dynamicpunch') && species.types.includes('Fighting') && abilities.includes('No Guard')};
 		case 'focusblast':
 			// Special cases for Blastoise and Regice; Blastoise wants Shell Smash, and Regice wants Thunderbolt
 			return {cull: movePool.includes('shellsmash') || hasRestTalk};
@@ -424,8 +424,8 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return {
 				cull: moves.has('hydropump') ||
 					(counter.get('Physical') >= 4 && movePool.includes('uturn')) ||
-					(moves.has('substitute') && !abilities.has('Contrary')),
-				isSetup: abilities.has('Contrary'),
+					(moves.has('substitute') && !abilities.includes('Contrary')),
+				isSetup: abilities.includes('Contrary'),
 			};
 		case 'poisonjab':
 			return {cull: !types.has('Poison') && counter.get('Status') >= 2};
@@ -444,7 +444,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'psyshock':
 			return {cull: moves.has('psychic')};
 		case 'bugbuzz':
-			return {cull: moves.has('uturn') && !counter.setupType && !abilities.has('Tinted Lens')};
+			return {cull: moves.has('uturn') && !counter.setupType && !abilities.includes('Tinted Lens')};
 		case 'leechlife':
 			return {cull:
 				(isDoubles && moves.has('lunge')) ||
@@ -509,7 +509,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 				species.id !== 'breloom' &&
 				['bulkup', 'nastyplot', 'painsplit', 'roost', 'swordsdance'].some(m => movePool.includes(m))
 			);
-			const shayminCase = abilities.has('Serene Grace') && movePool.includes('airslash') && !moves.has('airslash');
+			const shayminCase = abilities.includes('Serene Grace') && movePool.includes('airslash') && !moves.has('airslash');
 			return {cull: moves.has('rest') || moveBasedCull || shayminCase};
 		case 'helpinghand':
 			// Special case for Shuckle in Doubles, which doesn't want sets with no method to harm foes
@@ -528,7 +528,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		ability: string,
 		types: Set<string>,
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -549,7 +549,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'Analytic':
 			return (moves.has('rapidspin') || species.nfe || isDoubles);
 		case 'Blaze':
-			return (isDoubles && abilities.has('Solar Power')) || (!isDoubles && species.id === 'charizard');
+			return (isDoubles && abilities.includes('Solar Power')) || (!isDoubles && species.id === 'charizard');
 		case 'Chlorophyll':
 			return (species.baseStats.spe > 100 || !counter.get('Fire') && !moves.has('sunnyday') && !teamDetails.sun);
 		case 'Cloud Nine':
@@ -559,7 +559,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'Compound Eyes': case 'No Guard':
 			return !counter.get('inaccurate');
 		case 'Cursed Body':
-			return abilities.has('Infiltrator');
+			return abilities.includes('Infiltrator');
 		case 'Defiant':
 			return !counter.get('Physical');
 		case 'Download':
@@ -567,36 +567,36 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'Early Bird':
 			return (types.has('Grass') && isDoubles);
 		case 'Flash Fire':
-			return (this.dex.getEffectiveness('Fire', species) < -1 || abilities.has('Drought'));
+			return (this.dex.getEffectiveness('Fire', species) < -1 || abilities.includes('Drought'));
 		case 'Gluttony':
 			return !moves.has('bellydrum');
 		case 'Guts':
 			return (!moves.has('facade') && !moves.has('sleeptalk') && !species.nfe ||
-				abilities.has('Quick Feet') && !!counter.setupType);
+				abilities.includes('Quick Feet') && !!counter.setupType);
 		case 'Harvest':
-			return (abilities.has('Frisk') && !isDoubles);
+			return (abilities.includes('Frisk') && !isDoubles);
 		case 'Hustle': case 'Inner Focus':
-			return (counter.get('Physical') < 2 || abilities.has('Iron Fist'));
+			return (counter.get('Physical') < 2 || abilities.includes('Iron Fist'));
 		case 'Infiltrator':
-			return (moves.has('rest') && moves.has('sleeptalk')) || (isDoubles && abilities.has('Clear Body'));
+			return (moves.has('rest') && moves.has('sleeptalk')) || (isDoubles && abilities.includes('Clear Body'));
 		case 'Intimidate':
 			if (species.id === 'salamence' && moves.has('dragondance')) return true;
 			return ['bodyslam', 'bounce', 'rockclimb', 'tripleaxel'].some(m => moves.has(m));
 		case 'Iron Fist':
 			return (counter.get('ironfist') < 2 || moves.has('dynamicpunch'));
 		case 'Justified':
-			return (isDoubles && abilities.has('Inner Focus'));
+			return (isDoubles && abilities.includes('Inner Focus'));
 		case 'Lightning Rod':
 			return (species.types.includes('Ground') || counter.setupType === 'Physical');
 		case 'Limber':
 			return species.types.includes('Electric') || moves.has('facade');
 		case 'Mold Breaker':
 			return (
-				abilities.has('Adaptability') || abilities.has('Scrappy') || (abilities.has('Unburden') && !!counter.setupType) ||
-				(abilities.has('Sheer Force') && !!counter.get('sheerforce'))
+				abilities.includes('Adaptability') || abilities.includes('Scrappy') || (abilities.includes('Unburden') && !!counter.setupType) ||
+				(abilities.includes('Sheer Force') && !!counter.get('sheerforce'))
 			);
 		case 'Moody':
-			return !!counter.setupType && abilities.has('Simple');
+			return !!counter.setupType && abilities.includes('Simple');
 		case 'Moxie':
 			return (counter.get('Physical') < 2 || moves.has('stealthrock') || moves.has('defog'));
 		case 'Overgrow':
@@ -620,26 +620,26 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'Scrappy':
 			return (moves.has('earthquake') && species.id === 'miltank');
 		case 'Sheer Force':
-			return (!counter.get('sheerforce') || abilities.has('Guts'));
+			return (!counter.get('sheerforce') || abilities.includes('Guts'));
 		case 'Shell Armor':
 			return (species.id === 'omastar' && (moves.has('spikes') || moves.has('stealthrock')));
 		case 'Sniper':
 			return counter.get('Water') > 1 && !moves.has('focusenergy');
 		case 'Solar Power':
-			return (!teamDetails.sun || abilities.has('Harvest'));
+			return (!teamDetails.sun || abilities.includes('Harvest'));
 		case 'Speed Boost':
 			return moves.has('uturn');
 		case 'Sturdy':
-			return (moves.has('bulkup') || !!counter.get('recoil') || abilities.has('Solid Rock'));
+			return (moves.has('bulkup') || !!counter.get('recoil') || abilities.includes('Solid Rock'));
 		case 'Swarm':
 			return (!counter.get('Bug') || !!counter.get('recovery'));
 		case 'Swift Swim':
 			const neverWantsSwim = !moves.has('raindance') && [
 				'Intimidate', 'Rock Head', 'Water Absorb',
-			].some(m => abilities.has(m));
+			].some(m => abilities.includes(m));
 			const noSwimIfNoRain = !moves.has('raindance') && [
 				'Cloud Nine', 'Lightning Rod', 'Intimidate', 'Rock Head', 'Sturdy', 'Water Absorb', 'Water Veil', 'Weak Armor',
-			].some(m => abilities.has(m));
+			].some(m => abilities.includes(m));
 			return teamDetails.rain ? neverWantsSwim : noSwimIfNoRain;
 		case 'Synchronize':
 			return counter.get('Status') < 3;
@@ -647,12 +647,12 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return (
 				!counter.get('technician') ||
 				moves.has('tailslap') ||
-				abilities.has('Punk Rock')
+				abilities.includes('Punk Rock')
 			);
 		case 'Tinted Lens':
 			return (
 				// For Butterfree
-				(moves.has('hurricane') && abilities.has('Compound Eyes')) ||
+				(moves.has('hurricane') && abilities.includes('Compound Eyes')) ||
 				(counter.get('Status') > 2 && !counter.setupType) ||
 				// For Yanmega
 				moves.has('protect')
@@ -661,9 +661,9 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return species.id === 'bibarel';
 		case 'Unburden':
 			return (
-				abilities.has('Prankster') ||
+				abilities.includes('Prankster') ||
 				// intended for Hitmonlee
-				abilities.has('Reckless') ||
+				abilities.includes('Reckless') ||
 				!counter.setupType && !isDoubles
 			);
 		case 'Volt Absorb':
@@ -671,7 +671,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'Water Absorb':
 			return (
 				moves.has('raindance') ||
-				['Drizzle', 'Strong Jaw', 'Unaware', 'Volt Absorb'].some(abil => abilities.has(abil))
+				['Drizzle', 'Strong Jaw', 'Unaware', 'Volt Absorb'].some(abil => abilities.includes(abil))
 			);
 		case 'Weak Armor':
 			return (

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -5,6 +5,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Protect", "Sludge Bomb"],
+                "abilities": ["Chlorophyll", "Overgrow"],
                 "teraTypes": ["Dark", "Water"]
             }
         ]
@@ -15,6 +16,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Heat Wave", "Hurricane", "Protect", "Scorching Sands", "Will-O-Wisp"],
+                "abilities": ["Blaze", "Solar Power"],
                 "teraTypes": ["Dragon", "Fire", "Ground"]
             }
         ]
@@ -25,11 +27,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Fake Out", "Flip Turn", "Icy Wind", "Life Dew", "Wave Crash", "Yawn"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Dragon", "Grass"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dragon Pulse", "Muddy Water", "Protect", "Shell Smash"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -40,11 +44,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Coil", "Gunk Shot", "Knock Off", "Protect", "Stomping Tantrum"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Ground"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Dragon Tail", "Glare", "Gunk Shot", "Knock Off", "Toxic Spikes"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -55,6 +61,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Fake Out", "Grass Knot", "Knock Off", "Protect", "Volt Tackle"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Electric", "Grass"]
             }
         ]
@@ -65,11 +72,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Fake Out", "Grass Knot", "Knock Off", "Nuzzle", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Electric", "Grass"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Nasty Plot", "Protect", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -80,11 +89,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Psychic", "Psyshock", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Surge Surfer"],
                 "teraTypes": ["Electric", "Fairy", "Fighting", "Grass"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Nasty Plot", "Protect", "Psychic", "Psyshock", "Thunderbolt"],
+                "abilities": ["Surge Surfer"],
                 "teraTypes": ["Dark", "Electric", "Flying"]
             }
         ]
@@ -95,11 +106,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["High Horsepower", "Knock Off", "Leech Life", "Protect", "Stone Edge", "Swords Dance"],
+                "abilities": ["Sand Rush"],
                 "teraTypes": ["Bug", "Dark", "Rock"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["High Horsepower", "Knock Off", "Rapid Spin", "Rock Slide", "Super Fang"],
+                "abilities": ["Sand Rush"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -110,11 +123,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Drill Run", "Ice Shard", "Iron Head", "Knock Off", "Triple Axel"],
+                "abilities": ["Slush Rush"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Drill Run", "Ice Shard", "Iron Head", "Triple Axel"],
+                "abilities": ["Slush Rush"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -125,6 +140,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Follow Me", "Heal Pulse", "Helping Hand", "Life Dew", "Moonblast"],
+                "abilities": ["Friend Guard"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             }
         ]
@@ -135,11 +151,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Heal Pulse", "Icy Wind", "Knock Off", "Life Dew", "Moonblast", "Thunder Wave"],
+                "abilities": ["Magic Guard", "Unaware"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Fire Blast", "Follow Me", "Heal Pulse", "Helping Hand", "Life Dew", "Moonblast"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             }
         ]
@@ -150,6 +168,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Flamethrower", "Heat Wave", "Overheat", "Protect", "Scorching Sands", "Solar Beam"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]
@@ -160,6 +179,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Aurora Veil", "Blizzard", "Moonblast", "Protect"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Ice", "Steel", "Water"]
             }
         ]
@@ -170,6 +190,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Dazzling Gleam", "Disable", "Encore", "Fire Blast", "Heal Pulse", "Helping Hand", "Icy Wind", "Thunder Wave"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -180,6 +201,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Pollen Puff", "Sludge Bomb", "Strength Sap", "Stun Spore"],
+                "abilities": ["Effect Spore"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -190,6 +212,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Bug Buzz", "Protect", "Quiver Dance", "Sleep Powder", "Sludge Bomb"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug", "Steel", "Water"]
             }
         ]
@@ -200,6 +223,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Helping Hand", "Protect", "Rock Slide", "Stomping Tantrum", "Sucker Punch"],
+                "abilities": ["Arena Trap"],
                 "teraTypes": ["Fire", "Ghost", "Ground"]
             }
         ]
@@ -210,6 +234,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Iron Head", "Protect", "Rock Slide", "Stomping Tantrum", "Sucker Punch"],
+                "abilities": ["Sand Force", "Tangling Hair"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             }
         ]
@@ -220,6 +245,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Double-Edge", "Fake Out", "Helping Hand", "Icy Wind", "Knock Off", "Taunt", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -230,6 +256,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Fake Out", "Foul Play", "Helping Hand", "Icy Wind", "Knock Off", "Parting Shot", "Snarl", "Taunt", "Thunder Wave"],
+                "abilities": ["Fur Coat"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -240,11 +267,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Encore", "Grass Knot", "Hydro Pump", "Ice Beam", "Icy Wind", "Protect", "Psyshock"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "teraTypes": ["Grass", "Water"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Grass Knot", "Hydro Pump", "Ice Beam", "Protect", "Psyshock"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -255,11 +284,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Bulk Up", "Drain Punch", "Protect", "Rage Fist"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Close Combat", "Final Gambit", "Rage Fist", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -270,6 +301,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Howl", "Morning Sun", "Snarl", "Will-O-Wisp"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Normal", "Steel", "Water"]
             }
         ]
@@ -280,11 +312,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Extreme Speed", "Flare Blitz", "Rock Slide", "Stone Edge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Normal", "Rock"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Flare Blitz", "Morning Sun", "Protect", "Rock Slide", "Will-O-Wisp"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy", "Grass"]
             }
         ]
@@ -295,6 +329,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Circle Throw", "Close Combat", "Coaching", "Icy Wind", "Knock Off", "Liquidation"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Dragon", "Fire", "Ground", "Steel"]
             }
         ]
@@ -305,6 +340,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Knock Off", "Power Whip", "Protect", "Sludge Bomb", "Sucker Punch"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Dark", "Grass"]
             }
         ]
@@ -315,6 +351,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Acid Spray", "Hydro Pump", "Icy Wind", "Knock Off", "Muddy Water", "Sludge Bomb", "Toxic Spikes"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -325,6 +362,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Fire Punch", "High Horsepower", "Rock Slide", "Stone Edge"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -335,11 +373,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Double-Edge", "High Horsepower", "Protect", "Rock Slide", "Thunder Wave"],
+                "abilities": ["Galvanize"],
                 "teraTypes": ["Grass", "Ground"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Double-Edge", "Explosion", "High Horsepower", "Rock Slide"],
+                "abilities": ["Galvanize"],
                 "teraTypes": ["Grass", "Ground"]
             }
         ]
@@ -350,11 +390,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psyshock", "Scald", "Trick Room"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psyshock", "Scald", "Trick Room"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Fire", "Water"]
             }
         ]
@@ -365,6 +407,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Fire Blast", "Psychic", "Shell Side Arm", "Trick Room"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Fire", "Poison"]
             }
         ]
@@ -375,11 +418,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Brave Bird", "Double-Edge", "Drill Run", "Knock Off", "Quick Attack"],
+                "abilities": ["Early Bird"],
                 "teraTypes": ["Ground", "Normal"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Drill Run", "Protect", "Quick Attack", "Swords Dance"],
+                "abilities": ["Early Bird"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -390,6 +435,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Fake Out", "Hydro Pump", "Icy Wind"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -400,6 +446,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Helping Hand", "Ice Punch", "Knock Off", "Poison Gas", "Poison Jab", "Shadow Sneak"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -410,6 +457,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Drain Punch", "Gunk Shot", "Helping Hand", "Ice Punch", "Knock Off", "Poison Jab", "Protect", "Snarl"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -420,6 +468,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Hydro Pump", "Icicle Spear", "Protect", "Rock Blast", "Shell Smash"],
+                "abilities": ["Skill Link"],
                 "teraTypes": ["Fire", "Ice", "Rock", "Water"]
             }
         ]
@@ -430,11 +479,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Encore", "Protect", "Shadow Ball", "Sludge Bomb"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Focus Blast", "Protect", "Shadow Ball", "Sludge Bomb", "Trick"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Fighting", "Ghost"]
             }
         ]
@@ -445,6 +496,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Helping Hand", "Knock Off", "Low Sweep", "Poison Gas", "Psychic"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -455,11 +507,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Electroweb", "Foul Play", "Helping Hand", "Taunt", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Soundproof", "Static"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Protect", "Tera Blast", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Soundproof", "Static"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -470,11 +524,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Electroweb", "Energy Ball", "Leaf Storm", "Taunt", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Soundproof", "Static"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Foul Play", "Leaf Storm", "Protect", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Soundproof", "Static"],
                 "teraTypes": ["Dark", "Electric", "Grass", "Steel"]
             }
         ]
@@ -485,6 +541,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Energy Ball", "Leaf Storm", "Protect", "Psychic", "Trick Room"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Fire", "Poison", "Steel"]
             }
         ]
@@ -495,6 +552,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Protect", "Trick Room", "Wood Hammer"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -505,6 +563,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Fake Out", "Knock Off", "Poison Jab", "Protect"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -515,6 +574,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Coaching", "Fake Out", "Knock Off", "Poison Jab"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -525,6 +585,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Clear Smog", "Fire Blast", "Gunk Shot", "Poison Gas", "Protect", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Levitate", "Neutralizing Gas"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -535,6 +596,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Fire Blast", "Gunk Shot", "Haze", "Poison Gas", "Protect", "Strange Steam", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Levitate", "Neutralizing Gas"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -545,6 +607,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Helping Hand", "High Horsepower", "Protect", "Rock Slide", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Flying", "Grass", "Water"]
             }
         ]
@@ -555,6 +618,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Bug Bite", "Dual Wingbeat", "Protect", "Tailwind"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -565,6 +629,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Electroweb", "Follow Me", "Knock Off", "Protect", "Thunderbolt"],
+                "abilities": ["Static"],
                 "teraTypes": ["Flying", "Grass"]
             }
         ]
@@ -575,6 +640,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Follow Me", "Heat Wave", "Knock Off", "Protect", "Will-O-Wisp"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -585,6 +651,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Close Combat", "Double-Edge", "High Horsepower", "Lash Out", "Stone Edge", "Throat Chop"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Normal"]
             }
         ]
@@ -595,11 +662,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Bulk Up", "Protect", "Raging Bull", "Stone Edge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "High Horsepower", "Iron Head", "Rock Slide", "Stone Edge", "Throat Chop"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
@@ -610,11 +679,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Bulk Up", "Close Combat", "Protect", "Raging Bull", "Will-O-Wisp"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Fire", "Water"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Flare Blitz", "Rock Slide", "Stone Edge", "Wild Charge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Fire", "Water"]
             }
         ]
@@ -625,11 +696,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Aqua Jet", "Bulk Up", "Close Combat", "Liquidation", "Protect"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aqua Jet", "Close Combat", "Wave Crash", "Wild Charge", "Zen Headbutt"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             }
         ]
@@ -640,16 +713,19 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Protect", "Temper Flare", "Waterfall"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Protect", "Tera Blast", "Waterfall"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Helping Hand", "Icy Wind", "Taunt", "Thunder Wave", "Waterfall"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground", "Water"]
             }
         ]
@@ -660,6 +736,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Freeze-Dry", "Icy Wind", "Life Dew", "Muddy Water", "Protect"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -670,11 +747,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Transform"],
+                "abilities": ["Imposter"],
                 "teraTypes": ["Bug", "Dark", "Dragon", "Electric", "Fairy", "Fighting", "Fire", "Flying", "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic", "Rock", "Steel", "Water"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Transform"],
+                "abilities": ["Imposter"],
                 "teraTypes": ["Bug", "Dark", "Dragon", "Electric", "Fairy", "Fighting", "Fire", "Flying", "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic", "Rock", "Steel", "Water"]
             }
         ]
@@ -685,6 +764,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Helping Hand", "Icy Wind", "Muddy Water", "Protect", "Scald", "Wish", "Yawn"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Dragon", "Fire", "Ground"]
             }
         ]
@@ -695,11 +775,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Alluring Voice", "Helping Hand", "Protect", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Protect", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -710,6 +792,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Facade", "Flare Blitz", "Protect", "Quick Attack"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -720,16 +803,19 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Crunch", "Double-Edge", "Hammer Arm", "Heat Crash", "High Horsepower"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fire", "Ghost", "Ground"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Slam", "Encore", "Helping Hand", "High Horsepower", "Icy Wind", "Recycle", "Yawn"],
+                "abilities": ["Gluttony"],
                 "teraTypes": ["Ghost", "Ground"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Slam", "Crunch", "Curse", "High Horsepower", "Protect", "Recycle"],
+                "abilities": ["Gluttony"],
                 "teraTypes": ["Ground", "Poison"]
             }
         ]
@@ -740,6 +826,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Brave Bird", "Freeze-Dry", "Ice Beam", "Icy Wind", "Protect", "Roost", "Tailwind"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -750,6 +837,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Freezing Glare", "Hurricane", "Protect", "Recover", "Tailwind"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Flying", "Ground", "Steel"]
             }
         ]
@@ -760,11 +848,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Hurricane", "Protect", "Roost", "Tailwind", "Thunderbolt"],
+                "abilities": ["Static"],
                 "teraTypes": ["Electric", "Steel"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Heat Wave", "Hurricane", "Protect", "Tailwind", "Thunderbolt"],
+                "abilities": ["Static"],
                 "teraTypes": ["Electric", "Fire"]
             }
         ]
@@ -775,6 +865,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Brave Bird", "Close Combat", "Knock Off", "Protect", "Tailwind", "Thunderous Kick", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -785,6 +876,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Brave Bird", "Fire Blast", "Heat Wave", "Protect", "Scorching Sands", "Tailwind"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -795,6 +887,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Fiery Wrath", "Hurricane", "Nasty Plot", "Protect", "Tailwind"],
+                "abilities": ["Berserk"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -805,11 +898,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Dragon Claw", "Extreme Speed", "Fire Punch", "Iron Head", "Low Kick", "Stomping Tantrum"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Draco Meteor", "Fire Punch", "Low Kick", "Tailwind", "Tera Blast"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -820,11 +915,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Fire Blast", "Protect", "Psystrike"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Dark", "Fighting", "Fire", "Psychic"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Aura Sphere", "Nasty Plot", "Psystrike", "Recover"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -835,16 +932,19 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Coaching", "Encore", "Pollen Puff", "Tailwind", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Baton Pass", "Fire Blast", "Nasty Plot", "Pollen Puff", "Psychic"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Coaching", "Imprison", "Pollen Puff", "Transform"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -855,6 +955,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Encore", "Energy Ball", "Heal Pulse", "Knock Off", "Leech Seed"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Poison", "Steel", "Water"]
             }
         ]
@@ -865,6 +966,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Eruption", "Fire Blast", "Heat Wave", "Scorching Sands"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -875,6 +977,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Eruption", "Focus Blast", "Heat Wave", "Shadow Ball"],
+                "abilities": ["Blaze", "Frisk"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -885,11 +988,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dragon Dance", "Ice Punch", "Liquidation", "Protect"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fire", "Water"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Aqua Jet", "Ice Punch", "Liquidation", "Swords Dance"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -900,11 +1005,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Double-Edge", "Knock Off", "Protect", "Tidy Up"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Body Slam", "Follow Me", "Helping Hand", "Knock Off", "Protect", "U-turn"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -915,6 +1022,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Hurricane", "Hyper Voice", "Protect", "Tailwind"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -925,6 +1033,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Megahorn", "Protect", "Rage Powder", "Sticky Web"],
+                "abilities": ["Insomnia", "Swarm"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             }
         ]
@@ -935,11 +1044,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Electroweb", "Protect", "Scald", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Electroweb", "Ice Beam", "Scald", "Volt Switch"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -950,6 +1061,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Dragon Tail", "Electroweb", "Focus Blast", "Helping Hand", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Static"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -960,6 +1072,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Baton Pass", "Giga Drain", "Protect", "Quiver Dance", "Strength Sap"],
+                "abilities": ["Healer"],
                 "teraTypes": ["Poison", "Water"]
             }
         ]
@@ -970,6 +1083,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aqua Jet", "Ice Spinner", "Knock Off", "Liquidation", "Play Rough", "Superpower"],
+                "abilities": ["Huge Power"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -980,6 +1094,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Head Smash", "High Horsepower", "Protect", "Sucker Punch", "Wood Hammer"],
+                "abilities": ["Rock Head"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -990,11 +1105,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Hydro Pump", "Ice Beam", "Muddy Water", "Weather Ball"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Helping Hand", "Hypnosis", "Icy Wind", "Muddy Water"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Grass", "Steel"]
             }
         ]
@@ -1005,6 +1122,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Acrobatics", "Encore", "Helping Hand", "Pollen Puff", "Rage Powder", "Sleep Powder", "Strength Sap", "Tailwind"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1015,6 +1133,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dazzling Gleam", "Earth Power", "Leaf Storm", "Protect", "Sludge Bomb"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fairy", "Ground", "Poison"]
             }
         ]
@@ -1025,6 +1144,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Liquidation", "Recover", "Yawn"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Fire", "Poison", "Steel"]
             }
         ]
@@ -1035,6 +1155,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Gunk Shot", "Helping Hand", "High Horsepower", "Recover", "Toxic Spikes"],
+                "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Flying", "Ground", "Steel"]
             }
         ]
@@ -1045,6 +1166,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Alluring Voice", "Dazzling Gleam", "Protect", "Psychic", "Shadow Ball"],
+                "abilities": ["Magic Bounce"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -1055,6 +1177,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Foul Play", "Helping Hand", "Moonlight", "Snarl", "Thunder Wave"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -1065,6 +1188,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Brave Bird", "Haze", "Protect", "Tailwind", "Taunt"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Ghost", "Steel"]
             }
         ]
@@ -1075,11 +1199,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psyshock", "Scald", "Trick Room"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Grass", "Steel"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psyshock", "Scald", "Trick Room"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fire", "Water"]
             }
         ]
@@ -1090,6 +1216,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Fire Blast", "Protect", "Psyshock", "Sludge Bomb", "Trick Room"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -1100,11 +1227,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Body Press", "Explosion", "Iron Head", "Lunge"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting", "Fire"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Iron Head", "Rest", "Thunder Wave"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting", "Fire"]
             }
         ]
@@ -1115,6 +1244,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Play Rough", "Stomping Tantrum", "Super Fang"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1125,6 +1255,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Flip Turn", "Gunk Shot", "Icy Wind", "Taunt", "Thunder Wave", "Toxic Spikes"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -1135,6 +1266,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Crunch", "Gunk Shot", "Icy Wind", "Throat Chop", "Toxic Spikes"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -1145,6 +1277,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Crunch", "Gunk Shot", "Liquidation", "Protect", "Swords Dance", "Throat Chop"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Flying", "Poison", "Water"]
             }
         ]
@@ -1155,16 +1288,19 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Bullet Punch", "Close Combat", "Tailwind", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Fire", "Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "Protect", "Swords Dance"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "Knock Off"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Fighting", "Steel", "Water"]
             }
         ]
@@ -1175,11 +1311,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Facade", "Knock Off", "Protect"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Close Combat", "Knock Off", "Megahorn", "Rock Slide"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Bug", "Fighting", "Rock"]
             }
         ]
@@ -1190,6 +1328,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Heat Wave", "Power Gem", "Protect", "Shell Smash"],
+                "abilities": ["Weak Armor"],
                 "teraTypes": ["Fairy", "Fire", "Grass"]
             }
         ]
@@ -1200,11 +1339,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Brave Bird", "Fake Out", "Helping Hand", "Icy Wind", "Tailwind"],
+                "abilities": ["Insomnia", "Vital Spirit"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Brave Bird", "Drill Run", "Foul Play", "Ice Shard", "Ice Spinner"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Dark", "Flying", "Ground", "Ice"]
             }
         ]
@@ -1215,6 +1356,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Brave Bird", "Iron Defense", "Protect", "Roost", "Tailwind"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1225,6 +1367,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Dark Pulse", "Heat Wave", "Nasty Plot", "Protect", "Sucker Punch"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Dark", "Fire", "Ghost", "Grass"]
             }
         ]
@@ -1235,11 +1378,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Draco Meteor", "Muddy Water", "Protect", "Rain Dance"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Draco Meteor", "Protect", "Rain Dance", "Wave Crash"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1250,6 +1395,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["High Horsepower", "Ice Shard", "Knock Off", "Rapid Spin", "Stone Edge"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -1260,16 +1406,19 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Ice Beam", "Recover", "Thunderbolt", "Trick Room"],
+                "abilities": ["Download"],
                 "teraTypes": ["Electric", "Ghost"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Icy Wind", "Recover", "Thunderbolt", "Tri Attack"],
+                "abilities": ["Download"],
                 "teraTypes": ["Electric", "Ghost"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Recover", "Shadow Ball", "Tera Blast", "Trick Room"],
+                "abilities": ["Download"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -1280,11 +1429,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Decorate", "Fake Out", "Follow Me", "Pollen Puff", "Tailwind"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Decorate", "Fake Out", "Follow Me", "Tailwind"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1295,6 +1446,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Close Combat", "Coaching", "Fake Out", "Helping Hand", "Sucker Punch", "Triple Axel", "Wide Guard"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1305,6 +1457,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Heal Pulse", "Helping Hand", "Seismic Toss", "Soft-Boiled", "Thunder Wave"],
+                "abilities": ["Healer"],
                 "teraTypes": ["Fairy", "Ghost", "Poison"]
             }
         ]
@@ -1315,11 +1468,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Calm Mind", "Protect", "Scald", "Shadow Ball", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Electroweb", "Protect", "Scald", "Snarl", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -1330,6 +1485,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Extreme Speed", "Flare Blitz", "Sacred Fire", "Stomping Tantrum"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -1340,11 +1496,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Ice Beam", "Protect", "Scald", "Snarl", "Tailwind"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Dragon", "Grass"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Ice Beam", "Protect", "Scald"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Dragon", "Grass"]
             }
         ]
@@ -1355,11 +1513,13 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Dragon Dance", "High Horsepower", "Knock Off", "Protect", "Rock Slide", "Stone Edge"],
+                "abilities": ["Sand Stream"],
                 "teraTypes": ["Ghost", "Rock", "Steel"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Fire Blast", "High Horsepower", "Icy Wind", "Knock Off", "Protect", "Rock Slide", "Stone Edge", "Thunder Wave"],
+                "abilities": ["Sand Stream"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -1370,6 +1530,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Aeroblast", "Calm Mind", "Earth Power", "Recover"],
+                "abilities": ["Multiscale"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -1380,6 +1541,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Brave Bird", "Earth Power", "Protect", "Recover", "Sacred Fire", "Tailwind"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -1390,11 +1552,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Focus Blast", "Leaf Storm", "Protect", "Shed Tail"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Breaking Swipe", "Focus Blast", "Leaf Storm", "Protect"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1405,11 +1569,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Knock Off", "Overheat", "Protect", "Stone Edge"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Stellar"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Heat Wave", "Protect", "Vacuum Wave"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1420,6 +1586,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Flip Turn", "High Horsepower", "Ice Beam", "Icy Wind", "Knock Off", "Muddy Water"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -1430,6 +1597,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Crunch", "Howl", "Play Rough", "Sucker Punch", "Throat Chop"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Fairy"]
             }
         ]
@@ -1440,11 +1608,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Energy Ball", "Muddy Water", "Protect", "Rain Dance"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Fake Out", "Hydro Pump", "Ice Beam", "Icy Wind", "Leaf Storm"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -1455,11 +1625,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Fake Out", "Knock Off", "Leaf Blade", "Tailwind"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Knock Off", "Leaf Blade", "Protect", "Tailwind"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1470,6 +1642,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Hurricane", "Hydro Pump", "Muddy Water", "Tailwind", "Wide Guard"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -1480,6 +1653,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Dazzling Gleam", "Moonblast", "Mystical Fire", "Psychic", "Psyshock", "Trick"],
+                "abilities": ["Trace"],
                 "teraTypes": ["Fairy", "Fire", "Steel"]
             }
         ]
@@ -1490,11 +1664,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Baton Pass", "Bug Buzz", "Hurricane", "Hydro Pump", "Quiver Dance"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Bug Buzz", "Hurricane", "Protect", "Tailwind"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -1505,6 +1681,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Bullet Seed", "Close Combat", "Mach Punch", "Protect", "Rock Tomb", "Spore"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1515,6 +1692,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["After You", "Double-Edge", "Encore", "Icy Wind", "Knock Off", "Slack Off", "Thunder Wave"],
+                "abilities": ["Vital Spirit"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1525,6 +1703,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Double-Edge", "Giga Impact", "High Horsepower", "Knock Off"],
+                "abilities": ["Truant"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -1535,11 +1714,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Bullet Punch", "Close Combat", "Facade", "Fake Out", "Headlong Rush", "Knock Off"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Bullet Punch", "Close Combat", "Fake Out", "Feint", "Heavy Slam", "Knock Off"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1550,6 +1731,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Disable", "Encore", "Fake Out", "Foul Play", "Knock Off", "Quash", "Recover", "Will-O-Wisp"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1560,11 +1742,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Bullet Punch", "Close Combat", "Ice Punch", "Poison Jab", "Zen Headbutt"],
+                "abilities": ["Pure Power"],
                 "teraTypes": ["Fighting", "Fire"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Bullet Punch", "Close Combat", "Ice Punch", "Protect", "Zen Headbutt"],
+                "abilities": ["Pure Power"],
                 "teraTypes": ["Fighting", "Fire"]
             }
         ]
@@ -1575,11 +1759,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Alluring Voice", "Nasty Plot", "Protect", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Nuzzle", "Super Fang", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -1590,6 +1776,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Nuzzle", "Super Fang", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -1600,6 +1787,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Lunge", "Tailwind", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1610,6 +1798,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Bug Buzz", "Encore", "Tailwind", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1620,6 +1809,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Encore", "Gunk Shot", "Helping Hand", "Knock Off", "Poison Gas", "Thunder Wave", "Toxic Spikes"],
+                "abilities": ["Gluttony"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -1630,6 +1820,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Earth Power", "Heat Wave", "Helping Hand", "Protect", "Stealth Rock"],
+                "abilities": ["Solid Rock"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1640,6 +1831,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Fire Blast", "Heat Wave", "Protect", "Solar Beam", "Will-O-Wisp"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Dragon", "Grass"]
             }
         ]
@@ -1650,6 +1842,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dazzling Gleam", "Earth Power", "Nasty Plot", "Psychic", "Psyshock"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Ground"]
             }
         ]
@@ -1660,6 +1853,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Breaking Swipe", "Earth Power", "Protect", "Tailwind"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1670,6 +1864,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Knock Off", "Leaf Storm", "Spiky Shield", "Sucker Punch"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -1680,11 +1875,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Brave Bird", "Draco Meteor", "Fire Blast", "Helping Hand", "Roost", "Tailwind", "Will-O-Wisp"],
+                "abilities": ["Cloud Nine"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Brave Bird", "Protect", "Roost", "Will-O-Wisp"],
+                "abilities": ["Cloud Nine"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1695,6 +1892,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Facade", "Knock Off", "Protect", "Quick Attack"],
+                "abilities": ["Toxic Boost"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -1705,6 +1903,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Flamethrower", "Glare", "Gunk Shot", "Knock Off", "Protect"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Dark", "Fire", "Poison"]
             }
         ]
@@ -1715,6 +1914,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Muddy Water", "Protect"],
+                "abilities": ["Oblivious"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -1725,11 +1925,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Aqua Jet", "Close Combat", "Crabhammer", "Knock Off"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aqua Jet", "Crabhammer", "Knock Off", "Protect"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1740,6 +1942,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Dragon Tail", "Icy Wind", "Protect", "Recover", "Scald"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Dragon", "Grass", "Steel"]
             }
         ]
@@ -1750,6 +1953,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Gunk Shot", "Poltergeist", "Protect", "Shadow Sneak"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Ghost", "Poison"]
             }
         ]
@@ -1760,6 +1964,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Helping Hand", "Hurricane", "Leaf Storm", "Protect", "Tailwind", "Wide Guard"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1770,6 +1975,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Heal Pulse", "Helping Hand", "Icy Wind", "Protect", "Psychic", "Snarl", "Thunder Wave"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -1780,6 +1986,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Disable", "Foul Play", "Freeze-Dry", "Helping Hand", "Icy Wind", "Protect"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -1790,6 +1997,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Charm", "Endeavor", "Hydro Pump", "Icy Wind"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -1800,6 +2008,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Draco Meteor", "Dual Wingbeat", "Fire Blast", "Protect", "Tailwind"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
             }
         ]
@@ -1810,11 +2019,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Bullet Punch", "Hammer Arm", "Heavy Slam", "Knock Off", "Psychic Fangs", "Stomping Tantrum"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Agility", "Brick Break", "Heavy Slam", "Knock Off", "Protect", "Psychic Fangs"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -1825,11 +2036,13 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Curse", "Iron Defense", "Rest", "Rock Slide", "Stone Edge"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Iron Defense", "Rock Slide", "Stone Edge", "Thunder Wave"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1840,6 +2053,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Blizzard", "Icy Wind", "Protect", "Thunderbolt"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Electric", "Water"]
             }
         ]
@@ -1850,6 +2064,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Iron Head", "Thunder Wave"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1860,11 +2075,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Mist Ball", "Protect", "Recover", "Tailwind"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Aura Sphere", "Calm Mind", "Dragon Pulse", "Mist Ball", "Protect"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1875,11 +2092,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Luster Purge", "Protect", "Tailwind"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aura Sphere", "Draco Meteor", "Luster Purge", "Protect", "Trick"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dragon", "Steel"]
             }
         ]
@@ -1890,6 +2109,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Ice Beam", "Origin Pulse", "Thunder", "Water Spout"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1900,11 +2120,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Heat Crash", "Precipice Blades", "Protect", "Stone Edge", "Thunder Wave"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Fire"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Heat Crash", "Precipice Blades", "Protect", "Stone Edge", "Swords Dance"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -1915,11 +2137,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dragon Ascent", "Dragon Dance", "Earthquake", "Extreme Speed", "Swords Dance"],
+                "abilities": ["Air Lock"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Draco Meteor", "Dragon Ascent", "Earth Power", "Fire Blast", "Protect"],
+                "abilities": ["Air Lock"],
                 "teraTypes": ["Fire", "Flying", "Ground"]
             }
         ]
@@ -1930,11 +2154,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Iron Head", "Life Dew", "Protect", "Thunder Wave", "U-turn"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Dark", "Water"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Iron Head", "Psychic", "Thunderbolt", "Trick", "U-turn"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1945,6 +2171,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Extreme Speed", "Knock Off", "Protect", "Psycho Boost", "Superpower"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Ghost", "Stellar"]
             }
         ]
@@ -1955,6 +2182,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Extreme Speed", "Knock Off", "Protect", "Psycho Boost", "Superpower"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Ghost", "Stellar"]
             }
         ]
@@ -1965,6 +2193,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Knock Off", "Night Shade", "Spikes", "Thunder Wave"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1975,11 +2204,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Psycho Boost", "Superpower", "Taunt"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fighting", "Ghost", "Psychic"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Psycho Boost", "Superpower", "Taunt", "Thunder Wave"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fighting", "Psychic"]
             }
         ]
@@ -1990,6 +2221,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Headlong Rush", "Protect", "Shell Smash", "Wood Hammer"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -2000,6 +2232,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Close Combat", "Fake Out", "Knock Off", "Overheat", "Protect"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
             }
         ]
@@ -2010,11 +2243,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Flash Cannon", "Hydro Pump", "Ice Beam", "Icy Wind", "Protect", "Yawn"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Flash Cannon", "Hydro Pump", "Ice Beam", "Icy Wind", "Knock Off"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Flying", "Grass"]
             }
         ]
@@ -2025,11 +2260,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "Protect", "Quick Attack"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Flying"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "Final Gambit"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Flying", "Normal"]
             }
         ]
@@ -2040,6 +2277,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Bug Bite", "Helping Hand", "Knock Off", "Sticky Web", "Taunt"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Bug", "Steel"]
             }
         ]
@@ -2050,6 +2288,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Crunch", "Play Rough", "Snarl", "Throat Chop", "Volt Switch", "Wild Charge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Fairy", "Flying"]
             }
         ]
@@ -2060,6 +2299,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Fire Punch", "Head Smash", "Rock Slide", "Stomping Tantrum"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -2070,6 +2310,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Foul Play", "Iron Defense", "Rest", "Wide Guard"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting", "Flying"]
             }
         ]
@@ -2080,6 +2321,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Helping Hand", "Hurricane", "Pollen Puff", "Roost", "Toxic Spikes"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2090,6 +2332,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Follow Me", "Helping Hand", "Nuzzle", "Super Fang", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -2100,6 +2343,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aqua Jet", "Crunch", "Ice Spinner", "Protect", "Wave Crash"],
+                "abilities": ["Water Veil"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2110,6 +2354,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Clear Smog", "Earth Power", "Helping Hand", "Icy Wind", "Muddy Water", "Recover"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -2120,6 +2365,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Double-Edge", "Fake Out", "Knock Off", "Protect"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2130,6 +2376,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Shadow Ball", "Strength Sap", "Tailwind", "Will-O-Wisp"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Fairy", "Ghost", "Ground"]
             }
         ]
@@ -2140,6 +2387,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Mystical Fire", "Protect", "Shadow Ball", "Taunt", "Thunderbolt", "Trick", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy"]
             }
         ]
@@ -2150,6 +2398,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Heat Wave", "Protect", "Sucker Punch", "Tailwind"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Dark", "Fire", "Flying"]
             }
         ]
@@ -2160,6 +2409,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Fire Blast", "Gunk Shot", "Knock Off", "Poison Gas", "Protect", "Sucker Punch", "Taunt", "Toxic Spikes"],
+                "abilities": ["Aftermath"],
                 "teraTypes": ["Dark", "Flying"]
             }
         ]
@@ -2170,11 +2420,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Iron Defense", "Iron Head", "Trick Room"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Psychic Noise", "Trick Room"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2185,11 +2437,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Foul Play", "Helping Hand", "Icy Wind", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Foul Play", "Snarl", "Trick Room", "Will-O-Wisp"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2200,6 +2454,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Earthquake", "Protect", "Scale Shot", "Swords Dance"],
+                "abilities": ["Rough Skin"],
                 "teraTypes": ["Dragon", "Fire"]
             }
         ]
@@ -2210,11 +2465,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Protect"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Aura Sphere", "Flash Cannon", "Nasty Plot", "Protect", "Vacuum Wave"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -2225,6 +2482,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Helping Hand", "High Horsepower", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind"],
+                "abilities": ["Sand Stream"],
                 "teraTypes": ["Dragon", "Rock", "Steel", "Water"]
             }
         ]
@@ -2235,6 +2493,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Close Combat", "Fake Out", "Gunk Shot", "Protect", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Dry Skin"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -2245,6 +2504,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Helping Hand", "Hydro Pump", "Icy Wind", "Tailwind", "Tickle"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -2255,6 +2515,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Aurora Veil", "Blizzard", "Ice Shard", "Protect", "Wood Hammer"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Ice", "Water"]
             }
         ]
@@ -2265,6 +2526,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Fake Out", "Ice Shard", "Knock Off", "Low Kick", "Protect", "Triple Axel"],
+                "abilities": ["Pickpocket"],
                 "teraTypes": ["Dark", "Fighting", "Ghost", "Ice"]
             }
         ]
@@ -2275,6 +2537,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Dire Claw", "Fake Out", "Gunk Shot", "Switcheroo", "U-turn"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -2285,6 +2548,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Electroweb", "Flash Cannon", "Protect", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -2295,11 +2559,13 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["High Horsepower", "Protect", "Rock Polish", "Rock Slide"],
+                "abilities": ["Solid Rock"],
                 "teraTypes": ["Dragon", "Flying", "Ghost", "Ground"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Dragon Tail", "Heat Crash", "High Horsepower", "Ice Punch", "Megahorn", "Protect", "Rock Slide"],
+                "abilities": ["Solid Rock"],
                 "teraTypes": ["Dragon", "Flying", "Water"]
             }
         ]
@@ -2310,11 +2576,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Cross Chop", "Flamethrower", "Ice Punch", "Protect", "Volt Switch", "Wild Charge"],
+                "abilities": ["Motor Drive"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Cross Chop", "Flamethrower", "Ice Punch", "Knock Off", "Volt Switch", "Wild Charge"],
+                "abilities": ["Motor Drive"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -2325,6 +2593,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Fire Blast", "Heat Wave", "Knock Off", "Protect", "Thunderbolt"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]
@@ -2335,11 +2604,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Air Slash", "Bug Buzz", "Giga Drain", "U-turn"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Air Slash", "Bug Buzz", "Protect", "Tera Blast"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2350,6 +2621,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Double-Edge", "Knock Off", "Leaf Blade", "Protect", "Swords Dance", "Synthesis"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2360,11 +2632,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Blizzard", "Calm Mind", "Freeze-Dry", "Shadow Ball"],
+                "abilities": ["Ice Body"],
                 "teraTypes": ["Ghost", "Ice"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Blizzard", "Calm Mind", "Freeze-Dry", "Mud Shot"],
+                "abilities": ["Ice Body"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2375,11 +2649,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Dual Wingbeat", "High Horsepower", "Knock Off", "Protect", "Tailwind", "Toxic", "Toxic Spikes"],
+                "abilities": ["Poison Heal"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Earthquake", "Facade", "Protect", "Swords Dance"],
+                "abilities": ["Poison Heal"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2390,6 +2666,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["High Horsepower", "Ice Shard", "Icicle Crash", "Protect"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Ice", "Water"]
             }
         ]
@@ -2400,11 +2677,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Shadow Ball", "Swift", "Tri Attack", "Trick"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Nasty Plot", "Protect", "Shadow Ball", "Tera Blast"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2415,11 +2694,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Leaf Blade", "Night Slash", "Protect", "Psycho Cut", "Sacred Sword", "Swords Dance"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Night Slash", "Psycho Cut", "Sacred Sword", "Trick"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Fighting"]
             }
         ]
@@ -2430,11 +2711,13 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Rest", "Thunder Wave"],
+                "abilities": ["Magnet Pull"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Body Press", "Iron Defense", "Power Gem", "Rest", "Thunder Wave"],
+                "abilities": ["Magnet Pull"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2445,11 +2728,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Leech Life", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Leech Life", "Poltergeist", "Protect", "Trick Room"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -2460,6 +2745,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Poltergeist", "Protect", "Spikes", "Taunt", "Triple Axel", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Ghost", "Water"]
             }
         ]
@@ -2470,6 +2756,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Nasty Plot", "Protect", "Shadow Ball", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -2480,6 +2767,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Electroweb", "Hydro Pump", "Protect", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -2490,6 +2778,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Electroweb", "Overheat", "Protect", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -2500,6 +2789,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Blizzard", "Nasty Plot", "Protect", "Thunderbolt", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Ice"]
             }
         ]
@@ -2510,6 +2800,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Air Slash", "Electroweb", "Protect", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -2520,6 +2811,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Electroweb", "Leaf Storm", "Protect", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Poison", "Steel"]
             }
         ]
@@ -2530,6 +2822,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Helping Hand", "Knock Off", "Mystical Power", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Poison", "Steel"]
             }
         ]
@@ -2540,11 +2833,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dazzling Gleam", "Nasty Plot", "Protect", "Psychic", "Thunderbolt"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Psychic"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Ice Beam", "Psychic", "Thunderbolt", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Psychic"]
             }
         ]
@@ -2555,11 +2850,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Dazzling Gleam", "Energy Ball", "Fire Blast", "Nasty Plot", "Psychic", "Psyshock", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fairy", "Fire"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dazzling Gleam", "Fire Blast", "Nasty Plot", "Protect", "Psychic", "Psyshock", "Thunderbolt"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Fire"]
             }
         ]
@@ -2570,6 +2867,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Protect", "Thunder Wave"],
+                "abilities": ["Telepathy"],
                 "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
             }
         ]
@@ -2580,6 +2878,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Protect", "Thunder Wave"],
+                "abilities": ["Telepathy"],
                 "teraTypes": ["Dragon", "Fire", "Flying"]
             }
         ]
@@ -2590,11 +2889,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Hydro Pump", "Spacial Rend"],
+                "abilities": ["Telepathy"],
                 "teraTypes": ["Dragon", "Fire", "Steel", "Water"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Fire Blast", "Hydro Pump", "Protect", "Spacial Rend", "Thunder Wave"],
+                "abilities": ["Telepathy"],
                 "teraTypes": ["Dragon", "Fire", "Steel", "Water"]
             }
         ]
@@ -2605,6 +2906,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Fire Blast", "Hydro Pump", "Protect", "Spacial Rend", "Thunder Wave"],
+                "abilities": ["Telepathy"],
                 "teraTypes": ["Dragon", "Fire", "Steel", "Water"]
             }
         ]
@@ -2615,16 +2917,19 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Earth Power", "Magma Storm", "Protect", "Will-O-Wisp"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Fairy", "Grass"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Earth Power", "Flash Cannon", "Heat Wave", "Protect", "Tera Blast"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Grass"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Earth Power", "Flash Cannon", "Heat Wave", "Protect"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Fairy", "Grass"]
             }
         ]
@@ -2635,11 +2940,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Body Slam", "Knock Off", "Protect", "Substitute"],
+                "abilities": ["Slow Start"],
                 "teraTypes": ["Fairy", "Ghost"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Double-Edge", "Knock Off", "Protect", "Thunder Wave"],
+                "abilities": ["Slow Start"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -2650,11 +2957,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Aura Sphere", "Calm Mind", "Protect", "Shadow Ball"],
+                "abilities": ["Telepathy"],
                 "teraTypes": ["Fairy", "Fighting"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Breaking Swipe", "Icy Wind", "Rest", "Shadow Ball", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Telepathy"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -2665,6 +2974,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Draco Meteor", "Poltergeist", "Shadow Force", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dragon", "Fairy", "Ghost", "Poison", "Steel"]
             }
         ]
@@ -2675,6 +2985,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Helping Hand", "Icy Wind", "Lunar Blessing", "Psychic", "Thunder Wave"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fire", "Poison", "Steel"]
             }
         ]
@@ -2685,6 +2996,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Ice Beam", "Protect", "Scald", "Take Heart"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Dragon", "Grass", "Steel"]
             }
         ]
@@ -2695,11 +3007,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Ice Beam", "Protect", "Scald", "Tail Glow"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Grass", "Steel", "Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Energy Ball", "Hydro Pump", "Ice Beam", "Protect", "Scald", "Tail Glow"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -2710,6 +3024,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dark Pulse", "Focus Blast", "Protect", "Sludge Bomb"],
+                "abilities": ["Bad Dreams"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -2720,6 +3035,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Earth Power", "Protect", "Seed Flare", "Synthesis", "Tailwind"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Grass", "Ground", "Steel"]
             }
         ]
@@ -2730,6 +3046,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Air Slash", "Earth Power", "Protect", "Seed Flare", "Tailwind"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Flying", "Steel", "Water"]
             }
         ]
@@ -2740,6 +3057,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Extreme Speed", "Flare Blitz", "Phantom Force", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -2750,6 +3068,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Extreme Speed", "Stomping Tantrum", "Swords Dance", "X-Scissor"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2760,6 +3079,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Gunk Shot", "Judgment", "Recover", "Tailwind"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -2770,6 +3090,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Recover", "Sludge Bomb"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire", "Poison"]
             }
         ]
@@ -2780,6 +3101,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Calm Mind", "Ice Beam", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Electric", "Ice"]
             }
         ]
@@ -2790,11 +3112,13 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Earth Power", "Fire Blast", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fairy", "Fire", "Ground"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Tailwind", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2805,6 +3129,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Recover", "Snarl"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2815,6 +3140,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Extreme Speed", "Flare Blitz", "Liquidation", "Protect", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire", "Normal", "Water"]
             }
         ]
@@ -2825,6 +3151,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Calm Mind", "Earth Power", "Fire Blast", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Flying", "Ground"]
             }
         ]
@@ -2835,11 +3162,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Brick Break", "Extreme Speed", "Phantom Force", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Focus Blast", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -2850,6 +3179,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Tailwind", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -2860,11 +3190,13 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Ice Beam", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground", "Ice"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Earthquake", "Extreme Speed", "Stone Edge", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2875,6 +3207,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover", "Thunderbolt"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Electric", "Ground"]
             }
         ]
@@ -2885,6 +3218,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Extreme Speed", "Flare Blitz", "Gunk Shot", "Liquidation", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire", "Normal", "Poison"]
             }
         ]
@@ -2895,6 +3229,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Tailwind", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2905,6 +3240,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Calm Mind", "Earth Power", "Fire Blast", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2915,6 +3251,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Tailwind", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2925,11 +3262,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Tailwind", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Extreme Speed", "Flare Blitz", "Liquidation", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire", "Normal"]
             }
         ]
@@ -2940,11 +3279,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dragon Pulse", "Glare", "Knock Off", "Leaf Storm", "Protect"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Dragon", "Grass"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Glare", "Leaf Storm", "Protect", "Tera Blast"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fire", "Rock"]
             }
         ]
@@ -2955,6 +3296,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Close Combat", "Flare Blitz", "Head Smash", "Knock Off", "Wild Charge"],
+                "abilities": ["Reckless"],
                 "teraTypes": ["Dark", "Electric", "Rock"]
             }
         ]
@@ -2965,11 +3307,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Aqua Jet", "Flip Turn", "Hydro Pump", "Ice Beam", "Knock Off", "Megahorn", "Sacred Sword"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Dark", "Fire", "Water"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Aqua Jet", "Knock Off", "Liquidation", "Protect", "Sacred Sword", "Swords Dance"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Dark", "Fire", "Water"]
             }
         ]
@@ -2980,11 +3324,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Aqua Jet", "Ceaseless Edge", "Protect", "Razor Shell", "Sacred Sword", "Sucker Punch"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Fire", "Water"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Ceaseless Edge", "Flip Turn", "Razor Shell", "Sacred Sword", "Sucker Punch"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Fire", "Water"]
             }
         ]
@@ -2995,11 +3341,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["High Horsepower", "Overheat", "Protect", "Wild Charge"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["High Horsepower", "Overheat", "Protect", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -3010,11 +3358,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["High Horsepower", "Iron Head", "Rapid Spin", "Rock Slide"],
+                "abilities": ["Mold Breaker", "Sand Rush"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["High Horsepower", "Iron Head", "Protect", "Swords Dance"],
+                "abilities": ["Mold Breaker", "Sand Rush"],
                 "teraTypes": ["Flying", "Ground", "Water"]
             }
         ]
@@ -3025,11 +3375,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Knock Off", "Mach Punch", "Protect"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Drain Punch", "Ice Punch", "Knock Off", "Mach Punch"],
+                "abilities": ["Iron Fist"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
@@ -3040,11 +3392,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Knock Off", "Leaf Blade", "Pollen Puff", "Sticky Web"],
+                "abilities": ["Chlorophyll", "Swarm"],
                 "teraTypes": ["Rock", "Water"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Leaf Blade", "Lunge", "Protect", "Sticky Web"],
+                "abilities": ["Chlorophyll", "Swarm"],
                 "teraTypes": ["Rock", "Water"]
             }
         ]
@@ -3055,16 +3409,19 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Moonblast", "Stun Spore", "Tailwind"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Fire", "Ghost", "Steel"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Encore", "Moonblast", "Tailwind", "Taunt"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Fire", "Ghost", "Steel"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Encore", "Helping Hand", "Moonblast", "Tailwind"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Fire", "Ghost", "Steel"]
             }
         ]
@@ -3075,11 +3432,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Giga Drain", "Protect", "Quiver Dance", "Tera Blast"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire", "Rock"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Alluring Voice", "Energy Ball", "Pollen Puff", "Quiver Dance", "Sleep Powder"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3090,6 +3449,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Leaf Blade", "Protect", "Sleep Powder", "Victory Dance"],
+                "abilities": ["Chlorophyll", "Hustle"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -3100,11 +3460,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aqua Jet", "Flip Turn", "Psychic Fangs", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Aqua Jet", "Flip Turn", "Protect", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -3115,6 +3477,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Aqua Jet", "Flip Turn", "Last Respects", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3125,6 +3488,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Flip Turn", "Last Respects", "Muddy Water", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3135,11 +3499,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Gunk Shot", "High Horsepower", "Knock Off", "Protect", "Stone Edge", "Taunt"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Ground", "Poison"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Gunk Shot", "High Horsepower", "Knock Off", "Rock Slide"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Ground", "Poison"]
             }
         ]
@@ -3150,6 +3516,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Close Combat", "Coaching", "Fake Out", "Knock Off", "Poison Jab", "Snarl"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -3160,11 +3527,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Protect", "Sludge Bomb"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Poison"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Flamethrower", "Focus Blast", "Knock Off", "Protect", "Sludge Bomb"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -3175,11 +3544,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Bitter Malice", "Flamethrower", "Focus Blast", "Hyper Voice", "Nasty Plot", "Protect"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Bitter Malice", "Hyper Voice", "Protect", "Tera Blast"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -3190,6 +3561,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Bullet Seed", "Knock Off", "Protect", "Tail Slap", "Triple Axel"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Grass", "Ice", "Normal"]
             }
         ]
@@ -3200,6 +3572,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Fake Out", "Heal Pulse", "Helping Hand", "Protect", "Psychic", "Trick Room"],
+                "abilities": ["Shadow Tag"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -3210,6 +3583,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Focus Blast", "Protect", "Psychic", "Shadow Ball", "Trick Room"],
+                "abilities": ["Magic Guard"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3220,11 +3594,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Brave Bird", "Hydro Pump", "Knock Off", "Protect", "Tailwind"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Hydro Pump", "Protect", "Tailwind"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -3235,6 +3611,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Double-Edge", "High Horsepower", "Horn Leech", "Protect", "Swords Dance"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -3245,11 +3622,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Clear Smog", "Pollen Puff", "Protect", "Rage Powder", "Spore"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Pollen Puff", "Rage Powder", "Sludge Bomb", "Spore"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -3260,6 +3639,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Helping Hand", "Icy Wind", "Scald", "Wide Guard"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3270,6 +3650,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Bug Buzz", "Protect", "Sticky Web", "Thunder", "Volt Switch"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -3280,6 +3661,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Electroweb", "Flamethrower", "Giga Drain", "Knock Off", "Thunderbolt", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Poison"]
             }
         ]
@@ -3290,6 +3672,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Energy Ball", "Heat Wave", "Protect", "Shadow Ball", "Trick"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]
@@ -3300,11 +3683,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Iron Head", "Protect", "Scale Shot", "Swords Dance"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Dragon", "Fighting", "Steel"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Dragon Claw", "First Impression", "Iron Head", "Protect"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -3315,6 +3700,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Aqua Jet", "Close Combat", "Icicle Crash", "Protect"],
+                "abilities": ["Slush Rush", "Swift Swim"],
                 "teraTypes": ["Fighting", "Water"]
             }
         ]
@@ -3325,6 +3711,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Flash Cannon", "Freeze-Dry", "Haze", "Icy Wind", "Rapid Spin", "Recover"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3335,11 +3722,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Close Combat", "Fake Out", "Knock Off", "Triple Axel", "U-turn"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Fake Out", "Knock Off", "U-turn"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -3350,11 +3739,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dynamic Punch", "High Horsepower", "Poltergeist", "Protect"],
+                "abilities": ["No Guard"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Dynamic Punch", "High Horsepower", "Poltergeist", "Stone Edge"],
+                "abilities": ["No Guard"],
                 "teraTypes": ["Dragon", "Fairy", "Fighting"]
             }
         ]
@@ -3365,6 +3756,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Close Combat", "Protect", "Tailwind"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Fighting", "Flying"]
             }
         ]
@@ -3375,11 +3767,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Heat Wave", "Hurricane", "Psychic", "Tailwind"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fire", "Psychic", "Steel"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Esper Wing", "Hurricane", "Protect"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Psychic", "Steel"]
             }
         ]
@@ -3390,6 +3784,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Foul Play", "Knock Off", "Roost", "Snarl", "Tailwind", "Taunt", "Toxic", "U-turn"],
+                "abilities": ["Overcoat"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3400,11 +3795,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dark Pulse", "Draco Meteor", "Protect", "Snarl", "Tailwind"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dragon", "Poison"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Dark Pulse", "Draco Meteor", "Heat Wave", "Protect"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -3415,11 +3812,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Bug Buzz", "Heat Wave", "Protect", "Quiver Dance"],
+                "abilities": ["Flame Body", "Swarm"],
                 "teraTypes": ["Fire", "Ground", "Water"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Heat Wave", "Rage Powder", "Struggle Bug", "Tailwind"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -3430,11 +3829,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Body Press", "Coaching", "Iron Head", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Body Press", "Iron Defense", "Iron Head", "Protect"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -3445,11 +3846,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "High Horsepower", "Rock Slide", "Stone Edge"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting", "Ghost", "Rock"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "High Horsepower", "Protect", "Rock Slide"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting", "Ghost", "Rock"]
             }
         ]
@@ -3460,6 +3863,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Close Combat", "Coaching", "Leaf Storm", "Protect", "Stone Edge"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fire", "Rock", "Steel"]
             }
         ]
@@ -3470,6 +3874,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Bleakwind Storm", "Heat Wave", "Knock Off", "Protect", "Tailwind", "Taunt"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3480,11 +3885,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Bleakwind Storm", "Grass Knot", "Heat Wave", "Nasty Plot", "Protect"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fire", "Flying"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Bleakwind Storm", "Focus Blast", "Grass Knot", "Heat Wave", "U-turn"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fire", "Flying"]
             }
         ]
@@ -3495,16 +3902,19 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Grass Knot", "Nasty Plot", "Protect", "Wildbolt Storm"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Electric", "Grass"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Grass Knot", "Knock Off", "Protect", "Snarl", "Taunt", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Acrobatics", "Grass Knot", "Knock Off", "Protect", "Snarl", "Wildbolt Storm"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Electric", "Flying", "Steel"]
             }
         ]
@@ -3515,11 +3925,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Grass Knot", "Protect", "Sludge Bomb", "Volt Switch", "Wildbolt Storm"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Electric", "Poison"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Nasty Plot", "Protect", "Tera Blast", "Wildbolt Storm"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying", "Ice"]
             }
         ]
@@ -3530,6 +3942,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Blue Flare", "Draco Meteor", "Heat Wave", "Protect", "Tailwind"],
+                "abilities": ["Turboblaze"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -3540,6 +3953,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Bolt Strike", "Dragon Claw", "Dragon Dance", "Protect"],
+                "abilities": ["Teravolt"],
                 "teraTypes": ["Dragon", "Electric", "Fire", "Grass"]
             }
         ]
@@ -3550,6 +3964,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Earth Power", "Nasty Plot", "Protect", "Psychic", "Sandsear Storm", "Sludge Bomb"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Ground", "Poison", "Psychic"]
             }
         ]
@@ -3560,11 +3975,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Rock Slide", "Stealth Rock", "Stomping Tantrum", "Taunt", "U-turn"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Earthquake", "Protect", "Stone Edge", "Tera Blast"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -3575,11 +3992,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Earth Power", "Icicle Spear", "Protect", "Scale Shot"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Draco Meteor", "Earth Power", "Glaciate", "Protect"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -3590,11 +4009,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Draco Meteor", "Earth Power", "Fusion Flare", "Ice Beam", "Protect"],
+                "abilities": ["Turboblaze"],
                 "teraTypes": ["Fire"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Blizzard", "Earth Power", "Freeze-Dry", "Fusion Flare", "Protect"],
+                "abilities": ["Turboblaze"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -3605,6 +4026,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dragon Dance", "Fusion Bolt", "Icicle Spear", "Protect"],
+                "abilities": ["Teravolt"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -3615,11 +4037,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Hydro Pump", "Muddy Water", "Secret Sword", "Vacuum Wave"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting", "Steel", "Water"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Hydro Pump", "Muddy Water", "Protect", "Secret Sword", "Vacuum Wave"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting", "Steel", "Water"]
             }
         ]
@@ -3630,11 +4054,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Protect", "Psychic", "U-turn"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Close Combat", "Psychic", "Relic Song", "Tera Blast"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -3645,11 +4071,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Body Press", "Coaching", "Knock Off", "Leech Seed", "Spiky Shield", "Wood Hammer"],
+                "abilities": ["Bulletproof"],
                 "teraTypes": ["Fire", "Rock", "Steel", "Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Leech Seed", "Spiky Shield"],
+                "abilities": ["Bulletproof"],
                 "teraTypes": ["Fire", "Rock", "Steel", "Water"]
             }
         ]
@@ -3660,6 +4088,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Fire Blast", "Heat Wave", "Nasty Plot", "Protect", "Psyshock"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -3670,6 +4099,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dark Pulse", "Gunk Shot", "Hydro Pump", "Ice Beam", "Protect", "Taunt"],
+                "abilities": ["Battle Bond"],
                 "teraTypes": ["Dark", "Poison", "Water"]
             }
         ]
@@ -3680,6 +4110,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Brave Bird", "Overheat", "Protect", "Tailwind", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Gale Wings"],
                 "teraTypes": ["Flying", "Ground"]
             }
         ]
@@ -3690,6 +4121,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Hurricane", "Pollen Puff", "Protect", "Sleep Powder"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -3700,11 +4132,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Fire Blast", "Heat Wave", "Hyper Voice", "Protect", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Fire", "Normal", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Fire Blast", "Hyper Voice", "Protect", "Tera Blast"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -3715,6 +4149,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Moonblast", "Protect", "Synthesis"],
+                "abilities": ["Flower Veil"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3725,6 +4160,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Double-Edge", "High Horsepower", "Horn Leech", "Leaf Storm"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Ground", "Normal"]
             }
         ]
@@ -3735,11 +4171,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Fake Out", "Fake Tears", "Helping Hand", "Light Screen", "Psychic", "Reflect"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Fake Out", "Helping Hand", "Psychic", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -3750,6 +4188,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Alluring Voice", "Dark Pulse", "Protect", "Psychic", "Thunderbolt"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Dark", "Electric", "Fairy"]
             }
         ]
@@ -3760,6 +4199,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Knock Off", "Protect", "Psycho Cut", "Superpower", "Trick Room"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3770,6 +4210,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Draco Meteor", "Hydro Pump", "Protect", "Sludge Bomb"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -3780,11 +4221,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Muddy Water", "U-turn"],
+                "abilities": ["Mega Launcher"],
                 "teraTypes": ["Dark", "Dragon", "Fighting"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Heal Pulse", "Muddy Water", "Protect"],
+                "abilities": ["Mega Launcher"],
                 "teraTypes": ["Dark", "Fighting"]
             }
         ]
@@ -3795,11 +4238,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Hyper Voice", "Protect", "Substitute"],
+                "abilities": ["Pixilate"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Hyper Voice", "Protect", "Quick Attack", "Tera Blast"],
+                "abilities": ["Pixilate"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -3810,6 +4255,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Brave Bird", "Close Combat", "Protect", "Swords Dance"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Fighting", "Fire", "Flying"]
             }
         ]
@@ -3820,6 +4266,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Dazzling Gleam", "Helping Hand", "Nuzzle", "Super Fang", "Thunderbolt"],
+                "abilities": ["Cheek Pouch"],
                 "teraTypes": ["Electric", "Flying"]
             }
         ]
@@ -3830,6 +4277,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Moonblast", "Trick Room"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3840,6 +4288,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Breaking Swipe", "Draco Meteor", "Fire Blast", "Power Whip", "Protect", "Scald", "Sludge Bomb", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Fire", "Grass", "Poison", "Water"]
             }
         ]
@@ -3850,6 +4299,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Fire Blast", "Heavy Slam", "Hydro Pump", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Fire", "Water"]
             }
         ]
@@ -3860,6 +4310,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Dazzling Gleam", "Foul Play", "Light Screen", "Reflect", "Spikes", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -3870,6 +4321,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Poltergeist", "Protect", "Trick Room", "Wood Hammer"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Dark", "Water"]
             }
         ]
@@ -3880,6 +4332,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Avalanche", "Body Press", "Protect", "Recover"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting", "Poison", "Water"]
             }
         ]
@@ -3890,6 +4343,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Body Press", "Mountain Gale", "Protect", "Rock Slide"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting", "Flying", "Poison"]
             }
         ]
@@ -3900,11 +4354,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Hurricane", "Protect", "Tailwind"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Dragon", "Fire", "Steel"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Hurricane", "Protect", "Tailwind"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Dragon", "Fire", "Steel"]
             }
         ]
@@ -3915,11 +4371,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Diamond Storm", "Protect", "Trick Room"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Diamond Storm", "Moonblast", "Protect", "Trick Room"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Grass", "Steel"]
             }
         ]
@@ -3930,6 +4388,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Focus Blast", "Hyperspace Hole", "Protect", "Shadow Ball", "Trick"],
+                "abilities": ["Magician"],
                 "teraTypes": ["Dark", "Fighting", "Psychic"]
             }
         ]
@@ -3940,11 +4399,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Drain Punch", "Gunk Shot", "Hyperspace Fury", "Trick", "Zen Headbutt"],
+                "abilities": ["Magician"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Focus Blast", "Gunk Shot", "Hyperspace Fury", "Protect", "Psychic", "Trick"],
+                "abilities": ["Magician"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -3955,6 +4416,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Earth Power", "Heat Wave", "Protect", "Sludge Bomb", "Steam Eruption"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -3965,6 +4427,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Knock Off", "Leaf Storm", "Protect", "Spirit Shackle", "Tailwind"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Dark", "Ghost", "Water"]
             }
         ]
@@ -3975,6 +4438,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Knock Off", "Leaf Blade", "Protect", "Tailwind", "Triple Arrows"],
+                "abilities": ["Scrappy"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
@@ -3985,6 +4449,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Fake Out", "Flare Blitz", "Knock Off", "Parting Shot"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -3995,6 +4460,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Flip Turn", "Hydro Pump", "Hyper Voice", "Moonblast"],
+                "abilities": ["Liquid Voice"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4005,11 +4471,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Brave Bird", "Bullet Seed", "Protect", "Tailwind"],
+                "abilities": ["Skill Link"],
                 "teraTypes": ["Grass", "Steel"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Beak Blast", "Bullet Seed", "Knock Off", "Protect"],
+                "abilities": ["Skill Link"],
                 "teraTypes": ["Grass", "Steel"]
             }
         ]
@@ -4020,6 +4488,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Double-Edge", "Knock Off", "Stomping Tantrum", "U-turn"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -4030,6 +4499,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Bug Buzz", "Electroweb", "Protect", "Sticky Web", "Thunderbolt"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -4040,6 +4510,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Drain Punch", "Gunk Shot", "Ice Hammer", "Protect", "Wide Guard"],
+                "abilities": ["Iron Fist"],
                 "teraTypes": ["Fire", "Poison"]
             }
         ]
@@ -4050,6 +4521,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Hurricane", "Protect", "Quiver Dance", "Revelation Dance", "Tailwind"],
+                "abilities": ["Dancer"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4060,6 +4532,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Hurricane", "Protect", "Quiver Dance", "Revelation Dance", "Tailwind"],
+                "abilities": ["Dancer"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4070,6 +4543,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Hurricane", "Protect", "Quiver Dance", "Revelation Dance", "Tailwind"],
+                "abilities": ["Dancer"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -4080,6 +4554,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Hurricane", "Protect", "Quiver Dance", "Revelation Dance", "Tailwind"],
+                "abilities": ["Dancer"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -4090,11 +4565,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Moonblast", "Pollen Puff", "Protect", "Tailwind"],
+                "abilities": ["Shield Dust"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dazzling Gleam", "Moonblast", "Protect", "Quiver Dance", "Tera Blast"],
+                "abilities": ["Shield Dust"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4105,6 +4582,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Accelerock", "Close Combat", "Drill Run", "Protect", "Rock Slide", "Swords Dance"],
+                "abilities": ["Sand Rush"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4115,6 +4593,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Close Combat", "Knock Off", "Rock Slide", "Stone Edge"],
+                "abilities": ["No Guard"],
                 "teraTypes": ["Fighting", "Rock", "Water"]
             }
         ]
@@ -4125,6 +4604,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Accelerock", "Close Combat", "Protect", "Psychic Fangs", "Rock Slide", "Swords Dance"],
+                "abilities": ["Tough Claws"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4135,6 +4615,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Baneful Bunker", "Infestation", "Recover", "Toxic"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Grass", "Steel"]
             }
         ]
@@ -4145,6 +4626,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Heavy Slam", "High Horsepower", "Rest", "Stone Edge"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4155,6 +4637,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Liquidation", "Lunge", "Protect", "Sticky Web", "Wide Guard"],
+                "abilities": ["Water Bubble"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4165,16 +4648,19 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Leaf Blade", "Leaf Storm", "Pollen Puff", "Superpower"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Knock Off", "Leaf Blade", "Pollen Puff", "Protect", "Superpower"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Knock Off", "Leaf Storm", "Superpower", "Tera Blast"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Stellar"]
             }
         ]
@@ -4185,6 +4671,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Encore", "Fake Out", "Fire Blast", "Heat Wave", "Incinerate", "Poison Gas", "Protect", "Sludge Bomb"],
+                "abilities": ["Corrosion"],
                 "teraTypes": ["Fire", "Flying", "Water"]
             }
         ]
@@ -4195,6 +4682,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["High Jump Kick", "Knock Off", "Power Whip", "Rapid Spin", "Triple Axel"],
+                "abilities": ["Queenly Majesty"],
                 "teraTypes": ["Fighting", "Fire"]
             }
         ]
@@ -4205,6 +4693,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Draining Kiss", "Floral Healing", "Helping Hand", "Tailwind"],
+                "abilities": ["Triage"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -4215,6 +4704,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Hyper Voice", "Instruct", "Psyshock", "Trick Room"],
+                "abilities": ["Telepathy"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -4225,6 +4715,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Close Combat", "Gunk Shot", "Knock Off", "Rock Slide", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -4235,6 +4726,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Earth Power", "Protect", "Shadow Ball", "Shore Up", "Stealth Rock"],
+                "abilities": ["Water Compaction"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -4245,6 +4737,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Acrobatics", "Protect", "Rock Slide", "Shell Smash"],
+                "abilities": ["Shields Down"],
                 "teraTypes": ["Flying", "Rock", "Steel"]
             }
         ]
@@ -4255,6 +4748,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Double-Edge", "Knock Off", "Rapid Spin", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
+                "abilities": ["Comatose"],
                 "teraTypes": ["Fighting", "Grass"]
             }
         ]
@@ -4265,6 +4759,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Play Rough", "Protect", "Shadow Claw", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Disguise"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -4275,11 +4770,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Crunch", "Protect", "Psychic Fangs", "Wave Crash"],
+                "abilities": ["Strong Jaw"],
                 "teraTypes": ["Dark", "Psychic"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Aqua Jet", "Crunch", "Flip Turn", "Ice Fang", "Psychic Fangs", "Wave Crash"],
+                "abilities": ["Strong Jaw"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -4290,11 +4787,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Psychic Fangs", "Sunsteel Strike"],
+                "abilities": ["Full Metal Body"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Close Combat", "Flame Charge", "Protect", "Sunsteel Strike"],
+                "abilities": ["Full Metal Body"],
                 "teraTypes": ["Fighting", "Fire"]
             }
         ]
@@ -4305,16 +4804,19 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Moongeist Beam", "Moonlight", "Tailwind", "Wide Guard", "Will-O-Wisp"],
+                "abilities": ["Shadow Shield"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Meteor Beam", "Moonblast", "Moongeist Beam", "Protect"],
+                "abilities": ["Shadow Shield"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Moonblast", "Moongeist Beam", "Protect"],
+                "abilities": ["Shadow Shield"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -4325,16 +4827,19 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Brick Break", "Dragon Dance", "Knock Off", "Photon Geyser"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Earth Power", "Meteor Beam", "Photon Geyser", "Protect"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Earth Power", "Photon Geyser", "Protect"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -4345,11 +4850,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Photon Geyser", "Protect", "Sunsteel Strike"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Earthquake", "Photon Geyser", "Protect", "Sunsteel Strike", "Trick Room"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             }
         ]
@@ -4360,11 +4867,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Moongeist Beam", "Photon Geyser", "Protect", "Trick Room"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Moongeist Beam", "Photon Geyser", "Tera Blast", "Trick Room"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -4375,11 +4884,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Clanging Scales", "Clangorous Soul", "Drain Punch", "Iron Head"],
+                "abilities": ["Soundproof"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Clanging Scales", "Clangorous Soul", "Iron Head", "Protect"],
+                "abilities": ["Soundproof"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4390,11 +4901,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Flash Cannon", "Fleur Cannon", "Protect", "Trick Room"],
+                "abilities": ["Soul-Heart"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Aura Sphere", "Dazzling Gleam", "Flash Cannon", "Fleur Cannon"],
+                "abilities": ["Soul-Heart"],
                 "teraTypes": ["Fairy", "Fighting", "Water"]
             }
         ]
@@ -4405,11 +4918,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Fake Out", "Grassy Glide", "High Horsepower", "Wood Hammer"],
+                "abilities": ["Grassy Surge"],
                 "teraTypes": ["Fire", "Grass", "Steel"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Fake Out", "Grassy Glide", "U-turn", "Wood Hammer"],
+                "abilities": ["Grassy Surge"],
                 "teraTypes": ["Fire", "Grass", "Steel"]
             }
         ]
@@ -4420,6 +4935,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Court Change", "Gunk Shot", "High Jump Kick", "Protect", "Pyro Ball", "Sucker Punch", "U-turn"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Fighting", "Fire", "Poison"]
             }
         ]
@@ -4430,6 +4946,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Hydro Pump", "Ice Beam", "Muddy Water", "Scald"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4440,6 +4957,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Double-Edge", "High Horsepower", "Knock Off", "Protect", "Swords Dance"],
+                "abilities": ["Cheek Pouch"],
                 "teraTypes": ["Fairy", "Ghost", "Ground"]
             }
         ]
@@ -4450,6 +4968,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Brave Bird", "Iron Head", "Roost", "Tailwind", "U-turn"],
+                "abilities": ["Mirror Armor"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -4460,6 +4979,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Crunch", "Liquidation", "Protect", "Rock Slide", "Shell Smash"],
+                "abilities": ["Shell Armor", "Strong Jaw", "Swift Swim"],
                 "teraTypes": ["Dark", "Water"]
             }
         ]
@@ -4470,6 +4990,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Fire Blast", "Heat Wave", "Incinerate", "Protect", "Rapid Spin", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4480,11 +5001,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Dragon Dance", "Dragon Rush", "Grav Apple", "Protect", "Sucker Punch"],
+                "abilities": ["Ripen"],
                 "teraTypes": ["Fire", "Grass", "Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Grav Apple", "Protect", "Tera Blast"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Dragon", "Fire"]
             }
         ]
@@ -4495,6 +5018,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Apple Acid", "Dragon Pulse", "Leech Seed", "Protect"],
+                "abilities": ["Ripen", "Thick Fat"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4505,11 +5029,13 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Coil", "High Horsepower", "Rest", "Stone Edge"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Glare", "High Horsepower", "Rest", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Dragon", "Steel"]
             }
         ]
@@ -4520,6 +5046,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Brave Bird", "Protect", "Roost", "Surf", "Tailwind"],
+                "abilities": ["Gulp Missile"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4530,6 +5057,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Poison Jab", "Protect", "Psychic Fangs", "Waterfall"],
+                "abilities": ["Propeller Tail"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4540,11 +5068,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Overdrive", "Sludge Bomb", "Snarl", "Volt Switch"],
+                "abilities": ["Punk Rock"],
                 "teraTypes": ["Dark", "Electric", "Flying"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Overdrive", "Psychic Noise", "Sludge Bomb", "Volt Switch"],
+                "abilities": ["Punk Rock"],
                 "teraTypes": ["Electric", "Flying", "Psychic"]
             }
         ]
@@ -4555,11 +5085,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Overdrive", "Sludge Bomb", "Snarl", "Volt Switch"],
+                "abilities": ["Punk Rock"],
                 "teraTypes": ["Dark", "Electric", "Flying"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Overdrive", "Psychic Noise", "Sludge Bomb", "Volt Switch"],
+                "abilities": ["Punk Rock"],
                 "teraTypes": ["Electric", "Flying", "Psychic"]
             }
         ]
@@ -4570,11 +5102,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Protect", "Shadow Ball", "Shell Smash", "Tera Blast"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Baton Pass", "Protect", "Shadow Ball", "Shell Smash"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Dark", "Normal"]
             }
         ]
@@ -4585,6 +5119,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Mystical Fire", "Protect", "Psychic", "Trick Room"],
+                "abilities": ["Magic Bounce"],
                 "teraTypes": ["Fairy", "Fire", "Psychic", "Steel"]
             }
         ]
@@ -4595,11 +5130,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Fake Out", "Light Screen", "Parting Shot", "Reflect", "Spirit Break"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Fake Out", "Parting Shot", "Spirit Break", "Sucker Punch", "Taunt", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4610,11 +5147,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Fake Out", "Helping Hand", "Iron Head", "Knock Off", "U-turn"],
+                "abilities": ["Steely Spirit", "Tough Claws"],
                 "teraTypes": ["Fighting", "Steel"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "U-turn"],
+                "abilities": ["Steely Spirit", "Tough Claws"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -4625,6 +5164,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Alluring Voice", "Dazzling Gleam", "Decorate", "Encore", "Protect"],
+                "abilities": ["Aroma Veil"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4635,6 +5175,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
@@ -4645,6 +5186,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Electroweb", "Recover", "Thunderbolt", "Toxic Spikes"],
+                "abilities": ["Electric Surge"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -4655,6 +5197,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Bug Buzz", "Ice Beam", "Protect", "Quiver Dance"],
+                "abilities": ["Ice Scales"],
                 "teraTypes": ["Ground", "Water"]
             }
         ]
@@ -4665,11 +5208,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Heat Crash", "High Horsepower", "Protect", "Rock Polish", "Stone Edge"],
+                "abilities": ["Power Spot"],
                 "teraTypes": ["Fire", "Rock"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Heat Crash", "High Horsepower", "Rock Slide", "Stone Edge"],
+                "abilities": ["Power Spot"],
                 "teraTypes": ["Fire", "Rock"]
             }
         ]
@@ -4680,6 +5225,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Protect"],
+                "abilities": ["Ice Face"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4690,16 +5236,19 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Encore", "Expanding Force", "Hyper Voice", "Protect", "Shadow Ball"],
+                "abilities": ["Psychic Surge"],
                 "teraTypes": ["Fairy", "Psychic"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Expanding Force", "Hyper Voice", "Psyshock", "Trick"],
+                "abilities": ["Psychic Surge"],
                 "teraTypes": ["Psychic"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Encore", "Expanding Force", "Protect", "Shadow Ball", "Tera Blast", "Trick"],
+                "abilities": ["Psychic Surge"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -4710,6 +5259,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Follow Me", "Heal Pulse", "Helping Hand", "Protect", "Psychic"],
+                "abilities": ["Psychic Surge"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -4720,11 +5270,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Aura Wheel", "Electroweb", "Fake Out", "Knock Off", "Protect"],
+                "abilities": ["Hunger Switch"],
                 "teraTypes": ["Electric"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Aura Wheel", "Knock Off", "Parting Shot", "Protect", "Volt Switch"],
+                "abilities": ["Hunger Switch"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -4735,11 +5287,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["High Horsepower", "Iron Head", "Play Rough", "Protect", "Rock Slide"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fairy", "Rock"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Heat Crash", "Heavy Slam", "High Horsepower", "Stone Edge"],
+                "abilities": ["Heavy Metal"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -4750,11 +5304,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Draco Meteor", "Flash Cannon", "Iron Defense"],
+                "abilities": ["Stalwart"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Protect", "Snarl", "Thunder Wave"],
+                "abilities": ["Stalwart"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4765,11 +5321,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Draco Meteor", "Dragon Darts", "Fire Blast", "Protect", "Shadow Ball"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Dragon"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Dragon Claw", "Dragon Darts", "Phantom Force", "U-turn"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -4780,6 +5338,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Play Rough", "Protect", "Psychic Fangs", "Swords Dance"],
+                "abilities": ["Intrepid Sword"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4790,6 +5349,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Behemoth Blade", "Close Combat", "Play Rough", "Protect", "Swords Dance"],
+                "abilities": ["Intrepid Sword"],
                 "teraTypes": ["Fairy", "Fighting", "Fire", "Steel"]
             }
         ]
@@ -4800,11 +5360,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Coaching", "Crunch", "Howl", "Iron Head", "Psychic Fangs", "Stone Edge"],
+                "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Body Press", "Crunch", "Iron Defense", "Protect"],
+                "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Fighting", "Fire", "Steel"]
             }
         ]
@@ -4815,6 +5377,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Body Press", "Coaching", "Heavy Slam", "Iron Defense", "Protect", "Snarl", "Wide Guard"],
+                "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Fighting", "Fire", "Steel"]
             }
         ]
@@ -4825,16 +5388,19 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Cosmic Power", "Dynamax Cannon", "Flamethrower", "Recover"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Water"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Dynamax Cannon", "Fire Blast", "Recover", "Sludge Bomb", "Toxic Spikes"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Water"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dynamax Cannon", "Fire Blast", "Meteor Beam", "Protect"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -4845,6 +5411,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Poison Jab", "Protect", "Sucker Punch", "Wicked Blow"],
+                "abilities": ["Unseen Fist"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -4855,6 +5422,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aqua Jet", "Close Combat", "Ice Spinner", "Protect", "Surging Strikes", "U-turn"],
+                "abilities": ["Unseen Fist"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4865,6 +5433,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Jungle Healing", "Knock Off", "Power Whip", "Protect"],
+                "abilities": ["Leaf Guard"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -4875,11 +5444,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Electroweb", "Protect", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Transistor"],
                 "teraTypes": ["Electric"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Electroweb", "Protect", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Transistor"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -4890,6 +5461,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Draco Meteor", "Dragon Claw", "Dragon Energy", "Earth Power"],
+                "abilities": ["Dragon's Maw"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -4900,6 +5472,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Heavy Slam", "High Horsepower", "Icicle Crash", "Protect"],
+                "abilities": ["Chilling Neigh"],
                 "teraTypes": ["Fighting", "Ground", "Steel"]
             }
         ]
@@ -4910,16 +5483,19 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Draining Kiss", "Nasty Plot", "Protect", "Shadow Ball"],
+                "abilities": ["Grim Neigh"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dark Pulse", "Nasty Plot", "Protect", "Shadow Ball"],
+                "abilities": ["Grim Neigh"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Nasty Plot", "Protect", "Shadow Ball", "Tera Blast"],
+                "abilities": ["Grim Neigh"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4930,6 +5506,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Giga Drain", "Helping Hand", "Leaf Storm", "Leech Seed", "Pollen Puff", "Psychic"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4940,6 +5517,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Glacial Lance", "High Horsepower", "Protect", "Trick Room"],
+                "abilities": ["As One (Glastrier)"],
                 "teraTypes": ["Ground", "Ice"]
             }
         ]
@@ -4950,6 +5528,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Astral Barrage", "Encore", "Nasty Plot", "Pollen Puff", "Protect", "Psyshock"],
+                "abilities": ["As One (Spectrier)"],
                 "teraTypes": ["Dark", "Ghost"]
             }
         ]
@@ -4960,11 +5539,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Slam", "Double-Edge", "Earth Power", "Protect", "Psychic", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Double-Edge", "Earth Power", "Psychic", "Trick Room"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy", "Ground"]
             }
         ]
@@ -4975,6 +5556,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Protect", "Stone Axe", "Tailwind", "U-turn", "X-Scissor"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Bug", "Fighting", "Rock", "Steel"]
             }
         ]
@@ -4985,6 +5567,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Crunch", "Earthquake", "Facade", "Headlong Rush", "Protect"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -4995,6 +5578,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Blood Moon", "Earth Power", "Hyper Voice", "Protect"],
+                "abilities": ["Mind's Eye"],
                 "teraTypes": ["Ghost", "Normal", "Water"]
             }
         ]
@@ -5005,16 +5589,19 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Play Rough", "Protect", "Superpower", "Tailwind"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Earth Power", "Protect", "Springtide Storm", "Tailwind"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Protect", "Springtide Storm", "Superpower", "Tera Blast"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Stellar"]
             }
         ]
@@ -5025,6 +5612,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Earth Power", "Moonblast", "Mystical Fire", "Protect", "Springtide Storm"],
+                "abilities": ["Overcoat"],
                 "teraTypes": ["Fairy", "Ground"]
             }
         ]
@@ -5035,11 +5623,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Flower Trick", "Knock Off", "Sucker Punch", "Triple Axel", "U-turn"],
+                "abilities": ["Protean"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Flower Trick", "Knock Off", "Pollen Puff", "Protect", "Sucker Punch", "Taunt"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -5050,6 +5640,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Protect", "Shadow Ball", "Slack Off", "Torch Song"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -5060,6 +5651,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Aqua Jet", "Aqua Step", "Close Combat", "Knock Off", "Protect", "Triple Axel"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             }
         ]
@@ -5070,11 +5662,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Double-Edge", "Helping Hand", "Lash Out", "Protect", "Yawn"],
+                "abilities": ["Gluttony"],
                 "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Double-Edge", "High Horsepower", "Lash Out", "Play Rough"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Ground", "Normal"]
             }
         ]
@@ -5085,11 +5679,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Double-Edge", "Helping Hand", "Lash Out", "Protect", "Yawn"],
+                "abilities": ["Gluttony"],
                 "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Double-Edge", "High Horsepower", "Lash Out", "Play Rough"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Ground", "Normal"]
             }
         ]
@@ -5100,6 +5696,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Circle Throw", "Knock Off", "Lunge", "Sticky Web", "String Shot", "U-turn"],
+                "abilities": ["Stakeout"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5110,11 +5707,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["First Impression", "Protect", "Sucker Punch", "U-turn"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["First Impression", "Leech Life", "Protect", "Sucker Punch"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
             }
         ]
@@ -5125,6 +5724,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Double Shock", "Fake Out", "Protect", "Revival Blessing"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -5135,11 +5735,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Encore", "Population Bomb", "Protect", "Tidy Up"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Follow Me", "Population Bomb", "Protect", "Taunt", "Thunder Wave", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -5150,6 +5752,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Body Press", "Helping Hand", "Howl", "Play Rough", "Snarl", "Yawn"],
+                "abilities": ["Well-Baked Body"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5160,6 +5763,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Earth Power", "Energy Ball", "Hyper Voice", "Pollen Puff", "Protect", "Strength Sap"],
+                "abilities": ["Seed Sower"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -5170,6 +5774,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Double-Edge", "Parting Shot", "Protect", "Quick Attack"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Flying", "Normal", "Steel"]
             }
         ]
@@ -5180,6 +5785,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Double-Edge", "Parting Shot", "Protect", "Quick Attack"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Flying", "Normal", "Steel"]
             }
         ]
@@ -5190,6 +5796,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Double-Edge", "Parting Shot", "Protect", "Quick Attack"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Flying", "Normal", "Steel"]
             }
         ]
@@ -5200,6 +5807,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Double-Edge", "Parting Shot", "Protect", "Quick Attack"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Flying", "Normal", "Steel"]
             }
         ]
@@ -5210,6 +5818,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Protect", "Recover", "Salt Cure", "Stealth Rock", "Wide Guard"],
+                "abilities": ["Purifying Salt"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -5220,16 +5829,19 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Heat Wave", "Psyshock"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Fighting", "Fire", "Grass"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Heat Wave", "Protect", "Psychic", "Trick Room"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Heat Wave", "Meteor Beam", "Protect", "Psychic", "Psyshock"],
+                "abilities": ["Weak Armor"],
                 "teraTypes": ["Dark", "Grass"]
             }
         ]
@@ -5240,6 +5852,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Bitter Blade", "Poltergeist", "Protect", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Weak Armor"],
                 "teraTypes": ["Fire", "Ghost", "Grass"]
             }
         ]
@@ -5250,6 +5863,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Electroweb", "Muddy Water", "Slack Off", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Electromorphosis"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5260,6 +5874,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Hurricane", "Protect", "Tailwind", "Thunderbolt"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -5270,6 +5885,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Crunch", "Fire Fang", "Play Rough", "Psychic Fangs", "Wild Charge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -5280,11 +5896,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Encore", "Gunk Shot", "Knock Off", "Parting Shot", "Protect", "Taunt"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Gunk Shot", "Knock Off", "Super Fang", "U-turn"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -5295,11 +5913,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Poltergeist", "Power Whip", "Protect", "Shadow Sneak"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Fairy", "Ghost", "Grass", "Steel", "Water"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Disable", "Poltergeist", "Power Whip", "Protect", "Rapid Spin", "Strength Sap"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
             }
         ]
@@ -5310,6 +5930,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Rage Powder", "Spore"],
+                "abilities": ["Mycelium Might"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5320,11 +5941,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Protect", "Rock Slide"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Ground", "Water"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Rock Slide"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Ground", "Water"]
             }
         ]
@@ -5335,11 +5958,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Burning Jealousy", "Energy Ball", "Fire Blast", "Leaf Storm"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire", "Grass", "Steel"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Energy Ball", "Fire Blast", "Protect", "Rage Powder", "Will-O-Wisp"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire", "Grass", "Steel"]
             }
         ]
@@ -5350,6 +5975,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Psychic", "Revival Blessing", "Struggle Bug", "Trick Room"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5360,6 +5986,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Baton Pass", "Dazzling Gleam", "Lumina Crash", "Protect", "Shadow Ball"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -5370,6 +5997,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Fake Out", "Gigaton Hammer", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -5380,6 +6008,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Aqua Jet", "Liquidation", "Memento", "Stomping Tantrum", "Throat Chop"],
+                "abilities": ["Gooey"],
                 "teraTypes": ["Dark", "Ground"]
             }
         ]
@@ -5390,11 +6019,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Brave Bird", "Knock Off", "Rock Slide", "Sucker Punch"],
+                "abilities": ["Rocky Payload"],
                 "teraTypes": ["Rock"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Brave Bird", "Knock Off", "Protect", "Rock Slide"],
+                "abilities": ["Rocky Payload"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -5405,11 +6036,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Close Combat", "Flip Turn", "Jet Punch", "Wave Crash"],
+                "abilities": ["Zero to Hero"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Flip Turn", "Jet Punch", "Protect", "Wave Crash"],
+                "abilities": ["Zero to Hero"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5420,11 +6053,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Gunk Shot", "Iron Head", "Parting Shot", "Protect"],
+                "abilities": ["Filter"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Gunk Shot", "High Horsepower", "Iron Head", "Protect", "Shift Gear"],
+                "abilities": ["Filter"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5435,11 +6070,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Breaking Swipe", "Double-Edge", "Knock Off", "Shed Tail", "Taunt"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dragon", "Poison"]
             },
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Double-Edge", "Draco Meteor", "Knock Off", "Shed Tail"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dragon", "Fire", "Normal", "Poison"]
             }
         ]
@@ -5450,11 +6087,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Body Press", "Iron Defense", "Iron Head", "Protect"],
+                "abilities": ["Earth Eater"],
                 "teraTypes": ["Electric", "Fighting"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Heavy Slam", "Helping Hand", "Protect", "Shed Tail"],
+                "abilities": ["Earth Eater"],
                 "teraTypes": ["Electric", "Poison"]
             }
         ]
@@ -5465,11 +6104,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Bomb", "Spiky Shield", "Stealth Rock"],
+                "abilities": ["Toxic Debris"],
                 "teraTypes": ["Grass", "Water"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Earth Power", "Meteor Beam", "Sludge Bomb", "Spiky Shield"],
+                "abilities": ["Toxic Debris"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5480,6 +6121,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Body Press", "Last Respects", "Shadow Sneak", "Trick"],
+                "abilities": ["Fluffy"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -5490,6 +6132,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Brave Bird", "Close Combat", "Throat Chop", "U-turn"],
+                "abilities": ["Scrappy"],
                 "teraTypes": ["Fighting", "Fire", "Flying"]
             }
         ]
@@ -5500,6 +6143,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["High Horsepower", "Ice Shard", "Icicle Crash", "Liquidation", "Protect"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Ground", "Water"]
             }
         ]
@@ -5510,6 +6154,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Aqua Cutter", "Aqua Jet", "Night Slash", "Psycho Cut"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Psychic", "Water"]
             }
         ]
@@ -5520,6 +6165,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Avalanche", "Body Press", "Heavy Slam", "Wave Crash"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Dragon", "Grass", "Steel"]
             }
         ]
@@ -5530,16 +6176,19 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Icy Wind", "Muddy Water", "Rapid Spin"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Fire", "Steel"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Draco Meteor", "Muddy Water", "Nasty Plot", "Protect"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Dragon", "Fire", "Water"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Draco Meteor", "Hydro Pump", "Icy Wind", "Muddy Water"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Dragon", "Fire", "Water"]
             }
         ]
@@ -5550,6 +6199,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Hyper Voice", "Nasty Plot", "Protect", "Psychic", "Psyshock", "Trick Room"],
+                "abilities": ["Armor Tail"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -5560,11 +6210,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Earth Power", "Glare", "Hyper Drill", "Protect", "Tailwind"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Ghost", "Ground", "Normal"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Boomburst", "Earth Power", "Helping Hand", "Protect", "Tailwind"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Ghost", "Ground", "Normal"]
             }
         ]
@@ -5575,16 +6227,19 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Iron Head", "Protect", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fire", "Flying"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Iron Head", "Kowtow Cleave", "Protect", "Sucker Punch"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fire", "Flying"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Tera Blast"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Fairy", "Fire", "Flying"]
             }
         ]
@@ -5595,6 +6250,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Headlong Rush", "Ice Spinner", "Knock Off", "Protect", "Rapid Spin", "Rock Slide"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -5605,6 +6261,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Crunch", "Protect", "Rage Powder", "Seed Bomb", "Spore", "Sucker Punch"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -5615,11 +6272,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Earth Power", "Electroweb", "Protect", "Stealth Rock", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric", "Grass", "Ground"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Earth Power", "Protect", "Tera Blast", "Volt Switch"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Flying", "Ice"]
             }
         ]
@@ -5630,6 +6289,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Disable", "Encore", "Helping Hand", "Howl", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5640,11 +6300,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dazzling Gleam", "Moonblast", "Protect", "Shadow Ball"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Dazzling Gleam", "Moonblast", "Mystical Fire", "Shadow Ball"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -5655,6 +6317,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "First Impression", "Flare Blitz", "U-turn", "Wild Charge"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Bug", "Electric", "Fighting", "Fire"]
             }
         ]
@@ -5665,11 +6328,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Acrobatics", "Breaking Swipe", "Knock Off", "Protect", "Tailwind"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dragon Claw", "Dragon Dance", "Knock Off", "Protect"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Dark", "Fire"]
             }
         ]
@@ -5680,6 +6345,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["High Horsepower", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fire", "Ground", "Steel"]
             }
         ]
@@ -5690,11 +6356,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Energy Ball", "Fiery Dance", "Heat Wave", "Protect", "Sludge Wave"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fire", "Grass"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Acid Spray", "Energy Ball", "Heat Wave", "Protect"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -5705,11 +6373,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Drain Punch", "Fake Out", "Ice Punch", "Volt Switch", "Wild Charge"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Electric", "Fire"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Drain Punch", "Protect", "Swords Dance", "Thunder Punch"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -5720,6 +6390,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Dark Pulse", "Earth Power", "Hurricane", "Protect", "Tailwind", "Taunt"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Flying", "Ground", "Steel"]
             }
         ]
@@ -5730,11 +6401,13 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Electroweb", "High Horsepower", "Protect", "Rock Slide", "Stealth Rock", "Thunder Punch", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dragon Dance", "High Horsepower", "Ice Punch", "Protect", "Rock Slide", "Wild Charge"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Grass", "Rock"]
             }
         ]
@@ -5745,6 +6418,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Encore", "Freeze-Dry", "Hydro Pump", "Icy Wind", "Protect"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -5755,6 +6429,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Dazzling Gleam", "Encore", "Knock Off", "Moonblast", "Protect"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Dark", "Fairy", "Fighting"]
             }
         ]
@@ -5765,11 +6440,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Glaive Rush", "High Horsepower", "Ice Shard", "Icicle Crash"],
+                "abilities": ["Thermal Exchange"],
                 "teraTypes": ["Dragon", "Ground"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Icicle Spear", "Protect", "Scale Shot", "Swords Dance"],
+                "abilities": ["Thermal Exchange"],
                 "teraTypes": ["Dragon", "Steel"]
             }
         ]
@@ -5780,11 +6457,13 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Dazzling Gleam", "Focus Blast", "Make It Rain", "Psychic", "Shadow Ball", "Thunderbolt", "Trick"],
+                "abilities": ["Good as Gold"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Make It Rain", "Nasty Plot", "Protect", "Shadow Ball"],
+                "abilities": ["Good as Gold"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -5795,6 +6474,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Protect", "Ruination", "Spikes", "Stealth Rock", "Stomping Tantrum", "Throat Chop"],
+                "abilities": ["Vessel of Ruin"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -5805,11 +6485,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Icicle Crash", "Lash Out", "Protect", "Sucker Punch", "Throat Chop"],
+                "abilities": ["Sword of Ruin"],
                 "teraTypes": ["Dark", "Ghost"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Icicle Crash", "Protect", "Sacred Sword", "Sucker Punch"],
+                "abilities": ["Sword of Ruin"],
                 "teraTypes": ["Fighting", "Ghost"]
             }
         ]
@@ -5820,6 +6502,7 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Knock Off", "Leech Seed", "Pollen Puff", "Protect", "Ruination"],
+                "abilities": ["Tablets of Ruin"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -5830,11 +6513,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dark Pulse", "Heat Wave", "Nasty Plot", "Protect"],
+                "abilities": ["Beads of Ruin"],
                 "teraTypes": ["Dark", "Fire", "Water"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Dark Pulse", "Heat Wave", "Overheat", "Snarl"],
+                "abilities": ["Beads of Ruin"],
                 "teraTypes": ["Fire", "Water"]
             }
         ]
@@ -5845,6 +6530,7 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Collision Course", "Dragon Claw", "Flare Blitz", "U-turn"],
+                "abilities": ["Orichalcum Pulse"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -5855,11 +6541,13 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Draco Meteor", "Dragon Pulse", "Electro Drift", "Overheat", "Protect", "Volt Switch"],
+                "abilities": ["Hadron Engine"],
                 "teraTypes": ["Electric"]
             },
             {
                 "role": "Choice Item user",
                 "movepool": ["Draco Meteor", "Electro Drift", "Overheat", "Volt Switch"],
+                "abilities": ["Hadron Engine"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -5870,6 +6558,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Flip Turn", "Hydro Pump", "Protect"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -5880,11 +6569,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Leaf Blade", "Protect", "Swords Dance"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Fire", "Poison"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Leaf Blade", "Psyblade", "Wild Charge"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Fire", "Psychic"]
             }
         ]
@@ -5895,6 +6586,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Dragon Pulse", "Pollen Puff", "Recover", "Syrup Bomb"],
+                "abilities": ["Sticky Hold"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5905,11 +6597,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Matcha Gotcha", "Rage Powder", "Shadow Ball", "Trick Room"],
+                "abilities": ["Hospitality"],
                 "teraTypes": ["Grass", "Water"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Matcha Gotcha", "Protect", "Shadow Ball"],
+                "abilities": ["Hospitality"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -5920,6 +6614,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off", "Snarl"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -5930,11 +6625,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Focus Blast", "Protect", "Psyshock", "Sludge Bomb", "U-turn"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Fighting", "Poison"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Fake Out", "Focus Blast", "Psyshock", "Sludge Bomb", "U-turn"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Fighting", "Poison"]
             }
         ]
@@ -5945,11 +6642,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Gunk Shot", "Icy Wind", "Play Rough", "Roost"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Gunk Shot", "Icy Wind", "Play Rough", "U-turn"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             }
         ]
@@ -5960,11 +6659,13 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Ivy Cudgel", "Knock Off", "Spiky Shield", "Superpower", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Grass"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Follow Me", "Horn Leech", "Knock Off", "Spiky Shield"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -5975,11 +6676,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Follow Me", "Horn Leech", "Ivy Cudgel", "Spiky Shield"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Horn Leech", "Ivy Cudgel", "Power Whip", "Spiky Shield", "Swords Dance"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5990,11 +6693,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Follow Me", "Horn Leech", "Ivy Cudgel", "Spiky Shield"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Fire"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Horn Leech", "Ivy Cudgel", "Power Whip", "Spiky Shield", "Swords Dance"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -6005,11 +6710,13 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Follow Me", "Horn Leech", "Ivy Cudgel", "Spiky Shield"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Rock"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Horn Leech", "Ivy Cudgel", "Power Whip", "Spiky Shield", "Swords Dance"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -6020,16 +6727,19 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dragon Pulse", "Electro Shot", "Flash Cannon", "Protect"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Fairy", "Flying"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Draco Meteor", "Dragon Pulse", "Flash Cannon", "Snarl"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Fairy", "Fighting", "Flying"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aura Sphere", "Draco Meteor", "Flash Cannon", "Thunderbolt"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Dragon", "Electric", "Fairy", "Fighting", "Flying"]
             }
         ]
@@ -6040,6 +6750,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Earth Power", "Fickle Beam", "Leaf Storm", "Pollen Puff", "Protect"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -6050,6 +6761,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Burning Bulwark", "Dragon Claw", "Dragon Dance", "Heat Crash"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -6060,16 +6772,19 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Draco Meteor", "Protect", "Thunderbolt", "Thunderclap"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric", "Fairy", "Grass"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Electroweb", "Snarl", "Thunderbolt", "Thunderclap"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric", "Fairy", "Grass"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Dragon Pulse", "Protect", "Thunderclap"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric", "Fairy", "Grass"]
             }
         ]
@@ -6080,6 +6795,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Mighty Cleave", "Protect", "Swords Dance", "Zen Headbutt"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -6090,16 +6806,19 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Focus Blast", "Protect", "Psychic", "Psyshock", "Tachyon Cutter"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Focus Blast", "Psychic", "Psyshock", "Tachyon Cutter", "Volt Switch"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Agility", "Focus Blast", "Protect", "Psychic", "Psyshock", "Tachyon Cutter"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Psychic", "Steel"]
             }
         ]
@@ -6110,16 +6829,19 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Protect", "Tera Starstorm"],
+                "abilities": ["Tera Shift"],
                 "teraTypes": ["Stellar"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Dark Pulse", "Earth Power", "Tera Starstorm", "Tri Attack"],
+                "abilities": ["Tera Shift"],
                 "teraTypes": ["Stellar"]
             },
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dark Pulse", "Meteor Beam", "Protect", "Tera Starstorm"],
+                "abilities": ["Tera Shift"],
                 "teraTypes": ["Stellar"]
             }
         ]
@@ -6130,11 +6852,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Malignant Chain", "Nasty Plot", "Protect", "Recover", "Shadow Ball"],
+                "abilities": ["Poison Puppeteer"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Malignant Chain", "Parting Shot", "Poison Gas", "Protect", "Shadow Ball"],
+                "abilities": ["Poison Puppeteer"],
                 "teraTypes": ["Dark"]
             }
         ]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -5,11 +5,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Giga Drain", "Leech Seed", "Sleep Powder", "Sludge Bomb", "Substitute"],
+                "abilities": ["Chlorophyll", "Overgrow"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Energy Ball", "Knock Off", "Sleep Powder", "Sludge Bomb", "Synthesis", "Toxic"],
+                "abilities": ["Chlorophyll", "Overgrow"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             }
         ]
@@ -20,11 +22,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Focus Blast", "Hurricane", "Will-O-Wisp"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Dragon", "Fire", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Outrage", "Swords Dance"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Dragon", "Ground"]
             }
         ]
@@ -35,11 +39,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Hydro Pump", "Ice Beam", "Shell Smash"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Hydro Pump", "Ice Beam", "Shell Smash", "Tera Blast"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Electric", "Grass"]
             }
         ]
@@ -50,11 +56,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Earthquake", "Glare", "Gunk Shot", "Knock Off", "Sucker Punch", "Toxic Spikes"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Coil", "Earthquake", "Gunk Shot", "Sucker Punch", "Trailblaze"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -65,6 +73,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Fake Out", "Knock Off", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -75,11 +84,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Alluring Voice", "Encore", "Focus Blast", "Grass Knot", "Nasty Plot", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Grass", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Encore", "Focus Blast", "Nasty Plot", "Surf", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -90,11 +101,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Psychic", "Psyshock", "Surf", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Surge Surfer"],
                 "teraTypes": ["Fairy", "Fighting", "Grass", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock", "Surf", "Thunderbolt"],
+                "abilities": ["Surge Surfer"],
                 "teraTypes": ["Fairy", "Fighting", "Grass", "Water"]
             }
         ]
@@ -105,6 +118,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Knock Off", "Rapid Spin", "Spikes", "Stone Edge", "Swords Dance"],
+                "abilities": ["Sand Rush"],
                 "teraTypes": ["Dragon", "Steel", "Water"]
             }
         ]
@@ -115,11 +129,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Iron Head", "Knock Off", "Rapid Spin", "Spikes", "Triple Axel"],
+                "abilities": ["Slush Rush"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Ice Shard", "Knock Off", "Rapid Spin", "Swords Dance", "Triple Axel"],
+                "abilities": ["Slush Rush"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -130,11 +146,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flamethrower", "Knock Off", "Moonblast", "Moonlight", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Magic Guard", "Unaware"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Moonblast", "Moonlight"],
+                "abilities": ["Magic Guard", "Unaware"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -145,6 +163,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Fire Blast", "Nasty Plot", "Scorching Sands", "Solar Beam"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]
@@ -155,16 +174,19 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Aurora Veil", "Blizzard", "Encore", "Moonblast"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Aurora Veil", "Blizzard", "Moonblast", "Nasty Plot"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Moonblast"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -175,6 +197,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Alluring Voice", "Dazzling Gleam", "Fire Blast", "Knock Off", "Protect", "Stealth Rock", "Thunder Wave", "Wish"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -185,6 +208,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Leech Seed", "Sleep Powder", "Sludge Bomb", "Strength Sap"],
+                "abilities": ["Effect Spore"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -195,6 +219,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bug Buzz", "Quiver Dance", "Sleep Powder", "Sludge Wave"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug", "Poison", "Steel", "Water"]
             }
         ]
@@ -205,11 +230,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Earthquake", "Stone Edge", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Arena Trap"],
                 "teraTypes": ["Dark", "Fairy", "Flying", "Ghost", "Ground"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Stone Edge", "Sucker Punch", "Throat Chop"],
+                "abilities": ["Arena Trap"],
                 "teraTypes": ["Dark", "Fairy", "Flying", "Ghost", "Ground"]
             }
         ]
@@ -220,6 +247,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Iron Head", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Sand Force", "Tangling Hair"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -230,11 +258,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Double-Edge", "Gunk Shot", "Knock Off", "Switcheroo", "U-turn"],
+                "abilities": ["Limber"],
                 "teraTypes": ["Normal", "Poison"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Fake Out", "Knock Off", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -245,11 +275,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dark Pulse", "Hypnosis", "Nasty Plot", "Power Gem", "Thunderbolt"],
+                "abilities": ["Fur Coat"],
                 "teraTypes": ["Dark", "Electric"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dark Pulse", "Nasty Plot", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Fur Coat"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -260,11 +292,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Encore", "Grass Knot", "Hydro Pump", "Ice Beam", "Nasty Plot", "Psyshock"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Flip Turn", "Grass Knot", "Hydro Pump", "Ice Beam", "Nasty Plot"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -275,6 +309,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Rage Fist", "Rest", "Taunt"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Fairy", "Ghost", "Steel", "Water"]
             }
         ]
@@ -285,11 +320,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Morning Sun", "Roar", "Wild Charge", "Will-O-Wisp"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Normal"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Morning Sun", "Wild Charge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Normal"]
             }
         ]
@@ -300,6 +337,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Head Smash", "Morning Sun", "Wild Charge"],
+                "abilities": ["Rock Head"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -310,16 +348,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Knock Off", "Liquidation", "Rain Dance"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Dark", "Fighting", "Water"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Circle Throw", "Close Combat", "Knock Off", "Liquidation"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Ice Punch", "Knock Off", "Liquidation", "Poison Jab"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Fighting", "Steel", "Water"]
             }
         ]
@@ -330,16 +371,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Poison Jab", "Power Whip", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Knock Off", "Power Whip", "Sleep Powder", "Sludge Wave", "Strength Sap", "Sucker Punch"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Grass", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Power Whip", "Sludge Wave", "Sunny Day", "Weather Ball"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -350,6 +394,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Haze", "Knock Off", "Rapid Spin", "Sludge Bomb", "Surf", "Toxic", "Toxic Spikes"],
+                "abilities": ["Liquid Ooze"],
                 "teraTypes": ["Flying", "Grass"]
             }
         ]
@@ -360,6 +405,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Explosion", "Rock Polish", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Grass", "Ground", "Steel"]
             }
         ]
@@ -370,11 +416,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Double-Edge", "Earthquake", "Rock Polish", "Stone Edge"],
+                "abilities": ["Galvanize"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Double-Edge", "Earthquake", "Explosion", "Stone Edge"],
+                "abilities": ["Galvanize"],
                 "teraTypes": ["Electric", "Grass", "Ground"]
             }
         ]
@@ -385,11 +433,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Body Press", "Fire Blast", "Future Sight", "Ice Beam", "Psychic Noise", "Scald"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -400,16 +450,19 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Earthquake", "Fire Blast", "Foul Play", "Psychic", "Shell Side Arm", "Surf"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Ground", "Poison", "Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Fire Blast", "Psychic", "Shell Side Arm", "Trick Room"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Poison", "Psychic"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Fire Blast", "Psychic", "Shell Side Arm", "Slack Off", "Thunder Wave"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Ground", "Poison"]
             }
         ]
@@ -420,6 +473,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Brave Bird", "Double-Edge", "Drill Run", "Knock Off", "Swords Dance"],
+                "abilities": ["Early Bird"],
                 "teraTypes": ["Flying", "Ground", "Normal"]
             }
         ]
@@ -430,11 +484,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Flip Turn", "Knock Off", "Surf", "Triple Axel"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Dragon", "Grass", "Ground", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Flip Turn", "Hydro Pump", "Ice Beam", "Knock Off", "Surf"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Dragon", "Grass", "Ground", "Poison", "Steel"]
             }
         ]
@@ -445,11 +501,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak", "Toxic Spikes"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -460,6 +518,7 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -470,11 +529,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Drill Run", "Icicle Spear", "Rock Blast", "Shell Smash"],
+                "abilities": ["Skill Link"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Hydro Pump", "Icicle Spear", "Rock Blast", "Shell Smash"],
+                "abilities": ["Skill Link"],
                 "teraTypes": ["Ice", "Rock"]
             }
         ]
@@ -485,11 +546,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Focus Blast", "Nasty Plot", "Shadow Ball", "Sludge Wave", "Trick"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Fighting", "Ghost"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Destiny Bond", "Encore", "Focus Blast", "Shadow Ball", "Sludge Wave", "Toxic Spikes", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Fighting", "Ghost"]
             }
         ]
@@ -500,11 +563,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic Noise", "Thunder Wave", "Toxic"],
+                "abilities": ["Insomnia"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Focus Blast", "Protect", "Psychic Noise", "Toxic"],
+                "abilities": ["Insomnia"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
@@ -515,11 +580,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Explosion", "Foul Play", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Soundproof", "Static"],
                 "teraTypes": ["Dark", "Electric"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Taunt", "Tera Blast", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Soundproof", "Static"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -530,11 +597,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Energy Ball", "Leaf Storm", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Soundproof", "Static"],
                 "teraTypes": ["Electric", "Grass"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Giga Drain", "Leech Seed", "Substitute", "Thunderbolt"],
+                "abilities": ["Soundproof"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -545,16 +614,19 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Leech Seed", "Psychic", "Psychic Noise", "Sleep Powder", "Sludge Bomb", "Substitute"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Leech Seed", "Protect", "Psychic Noise", "Substitute"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Giga Drain", "Psychic", "Psyshock", "Substitute"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -565,11 +637,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Giga Drain", "Leaf Storm"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Fire"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Flamethrower", "Giga Drain", "Knock Off"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -580,11 +654,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["High Jump Kick", "Knock Off", "Mach Punch", "Poison Jab", "Stone Edge"],
+                "abilities": ["Reckless"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -595,11 +671,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Drain Punch", "Ice Punch", "Knock Off", "Mach Punch", "Rapid Spin", "Swords Dance"],
+                "abilities": ["Inner Focus", "Iron Fist"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Knock Off", "Poison Jab", "Rapid Spin"],
+                "abilities": ["Iron Fist"],
                 "teraTypes": ["Dark", "Poison", "Steel"]
             }
         ]
@@ -610,6 +688,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Fire Blast", "Gunk Shot", "Pain Split", "Sludge Bomb", "Toxic Spikes", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -620,6 +699,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Defog", "Fire Blast", "Gunk Shot", "Pain Split", "Strange Steam", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -630,6 +710,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Megahorn", "Stealth Rock", "Stone Edge", "Swords Dance"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Dragon", "Fairy", "Flying", "Grass", "Water"]
             }
         ]
@@ -640,11 +721,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bug Bite", "Close Combat", "Dual Wingbeat", "Swords Dance"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Close Combat", "Defog", "Dual Wingbeat", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -655,11 +738,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Body Slam", "Close Combat", "Earthquake", "Throat Chop"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fighting", "Ground", "Normal"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Body Slam", "Close Combat", "Throat Chop", "Zen Headbutt"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
             }
         ]
@@ -670,6 +755,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Iron Head", "Stone Edge", "Throat Chop"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
@@ -680,11 +766,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Raging Bull", "Substitute"],
+                "abilities": ["Cud Chew"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Flare Blitz", "Stone Edge", "Wild Charge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -695,16 +783,19 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Liquidation", "Substitute"],
+                "abilities": ["Cud Chew"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Aqua Jet", "Close Combat", "Stone Edge", "Wave Crash"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aqua Jet", "Bulk Up", "Close Combat", "Liquidation"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -715,11 +806,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Stone Edge", "Temper Flare", "Waterfall"],
+                "abilities": ["Intimidate", "Moxie"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Earthquake", "Tera Blast", "Waterfall"],
+                "abilities": ["Intimidate", "Moxie"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -730,16 +823,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Freeze-Dry", "Hydro Pump", "Ice Beam", "Sparkling Aria"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Ice", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Freeze-Dry", "Rest", "Sleep Talk", "Sparkling Aria"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Dragon", "Ghost", "Ground", "Poison", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Freeze-Dry", "Waterfall"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -750,6 +846,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Transform"],
+                "abilities": ["Imposter"],
                 "teraTypes": ["Bug", "Dark", "Dragon", "Electric", "Fairy", "Fighting", "Fire", "Flying", "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic", "Rock", "Steel", "Water"]
             }
         ]
@@ -760,11 +857,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Ice Beam", "Protect", "Scald", "Wish"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Ghost", "Ground", "Poison"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Protect", "Scald", "Wish"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Ghost", "Ground", "Poison"]
             }
         ]
@@ -775,11 +874,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Alluring Voice", "Calm Mind", "Shadow Ball", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Electric", "Fairy"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Substitute", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -790,6 +891,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Facade", "Flare Blitz", "Quick Attack", "Trailblaze", "Will-O-Wisp"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -800,11 +902,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Curse", "Rest", "Sleep Talk"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Poison"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Crunch", "Curse", "Earthquake", "Rest"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Poison"]
             }
         ]
@@ -815,6 +919,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Freeze-Dry", "Haze", "Roost", "Substitute", "U-turn"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -825,6 +930,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -835,6 +941,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Discharge", "Heat Wave", "Hurricane", "Roost", "U-turn", "Volt Switch"],
+                "abilities": ["Static"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -845,6 +952,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Knock Off", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fighting"]
             }
         ]
@@ -855,6 +963,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Fire Blast", "Roost", "Scorching Sands", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Dragon", "Ground", "Steel"]
             }
         ]
@@ -865,6 +974,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Agility", "Fiery Wrath", "Hurricane", "Nasty Plot", "Rest"],
+                "abilities": ["Berserk"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -875,16 +985,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Outrage", "Roost"],
+                "abilities": ["Multiscale"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Outrage"],
+                "abilities": ["Multiscale"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Earthquake", "Outrage", "Tera Blast"],
+                "abilities": ["Multiscale"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -895,6 +1008,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Fire Blast", "Nasty Plot", "Psystrike", "Recover"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Dark", "Fighting", "Fire", "Psychic"]
             }
         ]
@@ -905,16 +1019,19 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic", "Stealth Rock", "Taunt", "Toxic Spikes", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Dark", "Fairy", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Knock Off", "Leech Life", "Psychic Fangs", "Swords Dance"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Aura Sphere", "Bug Buzz", "Dark Pulse", "Earth Power", "Fire Blast", "Hydro Pump", "Nasty Plot", "Psychic", "Psyshock"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Dark", "Fighting", "Fire", "Ground", "Psychic", "Water"]
             }
         ]
@@ -925,11 +1042,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dragon Tail", "Encore", "Energy Ball", "Knock Off", "Leech Seed", "Synthesis"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Poison", "Steel", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Knock Off", "Petal Blizzard", "Swords Dance"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
@@ -940,6 +1059,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Eruption", "Fire Blast", "Focus Blast", "Scorching Sands"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -950,11 +1070,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Focus Blast", "Shadow Ball", "Substitute", "Will-O-Wisp"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Fighting", "Fire", "Ghost"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Eruption", "Fire Blast", "Focus Blast", "Shadow Ball"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -965,11 +1087,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Crunch", "Dragon Dance", "Ice Punch", "Liquidation"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Dark", "Dragon", "Steel", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Ice Punch", "Liquidation", "Trailblaze"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -980,11 +1104,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Double-Edge", "Knock Off", "Trick", "U-turn"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Brick Break", "Double-Edge", "Knock Off", "Tidy Up"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -995,6 +1121,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Defog", "Hurricane", "Hyper Voice", "Nasty Plot", "Roost"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Ground", "Normal", "Steel"]
             }
         ]
@@ -1005,6 +1132,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Knock Off", "Megahorn", "Poison Jab", "Sticky Web", "Sucker Punch", "Toxic Spikes"],
+                "abilities": ["Insomnia", "Swarm"],
                 "teraTypes": ["Ghost", "Steel"]
             }
         ]
@@ -1015,11 +1143,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Scald", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Ice Beam", "Scald", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -1030,6 +1160,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Agility", "Dazzling Gleam", "Focus Blast", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Static"],
                 "teraTypes": ["Electric", "Fairy"]
             }
         ]
@@ -1040,16 +1171,19 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Giga Drain", "Quiver Dance", "Sleep Powder", "Strength Sap"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Poison", "Steel", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Giga Drain", "Moonblast", "Quiver Dance", "Sludge Bomb", "Strength Sap"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fairy", "Poison"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Giga Drain", "Quiver Dance", "Strength Sap", "Tera Blast"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire", "Rock"]
             }
         ]
@@ -1060,11 +1194,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Aqua Jet", "Ice Spinner", "Knock Off", "Liquidation", "Play Rough", "Superpower"],
+                "abilities": ["Huge Power"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Aqua Jet", "Belly Drum", "Liquidation", "Play Rough"],
+                "abilities": ["Huge Power"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1075,6 +1211,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Head Smash", "Stealth Rock", "Sucker Punch", "Wood Hammer"],
+                "abilities": ["Rock Head"],
                 "teraTypes": ["Grass", "Rock"]
             }
         ]
@@ -1085,6 +1222,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Haze", "Hydro Pump", "Hypnosis", "Ice Beam", "Rest", "Surf"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1095,11 +1233,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Acrobatics", "Leech Seed", "Strength Sap", "Substitute"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Acrobatics", "Encore", "Sleep Powder", "Strength Sap", "U-turn"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1110,11 +1250,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Earth Power", "Leaf Storm", "Sludge Bomb"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fairy", "Grass", "Ground", "Poison"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earth Power", "Solar Beam", "Sunny Day", "Weather Ball"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -1125,6 +1267,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Ice Beam", "Recover", "Spikes", "Toxic"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Fairy", "Poison", "Steel"]
             }
         ]
@@ -1135,6 +1278,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Stealth Rock", "Toxic", "Toxic Spikes"],
+                "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -1145,6 +1289,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Alluring Voice", "Calm Mind", "Morning Sun", "Psychic", "Psyshock", "Shadow Ball", "Trick"],
+                "abilities": ["Magic Bounce"],
                 "teraTypes": ["Fairy", "Psychic"]
             }
         ]
@@ -1155,6 +1300,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Foul Play", "Protect", "Toxic", "Wish"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -1165,16 +1311,19 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Chilly Reception", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dragon", "Fairy", "Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Psyshock", "Trick Room"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Psychic", "Water"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Chilly Reception", "Future Sight", "Scald", "Slack Off"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dragon", "Fairy", "Water"]
             }
         ]
@@ -1185,11 +1334,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Chilly Reception", "Fire Blast", "Psychic Noise", "Psyshock", "Slack Off", "Sludge Bomb", "Thunder Wave"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Poison"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Fire Blast", "Future Sight", "Ice Beam", "Psychic Noise", "Sludge Bomb"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Poison", "Psychic"]
             }
         ]
@@ -1200,6 +1351,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Shadow Ball", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -1210,11 +1362,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dazzling Gleam", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Fairy", "Psychic"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Hyper Voice", "Nasty Plot", "Psyshock", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Normal"]
             }
         ]
@@ -1225,11 +1379,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Iron Head", "Rapid Spin", "Stealth Rock", "Toxic Spikes", "Volt Switch"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Iron Head", "Rapid Spin", "Spikes", "Stealth Rock"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting", "Water"]
             }
         ]
@@ -1240,6 +1396,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Coil", "Earthquake", "Roost"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Ghost", "Ground"]
             }
         ]
@@ -1250,11 +1407,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Encore", "Play Rough", "Thunder Wave"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Play Rough", "Roar", "Thunder Wave"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -1265,11 +1424,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Destiny Bond", "Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Flip Turn", "Gunk Shot", "Pain Split", "Thunder Wave", "Toxic", "Toxic Spikes"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Grass"]
             }
         ]
@@ -1280,6 +1441,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Crunch", "Gunk Shot", "Spikes", "Taunt", "Toxic Spikes"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Flying", "Poison"]
             }
         ]
@@ -1290,6 +1452,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Jet", "Crunch", "Gunk Shot", "Liquidation", "Swords Dance"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1300,16 +1463,19 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Bullet Punch", "Close Combat", "Defog", "Knock Off", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "Knock Off", "Swords Dance"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bullet Punch", "Close Combat", "Knock Off", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1320,11 +1486,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Facade", "Knock Off", "Trailblaze"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Earthquake", "Knock Off", "Megahorn", "Stone Edge"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Bug", "Fighting", "Rock"]
             }
         ]
@@ -1335,6 +1503,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Earthquake", "Rest", "Sleep Talk", "Throat Chop"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Ghost", "Ground"]
             }
         ]
@@ -1345,11 +1514,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earth Power", "Fire Blast", "Power Gem", "Shell Smash"],
+                "abilities": ["Weak Armor"],
                 "teraTypes": ["Dragon", "Grass"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Lava Plume", "Power Gem", "Recover", "Stealth Rock", "Yawn"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Dragon", "Grass"]
             }
         ]
@@ -1360,11 +1531,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Drill Run", "Ice Shard", "Ice Spinner", "Spikes"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Flying", "Ground", "Ice"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Brave Bird", "Freeze-Dry", "Rapid Spin", "Spikes"],
+                "abilities": ["Insomnia", "Vital Spirit"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1375,16 +1548,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Brave Bird", "Iron Defense", "Roost"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Brave Bird", "Roost", "Spikes", "Stealth Rock"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Dragon", "Fighting"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Roost", "Spikes", "Stealth Rock", "Whirlwind"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -1395,6 +1571,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch", "Will-O-Wisp"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Dark", "Fire", "Poison"]
             }
         ]
@@ -1405,16 +1582,19 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Hurricane", "Rain Dance", "Wave Crash"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Outrage", "Waterfall", "Wave Crash"],
+                "abilities": ["Sniper", "Swift Swim"],
                 "teraTypes": ["Dragon", "Water"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Dance", "Iron Head", "Outrage", "Wave Crash"],
+                "abilities": ["Sniper", "Swift Swim"],
                 "teraTypes": ["Dragon", "Steel", "Water"]
             }
         ]
@@ -1425,6 +1605,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Ice Shard", "Ice Spinner", "Knock Off", "Rapid Spin", "Stealth Rock"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Ghost", "Grass"]
             }
         ]
@@ -1435,11 +1616,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Discharge", "Ice Beam", "Recover", "Tri Attack"],
+                "abilities": ["Download"],
                 "teraTypes": ["Electric", "Ghost", "Poison"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Recover", "Shadow Ball", "Tera Blast", "Thunder Wave"],
+                "abilities": ["Download"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -1450,6 +1633,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Ceaseless Edge", "Spore", "Stealth Rock", "Sticky Web", "Whirlwind"],
+                "abilities": ["Own Tempo"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1460,11 +1644,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Close Combat", "Earthquake", "Rapid Spin", "Stone Edge", "Sucker Punch"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Rapid Spin", "Triple Axel"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -1475,6 +1661,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Heal Bell", "Seismic Toss", "Soft-Boiled", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Fairy", "Ghost", "Poison", "Steel"]
             }
         ]
@@ -1485,6 +1672,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Heal Bell", "Seismic Toss", "Soft-Boiled", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Fairy", "Ghost", "Poison", "Steel"]
             }
         ]
@@ -1495,11 +1683,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Scald", "Substitute", "Thunderbolt"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Scald", "Shadow Ball", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Electric", "Water"]
             }
         ]
@@ -1510,11 +1700,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Extreme Speed", "Flare Blitz", "Sacred Fire", "Stomping Tantrum"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Fire", "Normal"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Extreme Speed", "Flare Blitz", "Sacred Fire", "Stone Edge"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Fire", "Normal"]
             }
         ]
@@ -1525,16 +1717,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Rest", "Scald", "Sleep Talk"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Ice Beam", "Rest", "Scald", "Substitute"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Calm Mind", "Protect", "Scald", "Substitute"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1545,11 +1740,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Knock Off", "Stone Edge"],
+                "abilities": ["Sand Stream"],
                 "teraTypes": ["Ghost", "Rock"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Fire Blast", "Ice Beam", "Knock Off", "Stealth Rock", "Stone Edge", "Thunder Wave"],
+                "abilities": ["Sand Stream"],
                 "teraTypes": ["Ghost", "Rock"]
             }
         ]
@@ -1560,6 +1757,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Aeroblast", "Calm Mind", "Earth Power", "Recover"],
+                "abilities": ["Multiscale"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -1570,6 +1768,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Earthquake", "Recover", "Sacred Fire"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -1580,16 +1779,19 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Focus Blast", "Giga Drain", "Leaf Storm", "Rock Slide", "Shed Tail"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Grass", "Ground", "Steel"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Focus Blast", "Giga Drain", "Leech Seed", "Substitute"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Leaf Blade", "Rock Slide", "Swords Dance"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -1600,11 +1802,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Protect", "Stone Edge", "Swords Dance"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Fire Blast", "Knock Off", "Protect"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
             }
         ]
@@ -1615,6 +1819,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Flip Turn", "Ice Beam", "Knock Off", "Roar", "Stealth Rock"],
+                "abilities": ["Damp", "Torrent"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -1625,11 +1830,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Crunch", "Play Rough", "Poison Fang", "Sucker Punch", "Taunt", "Throat Chop"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy", "Poison"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Crunch", "Play Rough", "Poison Fang", "Sucker Punch", "Super Fang", "Throat Chop"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -1640,11 +1847,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Giga Drain", "Hydro Pump", "Ice Beam", "Rain Dance"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Grass", "Steel", "Water"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Giga Drain", "Hydro Pump", "Ice Beam", "Leaf Storm"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -1655,16 +1864,19 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Defog", "Knock Off", "Leaf Storm", "Sucker Punch", "Will-O-Wisp"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Dark", "Poison"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Knock Off", "Leaf Blade", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Dark", "Poison"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Knock Off", "Leaf Blade", "Low Kick", "Tailwind"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Dark", "Fighting"]
             }
         ]
@@ -1675,11 +1887,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hurricane", "Hydro Pump", "Knock Off", "Roost", "Surf", "U-turn"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Ground", "Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Hurricane", "Hydro Pump", "Surf", "U-turn"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -1690,6 +1904,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Healing Wish", "Moonblast", "Mystical Fire", "Psychic", "Psyshock", "Trick"],
+                "abilities": ["Trace"],
                 "teraTypes": ["Fairy", "Fighting", "Fire"]
             }
         ]
@@ -1700,11 +1915,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bug Buzz", "Hurricane", "Hydro Pump", "Quiver Dance"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Bug Buzz", "Hurricane", "Hydro Pump", "Sticky Web", "Stun Spore", "U-turn"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
@@ -1715,6 +1932,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bullet Seed", "Mach Punch", "Rock Tomb", "Spore", "Swords Dance"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Fighting", "Rock"]
             }
         ]
@@ -1725,11 +1943,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Bulk Up", "Knock Off", "Slack Off"],
+                "abilities": ["Vital Spirit"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Bulk Up", "Earthquake", "Slack Off"],
+                "abilities": ["Vital Spirit"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -1740,6 +1960,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Earthquake", "Giga Impact", "Knock Off"],
+                "abilities": ["Truant"],
                 "teraTypes": ["Ghost", "Ground", "Normal"]
             }
         ]
@@ -1750,11 +1971,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bullet Punch", "Close Combat", "Facade", "Headlong Rush", "Knock Off"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Bullet Punch", "Close Combat", "Headlong Rush", "Heavy Slam", "Knock Off", "Stone Edge"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1765,6 +1988,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Recover", "Taunt", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1775,6 +1999,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bullet Punch", "Close Combat", "Ice Punch", "Poison Jab", "Zen Headbutt"],
+                "abilities": ["Pure Power"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1785,6 +2010,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Alluring Voice", "Encore", "Grass Knot", "Nasty Plot", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Electric", "Fairy", "Grass"]
             }
         ]
@@ -1795,6 +2021,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Alluring Voice", "Encore", "Grass Knot", "Nasty Plot", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Electric", "Fairy", "Grass"]
             }
         ]
@@ -1805,11 +2032,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Roost", "Thunder Wave", "U-turn"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Lunge", "Roost", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1820,6 +2049,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Bug Buzz", "Encore", "Roost", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1830,16 +2060,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Clear Smog", "Earthquake", "Encore", "Ice Beam", "Knock Off", "Pain Split", "Sludge Bomb", "Toxic Spikes"],
+                "abilities": ["Liquid Ooze"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Protect", "Sludge Bomb", "Toxic"],
+                "abilities": ["Liquid Ooze"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Gunk Shot", "Knock Off", "Swords Dance"],
+                "abilities": ["Liquid Ooze"],
                 "teraTypes": ["Dark", "Ground", "Poison"]
             }
         ]
@@ -1850,6 +2083,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Overheat", "Roar", "Stealth Rock", "Will-O-Wisp"],
+                "abilities": ["Solid Rock"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -1860,11 +2094,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Lava Plume", "Rapid Spin", "Solar Beam", "Stealth Rock", "Yawn"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Grass"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Lava Plume", "Rapid Spin", "Solar Beam", "Stealth Rock", "Yawn"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Dragon", "Grass"]
             }
         ]
@@ -1875,11 +2111,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dazzling Gleam", "Earth Power", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Ghost", "Ground", "Psychic"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Focus Blast", "Psychic", "Psyshock", "Shadow Ball", "Trick"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fighting", "Ghost", "Ground", "Psychic"]
             }
         ]
@@ -1890,6 +2128,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Dance", "Earthquake", "Outrage", "Stone Edge", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Ground", "Rock", "Steel"]
             }
         ]
@@ -1900,11 +2139,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Focus Blast", "Knock Off", "Leaf Storm", "Spikes", "Sucker Punch", "Toxic Spikes"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Dark", "Grass", "Poison"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Drain Punch", "Knock Off", "Seed Bomb", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -1915,11 +2156,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Defog", "Earthquake", "Haze", "Roost", "Will-O-Wisp"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Brave Bird", "Dragon Dance", "Earthquake", "Roost"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -1930,6 +2173,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Facade", "Knock Off", "Quick Attack", "Swords Dance"],
+                "abilities": ["Toxic Boost"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -1940,11 +2184,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Giga Drain", "Glare", "Gunk Shot", "Knock Off", "Switcheroo"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Dark", "Fire", "Grass", "Ground", "Poison"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Gunk Shot", "Swords Dance", "Trailblaze"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Grass", "Ground"]
             }
         ]
@@ -1955,11 +2201,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Hydro Pump", "Ice Beam", "Spikes", "Stealth Rock"],
+                "abilities": ["Oblivious"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Liquidation", "Stone Edge"],
+                "abilities": ["Oblivious"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -1970,11 +2218,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Jet", "Close Combat", "Crabhammer", "Dragon Dance", "Knock Off"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aqua Jet", "Crabhammer", "Dragon Dance", "Knock Off", "Swords Dance"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1985,6 +2235,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dragon Tail", "Flip Turn", "Haze", "Ice Beam", "Recover", "Scald"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Dragon", "Steel"]
             }
         ]
@@ -1995,6 +2246,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Swords Dance", "Thunder Wave"],
+                "abilities": ["Cursed Body", "Frisk"],
                 "teraTypes": ["Ghost", "Poison"]
             }
         ]
@@ -2005,6 +2257,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Leech Seed", "Protect", "Substitute"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2015,11 +2268,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Heal Bell", "Knock Off", "Psychic Noise", "Recover", "Thunder Wave"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Electric", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic", "Psychic Noise", "Psyshock", "Recover"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Poison", "Steel"]
             }
         ]
@@ -2030,6 +2285,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Disable", "Earthquake", "Freeze-Dry", "Spikes", "Taunt"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Ghost", "Ground", "Water"]
             }
         ]
@@ -2040,6 +2296,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Endeavor", "Substitute", "Surf", "Whirlpool"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2050,6 +2307,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Dual Wingbeat", "Earthquake", "Outrage", "Roost"],
+                "abilities": ["Intimidate", "Moxie"],
                 "teraTypes": ["Dragon", "Ground", "Steel"]
             }
         ]
@@ -2060,11 +2318,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Agility", "Earthquake", "Heavy Slam", "Knock Off", "Psychic Fangs"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Bullet Punch", "Earthquake", "Heavy Slam", "Knock Off", "Psychic Fangs", "Stealth Rock"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2075,11 +2335,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Iron Defense", "Stealth Rock", "Stone Edge", "Thunder Wave"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Curse", "Iron Defense", "Rest", "Stone Edge"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2090,6 +2352,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Ice Beam", "Rest", "Sleep Talk", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -2100,11 +2363,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Curse", "Iron Defense", "Iron Head", "Rest"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Iron Defense", "Iron Head", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2115,6 +2380,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Aura Sphere", "Calm Mind", "Draco Meteor", "Psyshock", "Recover"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2125,11 +2391,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draco Meteor", "Psyshock", "Recover"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aura Sphere", "Calm Mind", "Draco Meteor", "Flip Turn", "Luster Purge"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dragon", "Psychic", "Steel"]
             }
         ]
@@ -2140,11 +2408,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Ice Beam", "Origin Pulse", "Thunder", "Water Spout"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Ice Beam", "Origin Pulse", "Thunder"],
+                "abilities": ["Drizzle"],
                 "teraTypes": ["Dragon", "Electric", "Steel"]
             }
         ]
@@ -2155,11 +2425,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Heat Crash", "Precipice Blades", "Roar", "Spikes", "Stealth Rock", "Stone Edge", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Fire"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Heat Crash", "Precipice Blades", "Stone Edge", "Swords Dance", "Thunder Wave"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -2170,16 +2442,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Ascent", "Dragon Dance", "Earthquake", "Outrage"],
+                "abilities": ["Air Lock"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Ascent", "Earthquake", "Extreme Speed", "Swords Dance", "U-turn"],
+                "abilities": ["Air Lock"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Ascent", "Earthquake", "Scale Shot", "Swords Dance"],
+                "abilities": ["Air Lock"],
                 "teraTypes": ["Dragon", "Flying"]
             }
         ]
@@ -2190,16 +2465,19 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Body Slam", "Iron Head", "Protect", "Wish"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Drain Punch", "Iron Head", "Stealth Rock", "U-turn"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Fire Punch", "Healing Wish", "Iron Head", "Protect", "U-turn", "Wish"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2210,11 +2488,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Extreme Speed", "Knock Off", "Psycho Boost", "Superpower"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Ice Beam", "Knock Off", "Psycho Boost", "Superpower"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fighting", "Psychic"]
             }
         ]
@@ -2225,11 +2505,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Extreme Speed", "Knock Off", "Psycho Boost", "Superpower"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Ice Beam", "Knock Off", "Psycho Boost", "Superpower"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fighting", "Psychic"]
             }
         ]
@@ -2240,16 +2522,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Cosmic Power", "Night Shade", "Recover", "Spikes", "Stealth Rock", "Taunt"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Knock Off", "Psychic Noise", "Recover", "Spikes", "Stealth Rock", "Teleport"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic", "Psychic Noise", "Psyshock", "Recover"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
@@ -2260,11 +2545,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Knock Off", "Psycho Boost", "Spikes", "Stealth Rock", "Superpower", "Taunt"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dark", "Fighting", "Ghost", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Focus Blast", "Nasty Plot", "Psycho Boost"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dark", "Fighting", "Psychic"]
             }
         ]
@@ -2275,6 +2562,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bullet Seed", "Headlong Rush", "Rock Blast", "Shell Smash"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Grass", "Ground", "Rock", "Water"]
             }
         ]
@@ -2285,11 +2573,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Grass Knot", "Gunk Shot", "Knock Off", "Mach Punch", "Overheat", "Stone Edge"],
+                "abilities": ["Blaze", "Iron Fist"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Close Combat", "Flare Blitz", "Gunk Shot", "Knock Off", "Mach Punch", "Stone Edge", "Swords Dance", "U-turn"],
+                "abilities": ["Blaze", "Iron Fist"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
             }
         ]
@@ -2300,6 +2590,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roost", "Stealth Rock", "Surf", "Yawn"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Flying", "Grass"]
             }
         ]
@@ -2310,6 +2601,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "Quick Attack", "U-turn"],
+                "abilities": ["Reckless"],
                 "teraTypes": ["Fighting", "Flying"]
             }
         ]
@@ -2320,6 +2612,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Knock Off", "Pounce", "Sticky Web", "Swords Dance", "Taunt"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2330,11 +2623,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Facade", "Play Rough", "Supercell Slam", "Throat Chop", "Trailblaze"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Ice Fang", "Play Rough", "Throat Chop", "Volt Switch", "Wild Charge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Electric", "Fairy"]
             }
         ]
@@ -2345,11 +2640,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Fire Punch", "Head Smash", "Rock Slide"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Ground", "Rock"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Fire Punch", "Rock Slide", "Zen Headbutt"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Psychic", "Rock"]
             }
         ]
@@ -2360,6 +2657,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Foul Play", "Iron Defense", "Rest"],
+                "abilities": ["Soundproof"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2370,6 +2668,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Hurricane", "Roost", "Spikes", "Toxic", "Toxic Spikes", "U-turn"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2380,11 +2679,13 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Nuzzle", "Super Fang", "Thunderbolt", "U-turn"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Discharge", "Encore", "Super Fang", "U-turn"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -2395,11 +2696,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Crunch", "Flip Turn", "Ice Spinner", "Low Kick", "Wave Crash"],
+                "abilities": ["Water Veil"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Crunch", "Ice Spinner", "Low Kick", "Wave Crash"],
+                "abilities": ["Water Veil"],
                 "teraTypes": ["Dark", "Fighting", "Ice", "Steel", "Water"]
             }
         ]
@@ -2410,11 +2713,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Clear Smog", "Earthquake", "Ice Beam", "Recover", "Stealth Rock", "Surf"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Recover", "Sludge Bomb", "Stealth Rock", "Surf"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -2425,11 +2730,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Knock Off", "Low Kick", "Triple Axel", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Ice", "Normal"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Double-Edge", "Fake Out", "Knock Off", "Low Kick", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2440,6 +2747,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Calm Mind", "Defog", "Shadow Ball", "Strength Sap"],
+                "abilities": ["Aftermath", "Unburden"],
                 "teraTypes": ["Fairy", "Ghost"]
             }
         ]
@@ -2450,16 +2758,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Energy Ball", "Mystical Fire", "Shadow Ball", "Thunderbolt", "Trick"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Fire", "Ghost"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dazzling Gleam", "Mystical Fire", "Nasty Plot", "Shadow Ball", "Substitute", "Thunderbolt"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Nasty Plot", "Shadow Ball", "Substitute", "Tera Blast"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2470,11 +2781,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Heat Wave", "Sucker Punch", "U-turn"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Dark", "Flying"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Brave Bird", "Heat Wave", "Lash Out", "Sucker Punch", "Thunder Wave"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Dark", "Flying"]
             }
         ]
@@ -2485,6 +2798,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Fire Blast", "Gunk Shot", "Knock Off", "Sucker Punch", "Taunt", "Toxic Spikes"],
+                "abilities": ["Aftermath"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -2495,11 +2809,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Hypnosis", "Iron Head", "Psychic", "Psychic Noise", "Stealth Rock"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Iron Head", "Psychic Noise", "Rest"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2510,6 +2826,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Foul Play", "Pain Split", "Poltergeist", "Shadow Sneak", "Sucker Punch", "Toxic", "Will-O-Wisp"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Dark", "Ghost"]
             }
         ]
@@ -2520,11 +2837,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Earthquake", "Outrage", "Spikes", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Rough Skin"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Fire Fang", "Iron Head", "Scale Shot", "Stone Edge", "Swords Dance"],
+                "abilities": ["Rough Skin"],
                 "teraTypes": ["Dragon", "Fire", "Ground", "Steel"]
             }
         ]
@@ -2535,11 +2854,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Stone Edge", "Swords Dance"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aura Sphere", "Flash Cannon", "Focus Blast", "Nasty Plot", "Shadow Ball", "Vacuum Wave"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Fighting", "Ghost"]
             }
         ]
@@ -2550,6 +2871,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind"],
+                "abilities": ["Sand Stream"],
                 "teraTypes": ["Dragon", "Rock", "Steel"]
             }
         ]
@@ -2560,11 +2882,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Knock Off", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Dry Skin"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Dry Skin"],
                 "teraTypes": ["Dark", "Fighting", "Ground"]
             }
         ]
@@ -2575,6 +2899,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Alluring Voice", "Encore", "Hydro Pump", "Ice Beam", "U-turn"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -2585,6 +2910,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Aurora Veil", "Blizzard", "Earthquake", "Ice Shard", "Wood Hammer"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Ice", "Water"]
             }
         ]
@@ -2595,6 +2921,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Ice Shard", "Knock Off", "Low Kick", "Swords Dance", "Triple Axel"],
+                "abilities": ["Pickpocket"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
         ]
@@ -2605,11 +2932,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Dire Claw", "Gunk Shot", "Throat Chop", "U-turn"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Acrobatics", "Close Combat", "Gunk Shot", "Swords Dance"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -2620,16 +2949,19 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Body Press", "Flash Cannon", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Magnet Pull"],
                 "teraTypes": ["Electric", "Fighting", "Flying", "Water"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Discharge", "Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Analytic", "Magnet Pull"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Discharge", "Flash Cannon", "Iron Defense", "Thunderbolt"],
+                "abilities": ["Magnet Pull"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2640,11 +2972,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Ice Punch", "Megahorn", "Rock Polish", "Stone Edge"],
+                "abilities": ["Solid Rock"],
                 "teraTypes": ["Bug", "Ground", "Rock"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dragon Tail", "Earthquake", "Ice Punch", "Megahorn", "Stone Edge"],
+                "abilities": ["Solid Rock"],
                 "teraTypes": ["Bug", "Dragon", "Grass", "Steel"]
             }
         ]
@@ -2655,11 +2989,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Ice Punch", "Knock Off", "Supercell Slam", "Volt Switch"],
+                "abilities": ["Motor Drive"],
                 "teraTypes": ["Dark", "Electric", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bulk Up", "Earthquake", "Ice Punch", "Supercell Slam"],
+                "abilities": ["Motor Drive"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2670,11 +3006,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Fire Blast", "Focus Blast", "Knock Off", "Scorching Sands", "Taunt", "Thunderbolt"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Electric", "Fighting", "Water"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Fire Blast", "Focus Blast", "Knock Off", "Thunderbolt", "Will-O-Wisp"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Electric", "Fighting", "Water"]
             }
         ]
@@ -2685,11 +3023,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Air Slash", "Bug Buzz", "Giga Drain", "U-turn"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Air Slash", "Bug Buzz", "Protect", "Tera Blast"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2700,6 +3040,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Double-Edge", "Knock Off", "Leaf Blade", "Substitute", "Swords Dance", "Synthesis"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Dark", "Normal"]
             }
         ]
@@ -2710,11 +3051,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Freeze-Dry", "Protect", "Wish"],
+                "abilities": ["Ice Body"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Freeze-Dry", "Mud Shot", "Protect", "Wish"],
+                "abilities": ["Ice Body"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2725,11 +3068,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Earthquake", "Protect", "Substitute", "Toxic"],
+                "abilities": ["Poison Heal"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Knock Off", "Protect", "Toxic", "Toxic Spikes", "U-turn"],
+                "abilities": ["Poison Heal"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2740,6 +3085,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Knock Off", "Stealth Rock"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Ice"]
             }
         ]
@@ -2750,11 +3096,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Agility", "Nasty Plot", "Shadow Ball", "Tera Blast"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Ice Beam", "Nasty Plot", "Shadow Ball", "Thunderbolt", "Tri Attack", "Trick"],
+                "abilities": ["Adaptability", "Download"],
                 "teraTypes": ["Electric", "Ghost"]
             }
         ]
@@ -2765,11 +3113,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Leaf Blade", "Night Slash", "Psycho Cut", "Sacred Sword", "Swords Dance"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Agility", "Night Slash", "Psycho Cut", "Sacred Sword"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Fighting"]
             }
         ]
@@ -2780,11 +3130,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Power Gem", "Rest", "Thunder Wave"],
+                "abilities": ["Magnet Pull"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Flash Cannon", "Power Gem", "Stealth Rock", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Magnet Pull"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2795,16 +3147,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Ghost", "Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Dark", "Fairy"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Focus Punch", "Pain Split", "Poltergeist", "Substitute"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2815,6 +3170,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Destiny Bond", "Poltergeist", "Spikes", "Taunt", "Triple Axel", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Ghost", "Ice"]
             }
         ]
@@ -2825,6 +3181,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Nasty Plot", "Shadow Ball", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Ghost"]
             }
         ]
@@ -2835,6 +3192,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hydro Pump", "Nasty Plot", "Pain Split", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Water"]
             }
         ]
@@ -2845,6 +3203,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Nasty Plot", "Overheat", "Pain Split", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fire"]
             }
         ]
@@ -2855,6 +3214,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Blizzard", "Nasty Plot", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -2865,6 +3225,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Nasty Plot", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -2875,6 +3236,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Leaf Storm", "Nasty Plot", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Grass"]
             }
         ]
@@ -2885,6 +3247,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Electric", "Steel"]
             }
         ]
@@ -2895,16 +3258,19 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dazzling Gleam", "Healing Wish", "Ice Beam", "Nasty Plot", "Psychic", "Shadow Ball", "Thunderbolt", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Electric", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Drain Punch", "Ice Beam", "Knock Off", "Psychic Noise", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Fighting"]
             }
         ]
@@ -2915,11 +3281,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Encore", "Explosion", "Fire Blast", "Knock Off", "Psychic", "Stealth Rock", "Taunt", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Fire"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dazzling Gleam", "Fire Blast", "Nasty Plot", "Psychic", "Psyshock", "Thunderbolt", "Trick", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Fire", "Psychic"]
             }
         ]
@@ -2930,11 +3298,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Flying", "Steel"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Fire Blast", "Heavy Slam"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Flying", "Steel"]
             }
         ]
@@ -2945,11 +3315,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Fire Blast", "Flash Cannon", "Heavy Slam", "Stealth Rock"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
             }
         ]
@@ -2960,11 +3332,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Hydro Pump", "Spacial Rend"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Hydro Pump", "Spacial Rend", "Thunder Wave"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -2975,6 +3349,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Hydro Pump", "Spacial Rend", "Thunder Wave"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -2985,6 +3360,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Flash Cannon", "Heavy Slam", "Lava Plume", "Magma Storm", "Stealth Rock"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Flying", "Grass", "Steel"]
             }
         ]
@@ -2995,11 +3371,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Double-Edge", "Knock Off", "Rest", "Sleep Talk"],
+                "abilities": ["Slow Start"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Knock Off", "Protect", "Substitute"],
+                "abilities": ["Slow Start"],
                 "teraTypes": ["Ghost", "Poison"]
             }
         ]
@@ -3010,16 +3388,19 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Dragon Tail", "Rest", "Shadow Ball", "Sleep Talk", "Will-O-Wisp"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dragon Pulse", "Rest", "Sleep Talk"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Defog", "Dragon Tail", "Rest", "Shadow Ball", "Will-O-Wisp"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -3030,6 +3411,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dragon", "Fairy", "Ghost", "Steel"]
             }
         ]
@@ -3040,6 +3422,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Moonblast", "Moonlight", "Psyshock", "Thunderbolt"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Poison", "Steel"]
             }
         ]
@@ -3050,11 +3433,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Rest", "Scald", "Sleep Talk", "Take Heart"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Grass Knot", "Ice Beam", "Scald", "Take Heart"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Grass", "Steel"]
             }
         ]
@@ -3065,6 +3450,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Energy Ball", "Hydro Pump", "Ice Beam", "Surf", "Tail Glow"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -3075,6 +3461,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Focus Blast", "Hypnosis", "Nasty Plot", "Sludge Bomb", "Substitute"],
+                "abilities": ["Bad Dreams"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -3085,11 +3472,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Earth Power", "Rest", "Seed Flare"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Grass", "Ground", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Leech Seed", "Seed Flare", "Substitute"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3100,11 +3489,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Dazzling Gleam", "Earth Power", "Seed Flare"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Leech Seed", "Seed Flare", "Substitute"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3115,11 +3506,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Earthquake", "Extreme Speed", "Recover", "Shadow Claw", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Extreme Speed", "Recover", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -3130,11 +3523,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Earth Power", "Ice Beam", "Judgment"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -3145,6 +3540,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Judgment", "Recover", "Sludge Bomb"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -3155,16 +3551,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Extreme Speed", "Gunk Shot", "Outrage", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Gunk Shot", "Outrage"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground", "Poison"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Recover", "Sludge Bomb"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -3175,6 +3574,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Ice Beam", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Electric", "Ice"]
             }
         ]
@@ -3185,6 +3585,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -3195,11 +3596,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Body Press", "Cosmic Power", "Recover", "Stored Power"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Recover", "Shadow Ball"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3210,16 +3613,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Extreme Speed", "Flare Blitz", "Recover", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire", "Ground"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire", "Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Energy Ball", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Grass", "Ground"]
             }
         ]
@@ -3230,6 +3636,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -3240,11 +3647,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Focus Blast", "Judgment", "Recover", "Will-O-Wisp"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fighting", "Normal"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Focus Blast", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fighting", "Ghost", "Normal"]
             }
         ]
@@ -3255,11 +3664,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Earth Power", "Ice Beam", "Judgment"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -3270,16 +3681,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Ice Beam", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Dragon", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Extreme Speed", "Stone Edge", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Recover", "Stone Edge"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -3290,6 +3704,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover", "Thunderbolt"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Electric", "Ground"]
             }
         ]
@@ -3300,11 +3715,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Gunk Shot", "Liquidation", "Recover", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Earthquake", "Extreme Speed", "Gunk Shot", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground", "Normal"]
             }
         ]
@@ -3315,6 +3732,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Cosmic Power", "Recover", "Stored Power"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3325,11 +3743,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Fire Blast", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Dragon", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Recover", "Stone Edge", "Swords Dance"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -3340,11 +3760,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Judgment", "Recover", "Will-O-Wisp"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3355,6 +3777,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Calm Mind", "Ice Beam", "Judgment", "Recover", "Will-O-Wisp"],
+                "abilities": ["Multitype"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3365,11 +3788,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Glare", "Leaf Storm", "Leech Seed", "Substitute", "Synthesis", "Tera Blast"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fire", "Rock"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Pulse", "Glare", "Leaf Storm", "Leech Seed", "Substitute", "Synthesis"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Dragon", "Grass", "Water"]
             }
         ]
@@ -3380,16 +3805,19 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Scald", "Wild Charge"],
+                "abilities": ["Reckless"],
                 "teraTypes": ["Dark", "Electric", "Fire", "Water"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Flare Blitz", "Head Smash", "Knock Off", "Wild Charge"],
+                "abilities": ["Reckless"],
                 "teraTypes": ["Fire"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bulk Up", "Drain Punch", "Flare Blitz", "Trailblaze"],
+                "abilities": ["Reckless"],
                 "teraTypes": ["Fighting", "Grass"]
             }
         ]
@@ -3400,11 +3828,13 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Aqua Jet", "Flip Turn", "Grass Knot", "Hydro Pump", "Ice Beam", "Knock Off", "Megahorn", "Sacred Sword"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Dark", "Grass", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aqua Jet", "Knock Off", "Liquidation", "Megahorn", "Sacred Sword", "Swords Dance"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Dark", "Water"]
             }
         ]
@@ -3415,6 +3845,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Ceaseless Edge", "Flip Turn", "Razor Shell", "Sacred Sword", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Poison", "Water"]
             }
         ]
@@ -3425,6 +3856,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["High Horsepower", "Overheat", "Supercell Slam", "Volt Switch"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -3435,6 +3867,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Iron Head", "Rapid Spin", "Rock Slide", "Swords Dance"],
+                "abilities": ["Mold Breaker", "Sand Rush"],
                 "teraTypes": ["Grass", "Ground", "Water"]
             }
         ]
@@ -3445,6 +3878,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Bulk Up", "Defog", "Drain Punch", "Knock Off", "Mach Punch"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3455,6 +3889,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Facade", "Knock Off", "Mach Punch"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -3465,6 +3900,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Knock Off", "Leaf Blade", "Lunge", "Sticky Web", "Swords Dance"],
+                "abilities": ["Chlorophyll", "Swarm"],
                 "teraTypes": ["Ghost", "Rock"]
             }
         ]
@@ -3475,11 +3911,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Encore", "Giga Drain", "Moonblast", "Stun Spore", "Taunt", "U-turn"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Hurricane", "Leech Seed", "Moonblast", "Substitute"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3490,11 +3928,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Giga Drain", "Quiver Dance", "Sleep Powder", "Tera Blast"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire", "Rock"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Alluring Voice", "Petal Dance", "Quiver Dance", "Sleep Powder"],
+                "abilities": ["Own Tempo"],
                 "teraTypes": ["Fairy", "Grass"]
             }
         ]
@@ -3505,6 +3945,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Ice Spinner", "Leaf Blade", "Sleep Powder", "Victory Dance"],
+                "abilities": ["Chlorophyll", "Hustle"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3515,6 +3956,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Aqua Jet", "Double-Edge", "Flip Turn", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -3525,6 +3967,7 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Aqua Jet", "Flip Turn", "Shadow Ball", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -3535,11 +3978,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Flip Turn", "Hydro Pump", "Ice Beam", "Shadow Ball"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Flip Turn", "Hydro Pump", "Shadow Ball", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -3550,6 +3995,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bulk Up", "Earthquake", "Gunk Shot", "Knock Off", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground", "Poison"]
             }
         ]
@@ -3560,11 +4006,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Knock Off", "Rest"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Poison"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Dragon Dance", "Knock Off", "Poison Jab"],
+                "abilities": ["Intimidate", "Moxie"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -3575,6 +4023,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Nasty Plot", "Psychic", "Sludge Bomb", "Trick", "U-turn"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -3585,6 +4034,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bitter Malice", "Flamethrower", "Focus Blast", "Hyper Voice", "Nasty Plot", "Trick", "U-turn"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Fighting", "Normal"]
             }
         ]
@@ -3595,6 +4045,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bullet Seed", "Tail Slap", "Tidy Up", "Triple Axel", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Grass", "Ice", "Normal"]
             }
         ]
@@ -3605,11 +4056,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic Noise", "Thunderbolt"],
+                "abilities": ["Shadow Tag"],
                 "teraTypes": ["Dark", "Electric", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Focus Blast", "Psychic", "Trick"],
+                "abilities": ["Shadow Tag"],
                 "teraTypes": ["Dark", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
             }
         ]
@@ -3620,6 +4073,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Focus Blast", "Psychic", "Psyshock", "Recover", "Shadow Ball"],
+                "abilities": ["Magic Guard"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -3630,6 +4084,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Defog", "Hydro Pump", "Knock Off", "Roost"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -3640,11 +4095,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Double-Edge", "High Horsepower", "Horn Leech", "Swords Dance"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Ground", "Normal"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Headbutt", "High Horsepower", "Horn Leech", "Swords Dance"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -3655,6 +4112,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Clear Smog", "Giga Drain", "Sludge Bomb", "Spore", "Toxic"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -3665,11 +4123,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Protect", "Scald", "Wish"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Flip Turn", "Protect", "Scald", "Wish"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3680,6 +4140,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Bug Buzz", "Giga Drain", "Sticky Web", "Thunder", "Volt Switch"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -3690,11 +4151,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Coil", "Drain Punch", "Fire Punch", "Knock Off", "Supercell Slam"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Close Combat", "Discharge", "Flamethrower", "Giga Drain", "Knock Off", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -3705,11 +4168,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Energy Ball", "Fire Blast", "Pain Split", "Shadow Ball", "Substitute", "Will-O-Wisp"],
+                "abilities": ["Flame Body", "Flash Fire"],
                 "teraTypes": ["Fire", "Ghost", "Grass"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Energy Ball", "Fire Blast", "Shadow Ball", "Trick"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Fire", "Ghost", "Grass"]
             }
         ]
@@ -3720,11 +4185,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Dragon Dance", "Earthquake", "Iron Head", "Outrage"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Close Combat", "Earthquake", "Iron Head", "Scale Shot", "Swords Dance"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3735,6 +4202,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Aqua Jet", "Close Combat", "Earthquake", "Icicle Crash", "Snowscape", "Swords Dance"],
+                "abilities": ["Slush Rush", "Swift Swim"],
                 "teraTypes": ["Fighting", "Ground", "Ice"]
             }
         ]
@@ -3745,11 +4213,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flash Cannon", "Freeze-Dry", "Haze", "Rapid Spin", "Recover"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Ice Beam", "Rapid Spin", "Recover", "Tera Blast"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -3760,16 +4230,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Triple Axel", "U-turn"],
+                "abilities": ["Reckless"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Close Combat", "Fake Out", "Knock Off", "U-turn"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Knock Off", "Poison Jab", "Swords Dance", "Triple Axel"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -3780,6 +4253,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Dynamic Punch", "Earthquake", "Poltergeist", "Stealth Rock", "Stone Edge"],
+                "abilities": ["No Guard"],
                 "teraTypes": ["Fighting", "Ghost", "Ground"]
             }
         ]
@@ -3790,6 +4264,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Roost"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -3800,16 +4275,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Agility", "Heat Wave", "Hurricane", "Psychic"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fairy", "Fire", "Psychic", "Steel"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Esper Wing", "Hurricane", "U-turn", "Vacuum Wave"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Fairy", "Fighting", "Psychic", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Defog", "Esper Wing", "Hurricane", "Roost"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Fairy", "Psychic", "Steel"]
             }
         ]
@@ -3820,11 +4298,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Defog", "Foul Play", "Roost", "Toxic", "U-turn"],
+                "abilities": ["Overcoat"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Defog", "Foul Play", "Knock Off", "Roost", "Toxic"],
+                "abilities": ["Overcoat"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3835,6 +4315,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Draco Meteor", "Fire Blast", "Flash Cannon", "Nasty Plot", "U-turn"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Dragon", "Fire", "Steel"]
             }
         ]
@@ -3845,11 +4326,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bug Buzz", "Fiery Dance", "Fire Blast", "Giga Drain", "Morning Sun", "Quiver Dance"],
+                "abilities": ["Flame Body", "Swarm"],
                 "teraTypes": ["Fire", "Grass"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Bug Buzz", "Fiery Dance", "Fire Blast", "Giga Drain", "Quiver Dance", "Tera Blast"],
+                "abilities": ["Flame Body", "Swarm"],
                 "teraTypes": ["Ground", "Water"]
             }
         ]
@@ -3860,16 +4343,19 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Close Combat", "Iron Head", "Stone Edge", "Swords Dance", "Taunt"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Aura Sphere", "Calm Mind", "Flash Cannon", "Vacuum Wave"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting", "Ghost", "Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Iron Defense", "Iron Head", "Stealth Rock", "Stone Edge", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Ghost", "Water"]
             }
         ]
@@ -3880,11 +4366,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Earthquake", "Stone Edge", "Swords Dance"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting", "Ground"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Earthquake", "Quick Attack", "Stone Edge"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -3895,6 +4383,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Leaf Blade", "Stone Edge", "Swords Dance"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -3905,6 +4394,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bleakwind Storm", "Focus Blast", "Grass Knot", "Heat Wave", "Nasty Plot", "U-turn"],
+                "abilities": ["Defiant", "Prankster"],
                 "teraTypes": ["Fighting", "Fire", "Flying"]
             }
         ]
@@ -3915,11 +4405,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bleakwind Storm", "Focus Blast", "Grass Knot", "Heat Wave", "Nasty Plot", "U-turn"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fighting", "Fire", "Flying"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Bleakwind Storm", "Heat Wave", "Knock Off", "U-turn"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Fire", "Flying"]
             }
         ]
@@ -3930,16 +4422,19 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Grass Knot", "Knock Off", "Nasty Plot", "Sludge Wave", "Taunt", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "abilities": ["Defiant", "Prankster"],
                 "teraTypes": ["Electric", "Grass", "Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Focus Blast", "Nasty Plot", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Acrobatics", "Focus Blast", "Grass Knot", "Knock Off", "Taunt", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "abilities": ["Defiant", "Prankster"],
                 "teraTypes": ["Electric", "Flying", "Grass", "Steel"]
             }
         ]
@@ -3950,11 +4445,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Grass Knot", "Nasty Plot", "Psychic", "Sludge Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Electric", "Poison", "Psychic"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Focus Blast", "Nasty Plot", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -3965,11 +4462,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Blue Flare", "Draco Meteor", "Dragon Tail", "Earth Power", "Will-O-Wisp"],
+                "abilities": ["Turboblaze"],
                 "teraTypes": ["Fire", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Flare Blitz", "Outrage", "Stone Edge"],
+                "abilities": ["Turboblaze"],
                 "teraTypes": ["Dragon", "Fire"]
             }
         ]
@@ -3980,6 +4479,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bolt Strike", "Dragon Dance", "Outrage", "Substitute"],
+                "abilities": ["Teravolt"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -3990,6 +4490,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earth Power", "Focus Blast", "Nasty Plot", "Psychic", "Rock Slide", "Sludge Wave", "Stealth Rock"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Ground", "Poison", "Psychic"]
             }
         ]
@@ -4000,6 +4501,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Taunt", "U-turn"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground", "Water"]
             }
         ]
@@ -4010,11 +4512,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Icicle Spear", "Scale Shot", "Tera Blast"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Draco Meteor", "Earth Power", "Freeze-Dry", "Ice Beam", "Outrage"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4025,11 +4529,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Earth Power", "Freeze-Dry", "Fusion Flare"],
+                "abilities": ["Turboblaze"],
                 "teraTypes": ["Dragon", "Fire"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Freeze-Dry", "Fusion Flare", "Ice Beam"],
+                "abilities": ["Turboblaze"],
                 "teraTypes": ["Dragon", "Fire"]
             }
         ]
@@ -4040,11 +4546,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Fusion Bolt", "Icicle Spear", "Scale Shot"],
+                "abilities": ["Teravolt"],
                 "teraTypes": ["Electric"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Icicle Spear", "Scale Shot", "Tera Blast"],
+                "abilities": ["Teravolt"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4055,11 +4563,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Air Slash", "Calm Mind", "Flip Turn", "Hydro Pump", "Secret Sword", "Vacuum Wave"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Hydro Pump", "Secret Sword", "Substitute", "Surf"],
+                "abilities": ["Justified"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4070,11 +4580,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Psyshock", "U-turn"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Knock Off", "Relic Song", "Triple Axel"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Dark", "Fighting"]
             }
         ]
@@ -4085,11 +4597,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Knock Off", "Spikes", "Synthesis", "Wood Hammer"],
+                "abilities": ["Bulletproof"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Synthesis", "Trailblaze"],
+                "abilities": ["Bulletproof"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4100,6 +4614,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Fighting", "Fire", "Grass", "Psychic"]
             }
         ]
@@ -4110,6 +4625,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Toxic Spikes", "U-turn"],
+                "abilities": ["Protean"],
                 "teraTypes": ["Dark", "Poison", "Water"]
             }
         ]
@@ -4120,6 +4636,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Gunk Shot", "Hydro Pump", "Ice Beam"],
+                "abilities": ["Battle Bond"],
                 "teraTypes": ["Poison", "Water"]
             }
         ]
@@ -4130,11 +4647,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Defog", "Overheat", "Roost", "Taunt", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Dragon", "Ground"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Brave Bird", "Flare Blitz", "Swords Dance", "Tera Blast"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4145,11 +4664,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bug Buzz", "Hurricane", "Quiver Dance", "Sleep Powder"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Hurricane", "Quiver Dance", "Sleep Powder", "Tera Blast"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4160,6 +4681,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Fire Blast", "Hyper Voice", "Will-O-Wisp", "Work Up"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -4170,11 +4692,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Moonblast", "Protect", "Wish"],
+                "abilities": ["Flower Veil"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Moonblast", "Synthesis", "Tera Blast"],
+                "abilities": ["Flower Veil"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4185,6 +4709,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Earthquake", "Horn Leech", "Milk Drink", "Rock Slide"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Ground", "Water"]
             }
         ]
@@ -4195,6 +4720,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Alluring Voice", "Light Screen", "Psychic Noise", "Reflect", "Thunder Wave", "Yawn"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -4205,6 +4731,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Alluring Voice", "Dark Pulse", "Nasty Plot", "Psychic", "Psyshock", "Thunderbolt"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Dark", "Electric", "Fairy"]
             }
         ]
@@ -4215,11 +4742,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Knock Off", "Rest", "Sleep Talk", "Superpower"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting", "Poison", "Steel"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Knock Off", "Psycho Cut", "Rest", "Superpower"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting", "Poison", "Steel"]
             }
         ]
@@ -4230,6 +4759,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Flip Turn", "Focus Blast", "Sludge Wave", "Toxic", "Toxic Spikes"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4240,6 +4770,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "U-turn", "Water Pulse"],
+                "abilities": ["Mega Launcher"],
                 "teraTypes": ["Dark", "Dragon", "Fighting"]
             }
         ]
@@ -4250,6 +4781,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Hyper Voice", "Protect", "Wish"],
+                "abilities": ["Pixilate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4260,6 +4792,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Acrobatics", "Brave Bird", "Close Combat", "Encore", "Stone Edge", "Swords Dance", "Throat Chop"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Fighting", "Flying"]
             }
         ]
@@ -4270,6 +4803,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Dazzling Gleam", "Nuzzle", "Super Fang", "Thunderbolt", "U-turn"],
+                "abilities": ["Cheek Pouch"],
                 "teraTypes": ["Electric", "Flying"]
             }
         ]
@@ -4280,11 +4814,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Moonblast", "Power Gem", "Spikes", "Stealth Rock"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Moonblast", "Rest", "Rock Polish"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4295,6 +4831,7 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Knock Off", "Power Whip", "Scald", "Sludge Bomb", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Fire", "Grass", "Ground", "Poison", "Water"]
             }
         ]
@@ -4305,6 +4842,7 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Heavy Slam", "Hydro Pump", "Knock Off", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Dragon", "Flying", "Ground", "Water"]
             }
         ]
@@ -4315,11 +4853,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Magnet Rise", "Play Rough", "Spikes", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Foul Play", "Spikes", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -4330,11 +4870,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Drain Punch", "Horn Leech", "Poltergeist", "Rest", "Trick Room", "Will-O-Wisp", "Wood Hammer"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Drain Punch", "Poltergeist", "Protect", "Toxic"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Dark", "Fairy", "Fighting", "Steel"]
             }
         ]
@@ -4345,6 +4887,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Avalanche", "Body Press", "Curse", "Rapid Spin", "Recover"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4355,6 +4898,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Avalanche", "Body Press", "Rapid Spin", "Recover", "Stone Edge"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Flying", "Ghost", "Poison"]
             }
         ]
@@ -4365,11 +4909,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Boomburst", "Draco Meteor", "Flamethrower", "Hurricane", "Roost", "U-turn"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Hurricane", "Roost", "U-turn"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -4380,11 +4926,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Diamond Storm", "Earth Power", "Moonblast", "Rock Polish", "Stealth Rock"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Diamond Storm", "Draining Kiss", "Earth Power"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -4395,6 +4943,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball", "Trick"],
+                "abilities": ["Magician"],
                 "teraTypes": ["Fighting", "Ghost", "Psychic"]
             }
         ]
@@ -4405,11 +4954,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Drain Punch", "Gunk Shot", "Hyperspace Fury", "Trick", "Zen Headbutt"],
+                "abilities": ["Magician"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Focus Blast", "Gunk Shot", "Hyperspace Fury", "Psychic", "Trick"],
+                "abilities": ["Magician"],
                 "teraTypes": ["Fighting", "Poison"]
             }
         ]
@@ -4420,6 +4971,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Flame Charge", "Flamethrower", "Haze", "Sludge Bomb", "Steam Eruption"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Fire", "Ground", "Water"]
             }
         ]
@@ -4430,11 +4982,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Defog", "Knock Off", "Leaf Storm", "Roost", "Spirit Shackle", "U-turn"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Dark", "Ghost", "Grass"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Leaf Blade", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -4445,6 +4999,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defog", "Knock Off", "Leaf Blade", "Roost", "Sucker Punch", "Swords Dance", "Triple Arrows", "U-turn"],
+                "abilities": ["Scrappy"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -4455,16 +5010,19 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Close Combat", "Fake Out", "Knock Off", "Overheat", "U-turn"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Earthquake", "Flare Blitz", "Knock Off", "Parting Shot", "Will-O-Wisp"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Flare Blitz", "Knock Off", "Swords Dance", "Trailblaze"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -4475,16 +5033,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Flip Turn", "Hydro Pump", "Moonblast", "Psychic"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Moonblast", "Sparkling Aria"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Fairy", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Draining Kiss", "Psychic", "Sparkling Aria"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Fairy", "Poison", "Steel"]
             }
         ]
@@ -4495,6 +5056,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Beak Blast", "Boomburst", "Bullet Seed", "Knock Off", "Roost", "U-turn"],
+                "abilities": ["Keen Eye", "Skill Link"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4505,7 +5067,14 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Double-Edge", "Earthquake", "Knock Off", "U-turn"],
-                "teraTypes": ["Ground", "Normal"]
+                "abilities": ["Stakeout"],
+                "teraTypes": ["Normal"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Double-Edge", "Earthquake", "Knock Off", "U-turn"],
+                "abilities": ["Adaptability", "Stakeout"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -4515,6 +5084,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Bug Buzz", "Discharge", "Energy Ball", "Sticky Web", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -4525,6 +5095,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Drain Punch", "Earthquake", "Ice Hammer", "Knock Off"],
+                "abilities": ["Iron Fist"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -4535,6 +5106,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
+                "abilities": ["Dancer"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4545,6 +5117,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
+                "abilities": ["Dancer"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4555,6 +5128,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
+                "abilities": ["Dancer"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -4565,6 +5139,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
+                "abilities": ["Dancer"],
                 "teraTypes": ["Fighting", "Ghost"]
             }
         ]
@@ -4575,11 +5150,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Bug Buzz", "Moonblast", "Sticky Web", "Stun Spore", "U-turn"],
+                "abilities": ["Shield Dust"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Bug Buzz", "Moonblast", "Quiver Dance", "Tera Blast"],
+                "abilities": ["Shield Dust"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4590,6 +5167,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Accelerock", "Close Combat", "Crunch", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance", "Taunt"],
+                "abilities": ["Sand Rush"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4600,6 +5178,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Knock Off", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
+                "abilities": ["No Guard"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4610,6 +5189,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Accelerock", "Close Combat", "Psychic Fangs", "Stone Edge", "Swords Dance", "Throat Chop"],
+                "abilities": ["Tough Claws"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4620,6 +5200,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Haze", "Liquidation", "Recover", "Toxic", "Toxic Spikes"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fairy", "Flying", "Grass", "Steel"]
             }
         ]
@@ -4630,6 +5211,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Earthquake", "Heavy Slam", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4640,6 +5222,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hydro Pump", "Leech Life", "Liquidation", "Mirror Coat", "Sticky Web"],
+                "abilities": ["Water Bubble"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
@@ -4650,11 +5233,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defog", "Knock Off", "Leaf Storm", "Superpower", "Synthesis"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Knock Off", "Leaf Storm", "Leech Life", "Superpower"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting", "Steel", "Water"]
             }
         ]
@@ -4665,11 +5250,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Flamethrower", "Protect", "Substitute", "Toxic"],
+                "abilities": ["Corrosion"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Fire Blast", "Nasty Plot", "Sludge Wave", "Tera Blast"],
+                "abilities": ["Corrosion"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -4680,6 +5267,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["High Jump Kick", "Knock Off", "Power Whip", "Rapid Spin", "Synthesis", "Triple Axel", "U-turn"],
+                "abilities": ["Queenly Majesty"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -4690,11 +5278,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Giga Drain", "Stored Power"],
+                "abilities": ["Triage"],
                 "teraTypes": ["Fairy", "Poison", "Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Draining Kiss", "Giga Drain", "Synthesis", "Tera Blast"],
+                "abilities": ["Triage"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4705,11 +5295,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Focus Blast", "Nasty Plot", "Psychic", "Psyshock", "Thunderbolt"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Electric", "Fighting", "Psychic"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Focus Blast", "Hyper Voice", "Nasty Plot", "Psyshock", "Thunderbolt", "Trick"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Electric", "Fighting", "Normal", "Psychic"]
             }
         ]
@@ -4720,11 +5312,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Knock Off", "Rock Slide", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Poison", "Steel"]
             }
         ]
@@ -4735,6 +5329,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Shadow Ball", "Shore Up", "Sludge Bomb", "Stealth Rock"],
+                "abilities": ["Water Compaction"],
                 "teraTypes": ["Poison", "Water"]
             }
         ]
@@ -4745,6 +5340,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Acrobatics", "Earthquake", "Power Gem", "Shell Smash"],
+                "abilities": ["Shields Down"],
                 "teraTypes": ["Flying", "Ground", "Steel", "Water"]
             }
         ]
@@ -4755,11 +5351,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Earthquake", "Knock Off", "Superpower", "U-turn", "Wood Hammer"],
+                "abilities": ["Comatose"],
                 "teraTypes": ["Fighting", "Grass", "Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Earthquake", "Knock Off", "Rapid Spin", "U-turn"],
+                "abilities": ["Comatose"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -4770,6 +5368,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Drain Punch", "Play Rough", "Shadow Claw", "Shadow Sneak", "Swords Dance", "Wood Hammer"],
+                "abilities": ["Disguise"],
                 "teraTypes": ["Fairy", "Fighting", "Ghost", "Grass"]
             }
         ]
@@ -4780,6 +5379,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Jet", "Crunch", "Flip Turn", "Ice Fang", "Psychic Fangs", "Swords Dance", "Wave Crash"],
+                "abilities": ["Strong Jaw"],
                 "teraTypes": ["Dark", "Psychic"]
             }
         ]
@@ -4790,11 +5390,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Boomburst", "Clanging Scales", "Clangorous Soul", "Close Combat", "Iron Head"],
+                "abilities": ["Soundproof"],
                 "teraTypes": ["Normal", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Iron Head", "Scale Shot", "Swords Dance"],
+                "abilities": ["Soundproof"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4805,11 +5407,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Close Combat", "Flame Charge", "Knock Off", "Psychic", "Sunsteel Strike"],
+                "abilities": ["Full Metal Body"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Morning Sun", "Psychic Fangs", "Sunsteel Strike"],
+                "abilities": ["Full Metal Body"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4820,11 +5424,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Moonblast", "Moongeist Beam", "Moonlight"],
+                "abilities": ["Shadow Shield"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Moongeist Beam", "Moonlight", "Psyshock"],
+                "abilities": ["Shadow Shield"],
                 "teraTypes": ["Dark", "Fairy"]
             }
         ]
@@ -4835,11 +5441,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Knock Off", "Photon Geyser", "Swords Dance"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Dark", "Ground", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Heat Wave", "Moonlight", "Photon Geyser"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Fairy", "Ground", "Steel"]
             }
         ]
@@ -4850,11 +5458,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Morning Sun", "Sunsteel Strike"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Photon Geyser", "Sunsteel Strike"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
@@ -4865,11 +5475,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Moongeist Beam", "Moonlight", "Photon Geyser"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Dark", "Fairy"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Brick Break", "Dragon Dance", "Moongeist Beam", "Photon Geyser"],
+                "abilities": ["Prism Armor"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4880,16 +5492,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Aura Sphere", "Flash Cannon", "Fleur Cannon", "Pain Split", "Spikes", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Soul-Heart"],
                 "teraTypes": ["Fairy", "Fighting", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Flash Cannon", "Fleur Cannon", "Shift Gear"],
+                "abilities": ["Soul-Heart"],
                 "teraTypes": ["Fairy", "Flying", "Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Fleur Cannon", "Iron Head", "Shift Gear", "Tera Blast"],
+                "abilities": ["Soul-Heart"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4900,6 +5515,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Grassy Glide", "High Horsepower", "Knock Off", "Swords Dance", "U-turn", "Wood Hammer"],
+                "abilities": ["Grassy Surge"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -4910,16 +5526,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Gunk Shot", "High Jump Kick", "Pyro Ball", "U-turn"],
+                "abilities": ["Libero"],
                 "teraTypes": ["Fire", "Poison"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Court Change", "High Jump Kick", "Pyro Ball", "Sucker Punch"],
+                "abilities": ["Libero"],
                 "teraTypes": ["Fighting", "Fire"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Court Change", "Gunk Shot", "High Jump Kick", "Pyro Ball", "U-turn"],
+                "abilities": ["Libero"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4930,11 +5549,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Hydro Pump", "Ice Beam", "U-turn"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Hydro Pump", "Ice Beam", "Scald", "U-turn"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4945,6 +5566,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Double-Edge", "Earthquake", "Knock Off", "Swords Dance"],
+                "abilities": ["Cheek Pouch"],
                 "teraTypes": ["Ghost", "Ground"]
             }
         ]
@@ -4955,6 +5577,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Brave Bird", "Defog", "Roost", "U-turn"],
+                "abilities": ["Mirror Armor"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -4965,6 +5588,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Crunch", "Earthquake", "Liquidation", "Shell Smash", "Stone Edge"],
+                "abilities": ["Shell Armor", "Strong Jaw", "Swift Swim"],
                 "teraTypes": ["Dark", "Ground", "Water"]
             }
         ]
@@ -4975,6 +5599,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flamethrower", "Overheat", "Rapid Spin", "Spikes", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Ghost", "Grass", "Water"]
             }
         ]
@@ -4985,11 +5610,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Dance", "Grav Apple", "Outrage", "Sucker Punch", "U-turn"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Dragon", "Grass"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Grav Apple", "Outrage", "Tera Blast"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -5000,6 +5627,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Apple Acid", "Draco Meteor", "Dragon Pulse", "Leech Seed", "Recover"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5010,16 +5638,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Coil", "Earthquake", "Glare", "Rest", "Stone Edge"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Glare", "Rest", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Dragon", "Water"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Coil", "Earthquake", "Rock Blast", "Scale Shot"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -5030,6 +5661,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Defog", "Roost", "Surf"],
+                "abilities": ["Gulp Missile"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5040,6 +5672,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Flip Turn", "Poison Jab", "Psychic Fangs", "Throat Chop", "Waterfall"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -5050,11 +5683,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Boomburst", "Overdrive", "Sludge Wave", "Volt Switch"],
+                "abilities": ["Punk Rock"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Boomburst", "Gunk Shot", "Overdrive", "Shift Gear"],
+                "abilities": ["Punk Rock"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -5065,11 +5700,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Giga Drain", "Shadow Ball", "Shell Smash", "Stored Power", "Strength Sap", "Tera Blast"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Giga Drain", "Shadow Ball", "Shell Smash", "Stored Power", "Strength Sap"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Psychic"]
             }
         ]
@@ -5080,11 +5717,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic", "Psyshock"],
+                "abilities": ["Magic Bounce"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Draining Kiss", "Mystical Fire", "Nuzzle", "Psychic", "Psychic Noise"],
+                "abilities": ["Magic Bounce"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -5095,11 +5734,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Light Screen", "Parting Shot", "Reflect", "Spirit Break", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Parting Shot", "Spirit Break", "Sucker Punch", "Taunt", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -5110,6 +5751,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
+                "abilities": ["Steely Spirit", "Tough Claws"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -5120,11 +5762,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Alluring Voice", "Calm Mind", "Psychic", "Psyshock", "Recover"],
+                "abilities": ["Aroma Veil"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Alluring Voice", "Calm Mind", "Recover", "Tera Blast"],
+                "abilities": ["Aroma Veil"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5135,6 +5779,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fighting", "Ghost", "Steel"]
             }
         ]
@@ -5145,11 +5790,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Discharge", "Recover", "Scald", "Spikes", "Thunderbolt", "Toxic Spikes"],
+                "abilities": ["Electric Surge"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Liquidation", "Recover", "Zing Zap"],
+                "abilities": ["Electric Surge"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -5160,11 +5807,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Bug Buzz", "Giga Drain", "Ice Beam", "Quiver Dance", "Tera Blast"],
+                "abilities": ["Ice Scales"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bug Buzz", "Giga Drain", "Hurricane", "Ice Beam", "Quiver Dance"],
+                "abilities": ["Ice Scales"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5175,6 +5824,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Heat Crash", "Rock Polish", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Power Spot"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -5185,11 +5835,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Belly Drum", "Ice Spinner", "Iron Head", "Liquidation", "Substitute", "Zen Headbutt"],
+                "abilities": ["Ice Face"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute", "Tera Blast"],
+                "abilities": ["Ice Face"],
                 "teraTypes": ["Electric", "Ground"]
             }
         ]
@@ -5200,6 +5852,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Expanding Force", "Healing Wish", "Hyper Voice", "Shadow Ball"],
+                "abilities": ["Psychic Surge"],
                 "teraTypes": ["Psychic"]
             }
         ]
@@ -5210,6 +5863,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Healing Wish", "Hyper Voice", "Psychic", "Psyshock", "Shadow Ball"],
+                "abilities": ["Psychic Surge"],
                 "teraTypes": ["Fairy", "Psychic"]
             }
         ]
@@ -5220,11 +5874,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Aura Wheel", "Parting Shot", "Protect", "Rapid Spin"],
+                "abilities": ["Hunger Switch"],
                 "teraTypes": ["Dark", "Electric"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Aura Wheel", "Knock Off", "Protect", "Rapid Spin"],
+                "abilities": ["Hunger Switch"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -5235,11 +5891,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Iron Head", "Play Rough", "Rock Slide", "Stealth Rock", "Superpower"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Heat Crash", "Heavy Slam", "Knock Off", "Stone Edge", "Supercell Slam", "Superpower"],
+                "abilities": ["Heavy Metal"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -5250,6 +5908,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Draco Meteor", "Flash Cannon", "Iron Defense", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Light Metal"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -5260,11 +5919,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Shadow Ball", "Thunderbolt", "U-turn"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Dragon", "Fire", "Ghost"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Dragon Darts", "Fire Blast", "Tera Blast"],
+                "abilities": ["Clear Body"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -5275,6 +5936,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Crunch", "Play Rough", "Psychic Fangs", "Swords Dance", "Wild Charge"],
+                "abilities": ["Intrepid Sword"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -5285,6 +5947,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Behemoth Blade", "Close Combat", "Play Rough", "Swords Dance"],
+                "abilities": ["Intrepid Sword"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -5295,11 +5958,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Crunch", "Iron Head", "Psychic Fangs", "Stone Edge"],
+                "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Dark", "Fighting", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Crunch", "Iron Defense", "Iron Head", "Rest", "Stone Edge"],
+                "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -5310,6 +5975,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Crunch", "Heavy Slam", "Iron Defense", "Stone Edge"],
+                "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -5320,11 +5986,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dynamax Cannon", "Fire Blast", "Recover", "Sludge Bomb"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Fire"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Dynamax Cannon", "Flamethrower", "Recover", "Toxic", "Toxic Spikes"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -5335,6 +6003,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Poison Jab", "Sucker Punch", "Swords Dance", "U-turn", "Wicked Blow"],
+                "abilities": ["Unseen Fist"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -5345,6 +6014,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Jet", "Close Combat", "Ice Spinner", "Surging Strikes", "Swords Dance", "U-turn"],
+                "abilities": ["Unseen Fist"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5355,11 +6025,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Close Combat", "Knock Off", "Power Whip", "Swords Dance", "Synthesis"],
+                "abilities": ["Leaf Guard"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Knock Off", "Power Whip", "U-turn"],
+                "abilities": ["Leaf Guard"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
             }
         ]
@@ -5370,11 +6042,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Explosion", "Rapid Spin", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Transistor"],
                 "teraTypes": ["Electric"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Rapid Spin", "Tera Blast", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Transistor"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -5385,16 +6059,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Draco Meteor", "Dragon Dance", "Earthquake", "Outrage"],
+                "abilities": ["Dragon's Maw"],
                 "teraTypes": ["Dragon"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Claw", "Dragon Dance", "Earthquake", "Tera Blast"],
+                "abilities": ["Dragon's Maw"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Dragon Energy", "Earthquake", "Outrage"],
+                "abilities": ["Dragon's Maw"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -5405,6 +6082,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Heavy Slam", "High Horsepower", "Icicle Crash", "Swords Dance"],
+                "abilities": ["Chilling Neigh"],
                 "teraTypes": ["Fighting", "Ground", "Steel"]
             }
         ]
@@ -5415,11 +6093,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Draining Kiss", "Nasty Plot", "Shadow Ball", "Substitute", "Will-O-Wisp"],
+                "abilities": ["Grim Neigh"],
                 "teraTypes": ["Dark", "Fairy"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Nasty Plot", "Shadow Ball", "Substitute", "Tera Blast", "Will-O-Wisp"],
+                "abilities": ["Grim Neigh"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -5430,11 +6110,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Encore", "Giga Drain", "Leech Seed", "Psychic", "Psyshock"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Encore", "Giga Drain", "Leech Seed", "Psychic", "Psyshock"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -5445,11 +6127,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Agility", "Close Combat", "Glacial Lance", "High Horsepower"],
+                "abilities": ["As One (Glastrier)"],
                 "teraTypes": ["Fighting", "Ground"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Glacial Lance", "High Horsepower", "Trick Room"],
+                "abilities": ["As One (Glastrier)"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -5460,6 +6144,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Astral Barrage", "Nasty Plot", "Pollen Puff", "Psyshock", "Trick"],
+                "abilities": ["As One (Spectrier)"],
                 "teraTypes": ["Dark", "Ghost"]
             }
         ]
@@ -5470,6 +6155,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Earthquake", "Megahorn", "Psychic Noise", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5480,6 +6166,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Defog", "Stone Axe", "Swords Dance", "U-turn", "X-Scissor"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Bug", "Fighting", "Rock"]
             }
         ]
@@ -5490,6 +6177,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Crunch", "Facade", "Headlong Rush", "Swords Dance", "Throat Chop", "Trailblaze"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -5500,11 +6188,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Blood Moon", "Calm Mind", "Earth Power", "Moonlight"],
+                "abilities": ["Mind's Eye"],
                 "teraTypes": ["Ghost", "Normal", "Poison"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Blood Moon", "Calm Mind", "Moonlight", "Vacuum Wave"],
+                "abilities": ["Mind's Eye"],
                 "teraTypes": ["Fighting", "Ghost", "Normal", "Poison"]
             }
         ]
@@ -5515,11 +6205,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Play Rough", "Substitute", "Superpower", "Taunt", "Zen Headbutt"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Moonblast", "Mystical Fire", "Substitute"],
+                "abilities": ["Cute Charm"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5530,11 +6222,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Moonblast", "Mystical Fire", "Psychic", "Superpower"],
+                "abilities": ["Overcoat"],
                 "teraTypes": ["Fairy", "Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Agility", "Earth Power", "Moonblast", "Mystical Fire", "Superpower"],
+                "abilities": ["Overcoat"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5545,6 +6239,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Flower Trick", "Knock Off", "Toxic Spikes", "Triple Axel", "U-turn"],
+                "abilities": ["Protean"],
                 "teraTypes": ["Dark", "Grass"]
             }
         ]
@@ -5555,11 +6250,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flame Charge", "Shadow Ball", "Slack Off", "Torch Song"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Hex", "Slack Off", "Torch Song", "Will-O-Wisp"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -5570,11 +6267,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Aqua Step", "Close Combat", "Knock Off", "Rapid Spin", "Roost", "Triple Axel", "U-turn"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aqua Step", "Close Combat", "Knock Off", "Roost", "Swords Dance", "Triple Axel"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Fighting", "Water"]
             }
         ]
@@ -5585,6 +6284,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Curse", "Double-Edge", "High Horsepower", "Lash Out"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5595,6 +6295,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Curse", "Double-Edge", "High Horsepower", "Lash Out"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5605,6 +6306,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Circle Throw", "Knock Off", "Spikes", "Sticky Web", "Toxic Spikes", "U-turn"],
+                "abilities": ["Stakeout"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -5615,16 +6317,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["First Impression", "Knock Off", "Leech Life", "Sucker Punch"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["First Impression", "Knock Off", "Sucker Punch", "U-turn"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Knock Off", "Leech Life", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -5634,7 +6339,14 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Double Shock", "Ice Punch", "Knock Off", "Nuzzle", "Revival Blessing"],
+                "movepool": ["Close Combat", "Double Shock", "Knock Off", "Nuzzle", "Revival Blessing"],
+                "abilities": ["Natural Cure", "Volt Absorb"],
+                "teraTypes": ["Electric"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Double Shock", "Ice Punch", "Revival Blessing"],
+                "abilities": ["Iron Fist"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -5645,6 +6357,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bite", "Encore", "Population Bomb", "Tidy Up"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -5655,6 +6368,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Play Rough", "Protect", "Stomping Tantrum", "Wish"],
+                "abilities": ["Well-Baked Body"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5665,11 +6379,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Energy Ball", "Hyper Voice", "Strength Sap"],
+                "abilities": ["Seed Sower"],
                 "teraTypes": ["Grass", "Ground", "Poison"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Hyper Voice", "Leech Seed", "Protect", "Substitute"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Poison", "Water"]
             }
         ]
@@ -5680,6 +6396,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Brave Bird", "Facade", "Protect", "Quick Attack", "U-turn"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -5690,6 +6407,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Brave Bird", "Double-Edge", "Foul Play", "Parting Shot", "Quick Attack"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Flying", "Normal"]
             }
         ]
@@ -5700,6 +6418,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Brave Bird", "Facade", "Protect", "Quick Attack", "U-turn"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -5710,6 +6429,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Brave Bird", "Double-Edge", "Foul Play", "Parting Shot", "Quick Attack"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Flying", "Normal"]
             }
         ]
@@ -5720,16 +6440,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Protect", "Recover", "Salt Cure", "Stealth Rock"],
+                "abilities": ["Purifying Salt"],
                 "teraTypes": ["Dragon", "Ghost"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Protect", "Recover", "Salt Cure", "Stealth Rock"],
+                "abilities": ["Purifying Salt"],
                 "teraTypes": ["Dragon", "Ghost"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Recover", "Salt Cure"],
+                "abilities": ["Purifying Salt"],
                 "teraTypes": ["Dragon", "Ghost"]
             }
         ]
@@ -5740,11 +6463,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Focus Blast", "Psyshock"],
+                "abilities": ["Weak Armor"],
                 "teraTypes": ["Fighting", "Fire", "Grass", "Psychic"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Armor Cannon", "Energy Ball", "Meteor Beam", "Psyshock"],
+                "abilities": ["Weak Armor"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]
@@ -5755,6 +6480,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bitter Blade", "Close Combat", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Weak Armor"],
                 "teraTypes": ["Fighting", "Fire", "Ghost"]
             }
         ]
@@ -5765,6 +6491,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Muddy Water", "Slack Off", "Thunderbolt", "Toxic", "Volt Switch"],
+                "abilities": ["Electromorphosis"],
                 "teraTypes": ["Electric", "Water"]
             }
         ]
@@ -5775,6 +6502,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Hurricane", "Roost", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Electric", "Flying", "Steel", "Water"]
             }
         ]
@@ -5785,6 +6513,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Crunch", "Play Rough", "Psychic Fangs", "Retaliate", "Wild Charge"],
+                "abilities": ["Stakeout"],
                 "teraTypes": ["Dark", "Fairy"]
             }
         ]
@@ -5795,16 +6524,19 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Gunk Shot", "Knock Off", "Super Fang", "U-turn"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Encore", "Gunk Shot", "Knock Off", "Parting Shot"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Gunk Shot", "Knock Off", "Low Kick", "Swords Dance"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -5815,6 +6547,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Leech Seed", "Poltergeist", "Power Whip", "Rapid Spin", "Spikes", "Strength Sap", "Substitute"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
             }
         ]
@@ -5825,6 +6558,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
+                "abilities": ["Mycelium Might"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5835,11 +6569,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Ground", "Rock", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stone Edge", "Swords Dance"],
+                "abilities": ["Anger Shell"],
                 "teraTypes": ["Dark", "Ground", "Rock", "Water"]
             }
         ]
@@ -5850,16 +6586,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flamethrower", "Leech Seed", "Protect", "Substitute"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Energy Ball", "Flamethrower", "Leaf Storm", "Overheat"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire", "Grass"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Energy Ball", "Fire Blast", "Stomping Tantrum", "Sunny Day"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire", "Grass", "Ground"]
             }
         ]
@@ -5870,6 +6609,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Bug Buzz", "Earth Power", "Psychic", "Revival Blessing", "Trick Room"],
+                "abilities": ["Synchronize"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5880,11 +6620,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Lumina Crash", "Shadow Ball", "U-turn"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Fairy", "Ghost", "Psychic"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Protect", "Roost", "Stored Power", "Substitute"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -5895,11 +6637,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Gigaton Hammer", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Gigaton Hammer", "Knock Off", "Play Rough", "Swords Dance"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5910,6 +6654,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Jet", "Liquidation", "Stomping Tantrum", "Throat Chop"],
+                "abilities": ["Gooey"],
                 "teraTypes": ["Dark", "Ground", "Water"]
             }
         ]
@@ -5920,11 +6665,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Knock Off", "Roost", "Stone Edge", "Sucker Punch", "U-turn"],
+                "abilities": ["Rocky Payload"],
                 "teraTypes": ["Rock"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Knock Off", "Roost", "Stealth Rock", "Sucker Punch", "U-turn"],
+                "abilities": ["Big Pecks"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -5935,6 +6682,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Bulk Up", "Close Combat", "Flip Turn", "Ice Punch", "Jet Punch", "Wave Crash"],
+                "abilities": ["Zero to Hero"],
                 "teraTypes": ["Fighting", "Water"]
             }
         ]
@@ -5945,6 +6693,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Gunk Shot", "High Horsepower", "Iron Head", "Shift Gear"],
+                "abilities": ["Filter"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5955,6 +6704,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Draco Meteor", "Knock Off", "Rapid Spin", "Shed Tail", "Taunt"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dragon", "Fairy", "Ghost", "Steel"]
             }
         ]
@@ -5965,11 +6715,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Coil", "Iron Tail", "Rest"],
+                "abilities": ["Earth Eater"],
                 "teraTypes": ["Electric", "Fighting"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Heavy Slam", "Rest", "Shed Tail", "Spikes", "Stealth Rock"],
+                "abilities": ["Earth Eater"],
                 "teraTypes": ["Electric", "Fighting", "Ghost", "Poison"]
             }
         ]
@@ -5980,11 +6732,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock"],
+                "abilities": ["Toxic Debris"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earth Power", "Energy Ball", "Meteor Beam", "Sludge Wave"],
+                "abilities": ["Toxic Debris"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -5995,16 +6749,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Play Rough", "Poltergeist", "Roar", "Shadow Sneak", "Trick", "Will-O-Wisp"],
+                "abilities": ["Fluffy"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Poltergeist", "Rest", "Sleep Talk"],
+                "abilities": ["Fluffy"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Body Press", "Play Rough", "Poltergeist", "Shadow Sneak"],
+                "abilities": ["Fluffy"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -6015,11 +6772,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Close Combat", "Throat Chop", "U-turn"],
+                "abilities": ["Scrappy"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Brave Bird", "Close Combat", "Roost", "Swords Dance", "Throat Chop"],
+                "abilities": ["Scrappy"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -6030,11 +6789,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Liquidation", "Play Rough"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Belly Drum", "Earthquake", "Ice Shard", "Ice Spinner"],
+                "abilities": ["Slush Rush", "Thick Fat"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -6045,11 +6806,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Cutter", "Aqua Jet", "Flip Turn", "Night Slash", "Psycho Cut"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aqua Cutter", "Fillet Away", "Night Slash", "Psycho Cut"],
+                "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Psychic", "Water"]
             }
         ]
@@ -6060,6 +6823,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Rest", "Sleep Talk", "Wave Crash"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Dragon", "Fairy"]
             }
         ]
@@ -6070,6 +6834,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Draco Meteor", "Hydro Pump", "Nasty Plot", "Rapid Spin", "Surf"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -6080,11 +6845,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Protect", "Psychic Noise", "Wish"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Fairy", "Ground", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Future Sight", "Hyper Voice", "Protect", "Wish"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Fairy", "Ground", "Water"]
             }
         ]
@@ -6095,16 +6862,19 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Ghost", "Ground"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Fairy", "Ghost"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Boomburst", "Calm Mind", "Roost", "Shadow Ball"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -6115,6 +6885,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Supreme Overlord"],
                 "teraTypes": ["Dark", "Flying"]
             }
         ]
@@ -6125,16 +6896,19 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Rapid Spin", "Stone Edge"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Rapid Spin", "Stone Edge"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Close Combat", "Headlong Rush", "Ice Spinner", "Knock Off", "Rapid Spin", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -6145,16 +6919,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Seed Bomb", "Spore", "Sucker Punch"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fighting", "Poison"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Crunch", "Seed Bomb", "Spore", "Sucker Punch"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Dark", "Poison"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Crunch", "Seed Bomb", "Sucker Punch"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -6165,6 +6942,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Earth Power", "Spikes", "Stealth Rock", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric", "Grass", "Ground"]
             }
         ]
@@ -6175,11 +6953,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Play Rough", "Protect", "Thunder Wave", "Wish"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Encore", "Protect", "Thunder Wave", "Wish"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -6190,6 +6970,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Moonblast", "Mystical Fire", "Psyshock", "Shadow Ball", "Thunderbolt"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric", "Fairy", "Fire", "Ghost", "Psychic"]
             }
         ]
@@ -6200,11 +6981,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Flame Charge", "Leech Life", "Wild Charge"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric", "Fighting"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Earthquake", "First Impression", "Flare Blitz", "U-turn", "Wild Charge"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Bug", "Electric", "Fighting", "Fire"]
             }
         ]
@@ -6215,16 +6998,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Knock Off", "Outrage", "Roost"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Dark", "Dragon", "Ground", "Poison", "Steel"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Acrobatics", "Dragon Dance", "Iron Head", "Knock Off", "Outrage"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Flying", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Iron Head", "Knock Off", "Outrage", "U-turn"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Dark", "Dragon", "Steel"]
             }
         ]
@@ -6235,11 +7021,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Flip Turn", "Hydro Pump"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fire", "Water"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Hydro Steam", "Sunny Day"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -6250,6 +7038,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Volt Switch"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -6260,6 +7049,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Energy Ball", "Fiery Dance", "Fire Blast", "Morning Sun", "Sludge Wave", "Toxic Spikes", "U-turn"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]
@@ -6270,11 +7060,13 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Close Combat", "Drain Punch", "Fake Out", "Heavy Slam", "Ice Punch", "Thunder Punch", "Volt Switch", "Wild Charge"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Electric", "Fighting"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Drain Punch", "Ice Punch", "Swords Dance", "Thunder Punch", "Wild Charge"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Flying", "Steel"]
             }
         ]
@@ -6285,6 +7077,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Earth Power", "Fire Blast", "Hurricane", "Hydro Pump", "U-turn"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Dark", "Flying", "Ground"]
             }
         ]
@@ -6295,11 +7088,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Earthquake", "Spikes", "Stealth Rock", "Stone Edge", "Thunder Punch", "Volt Switch"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Grass", "Water"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Stone Edge", "Wild Charge"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Grass", "Ground", "Rock"]
             }
         ]
@@ -6310,6 +7105,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Encore", "Flip Turn", "Freeze-Dry", "Hydro Pump", "Ice Beam", "Substitute"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Ice", "Water"]
             }
         ]
@@ -6320,16 +7116,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Knock Off", "Spirit Break", "Swords Dance"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Close Combat", "Moonblast", "Psychic"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fairy", "Fighting", "Steel"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Encore", "Knock Off", "Moonblast"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Dark", "Fairy", "Fighting", "Steel"]
             }
         ]
@@ -6340,6 +7139,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Leaf Blade", "Megahorn", "Psyblade", "Swords Dance"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -6350,16 +7150,19 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Glaive Rush", "Ice Shard", "Icicle Crash"],
+                "abilities": ["Thermal Exchange"],
                 "teraTypes": ["Dragon", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Glaive Rush", "Icicle Crash"],
+                "abilities": ["Thermal Exchange"],
                 "teraTypes": ["Dragon", "Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Icicle Spear", "Scale Shot", "Swords Dance"],
+                "abilities": ["Thermal Exchange"],
                 "teraTypes": ["Dragon", "Ground"]
             }
         ]
@@ -6370,11 +7173,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Focus Blast", "Make It Rain", "Nasty Plot", "Shadow Ball", "Trick"],
+                "abilities": ["Good as Gold"],
                 "teraTypes": ["Fighting", "Ghost", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Make It Rain", "Nasty Plot", "Recover", "Shadow Ball", "Thunder Wave"],
+                "abilities": ["Good as Gold"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             }
         ]
@@ -6385,11 +7190,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Spikes", "Stealth Rock", "Throat Chop", "Whirlwind"],
+                "abilities": ["Vessel of Ruin"],
                 "teraTypes": ["Ghost", "Poison"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Heavy Slam", "Ruination", "Spikes", "Stealth Rock", "Throat Chop"],
+                "abilities": ["Vessel of Ruin"],
                 "teraTypes": ["Ghost", "Poison", "Steel"]
             }
         ]
@@ -6400,11 +7207,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Crunch", "Ice Shard", "Icicle Crash", "Sacred Sword", "Throat Chop"],
+                "abilities": ["Sword of Ruin"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Ice Shard", "Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
+                "abilities": ["Sword of Ruin"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
         ]
@@ -6415,6 +7224,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Giga Drain", "Knock Off", "Leech Seed", "Protect", "Ruination", "Stun Spore"],
+                "abilities": ["Tablets of Ruin"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -6425,11 +7235,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Psychic", "Will-O-Wisp"],
+                "abilities": ["Beads of Ruin"],
                 "teraTypes": ["Dark", "Fire"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Flamethrower", "Overheat", "Psychic"],
+                "abilities": ["Beads of Ruin"],
                 "teraTypes": ["Dark", "Fire"]
             }
         ]
@@ -6440,11 +7252,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Flare Blitz", "Outrage", "U-turn"],
+                "abilities": ["Orichalcum Pulse"],
                 "teraTypes": ["Fire"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Collision Course", "Flare Blitz", "Scale Shot", "Swords Dance"],
+                "abilities": ["Orichalcum Pulse"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -6455,11 +7269,13 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Draco Meteor", "Electro Drift", "Substitute"],
+                "abilities": ["Hadron Engine"],
                 "teraTypes": ["Electric"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Electro Drift", "Overheat", "Volt Switch"],
+                "abilities": ["Hadron Engine"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -6470,6 +7286,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Recover", "Sucker Punch"],
+                "abilities": ["Sticky Hold"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -6480,6 +7297,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Matcha Gotcha", "Shadow Ball", "Strength Sap"],
+                "abilities": ["Heatproof"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -6490,6 +7308,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -6500,11 +7319,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Nasty Plot", "Psyshock", "Sludge Wave", "U-turn"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Fighting", "Poison"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Fake Out", "Psychic Noise", "Sludge Wave", "U-turn"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -6515,16 +7336,19 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Beat Up", "Gunk Shot", "Heat Wave", "Play Rough", "U-turn"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Beat Up", "Gunk Shot", "Play Rough", "Roost", "U-turn"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Gunk Shot", "Play Rough", "Swords Dance", "Tera Blast"],
+                "abilities": ["Toxic Chain"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -6535,11 +7359,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Ivy Cudgel", "Knock Off", "Spikes", "Superpower", "Synthesis", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Grass"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Ivy Cudgel", "Knock Off", "Superpower", "Swords Dance"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -6550,11 +7376,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Ivy Cudgel", "Spikes", "Synthesis", "U-turn", "Wood Hammer"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Horn Leech", "Ivy Cudgel", "Knock Off", "Play Rough", "Power Whip", "Swords Dance"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -6565,6 +7393,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Horn Leech", "Ivy Cudgel", "Knock Off", "Power Whip", "Stomping Tantrum", "Swords Dance"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -6575,11 +7404,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Ivy Cudgel", "Power Whip", "Spikes", "Superpower", "Synthesis"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Rock"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Horn Leech", "Ivy Cudgel", "Power Whip", "Superpower", "Swords Dance"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -6590,16 +7421,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Iron Head", "Outrage", "Swords Dance"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Draco Meteor", "Dragon Tail", "Flash Cannon", "Stealth Rock", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aura Sphere", "Draco Meteor", "Flash Cannon", "Thunderbolt"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Dragon", "Electric", "Fighting"]
             }
         ]
@@ -6610,16 +7444,19 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Dragon Tail", "Earth Power", "Fickle Beam", "Leaf Storm"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Earth Power", "Fickle Beam", "Giga Drain", "Nasty Plot", "Recover"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Draco Meteor", "Earth Power", "Fickle Beam", "Leaf Storm"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -6630,11 +7467,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Heat Crash", "Outrage"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dragon Dance", "Heat Crash", "Morning Sun", "Outrage"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -6645,11 +7484,13 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Discharge", "Draco Meteor", "Thunderbolt", "Thunderclap", "Volt Switch"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dragon Pulse", "Thunderbolt", "Thunderclap"],
+                "abilities": ["Protosynthesis"],
                 "teraTypes": ["Electric", "Fairy"]
             }
         ]
@@ -6660,11 +7501,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Mighty Cleave", "Swords Dance", "Zen Headbutt"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Close Combat", "Mighty Cleave", "Swords Dance", "Zen Headbutt"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -6675,6 +7518,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Psyshock", "Tachyon Cutter", "Volt Switch"],
+                "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -6685,11 +7529,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Dark Pulse", "Rapid Spin", "Rest", "Tera Starstorm"],
+                "abilities": ["Tera Shift"],
                 "teraTypes": ["Stellar"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Rapid Spin", "Rest", "Tera Starstorm"],
+                "abilities": ["Tera Shift"],
                 "teraTypes": ["Stellar"]
             }
         ]
@@ -6700,6 +7546,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Malignant Chain", "Nasty Plot", "Parting Shot", "Recover", "Shadow Ball"],
+                "abilities": ["Poison Puppeteer"],
                 "teraTypes": ["Dark"]
             }
         ]

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -47,17 +47,15 @@ interface BSSFactorySet {
 }
 export class MoveCounter extends Utils.Multiset<string> {
 	damagingMoves: Set<Move>;
-	ironFist: number;
 
 	constructor() {
 		super();
 		this.damagingMoves = new Set();
-		this.ironFist = 0;
 	}
 }
 
 type MoveEnforcementChecker = (
-	movePool: string[], moves: Set<string>, abilities: Set<string>, types: string[],
+	movePool: string[], moves: Set<string>, abilities: string[], types: string[],
 	counter: MoveCounter, species: Species, teamDetails: RandomTeamsTypes.TeamDetails,
 	isLead: boolean, isDoubles: boolean, teraType: string, role: RandomTeamsTypes.Role,
 ) => boolean;
@@ -210,7 +208,7 @@ export class RandomTeams {
 			Grass: (movePool, moves, abilities, types, counter, species) => (
 				!counter.get('Grass') && (
 					movePool.includes('leafstorm') || species.baseStats.atk >= 100 ||
-					types.includes('Electric') || abilities.has('Seed Sower')
+					types.includes('Electric') || abilities.includes('Seed Sower')
 				)
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
@@ -224,9 +222,9 @@ export class RandomTeams {
 			},
 			Psychic: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => {
 				if (counter.get('Psychic')) return false;
-				if (movePool.includes('calmmind') || abilities.has('Strong Jaw')) return true;
+				if (movePool.includes('calmmind') || abilities.includes('Strong Jaw')) return true;
 				if (isDoubles && movePool.includes('psychicfangs')) return true;
-				return abilities.has('Psychic Surge') || ['Bug', 'Electric', 'Fighting', 'Fire', 'Grass', 'Poison'].some(m => types.includes(m));
+				return abilities.includes('Psychic Surge') || ['Bug', 'Electric', 'Fighting', 'Fire', 'Grass', 'Poison'].some(m => types.includes(m));
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
 			Steel: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => (
@@ -366,7 +364,7 @@ export class RandomTeams {
 		moves: Set<string> | null,
 		species: Species,
 		teraType: string,
-		abilities: Set<string> = new Set(),
+		abilities: string[],
 	): MoveCounter {
 		// This is primarily a helper function for random setbuilder functions.
 		const counter = new MoveCounter();
@@ -405,9 +403,9 @@ export class RandomTeams {
 					counter.damagingMoves.add(move);
 				}
 				if (move.flags['bite']) counter.add('strongjaw');
-				if (move.flags['punch']) counter.ironFist++;
+				if (move.flags['punch']) counter.add('ironfist');
 				if (move.flags['sound']) counter.add('sound');
-				if (move.priority > 0 || (moveid === 'grassyglide' && abilities.has('Grassy Surge'))) {
+				if (move.priority > 0 || (moveid === 'grassyglide' && abilities.includes('Grassy Surge'))) {
 					counter.add('priority');
 				}
 			}
@@ -441,7 +439,7 @@ export class RandomTeams {
 	cullMovePool(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -608,7 +606,7 @@ export class RandomTeams {
 
 		if (!types.includes('Dark') && teraType !== 'Dark') this.incompatibleMoves(moves, movePool, 'knockoff', 'suckerpunch');
 
-		if (!abilities.has('Prankster')) this.incompatibleMoves(moves, movePool, 'thunderwave', 'yawn');
+		if (!abilities.includes('Prankster')) this.incompatibleMoves(moves, movePool, 'thunderwave', 'yawn');
 
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
 		if (species.id === 'cyclizar') this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
@@ -652,7 +650,7 @@ export class RandomTeams {
 		move: string,
 		moves: Set<string>,
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -669,7 +667,7 @@ export class RandomTeams {
 	}
 
 	// Returns the type of a given move for STAB/coverage enforcement purposes
-	getMoveType(move: Move, species: Species, abilities: Set<string>, teraType: string): string {
+	getMoveType(move: Move, species: Species, abilities: string[], teraType: string): string {
 		if (move.id === 'terablast') return teraType;
 		if (['judgment', 'revelationdance'].includes(move.id)) return species.types[0];
 
@@ -687,10 +685,10 @@ export class RandomTeams {
 
 		const moveType = move.type;
 		if (moveType === 'Normal') {
-			if (abilities.has('Aerilate')) return 'Flying';
-			if (abilities.has('Galvanize')) return 'Electric';
-			if (abilities.has('Pixilate')) return 'Fairy';
-			if (abilities.has('Refrigerate')) return 'Ice';
+			if (abilities.includes('Aerilate')) return 'Flying';
+			if (abilities.includes('Galvanize')) return 'Electric';
+			if (abilities.includes('Pixilate')) return 'Fairy';
+			if (abilities.includes('Refrigerate')) return 'Ice';
 		}
 		return moveType;
 	}
@@ -698,7 +696,7 @@ export class RandomTeams {
 	// Generate random moveset for a given species, role, tera type.
 	randomMoveset(
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -740,7 +738,7 @@ export class RandomTeams {
 		// Add other moves you really want to have, e.g. STAB, recovery, setup.
 
 		// Enforce Facade if Guts is a possible ability
-		if (movePool.includes('facade') && abilities.has('Guts')) {
+		if (movePool.includes('facade') && abilities.includes('Guts')) {
 			counter = this.addMove('facade', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 				movePool, teraType, role);
 		}
@@ -810,12 +808,12 @@ export class RandomTeams {
 					movePool, teraType, role);
 			}
 			// Enforce Tailwind on Prankster and Gale Wings users
-			if (movePool.includes('tailwind') && (abilities.has('Prankster') || abilities.has('Gale Wings'))) {
+			if (movePool.includes('tailwind') && (abilities.includes('Prankster') || abilities.includes('Gale Wings'))) {
 				counter = this.addMove('tailwind', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			}
 			// Enforce Thunder Wave on Prankster users as well
-			if (movePool.includes('thunderwave') && abilities.has('Prankster')) {
+			if (movePool.includes('thunderwave') && abilities.includes('Prankster')) {
 				counter = this.addMove('thunderwave', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			}
@@ -831,7 +829,7 @@ export class RandomTeams {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
 				if (
-					types.includes(moveType) && (move.priority > 0 || (moveid === 'grassyglide' && abilities.has('Grassy Surge'))) &&
+					types.includes(moveType) && (move.priority > 0 || (moveid === 'grassyglide' && abilities.includes('Grassy Surge'))) &&
 					(move.basePower || move.basePowerCallback)
 				) {
 					priorityMoves.push(moveid);
@@ -1015,7 +1013,7 @@ export class RandomTeams {
 		ability: string,
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
@@ -1024,123 +1022,28 @@ export class RandomTeams {
 		teraType: string,
 		role: RandomTeamsTypes.Role,
 	): boolean {
-		if ([
-			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Galvanize', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
-			'Liquid Voice', 'Marvel Scale', 'Misty Surge', 'Moody', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Shed Skin',
-			'Sniper', 'Snow Cloak', 'Steadfast', 'Steam Engine', 'Sweet Veil',
-		].includes(ability)) return true;
-
 		switch (ability) {
-		// Abilities which are primarily useful for certain moves
-		case 'Contrary': case 'Serene Grace': case 'Skill Link': case 'Strong Jaw':
-			return !counter.get(toID(ability));
-		case 'Chlorophyll':
-			return (!moves.has('sunnyday') && !teamDetails.sun && species.id !== 'lilligant');
-		case 'Cloud Nine':
-			return (species.id !== 'golduck');
-		case 'Competitive':
-			return species.id === 'kilowattrel';
-		case 'Compound Eyes': case 'No Guard':
-			return !counter.get('inaccurate');
-		case 'Cursed Body':
-			return abilities.has('Infiltrator');
+		// Abilities which are primarily useful for certain moves or with team support
+		case 'Chlorophyll': case 'Solar Power':
+			return !teamDetails.sun;
 		case 'Defiant':
-			return (!counter.get('Physical') || (abilities.has('Prankster') && (moves.has('thunderwave') || moves.has('taunt'))));
-		case 'Flame Body':
-			return (species.id === 'magcargo' && moves.has('shellsmash'));
-		case 'Flash Fire':
-			return (
-				['Drought', 'Flame Body', 'Intimidate', 'Rock Head', 'Weak Armor'].some(m => abilities.has(m)) &&
-				this.dex.getEffectiveness('Fire', species) < 0
-			);
-		case 'Guts':
-			return (!moves.has('facade') && !moves.has('sleeptalk'));
-		case 'Hustle':
-			// some of this is just for Delibird in singles/doubles
-			return (!counter.get('Physical') || moves.has('fakeout') || moves.has('rapidspin'));
-		case 'Insomnia':
-			return (role === 'Wallbreaker');
-		case 'Intimidate':
-			if (abilities.has('Hustle')) return true;
-			if (abilities.has('Sheer Force') && !!counter.get('sheerforce')) return true;
-			return (abilities.has('Stakeout'));
-		case 'Iron Fist':
-			return !counter.ironFist || moves.has('dynamicpunch');
-		case 'Justified':
-			return !counter.get('Physical');
-		case 'Libero': case 'Protean':
-			return role === 'Offensive Protect' || (species.id === 'meowscarada' && role === 'Fast Attacker');
-		case 'Lightning Rod':
-			return species.id === 'rhyperior';
-		case 'Mold Breaker':
-			return (['Sharpness', 'Sheer Force', 'Unburden'].some(m => abilities.has(m)));
-		case 'Moxie':
-			// AV Pivot part is currently only for Mightyena)
-			return (!counter.get('Physical') || moves.has('stealthrock') || role === 'AV Pivot');
-		case 'Natural Cure':
-			return species.id === 'pawmot';
-		case 'Neutralizing Gas':
-			return !isDoubles;
-		case 'Overcoat':
-			return types.includes('Grass');
+			return (species.id === 'thundurus' && !!counter.get('Status'));
+		case 'Hydration': case 'Swift Swim':
+			return !teamDetails.rain;
+		case 'Iron Fist': case 'Skill Link': case 'Strong Jaw':
+			return !counter.get(toID(ability));
 		case 'Overgrow':
 			return !counter.get('Grass');
-		case 'Own Tempo':
-			return (!isDoubles || (counter.get('Special')) > 1);
 		case 'Prankster':
-			return (!counter.get('Status') || (species.id === 'grafaiai' && role === 'Setup Sweeper'));
-		case 'Reckless':
-			return !counter.get('recoil');
-		case 'Regenerator':
-			return (species.id === 'mienshao' && role === 'Wallbreaker');
-		case 'Rock Head':
-			return !counter.get('recoil');
+			return !counter.get('Status');
 		case 'Sand Force': case 'Sand Rush':
 			return !teamDetails.sand;
-		case 'Sap Sipper':
-			return species.id === 'wyrdeer';
-		case 'Seed Sower':
-			return role === 'Bulky Support';
-		case 'Sheer Force':
-			const abilitiesCase = (abilities.has('Guts') || abilities.has('Sharpness'));
-			const movesCase = (moves.has('bellydrum') || moves.has('flamecharge'));
-			return (!counter.get('sheerforce') || abilitiesCase || movesCase);
 		case 'Slush Rush':
 			return !teamDetails.snow;
-		case 'Solar Power':
-			return (!teamDetails.sun || !counter.get('Special'));
-		case 'Speed Boost':
-			return (species.id === 'yanmega' && !moves.has('protect'));
-		case 'Sticky Hold':
-			return (species.id === 'muk');
-		case 'Sturdy':
-			return (!!counter.get('recoil') && species.id !== 'skarmory');
 		case 'Swarm':
-			return (!counter.get('Bug') || !!counter.get('recovery'));
-		case 'Swift Swim':
-			return (
-				abilities.has('Intimidate') || (!moves.has('raindance') && !teamDetails.rain) ||
-				(species.id === 'drednaw' && moves.has('crunch'))
-			);
-		case 'Synchronize':
-			return (species.id !== 'umbreon' && species.id !== 'rabsca');
-		case 'Technician':
-			return (!counter.get('technician') || abilities.has('Punk Rock') || abilities.has('Fur Coat'));
-		case 'Tinted Lens':
-			const yanmegaCase = (species.id === 'yanmega' && moves.has('protect'));
-			return (yanmegaCase || species.id === 'illumise');
-		case 'Unburden':
-			return (abilities.has('Prankster') || !counter.get('setup') || species.id === 'sceptile');
-		case 'Vital Spirit':
-			// Magmar and Electabuzz want their contact status abilities in Doubles
-			return (species.nfe && isDoubles);
-		case 'Volt Absorb':
-			if (abilities.has('Iron Fist') && counter.ironFist >= 2) return true;
-			return (this.dex.getEffectiveness('Electric', species) < -1);
-		case 'Water Absorb':
-			return (['lanturn', 'politoed', 'quagsire'].includes(species.id) || moves.has('raindance'));
-		case 'Weak Armor':
-			return (moves.has('shellsmash') && species.id !== 'magcargo');
+			return !counter.get('Bug');
+		case 'Torrent':
+			return (!counter.get('Water') && !moves.has('flipturn'));
 		}
 
 		return false;
@@ -1150,7 +1053,7 @@ export class RandomTeams {
 	getAbility(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
@@ -1159,139 +1062,52 @@ export class RandomTeams {
 		teraType: string,
 		role: RandomTeamsTypes.Role,
 	): string {
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData.length <= 1) return abilityData[0].name;
+		if (abilities.length <= 1) return abilities[0];
 
 		// Hard-code abilities here
-		if (species.id === 'florges') return 'Flower Veil';
-		if (species.id === 'bombirdier' && !counter.get('Rock')) return 'Big Pecks';
-		if (species.id === 'scovillain') return 'Chlorophyll';
-		if (species.id === 'regirock' || (species.id === 'carbink' && moves.has('irondefense'))) return 'Clear Body';
-		if (species.id === 'empoleon') return 'Competitive';
-		if (species.id === 'swampert' && !counter.get('Water') && !moves.has('flipturn')) return 'Damp';
-		if (species.id === 'thundurus' && (role === 'Offensive Protect' || moves.has('terablast'))) return 'Defiant';
-		if (species.id === 'dodrio') return 'Early Bird';
-		if (species.id === 'chandelure') return 'Flash Fire';
-		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
-		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
-		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
-		if (species.id === 'jumpluff') return 'Infiltrator';
-		if (species.id === 'toucannon' && !counter.get('skilllink')) return 'Keen Eye';
-		if (species.id === 'reuniclus') return 'Magic Guard';
-		if (species.id === 'smeargle' && !counter.get('technician')) return 'Own Tempo';
-		if (species.id === 'zebstrika') return moves.has('thunderbolt') ? 'Lightning Rod' : 'Sap Sipper';
-		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
-		if (species.id === 'braviaryhisui') {
-			return (role === 'Setup Sweeper' || role === 'Doubles Wallbreaker') ? 'Sheer Force' : 'Tinted Lens';
-		}
-		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
-		if (species.id === 'charizard' && moves.has('sunnyday')) return 'Solar Power';
-		if (species.id === 'dipplin') return 'Sticky Hold';
-		if (species.id === 'breloom' || species.id === 'cinccino') return 'Technician';
-		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
+		if (species.id === 'drifblim') return moves.has('defog') ? 'Aftermath' : 'Unburden';
+		if (species.id === 'hitmonchan' && counter.get('ironfist')) return 'Iron Fist';
+		if ((species.id === 'thundurus' || species.id === 'tornadus') && !counter.get('Physical')) return 'Prankster';
+		if (species.id === 'swampert' && (counter.get('Water') || moves.has('flipturn'))) return 'Torrent';
+		if (species.id === 'toucannon' && counter.get('skilllink')) return 'Skill Link';
+		if (abilities.includes('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
+		if (abilities.includes('Strong Jaw') && counter.get('strongjaw')) return 'Strong Jaw';
 
-		// singles
-		if (!isDoubles) {
-			if (species.id === 'hypno') return 'Insomnia';
-			if (species.id === 'hitmontop') return (role === 'Bulky Setup') ? 'Technician' : 'Intimidate';
-			if (species.id === 'staraptor') return 'Reckless';
-			if (species.id === 'arcaninehisui') return 'Rock Head';
-			if (['raikou', 'suicune', 'vespiquen'].includes(species.id)) return 'Pressure';
-			if (species.id === 'enamorus' && moves.has('calmmind')) return 'Cute Charm';
-			if (species.id === 'klawf' && role === 'Setup Sweeper') return 'Anger Shell';
-			if (abilities.has('Cud Chew') && moves.has('substitute')) return 'Cud Chew';
-			if (abilities.has('Harvest') && (moves.has('protect') || moves.has('substitute'))) return 'Harvest';
-			if (abilities.has('Serene Grace') && moves.has('headbutt')) return 'Serene Grace';
-			if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';
-			if (abilities.has('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
-			if (abilities.has('Soundproof') && (moves.has('substitute') || counter.get('setup'))) return 'Soundproof';
+		// ffa abilities that differ from doubles
+		if (this.format.gameType === 'freeforall') {
+			if (species.id === 'bellossom') return 'Chlorophyll';
+			if (species.id === 'sinistcha') return 'Heatproof';
+			if (species.id === 'oranguru') return 'Inner Focus';
+			if (species.id === 'duraludon') return 'Light Metal';
+			if (species.id === 'clefairy') return 'Magic Guard';
+			if (species.id === 'blissey') return 'Natural Cure';
+			if (species.id === 'barraskewda') return 'Swift Swim';
+			if (abilities.includes('Pressure') && abilities.includes('Telepathy')) return 'Pressure';
 		}
 
-		// doubles, multi, and ffa
-		if (isDoubles) {
-			if (species.id === 'gumshoos' || species.id === 'porygonz') return 'Adaptability';
-			if (species.id === 'farigiraf') return 'Armor Tail';
-			if (['dragapult', 'tentacruel'].includes(species.id)) return 'Clear Body';
-			if (species.id === 'altaria') return 'Cloud Nine';
-			if (species.id === 'kilowattrel' || species.id === 'meowsticf') return 'Competitive';
-			if (species.id === 'kingambit') return 'Defiant';
-			if (species.id === 'armarouge' && !moves.has('meteorbeam')) return 'Flash Fire';
-			if (species.id === 'talonflame') return 'Gale Wings';
-			if (
-				['oinkologne', 'oinkolognef', 'snorlax', 'swalot'].includes(species.id) && role !== 'Doubles Wallbreaker'
-			) return 'Gluttony';
-			if (species.id === 'conkeldurr' && role === 'Doubles Wallbreaker') return 'Guts';
-			if (species.id !== 'arboliva' && abilities.has('Harvest')) return 'Harvest';
-			if (species.id === 'dragonite' || species.id === 'lucario') return 'Inner Focus';
-			if (species.id === 'primarina') return 'Liquid Voice';
-			if (species.id === 'kommoo') return 'Soundproof';
-			if (
-				(species.id === 'flapple' && role === 'Doubles Bulky Attacker') ||
-				(species.id === 'appletun' && this.randomChance(1, 2))
-			) return 'Ripen';
-			if (species.id === 'magnezone') return 'Sturdy';
-			if (species.id === 'clefable' && role === 'Doubles Support') return 'Unaware';
-			if (['drifblim', 'hitmonlee', 'sceptile'].includes(species.id) && !moves.has('shedtail')) return 'Unburden';
-			if (abilities.has('Intimidate')) return 'Intimidate';
-
-			// just doubles and multi
-			if (this.format.gameType !== 'freeforall') {
-				if (species.id === 'clefairy') return 'Friend Guard';
-				if (species.id === 'blissey') return 'Healer';
-				if (species.id === 'sinistcha') return 'Hospitality';
-				if (species.id === 'duraludon') return 'Stalwart';
-				if (species.id === 'barraskewda') return 'Propeller Tail';
-				if (species.id === 'oranguru' || abilities.has('Pressure') && abilities.has('Telepathy')) return 'Telepathy';
-
-				if (this.randomChance(1, 2) && species.id === 'mukalola') return 'Power of Alchemy';
-			}
-		}
-
-		let abilityAllowed: Ability[] = [];
+		const abilityAllowed: string[] = [];
 		// Obtain a list of abilities that are allowed (not culled)
-		for (const ability of abilityData) {
-			if (ability.rating >= 1 && !this.shouldCullAbility(
-				ability.name, types, moves, abilities, counter, teamDetails, species, isLead, isDoubles, teraType, role
+		for (const ability of abilities) {
+			if (!this.shouldCullAbility(
+				ability, types, moves, abilities, counter, teamDetails, species, isLead, isDoubles, teraType, role
 			)) {
 				abilityAllowed.push(ability);
 			}
 		}
 
-		// If all abilities are rejected, re-allow all abilities
+		// Pick a random allowed ability
+		if (abilityAllowed.length >= 1) return this.sample(abilityAllowed);
+
+		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
 		if (!abilityAllowed.length) {
-			for (const ability of abilityData) {
-				if (ability.rating > 0) abilityAllowed.push(ability);
-			}
-			if (!abilityAllowed.length) abilityAllowed = abilityData;
+			const weatherAbilities = abilities.filter(
+				a => ['Chlorophyll', 'Hydration', 'Sand Force', 'Sand Rush', 'Slush Rush', 'Solar Power', 'Swift Swim'].includes(a)
+			);
+			if (weatherAbilities.length) return this.sample(weatherAbilities);
 		}
 
-		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
-		// Sort abilities by rating with an element of randomness
-		// All three abilities can be chosen
-		if (abilityAllowed[2] && abilityAllowed[0].rating - 0.5 <= abilityAllowed[2].rating) {
-			if (abilityAllowed[1].rating <= abilityAllowed[2].rating) {
-				if (this.randomChance(1, 2)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
-			} else {
-				if (this.randomChance(1, 3)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
-			}
-			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-				if (this.randomChance(2, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			} else {
-				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			}
-		} else {
-			// Third ability cannot be chosen
-			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
-				if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			}
-		}
-
-		// After sorting, choose the first ability
-		return abilityAllowed[0].name;
+		// Pick a random ability
+		return this.sample(abilities);
 	}
 
 	getPriorityItem(
@@ -1613,17 +1429,18 @@ export class RandomTeams {
 	): RandomTeamsTypes.RandomSet {
 		const species = this.dex.species.get(s);
 		const forme = this.getForme(species);
-		const sets = (this as any)[`random${isDoubles ? 'Doubles' : ''}Sets`][species.id]["sets"];
-		const possibleSets = [];
+		const sets = this[`random${isDoubles ? 'Doubles' : ''}Sets`][species.id]["sets"];
+		const possibleSets: RandomTeamsTypes.RandomSetData[] = [];
 
 		const ruleTable = this.dex.formats.getRuleTable(this.format);
 
 		for (const set of sets) {
 			// Prevent Fast Bulky Setup on lead Paradox Pokemon, since it generates Booster Energy.
-			const abilities = new Set(Object.values(species.abilities));
-			if (isLead && (abilities.has('Protosynthesis') || abilities.has('Quark Drive')) && set.role === 'Fast Bulky Setup') {
-				continue;
-			}
+			const abilities = set.abilities!;
+			if (
+				isLead && (abilities.includes('Protosynthesis') || abilities.includes('Quark Drive')) &&
+				set.role === 'Fast Bulky Setup'
+			) continue;
 			// Prevent Tera Blast user if the team already has one, or if Terastallizion is prevented.
 			if ((teamDetails.teraBlast || ruleTable.has('terastalclause')) && set.role === 'Tera Blast user') {
 				continue;
@@ -1636,7 +1453,7 @@ export class RandomTeams {
 		for (const movename of set.movepool) {
 			movePool.push(this.dex.moves.get(movename).id);
 		}
-		const teraTypes = set.teraTypes;
+		const teraTypes = set.teraTypes!;
 		let teraType = this.sampleIfArray(teraTypes);
 
 		let ability = '';
@@ -1646,8 +1463,7 @@ export class RandomTeams {
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const types = species.types;
-		const abilities = new Set(Object.values(species.abilities));
-		if (species.unreleasedHidden) abilities.delete(species.abilities.H);
+		const abilities = set.abilities!;
 
 		// Get moves
 		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, isDoubles, movePool, teraType, role);

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -5,6 +5,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Brick Break", "Double-Edge", "Fake Out", "Fire Punch", "Gunk Shot", "Knock Off", "U-turn"],
+                "abilities": ["Pickup"],
                 "teraTypes": ["Dark", "Normal"]
             }
         ]
@@ -15,11 +16,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Pounce", "Recycle", "Sucker Punch", "Tera Blast"],
+                "abilities": ["Ripen"],
                 "teraTypes": ["Dragon", "Grass"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defense Curl", "Pounce", "Recycle", "Rollout"],
+                "abilities": ["Ripen"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -30,6 +33,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Crunch", "Flip Turn", "Psychic Fangs", "Waterfall"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -40,6 +44,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Claw", "Dragon Dance", "Iron Head", "Outrage", "Stomping Tantrum"],
+                "abilities": ["Mold Breaker"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -50,6 +55,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Aqua Jet", "Belly Drum", "Facade", "Substitute"],
+                "abilities": ["Huge Power"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -60,6 +66,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Claw", "Dragon Dance", "Fire Fang", "Iron Head", "Outrage"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -70,6 +77,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Stone Edge", "Waterfall"],
+                "abilities": ["Oblivious"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -80,11 +88,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Flip Turn", "Hydro Pump", "Ice Beam", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Aqua Jet", "Flip Turn", "Ice Beam", "Wave Crash"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -95,16 +105,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Poison Jab", "Power Whip", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Knock Off", "Power Whip", "Sleep Powder", "Sludge Bomb", "Strength Sap", "Sucker Punch"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Power Whip", "Sludge Bomb", "Sunny Day", "Weather Ball"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -115,6 +128,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Curse", "Icicle Spear", "Rapid Spin", "Recover", "Stone Edge"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -125,6 +139,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Body Slam", "Double-Edge", "Flame Charge", "Supercell Slam", "Thunder Wave", "Trailblaze", "Volt Switch"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Fire", "Grass", "Normal"]
             }
         ]
@@ -135,6 +150,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Rock Blast", "Spikes", "Stealth Rock", "Stone Edge", "Sucker Punch"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Dragon", "Fairy"]
             }
         ]
@@ -145,6 +161,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Dazzling Gleam", "Giga Drain", "Rapid Spin", "Synthesis", "Zen Headbutt"],
+                "abilities": ["Oblivious"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -155,6 +172,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Poltergeist", "Power Whip", "Rapid Spin", "Spikes", "Strength Sap"],
+                "abilities": ["Wind Rider"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
             }
         ]
@@ -165,11 +183,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Flash Cannon", "Hypnosis", "Psychic", "Stealth Rock"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Flash Cannon", "Psychic", "Shadow Ball"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Water"]
             }
         ]
@@ -180,11 +200,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Crunch", "Flip Turn", "Ice Spinner", "Wave Crash"],
+                "abilities": ["Swift Swim", "Water Veil"],
                 "teraTypes": ["Ice", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Crunch", "Ice Spinner", "Wave Crash"],
+                "abilities": ["Swift Swim", "Water Veil"],
                 "teraTypes": ["Ice", "Water"]
             }
         ]
@@ -195,11 +217,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Giga Drain", "Knock Off", "Power Whip", "Sleep Powder", "Sludge Bomb", "Synthesis"],
+                "abilities": ["Chlorophyll", "Overgrow"],
                 "teraTypes": ["Dark", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Power Whip", "Sludge Bomb", "Sunny Day", "Weather Ball"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -210,11 +234,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Drain Punch", "Giga Drain", "Leaf Storm", "Poison Jab", "Spikes", "Sucker Punch", "Toxic Spikes"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bullet Seed", "Drain Punch", "Sucker Punch", "Swords Dance", "Thunder Punch"],
+                "abilities": ["Water Absorb"],
                 "teraTypes": ["Dark", "Electric", "Fighting", "Grass"]
             }
         ]
@@ -225,11 +251,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bullet Seed", "Crunch", "Leaf Storm", "Stomping Tantrum"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Dark", "Ground"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Giga Drain", "Leaf Storm", "Stomping Tantrum", "Super Fang", "Thief"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Poison", "Water"]
             }
         ]
@@ -240,11 +268,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Knock Off", "Liquidation", "Play Rough", "Yawn"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Belly Drum", "Earthquake", "Ice Shard", "Icicle Spear"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Ice"]
             }
         ]
@@ -255,6 +285,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Clear Smog", "Flame Charge", "Lava Plume", "Will-O-Wisp"],
+                "abilities": ["Flame Body", "Flash Fire"],
                 "teraTypes": ["Dragon", "Fire"]
             }
         ]
@@ -265,6 +296,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Brick Break", "Dragon Dance", "Flare Blitz", "Outrage", "Thunder Punch"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Dragon", "Electric", "Fighting"]
             }
         ]
@@ -275,6 +307,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Drain Punch", "Rock Slide", "Spikes", "Synthesis", "Wood Hammer"],
+                "abilities": ["Bulletproof"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -285,6 +318,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Crunch", "Ice Fang", "Liquidation", "Shell Smash"],
+                "abilities": ["Strong Jaw"],
                 "teraTypes": ["Dark", "Ice", "Steel"]
             }
         ]
@@ -295,6 +329,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Bullet Seed", "Double-Edge", "Swords Dance", "Synthesis"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Grass", "Normal", "Steel"]
             }
         ]
@@ -305,16 +340,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Flare Blitz", "Knock Off", "Slack Off"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Dark", "Dragon"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Flare Blitz", "Gunk Shot", "Knock Off", "Swords Dance", "Thunder Punch", "U-turn"],
+                "abilities": ["Blaze", "Iron Fist"],
                 "teraTypes": ["Dark", "Electric", "Fire", "Poison"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Flamethrower", "Knock Off", "Slack Off", "Stealth Rock", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Dragon", "Fairy"]
             }
         ]
@@ -325,11 +363,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Discharge", "Ice Beam", "Scald", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Discharge", "Flip Turn", "Scald", "Volt Switch"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -340,11 +380,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Knock Off", "Psychic", "Recover", "Thunder Wave"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic", "Recover"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -355,11 +397,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Flip Turn", "Ice Beam", "Water Pulse"],
+                "abilities": ["Mega Launcher"],
                 "teraTypes": ["Dark", "Dragon", "Fighting", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Flip Turn", "Ice Beam", "Water Pulse"],
+                "abilities": ["Mega Launcher"],
                 "teraTypes": ["Dark", "Dragon", "Fighting", "Water"]
             }
         ]
@@ -370,11 +414,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Fire Blast", "Psyshock"],
+                "abilities": ["Magic Guard"],
                 "teraTypes": ["Fire"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Alluring Voice", "Draining Kiss", "Encore", "Protect", "Thunder Wave", "Wish"],
+                "abilities": ["Magic Guard"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -385,6 +431,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aqua Jet", "Crabhammer", "Dragon Dance", "Knock Off"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -395,6 +442,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Dazzling Gleam", "Encore", "Giga Drain", "Stun Spore", "Taunt"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -405,6 +453,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Earthquake", "Gunk Shot", "Ice Punch", "Knock Off", "Thunder Punch"],
+                "abilities": ["Iron Fist"],
                 "teraTypes": ["Dark", "Ground", "Poison"]
             }
         ]
@@ -415,11 +464,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Fire Punch", "Head Smash", "Rock Slide", "Zen Headbutt"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Psychic", "Rock"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Fire Punch", "Rock Slide", "Swords Dance", "Zen Headbutt"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Ground", "Rock"]
             }
         ]
@@ -430,6 +481,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Earthquake", "Gunk Shot", "Knock Off", "Sucker Punch"],
+                "abilities": ["Dry Skin"],
                 "teraTypes": ["Dark", "Fighting", "Ground"]
             }
         ]
@@ -440,6 +492,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Blizzard", "Liquidation", "Play Rough", "Snowscape", "Surf"],
+                "abilities": ["Slush Rush"],
                 "teraTypes": ["Ice", "Water"]
             }
         ]
@@ -450,6 +503,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Iron Head", "Play Rough", "Rock Slide", "Stealth Rock", "Superpower"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -460,11 +514,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Bug Buzz", "Moonblast", "Sticky Web", "Stun Spore", "U-turn"],
+                "abilities": ["Shield Dust"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Bug Buzz", "Moonblast", "Quiver Dance", "Tera Blast"],
+                "abilities": ["Shield Dust"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -475,6 +531,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Eruption", "Extrasensory", "Fire Blast", "Play Rough"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -485,6 +542,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Bullet Seed", "Headbutt", "Synthesis", "Thunder Wave"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -495,6 +553,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Crunch", "Outrage", "Roar", "Thunder Wave", "Work Up"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -505,6 +564,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Ice Beam", "Leech Life", "Liquidation", "Sticky Web", "Surf"],
+                "abilities": ["Water Bubble"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -515,11 +575,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance", "Throat Chop"],
+                "abilities": ["Arena Trap"],
                 "teraTypes": ["Fairy", "Ground", "Rock"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Earthquake", "Stone Edge", "Tera Blast", "Throat Chop"],
+                "abilities": ["Arena Trap"],
                 "teraTypes": ["Fairy", "Grass"]
             }
         ]
@@ -530,6 +592,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Iron Head", "Stealth Rock", "Stone Edge", "Swords Dance"],
+                "abilities": ["Sand Force", "Tangling Hair"],
                 "teraTypes": ["Ground", "Rock", "Steel"]
             }
         ]
@@ -540,6 +603,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Body Slam", "Brave Bird", "Double-Edge", "Knock Off", "Swords Dance"],
+                "abilities": ["Early Bird"],
                 "teraTypes": ["Dark", "Flying", "Normal"]
             }
         ]
@@ -550,6 +614,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dragon Dance", "Extreme Speed", "Iron Head", "Outrage", "Rest"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -560,11 +625,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Defog", "Knock Off", "Pain Split", "Shadow Ball", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Aftermath"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Acrobatics", "Defog", "Knock Off", "Pain Split", "Shadow Ball", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Fairy", "Flying"]
             }
         ]
@@ -575,6 +642,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Poison Jab", "Rapid Spin", "Rock Slide", "Swords Dance"],
+                "abilities": ["Mold Breaker", "Sand Rush"],
                 "teraTypes": ["Ground", "Poison", "Rock"]
             }
         ]
@@ -585,11 +653,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Drain Punch", "Encore", "Knock Off", "Psychic", "Thunder Wave"],
+                "abilities": ["Inner Focus", "Insomnia"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Encore", "Knock Off", "Psychic", "Thunder Wave"],
+                "abilities": ["Inner Focus", "Insomnia"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -600,6 +670,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Aqua Jet", "Brave Bird", "Defog", "Roost", "Surf"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -610,16 +681,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Coil", "Earthquake", "Roost"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Ground", "Poison"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
+                "abilities": ["Serene Grace"],
                 "teraTypes": ["Ghost", "Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Hyper Voice", "Roost", "Shadow Ball"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Fairy", "Ghost"]
             }
         ]
@@ -630,16 +704,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Draco Meteor", "Dragon Pulse", "Flash Cannon", "Iron Defense"],
+                "abilities": ["Light Metal"],
                 "teraTypes": ["Fairy", "Fighting"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Body Press", "Draco Meteor", "Flash Cannon", "Thunderbolt"],
+                "abilities": ["Light Metal"],
                 "teraTypes": ["Dragon", "Electric", "Fighting", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Draco Meteor", "Dragon Pulse", "Flash Cannon", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Light Metal"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -650,6 +727,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
             }
         ]
@@ -660,11 +738,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Double-Edge", "Protect", "Shadow Ball", "Wish"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Protect", "Tera Blast", "Wish"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -675,11 +755,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Glare", "Gunk Shot", "Knock Off", "Toxic Spikes"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Coil", "Earthquake", "Gunk Shot", "Trailblaze"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Grass", "Ground"]
             }
         ]
@@ -690,6 +772,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Cross Chop", "Ice Punch", "Knock Off", "Psychic", "Supercell Slam", "Taunt", "Volt Switch"],
+                "abilities": ["Static", "Vital Spirit"],
                 "teraTypes": ["Dark", "Electric", "Fighting", "Ice"]
             }
         ]
@@ -700,11 +783,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Nasty Plot", "Psychic", "Thunderbolt"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Dark", "Electric", "Psychic"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Dark Pulse", "Nasty Plot", "Psychic", "Thunder Wave", "Thunderbolt", "Trick"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Dark", "Electric", "Psychic"]
             }
         ]
@@ -715,6 +800,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Moonlight", "Psychic", "Sleep Powder", "Stun Spore"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -725,6 +811,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Double-Edge", "Haze", "Hypnosis", "Ice Beam", "Waterfall"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Ice", "Normal"]
             }
         ]
@@ -735,6 +822,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Encore", "Flamethrower", "Psychic", "Will-O-Wisp"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Dragon", "Fairy"]
             }
         ]
@@ -745,6 +833,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Play Rough", "Protect", "Stomping Tantrum", "Wish"],
+                "abilities": ["Own Tempo"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -755,6 +844,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Agility", "Boomburst", "Encore", "Ice Beam", "Surf"],
+                "abilities": ["Water Veil"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -765,6 +855,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Alluring Voice", "Ice Beam", "Surf", "Thief", "U-turn"],
+                "abilities": ["Storm Drain", "Swift Swim"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -775,11 +866,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Moonblast", "Psychic", "Synthesis"],
+                "abilities": ["Flower Veil"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Moonblast", "Synthesis", "Tera Blast"],
+                "abilities": ["Flower Veil"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -790,11 +883,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Acrobatics", "Flare Blitz", "Swords Dance", "Tera Blast"],
+                "abilities": ["Gale Wings"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Defog", "Double-Edge", "Heat Wave", "Roost", "Taunt", "U-turn"],
+                "abilities": ["Gale Wings"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -805,11 +900,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Protect", "Stored Power", "Substitute"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Protect", "Stored Power", "Substitute", "Tera Blast"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -820,6 +917,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Defog", "Leaf Storm", "Superpower", "Synthesis"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -830,11 +928,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Clear Smog", "Foul Play", "Giga Drain", "Leaf Storm", "Sludge Bomb", "Spore", "Stun Spore"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Sludge Bomb", "Spore", "Synthesis"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -845,6 +945,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Crunch", "Icicle Spear", "Outrage", "Swords Dance"],
+                "abilities": ["Thermal Exchange"],
                 "teraTypes": ["Dragon", "Fairy", "Ice"]
             }
         ]
@@ -855,6 +956,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Ice Beam", "Spikes", "Surf", "Toxic Spikes", "U-turn"],
+                "abilities": ["Protean"],
                 "teraTypes": ["Ice", "Water"]
             }
         ]
@@ -865,6 +967,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Flamethrower", "Roar", "Slack Off", "Stomping Tantrum", "Will-O-Wisp"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Dragon", "Fairy"]
             }
         ]
@@ -875,11 +978,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dazzling Gleam", "Nasty Plot", "Shadow Ball", "Sludge Bomb", "Trick"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fairy", "Ghost", "Poison"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Nasty Plot", "Shadow Ball", "Sludge Bomb", "Thunderbolt", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Ghost", "Poison"]
             }
         ]
@@ -890,6 +995,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Explosion", "Rock Blast", "Rock Polish", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -900,6 +1006,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Double-Edge", "Earthquake", "Explosion", "Rock Blast", "Rock Polish", "Stealth Rock", "Stone Edge", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Galvanize"],
                 "teraTypes": ["Grass", "Ground"]
             }
         ]
@@ -910,11 +1017,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Iron Head", "Scale Shot", "Swords Dance"],
+                "abilities": ["Rough Skin"],
                 "teraTypes": ["Dragon", "Ground", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Claw", "Earthquake", "Iron Head", "Outrage", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Rough Skin"],
                 "teraTypes": ["Dragon", "Ground", "Steel"]
             }
         ]
@@ -925,11 +1034,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Nasty Plot", "Power Gem", "Shadow Ball", "Substitute"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Nasty Plot", "Power Gem", "Shadow Ball", "Substitute", "Tera Blast"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -940,11 +1051,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Nasty Plot", "Power Gem", "Shadow Ball", "Substitute"],
+                "abilities": ["Run Away"],
                 "teraTypes": ["Fairy", "Ghost"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Nasty Plot", "Shadow Ball", "Substitute", "Tera Blast"],
+                "abilities": ["Run Away"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -955,11 +1068,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dazzling Gleam", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Fairy", "Ghost"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Hyper Voice", "Nasty Plot", "Psychic", "Psyshock", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -970,11 +1085,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dual Wingbeat", "Earthquake", "Knock Off", "Swords Dance"],
+                "abilities": ["Immunity"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Earthquake", "Knock Off", "Spikes", "Stealth Rock", "Toxic Spikes", "U-turn"],
+                "abilities": ["Immunity"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -985,6 +1102,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Dazzling Gleam", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock"],
+                "abilities": ["Toxic Debris"],
                 "teraTypes": ["Ghost", "Grass"]
             }
         ]
@@ -995,6 +1113,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dynamic Punch", "Earthquake", "Poltergeist", "Rock Tomb", "Stealth Rock"],
+                "abilities": ["No Guard"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1005,6 +1124,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dragon Pulse", "Rest", "Sleep Talk", "Sludge Bomb", "Thunderbolt"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Poison", "Water"]
             }
         ]
@@ -1015,6 +1135,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dark Pulse", "Nasty Plot", "Psychic", "Thunderbolt", "Trick"],
+                "abilities": ["Shadow Tag"],
                 "teraTypes": ["Dark", "Electric", "Fairy"]
             }
         ]
@@ -1025,6 +1146,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Pain Split", "Play Rough", "Poltergeist", "Roar", "Shadow Sneak", "Yawn"],
+                "abilities": ["Fluffy"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -1035,6 +1157,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Drain Punch", "Gunk Shot", "Poison Jab", "Shadow Sneak"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1045,6 +1168,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Drain Punch", "Gunk Shot", "Knock Off", "Poison Jab"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark", "Fighting"]
             }
         ]
@@ -1055,6 +1179,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Drain Punch", "Grassy Glide", "Knock Off", "Swords Dance", "U-turn", "Wood Hammer"],
+                "abilities": ["Grassy Surge"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -1065,6 +1190,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Flare Blitz", "Morning Sun", "Roar", "Wild Charge", "Will-O-Wisp"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dragon", "Fairy", "Fighting"]
             }
         ]
@@ -1075,11 +1201,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Flare Blitz", "Head Smash", "Morning Sun", "Stealth Rock", "Wild Charge", "Will-O-Wisp"],
+                "abilities": ["Rock Head"],
                 "teraTypes": ["Dragon", "Fairy"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Flare Blitz", "Head Smash", "Wild Charge"],
+                "abilities": ["Rock Head"],
                 "teraTypes": ["Fighting", "Fire", "Rock"]
             }
         ]
@@ -1090,6 +1218,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Lunge", "Sticky Web", "Thunder Wave", "Volt Switch", "Wild Charge"],
+                "abilities": ["Swarm"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -1100,11 +1229,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Fire Punch", "Giga Drain", "Pain Split", "Sludge Bomb", "Thunder Wave", "Toxic Spikes"],
+                "abilities": ["Sticky Hold"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bullet Seed", "Fire Punch", "Gunk Shot", "Swords Dance"],
+                "abilities": ["Sticky Hold"],
                 "teraTypes": ["Fire", "Grass", "Poison"]
             }
         ]
@@ -1115,11 +1246,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hyper Voice", "Rest", "Shadow Ball", "Thunder Wave"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Heal Bell", "Hyper Voice", "Rest", "Thunder Wave"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1130,11 +1263,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draining Kiss", "Mystical Fire", "Nuzzle", "Psychic"],
+                "abilities": ["Magic Bounce"],
                 "teraTypes": ["Electric", "Fairy"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic"],
+                "abilities": ["Magic Bounce"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1145,11 +1280,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind", "Yawn"],
+                "abilities": ["Sand Stream"],
                 "teraTypes": ["Dragon", "Rock", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Earthquake", "Slack Off", "Stone Edge"],
+                "abilities": ["Sand Stream"],
                 "teraTypes": ["Dragon", "Rock", "Steel"]
             }
         ]
@@ -1160,6 +1297,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Defog", "Hurricane", "Hyper Voice", "Nasty Plot", "Roost"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1170,6 +1308,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Acrobatics", "Encore", "Sleep Powder", "Strength Sap", "Stun Spore", "U-turn"],
+                "abilities": ["Chlorophyll", "Infiltrator"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1179,7 +1318,14 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Dragon Pulse", "Flip Turn", "Ice Beam", "Rain Dance", "Surf"],
+                "movepool": ["Dragon Pulse", "Flip Turn", "Ice Beam", "Surf"],
+                "abilities": ["Sniper", "Swift Swim"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Pulse", "Ice Beam", "Rain Dance", "Surf"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1190,6 +1336,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Flamethrower", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Dark", "Fire", "Poison"]
             }
         ]
@@ -1200,11 +1347,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Alluring Voice", "Encore", "Flamethrower", "Protect", "Thunder Wave", "Wish"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Draining Kiss", "Protect", "Wish"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -1215,16 +1364,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Burning Jealousy", "Dark Pulse", "Draining Kiss", "Nasty Plot", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Dark", "Fairy", "Fire"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Dazzling Gleam", "Light Screen", "Parting Shot", "Reflect", "Taunt", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Dark Pulse", "Dazzling Gleam", "Parting Shot", "Sucker Punch", "Taunt", "Thunder Wave"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -1235,11 +1387,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hypnosis", "Knock Off", "Psycho Cut", "Rest", "Sleep Talk", "Superpower"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Knock Off", "Psycho Cut", "Superpower", "Trick", "Trick Room"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -1250,6 +1404,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Outrage"],
+                "abilities": ["Bulletproof"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -1260,6 +1415,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Giga Drain", "Leech Life", "Thunder", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -1270,6 +1426,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flamethrower", "Pain Split", "Sludge Bomb", "Toxic Spikes", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1280,11 +1437,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Ice Punch", "Iron Head", "Swords Dance"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Fighting", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Ice Punch", "Iron Head", "Swords Dance", "U-turn"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -1295,6 +1454,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flare Blitz", "Leech Life", "Morning Sun", "U-turn", "Wild Charge", "Will-O-Wisp"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1305,6 +1465,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Facade", "Rock Blast", "Stone Edge"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -1315,11 +1476,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Bulldoze", "Curse", "Play Rough"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Ground"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Bullet Seed", "Double-Edge", "Play Rough", "Thief", "Yawn"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Grass"]
             }
         ]
@@ -1330,11 +1493,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Flamethrower", "Hyper Voice", "Will-O-Wisp", "Work Up"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Fire", "Normal"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Flamethrower", "Hyper Voice", "Solar Beam", "Sunny Day"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Fire", "Grass", "Normal"]
             }
         ]
@@ -1345,11 +1510,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Flare Blitz", "Leech Life", "Trailblaze"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Bug", "Dragon", "Fire"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Leech Life", "Overheat", "Parting Shot", "Will-O-Wisp"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dragon", "Fairy"]
             }
         ]
@@ -1360,11 +1527,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Energy Ball", "Flamethrower", "Pain Split", "Shadow Ball", "Will-O-Wisp"],
+                "abilities": ["Flame Body", "Flash Fire"],
                 "teraTypes": ["Fairy", "Ghost", "Grass"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flamethrower", "Hex", "Pain Split", "Will-O-Wisp"],
+                "abilities": ["Flame Body", "Flash Fire"],
                 "teraTypes": ["Fairy", "Grass"]
             }
         ]
@@ -1375,11 +1544,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Ice Beam", "Surf", "Synthesis"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Giga Drain", "Ice Beam", "Rain Dance", "Surf"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -1390,16 +1561,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Belly Drum", "Cross Chop", "Mach Punch", "Temper Flare", "Thunder Punch"],
+                "abilities": ["Flame Body", "Vital Spirit"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Cross Chop", "Fire Blast", "Flare Blitz", "Thunder Punch", "Will-O-Wisp"],
+                "abilities": ["Flame Body", "Vital Spirit"],
                 "teraTypes": ["Electric", "Fire", "Grass"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Cross Chop", "Flare Blitz", "Overheat", "Thunder Punch"],
+                "abilities": ["Flame Body", "Vital Spirit"],
                 "teraTypes": ["Electric", "Fighting", "Fire"]
             }
         ]
@@ -1410,6 +1584,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flash Cannon", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Analytic", "Magnet Pull"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -1420,6 +1595,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Bullet Punch", "Drain Punch", "Earthquake", "Heavy Slam", "Knock Off", "Stone Edge"],
+                "abilities": ["Guts", "Thick Fat"],
                 "teraTypes": ["Dark", "Ground", "Steel"]
             }
         ]
@@ -1430,16 +1606,19 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Stone Edge", "Throat Chop", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fighting", "Ground", "Poison", "Rock"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Earthquake", "Stone Edge", "Throat Chop"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Fighting", "Ground", "Rock"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Gunk Shot", "Stone Edge", "Throat Chop", "U-turn"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fighting", "Ground", "Poison", "Rock"]
             }
         ]
@@ -1450,6 +1629,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Gunk Shot", "Liquidation", "Poison Jab", "Recover", "Toxic Spikes"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fairy", "Flying", "Grass", "Steel"]
             }
         ]
@@ -1460,11 +1640,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Static"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Agility", "Dazzling Gleam", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Static"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -1475,6 +1657,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Crunch", "Hone Claws", "Play Rough", "Trailblaze"],
+                "abilities": ["Stakeout"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -1485,11 +1668,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Trailblaze", "Zen Headbutt"],
+                "abilities": ["Pure Power"],
                 "teraTypes": ["Fighting", "Psychic", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Ice Punch", "Poison Jab", "Zen Headbutt"],
+                "abilities": ["Pure Power"],
                 "teraTypes": ["Fighting", "Poison", "Psychic"]
             }
         ]
@@ -1500,6 +1685,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Double-Edge", "Fake Out", "Knock Off", "Play Rough", "Thunder Wave", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -1510,11 +1696,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Gunk Shot", "Knock Off", "Parting Shot", "Play Rough", "Thunder Wave"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Fairy", "Poison"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Hypnosis", "Nasty Plot", "Power Gem", "Thunderbolt"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Dark", "Electric"]
             }
         ]
@@ -1525,11 +1713,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Iron Head", "Knock Off", "Swords Dance", "Trailblaze"],
+                "abilities": ["Tough Claws"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Iron Head", "Knock Off", "Play Rough", "Stealth Rock", "U-turn"],
+                "abilities": ["Tough Claws"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -1540,16 +1730,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Fake Out", "High Jump Kick", "Knock Off", "U-turn"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance", "U-turn"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -1560,6 +1753,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Acid Armor", "Draining Kiss", "Recover", "Stored Power"],
+                "abilities": ["Aroma Veil"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1570,6 +1764,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bullet Seed", "Knock Off", "Tail Slap", "Tidy Up", "Triple Axel"],
+                "abilities": ["Skill Link"],
                 "teraTypes": ["Grass", "Ice", "Normal"]
             }
         ]
@@ -1580,11 +1775,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Shadow Ball", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Nasty Plot", "Shadow Ball", "Thunderbolt", "Trick", "Will-O-Wisp"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Ghost"]
             }
         ]
@@ -1595,6 +1792,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Earthquake", "Heavy Slam", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Fighting", "Ground", "Steel"]
             }
         ]
@@ -1605,6 +1803,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Ice Beam", "Liquidation", "Rest", "Roar", "Sleep Talk", "Sludge Wave", "Yawn"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -1615,6 +1814,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Crunch", "Curse", "Earthquake", "Rest", "Sleep Talk"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Ground"]
             }
         ]
@@ -1625,11 +1825,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dark Pulse", "Heat Wave", "Hurricane", "Nasty Plot", "Sucker Punch"],
+                "abilities": ["Super Luck"],
                 "teraTypes": ["Dark", "Fairy", "Flying", "Steel"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Brave Bird", "Sucker Punch", "Thunder Wave", "U-turn"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1640,6 +1842,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Curse", "Earthquake", "Recover", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Purifying Salt"],
                 "teraTypes": ["Dragon", "Fairy"]
             }
         ]
@@ -1650,6 +1853,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Defog", "Draco Meteor", "Heat Wave", "Hurricane", "Roost", "U-turn"],
+                "abilities": ["Infiltrator"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1660,6 +1864,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Pain Split", "Power Gem", "Thunder Wave"],
+                "abilities": ["Magnet Pull"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -1670,6 +1875,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Fire Blast", "Growth", "Trailblaze"],
+                "abilities": ["Simple"],
                 "teraTypes": ["Grass", "Ground"]
             }
         ]
@@ -1680,6 +1886,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["First Impression", "Leech Life", "Sucker Punch", "U-turn"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
             }
         ]
@@ -1690,6 +1897,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Sleep Powder", "Sludge Bomb", "Strength Sap", "Stun Spore"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1700,11 +1908,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Aqua Jet", "Encore", "Flip Turn", "Ice Beam", "Knock Off", "Sacred Sword", "Surf", "X-Scissor"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Dark", "Fighting", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aqua Jet", "Knock Off", "Liquidation", "Sacred Sword", "Swords Dance"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Dark", "Fighting", "Water"]
             }
         ]
@@ -1715,6 +1925,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Discharge", "Encore", "Nuzzle", "Play Rough", "Super Fang", "Volt Switch"],
+                "abilities": ["Natural Cure", "Static"],
                 "teraTypes": ["Electric", "Fairy", "Grass"]
             }
         ]
@@ -1725,6 +1936,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Iron Head", "Night Slash", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Defiant"],
                 "teraTypes": ["Dark", "Fairy", "Steel"]
             }
         ]
@@ -1735,11 +1947,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Giga Drain", "Leaf Storm", "Pollen Puff", "Sleep Powder", "Stun Spore", "Synthesis"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Poison", "Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Giga Drain", "Leaf Storm", "Stun Spore", "Synthesis", "Tera Blast"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire", "Rock"]
             }
         ]
@@ -1750,6 +1964,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Gunk Shot", "Ice Shard", "Knock Off", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Pickup"],
                 "teraTypes": ["Dark", "Ground", "Poison"]
             }
         ]
@@ -1760,11 +1975,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Horn Leech", "Poltergeist", "Rest", "Will-O-Wisp"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Horn Leech", "Poltergeist", "Protect", "Will-O-Wisp"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -1775,11 +1992,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Encore", "Nuzzle", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Encore", "Nasty Plot", "Surf", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -1790,11 +2009,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Acrobatics", "Bullet Seed", "Flame Charge", "Knock Off", "Swords Dance"],
+                "abilities": ["Pickup", "Skill Link"],
                 "teraTypes": ["Flying", "Grass", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Bullet Seed", "Knock Off", "Roost", "Swords Dance", "U-turn"],
+                "abilities": ["Pickup", "Skill Link"],
                 "teraTypes": ["Flying", "Grass", "Steel"]
             }
         ]
@@ -1805,6 +2026,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Lunge", "Rapid Spin", "Rock Blast", "Spikes", "Stealth Rock", "Toxic Spikes"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1815,6 +2037,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flip Turn", "Haze", "Ice Beam", "Roost", "Surf", "Yawn"],
+                "abilities": ["Competitive"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1825,11 +2048,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Belly Drum", "Body Slam", "Encore", "Hypnosis", "Waterfall"],
+                "abilities": ["Swift Swim", "Water Absorb"],
                 "teraTypes": ["Dragon", "Normal", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Belly Drum", "Body Slam", "Tera Blast", "Waterfall"],
+                "abilities": ["Swift Swim", "Water Absorb"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -1840,6 +2065,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Giga Drain", "Scald", "Shadow Ball", "Stun Spore"],
+                "abilities": ["Heatproof"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
             }
         ]
@@ -1850,6 +2076,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Crunch", "Play Rough", "Poison Fang", "Sucker Punch", "Super Fang", "Taunt", "Yawn"],
+                "abilities": ["Rattled"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -1860,6 +2087,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Encore", "Flip Turn", "Moonblast", "Surf", "Triple Axel"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Fairy", "Ice", "Steel", "Water"]
             }
         ]
@@ -1870,11 +2098,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Discharge", "Ice Beam", "Recover", "Tri Attack"],
+                "abilities": ["Download"],
                 "teraTypes": ["Electric", "Ghost", "Poison"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Agility", "Recover", "Shadow Ball", "Tera Blast"],
+                "abilities": ["Download"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
         ]
@@ -1885,11 +2115,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Encore", "Flip Turn", "Ice Beam", "Knock Off", "Surf", "Yawn"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "teraTypes": ["Dark", "Fairy", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Ice Beam", "Nasty Plot", "Surf", "Trailblaze"],
+                "abilities": ["Cloud Nine", "Swift Swim"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -1900,6 +2132,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Encore", "Liquidation", "Rapid Spin", "Roost"],
+                "abilities": ["Moxie"],
                 "teraTypes": ["Dragon", "Steel"]
             }
         ]
@@ -1910,11 +2143,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Crunch", "Gunk Shot", "Liquidation", "Swords Dance"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Poison", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Crunch", "Gunk Shot", "Spikes", "Taunt", "Toxic Spikes"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -1925,11 +2160,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Draining Kiss", "Knock Off", "Psychic", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Trace"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic"],
+                "abilities": ["Trace"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1940,6 +2177,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Cosmic Power", "Gunk Shot", "Leech Life", "Recover"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -1950,6 +2188,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Megahorn", "Rock Blast", "Rock Polish", "Stealth Rock", "Stone Edge", "Swords Dance"],
+                "abilities": ["Lightning Rod"],
                 "teraTypes": ["Dragon", "Fairy", "Flying", "Grass", "Water"]
             }
         ]
@@ -1960,6 +2199,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Crunch", "Earthquake", "Ice Punch", "Swords Dance"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Dark", "Fighting", "Ground"]
             }
         ]
@@ -1970,6 +2210,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Play Rough", "Stealth Rock", "Stomping Tantrum", "Stone Edge", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Vital Spirit"],
                 "teraTypes": ["Fairy", "Ground", "Rock"]
             }
         ]
@@ -1980,6 +2221,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Power Gem", "Rapid Spin", "Spikes", "Stealth Rock", "Temper Flare", "Will-O-Wisp"],
+                "abilities": ["Flash Fire"],
                 "teraTypes": ["Ghost", "Steel"]
             }
         ]
@@ -1990,6 +2232,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Defog", "Roost", "Taunt", "U-turn"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2000,11 +2243,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Brave Bird", "Leaf Blade", "Roost", "Swords Dance"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Defog", "Giga Drain", "Knock Off", "Roost"],
+                "abilities": ["Long Reach", "Overgrow"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -2015,6 +2260,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Brave Bird", "Close Combat", "Hone Claws", "Roost"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2025,11 +2271,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Pulse", "Flamethrower", "Nasty Plot", "Sludge Bomb"],
+                "abilities": ["Corrosion"],
                 "teraTypes": ["Dragon", "Fire", "Poison"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Flamethrower", "Knock Off", "Sludge Bomb", "Thunder Wave", "Toxic Spikes", "Will-O-Wisp"],
+                "abilities": ["Corrosion"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -2040,6 +2288,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Crunch", "Earthquake", "Fire Fang", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Ground"]
             }
         ]
@@ -2050,6 +2299,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Knock Off", "Rapid Spin", "Spikes", "Stone Edge", "Swords Dance"],
+                "abilities": ["Sand Rush"],
                 "teraTypes": ["Dragon", "Steel", "Water"]
             }
         ]
@@ -2060,11 +2310,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Ice Shard", "Rapid Spin", "Swords Dance", "Triple Axel"],
+                "abilities": ["Slush Rush"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Triple Axel"],
+                "abilities": ["Slush Rush"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -2075,6 +2327,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Giga Drain", "Shadow Ball", "Shore Up", "Sludge Bomb", "Stealth Rock"],
+                "abilities": ["Water Compaction"],
                 "teraTypes": ["Fairy", "Poison", "Water"]
             }
         ]
@@ -2085,11 +2338,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Flare Blitz", "Gunk Shot", "High Jump Kick", "Sucker Punch", "U-turn"],
+                "abilities": ["Libero"],
                 "teraTypes": ["Fighting", "Fire"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Flare Blitz", "Gunk Shot", "High Jump Kick", "U-turn"],
+                "abilities": ["Libero"],
                 "teraTypes": ["Fighting", "Fire", "Poison"]
             }
         ]
@@ -2100,11 +2355,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Knock Off", "Rest"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Poison"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Dragon Dance", "Knock Off", "Poison Jab"],
+                "abilities": ["Intimidate", "Moxie"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -2115,11 +2372,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bug Bite", "Close Combat", "Dual Wingbeat", "Swords Dance"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Close Combat", "Defog", "Dual Wingbeat", "U-turn"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2130,6 +2389,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Bullet Seed", "Defog", "Sucker Punch", "Synthesis"],
+                "abilities": ["Chlorophyll", "Pickpocket"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -2140,11 +2400,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Flip Turn", "Haze", "Icicle Spear", "Surf", "Thief"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Poison", "Steel", "Water"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Aqua Jet", "Fake Out", "Icicle Spear", "Surf"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Poison", "Steel", "Water"]
             }
         ]
@@ -2155,6 +2417,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Brick Break", "Double-Edge", "Knock Off", "Tidy Up"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -2165,6 +2428,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Electroweb", "Giga Drain", "Lunge", "Sticky Web", "Synthesis"],
+                "abilities": ["Chlorophyll", "Swarm"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2175,6 +2439,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Icicle Spear", "Liquidation", "Rock Blast", "Shell Smash"],
+                "abilities": ["Skill Link"],
                 "teraTypes": ["Ice", "Rock", "Steel", "Water"]
             }
         ]
@@ -2185,6 +2450,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Clear Smog", "Ice Beam", "Recover", "Stealth Rock", "Surf", "Yawn"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -2195,6 +2461,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Flash Cannon", "Ice Beam", "Rock Blast", "Stealth Rock"],
+                "abilities": ["Sturdy"],
                 "teraTypes": ["Fairy", "Flying", "Ground"]
             }
         ]
@@ -2205,11 +2472,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Crunch", "Ice Fang", "Play Rough", "Roar", "Thunder Wave", "Volt Switch", "Wild Charge"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Crunch", "Facade", "Play Rough", "Trailblaze", "Wild Charge"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2220,11 +2489,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Encore", "Gunk Shot", "Knock Off", "Parting Shot"],
+                "abilities": ["Prankster"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Double-Edge", "Gunk Shot", "Knock Off", "Swords Dance"],
+                "abilities": ["Pickpocket"],
                 "teraTypes": ["Dark", "Normal", "Poison"]
             }
         ]
@@ -2235,6 +2506,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Drain Punch", "Giga Drain", "Sludge Bomb", "Spore", "Stun Spore"],
+                "abilities": ["Effect Spore"],
                 "teraTypes": ["Poison", "Steel", "Water"]
             }
         ]
@@ -2245,11 +2517,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Dazzling Gleam", "Gunk Shot", "Pain Split", "Poltergeist", "Shadow Sneak", "Thunder Wave", "Trick", "Will-O-Wisp"],
+                "abilities": ["Cursed Body", "Insomnia"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dazzling Gleam", "Nasty Plot", "Shadow Ball", "Thunderbolt", "Will-O-Wisp"],
+                "abilities": ["Cursed Body", "Insomnia"],
                 "teraTypes": ["Electric", "Fairy"]
             }
         ]
@@ -2260,6 +2534,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Coil", "Earthquake", "Glare", "Rest", "Rock Blast", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Shed Skin"],
                 "teraTypes": ["Dragon", "Steel"]
             }
         ]
@@ -2270,11 +2545,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Giga Drain", "Shadow Ball", "Shell Smash", "Stored Power", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Fairy", "Psychic"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Giga Drain", "Shadow Ball", "Shell Smash", "Tera Blast", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2285,6 +2562,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Horn Leech", "Milk Drink", "Rock Slide", "Stomping Tantrum"],
+                "abilities": ["Sap Sipper"],
                 "teraTypes": ["Ground", "Water"]
             }
         ]
@@ -2295,6 +2573,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flip Turn", "Gunk Shot", "Hydro Pump", "Sludge Bomb", "Toxic Spikes"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Poison", "Water"]
             }
         ]
@@ -2305,6 +2584,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Belly Drum", "Body Slam", "Crunch", "Trailblaze"],
+                "abilities": ["Cheek Pouch"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2315,6 +2595,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Body Slam", "Gunk Shot", "Hammer Arm", "Ice Punch", "Play Rough", "Slack Off", "Throat Chop"],
+                "abilities": ["Truant"],
                 "teraTypes": ["Fairy", "Fighting", "Normal"]
             }
         ]
@@ -2325,6 +2606,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Curse", "Earthquake", "Fire Blast", "Liquidation", "Slack Off", "Thunder Wave", "Zen Headbutt"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -2335,6 +2617,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Curse", "Earthquake", "Slack Off", "Thunder Wave", "Zen Headbutt"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Fairy", "Ground"]
             }
         ]
@@ -2345,11 +2628,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Giga Drain", "Protect", "Strength Sap"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Earth Power", "Giga Drain", "Leaf Storm", "Strength Sap", "Tera Blast"],
+                "abilities": ["Harvest"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -2360,6 +2645,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Lava Plume", "Recover", "Stealth Rock", "Will-O-Wisp", "Yawn"],
+                "abilities": ["Flame Body"],
                 "teraTypes": ["Dragon", "Grass"]
             }
         ]
@@ -2370,6 +2656,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Brick Break", "Ice Shard", "Knock Off", "Swords Dance", "Triple Axel"],
+                "abilities": ["Inner Focus", "Pickpocket"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
         ]
@@ -2380,6 +2667,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Gunk Shot", "Swords Dance", "Throat Chop", "Toxic Spikes"],
+                "abilities": ["Inner Focus", "Pickpocket"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -2390,11 +2678,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Glare", "Knock Off", "Leaf Storm", "Substitute", "Synthesis"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Grass", "Poison", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Glare", "Knock Off", "Leaf Storm", "Substitute", "Synthesis", "Tera Blast"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fire", "Rock"]
             }
         ]
@@ -2405,6 +2695,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Bug Buzz", "Icy Wind", "Rest", "Sleep Talk"],
+                "abilities": ["Ice Scales"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -2415,6 +2706,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Crunch", "Ice Shard", "Icicle Spear", "Spikes"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -2425,11 +2717,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bullet Seed", "Ice Shard", "Icicle Spear", "Swords Dance"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Grass", "Ice", "Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Blizzard", "Bullet Seed", "Giga Drain", "Ice Shard", "Trailblaze"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Ice", "Water"]
             }
         ]
@@ -2440,11 +2734,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Encore", "Play Rough", "Thunder Wave"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Earthquake", "Play Rough", "Trailblaze"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2455,6 +2751,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Haze", "Hydro Pump", "Light Screen", "Reflect", "Surf", "U-turn"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2465,6 +2762,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Psychic", "Recover", "Shadow Ball", "Thunder Wave"],
+                "abilities": ["Magic Guard"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -2475,6 +2773,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Knock Off", "Megahorn", "Poison Jab", "Sticky Web", "Sucker Punch", "Toxic Spikes"],
+                "abilities": ["Insomnia", "Swarm"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -2485,6 +2784,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic", "Shadow Ball", "Thunder Wave", "Trick"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Ghost", "Psychic"]
             }
         ]
@@ -2495,6 +2795,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bullet Seed", "Play Rough", "Shadow Claw", "Sucker Punch", "U-turn"],
+                "abilities": ["Protean"],
                 "teraTypes": ["Fairy", "Grass"]
             }
         ]
@@ -2505,11 +2806,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Ice Beam", "Rapid Spin", "Surf", "Yawn"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Ice Beam", "Shell Smash", "Surf", "Tera Blast"],
+                "abilities": ["Torrent"],
                 "teraTypes": ["Electric", "Grass"]
             }
         ]
@@ -2520,11 +2823,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Earthquake", "Hypnosis", "Megahorn", "Shadow Ball", "Thunder Wave", "Trick"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Bug", "Ghost", "Ground"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Earth Power", "Shadow Ball", "Tera Blast", "Thunderbolt"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -2535,6 +2840,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Double-Edge", "Heat Wave", "U-turn"],
+                "abilities": ["Reckless"],
                 "teraTypes": ["Flying", "Normal"]
             }
         ]
@@ -2545,6 +2851,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Fire Blast", "Gunk Shot", "Knock Off", "Sucker Punch", "Taunt", "Toxic Spikes"],
+                "abilities": ["Aftermath"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -2555,6 +2862,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earth Power", "Solar Beam", "Sunny Day", "Weather Ball"],
+                "abilities": ["Chlorophyll"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -2565,6 +2873,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Bug Buzz", "Giga Drain", "Hydro Pump", "Ice Beam", "Sticky Web"],
+                "abilities": ["Swift Swim"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
@@ -2575,6 +2884,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Brave Bird", "Defog", "Haze", "Heat Wave", "Roost"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2585,11 +2895,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Freeze-Dry", "Ice Shard", "Icicle Spear", "Stealth Rock"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Freeze-Dry", "Ice Shard", "Icicle Spear", "Stealth Rock"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Ice"]
             }
         ]
@@ -2600,11 +2912,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Acid Spray", "Discharge", "Muddy Water", "Thunder Wave", "Volt Switch"],
+                "abilities": ["Static"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Rain Dance", "Thunder", "Volt Switch", "Weather Ball"],
+                "abilities": ["Static"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2615,6 +2929,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Crunch", "Double-Edge", "Encore", "Low Sweep", "Switcheroo", "Thunder Wave", "U-turn"],
+                "abilities": ["Own Tempo", "Pickup"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2625,6 +2940,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Circle Throw", "Knock Off", "Leech Life", "Spikes", "Sticky Web", "Toxic Spikes"],
+                "abilities": ["Stakeout"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2635,6 +2951,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Crunch", "Earthquake", "Facade", "Swords Dance"],
+                "abilities": ["Quick Feet"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2645,6 +2962,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Rapid Spin", "Sludge Bomb", "Surf", "Toxic Spikes"],
+                "abilities": ["Clear Body", "Liquid Ooze"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -2655,6 +2973,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Flare Blitz", "Head Smash", "Superpower", "Wild Charge"],
+                "abilities": ["Blaze"],
                 "teraTypes": ["Electric", "Fighting", "Fire", "Rock"]
             }
         ]
@@ -2665,11 +2984,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Bulk Up", "Defog", "Drain Punch", "Knock Off", "Stone Edge"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Bulk Up", "Defog", "Drain Punch", "Knock Off", "Mach Punch"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -2680,6 +3001,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Encore", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Mold Breaker", "Pickpocket"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -2690,6 +3012,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spikes", "Spore", "Toxic Spikes"],
+                "abilities": ["Mycelium Might"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2700,16 +3023,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Flare Blitz", "Protect", "Rock Slide", "Swords Dance"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Dragon", "Fire", "Rock"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Flare Blitz", "Overheat", "Protect", "Rock Slide"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Dragon", "Fire", "Rock"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Flare Blitz", "Protect", "Swords Dance", "Tera Blast"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Fighting", "Grass", "Ground"]
             }
         ]
@@ -2720,6 +3046,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Ice Punch", "Liquidation", "Trailblaze"],
+                "abilities": ["Sheer Force"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -2730,6 +3057,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "First Impression", "Stone Edge", "Superpower"],
+                "abilities": ["Arena Trap"],
                 "teraTypes": ["Bug", "Fighting"]
             }
         ]
@@ -2740,11 +3068,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Drain Punch", "Giga Drain", "Leaf Storm", "Rock Slide", "Synthesis", "Thunder Punch"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Electric", "Fighting", "Grass", "Rock"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Acrobatics", "Bullet Seed", "Drain Punch", "Swords Dance"],
+                "abilities": ["Unburden"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -2755,6 +3085,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Bullet Seed", "Crunch", "Earth Power", "Shell Smash"],
+                "abilities": ["Overgrow"],
                 "teraTypes": ["Grass", "Ground"]
             }
         ]
@@ -2765,11 +3096,13 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Knock Off", "Spark", "Tera Blast", "Thunder Wave"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Ground", "Ice"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Charge Beam", "Knock Off", "Spark", "Thunder Wave"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -2780,6 +3113,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "High Jump Kick", "Rapid Spin", "Rock Slide"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Fighting", "Rock"]
             }
         ]
@@ -2790,6 +3124,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Gunk Shot", "Iron Head", "Parting Shot", "Taunt", "Toxic Spikes"],
+                "abilities": ["Overcoat"],
                 "teraTypes": ["Poison", "Steel", "Water"]
             }
         ]
@@ -2800,6 +3135,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Leech Life", "Morning Sun", "Sleep Powder", "Stun Spore", "Toxic Spikes"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -2810,11 +3146,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Explosion", "Foul Play", "Thief", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Static"],
                 "teraTypes": ["Dark", "Electric"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Tera Blast", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Static"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -2825,6 +3163,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Giga Drain", "Leaf Storm", "Taunt", "Thief", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Aftermath", "Static"],
                 "teraTypes": ["Electric", "Grass"]
             }
         ]
@@ -2835,6 +3174,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Defog", "Knock Off", "Roost", "U-turn"],
+                "abilities": ["Overcoat"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2845,11 +3185,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Encore", "Energy Ball", "Extrasensory", "Fire Blast", "Healing Wish", "Hypnosis", "Nasty Plot", "Will-O-Wisp"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Grass"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Energy Ball", "Fire Blast", "Nasty Plot", "Tera Blast"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -2860,16 +3202,19 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Moonblast"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Aurora Veil", "Blizzard", "Moonblast", "Nasty Plot"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Blizzard", "Moonblast", "Nasty Plot", "Tera Blast"],
+                "abilities": ["Snow Warning"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2880,6 +3225,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hurricane", "Roost", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -2890,6 +3236,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Aqua Jet", "Ice Beam", "Liquidation", "Stomping Tantrum", "Throat Chop"],
+                "abilities": ["Gooey"],
                 "teraTypes": ["Dark", "Ground", "Water"]
             }
         ]
@@ -2900,6 +3247,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Hurricane", "Knock Off", "Roost", "Surf"],
+                "abilities": ["Hydration"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2909,7 +3257,14 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Curse", "Earthquake", "Liquidation", "Recover", "Spikes", "Stealth Rock"],
+                "movepool": ["Earthquake", "Liquidation", "Recover", "Spikes", "Stealth Rock"],
+                "abilities": ["Unaware", "Water Absorb"],
+                "teraTypes": ["Poison", "Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Curse", "Earthquake", "Liquidation", "Recover"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -2920,11 +3275,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover"],
+                "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Flying", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Spikes", "Stealth Rock", "Toxic Spikes"],
+                "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -2935,11 +3292,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Air Slash", "Bug Buzz", "Giga Drain", "Hypnosis", "Protect", "U-turn"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Bug", "Flying", "Grass"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Double-Edge", "Leech Life", "Protect", "Swords Dance", "Tera Blast"],
+                "abilities": ["Speed Boost"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2950,6 +3309,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Crunch", "Double-Edge", "Stomping Tantrum", "U-turn", "Yawn"],
+                "abilities": ["Adaptability", "Stakeout"],
                 "teraTypes": ["Ground", "Normal"]
             }
         ]
@@ -2960,11 +3320,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Burning Jealousy", "Knock Off", "Sludge Bomb", "Trick", "U-turn"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Dark", "Poison"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Burning Jealousy", "Dark Pulse", "Nasty Plot", "Sludge Bomb"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -2975,11 +3337,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Bitter Malice", "Burning Jealousy", "Knock Off", "Trick", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Fairy", "Ghost"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Bitter Malice", "Burning Jealousy", "Nasty Plot", "Tera Blast", "Will-O-Wisp"],
+                "abilities": ["Illusion"],
                 "teraTypes": ["Fairy"]
             }
         ]

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -63,7 +63,7 @@ export class RandomBabyTeams extends RandomTeams {
 	cullMovePool(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
@@ -143,8 +143,8 @@ export class RandomBabyTeams extends RandomTeams {
 
 			// These moves are redundant with each other
 			[
-				['alluringvoice', 'dazlinggleam', 'drainingkiss', 'moonblast'],
-			    ['alluringvoice', 'dazlinggleam', 'drainingkiss', 'moonblast'],
+				['alluringvoice', 'dazzlinggleam', 'drainingkiss', 'moonblast'],
+			    ['alluringvoice', 'dazzlinggleam', 'drainingkiss', 'moonblast'],
 			],
 			[['bulletseed', 'gigadrain', 'leafstorm', 'seedbomb'], ['bulletseed', 'gigadrain', 'leafstorm', 'seedbomb']],
 			[['hypnosis', 'thunderwave', 'toxic', 'willowisp', 'yawn'], ['hypnosis', 'thunderwave', 'toxic', 'willowisp', 'yawn']],
@@ -164,7 +164,7 @@ export class RandomBabyTeams extends RandomTeams {
 	// Generate random moveset for a given species, role, tera type.
 	randomMoveset(
 		types: string[],
-		abilities: Set<string>,
+		abilities: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
 		isLead: boolean,
@@ -208,7 +208,7 @@ export class RandomBabyTeams extends RandomTeams {
 		// Add other moves you really want to have, e.g. STAB, recovery, setup.
 
 		// Enforce Facade if Guts is a possible ability
-		if (movePool.includes('facade') && abilities.has('Guts')) {
+		if (movePool.includes('facade') && abilities.includes('Guts')) {
 			counter = this.addMove('facade', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 				movePool, teraType, role);
 		}
@@ -246,7 +246,7 @@ export class RandomBabyTeams extends RandomTeams {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
 				if (
-					types.includes(moveType) && (move.priority > 0 || (moveid === 'grassyglide' && abilities.has('Grassy Surge'))) &&
+					types.includes(moveType) && (move.priority > 0 || (moveid === 'grassyglide' && abilities.includes('Grassy Surge'))) &&
 					(move.basePower || move.basePowerCallback)
 				) {
 					priorityMoves.push(moveid);
@@ -313,7 +313,7 @@ export class RandomBabyTeams extends RandomTeams {
 		}
 
 		// Enforce contrary moves
-		if (abilities.has('Contrary')) {
+		if (abilities.includes('Contrary')) {
 			const contraryMoves = movePool.filter(moveid => CONTRARY_MOVES.includes(moveid));
 			for (const moveid of contraryMoves) {
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
@@ -418,7 +418,7 @@ export class RandomBabyTeams extends RandomTeams {
 	getAbility(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
@@ -427,95 +427,35 @@ export class RandomBabyTeams extends RandomTeams {
 		teraType: string,
 		role: RandomTeamsTypes.Role,
 	): string {
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData.length <= 1) return abilityData[0].name;
+		if (abilities.length <= 1) return abilities[0];
 
 		// Hard-code abilities here
-		// Culling method is inherited, but it makes some format-specific assumptions
-		// so it requires some adjusting here
-		if (species.id === 'applin') return 'Ripen';
-		if (species.id === 'blitzle') return 'Sap Sipper';
-		if (species.id === 'chinchou') return 'Volt Absorb';
-		if (species.id === 'deerling') return 'Serene Grace';
-		if (species.id === 'doduo') return 'Early Bird';
-		if (species.id === 'geodudealola') return 'Galvanize';
-		if (species.id === 'growlithehisui') return 'Rock Head';
-		if (species.id === 'gligar') return 'Immunity';
-		if (species.id === 'minccino') return 'Skill Link';
-		if (species.id === 'rellor') return 'Shed Skin';
-		if (species.id === 'riolu') return 'Inner Focus';
-		if (species.id === 'shroomish') return 'Effect Spore';
-		if (species.id === 'silicobra') return 'Shed Skin';
-		if (species.id === 'tepig') return 'Blaze';
-		if (species.id === 'timburr') return 'Guts';
-		if (species.id === 'tyrogue') return 'Guts';
+		if (species.id === 'rowlet' && counter.get('Grass')) return 'Overgrow';
+		if (species.id === 'pikipek' && counter.get('skilllink')) return 'Skill Link';
 
-		// Random abilities
-		if (species.id === 'litwick') return this.randomChance(1, 2) ? 'Flame Body' : 'Flash Fire';
-		if (species.id === 'solosis') return this.randomChance(4, 5) ? 'Magic Guard' : 'Regenerator';
-		if (species.id === 'tinkatink') return this.randomChance(1, 2) ? 'Mold Breaker' : 'Pickpocket';
-
-		// Abilities based on something else
-		if (species.id === 'cetoddle' && role === 'Wallbreaker') return 'Sheer Force';
-		if (species.id === 'cranidos' && moves.has('trailblaze')) return 'Mold Breaker';
-		if (species.id === 'murkrow' && role === 'Setup Sweeper') return 'Super Luck';
-
-		// Non-pokemon-specific ability rules
-		if (abilities.has('Harvest') && role === 'Bulky Attacker') return 'Harvest';
-		if (abilities.has('Guts') && moves.has('facade')) return 'Guts';
-		if (abilities.has('Quick Feet') && moves.has('facade')) return 'Quick Feet';
-		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
-		if (abilities.has('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
-		if (abilities.has('Unburden') && moves.has('acrobatics')) return 'Unburden';
-		if (moves.has('sunnyday') && abilities.has('Solar Power') && !abilities.has('Chlorophyll')) return 'Solar Power';
-
-		let abilityAllowed: Ability[] = [];
-		// Obtain a list of abilities that are allowed (not culled and rating>=1)
-		for (const ability of abilityData) {
-			if (ability.rating >= 1 && !this.shouldCullAbility(
-				ability.name, types, moves, abilities, counter, teamDetails, species, isLead, isDoubles, teraType, role
+		const abilityAllowed: string[] = [];
+		// Obtain a list of abilities that are allowed (not culled)
+		for (const ability of abilities) {
+			if (!this.shouldCullAbility(
+				ability, types, moves, abilities, counter, teamDetails, species, isLead, isDoubles, teraType, role
 			)) {
 				abilityAllowed.push(ability);
 			}
 		}
 
+		// Pick a random allowed ability
+		if (abilityAllowed.length >= 1) return this.sample(abilityAllowed);
+
+		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
 		if (!abilityAllowed.length) {
-			// Pickup is much better in babyrands, so if everything is culled favor it
-			if (abilities.has('Pickup')) return 'Pickup';
-			// If all abilities are rejected, re-allow all abilities
-			for (const ability of abilityData) {
-				if (ability.rating > 0) abilityAllowed.push(ability);
-			}
-			if (!abilityAllowed.length) abilityAllowed = abilityData;
+			const weatherAbilities = abilities.filter(
+				a => ['Chlorophyll', 'Hydration', 'Sand Force', 'Sand Rush', 'Slush Rush', 'Solar Power', 'Swift Swim'].includes(a)
+			);
+			if (weatherAbilities.length) return this.sample(weatherAbilities);
 		}
 
-		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
-		// Sort abilities by rating with an element of randomness
-		// All three abilities can be chosen
-		if (abilityAllowed[2] && abilityAllowed[0].rating - 0.5 <= abilityAllowed[2].rating) {
-			if (abilityAllowed[1].rating <= abilityAllowed[2].rating) {
-				if (this.randomChance(1, 2)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
-			} else {
-				if (this.randomChance(1, 3)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
-			}
-			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-				if (this.randomChance(2, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			} else {
-				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			}
-		} else {
-			// Third ability cannot be chosen
-			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
-				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
-				if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
-			}
-		}
-
-		// After sorting, choose the first ability
-		return abilityAllowed[0].name;
+		// Pick a random ability
+		return this.sample(abilities);
 	}
 
 	getPriorityItem(
@@ -630,8 +570,7 @@ export class RandomBabyTeams extends RandomTeams {
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const types = species.types;
-		const abilities = new Set(Object.values(species.abilities));
-		if (species.unreleasedHidden) abilities.delete(species.abilities.H);
+		const abilities = set.abilities!;
 
 		// Get moves
 		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, isDoubles, movePool, teraType!, role);
@@ -653,7 +592,7 @@ export class RandomBabyTeams extends RandomTeams {
 
 		// Prepare optimal HP for Belly Drum and Life Orb
 		let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-		let targetHP = Math.floor(hp / 10) * 10 - 1;
+		let targetHP = hp;
 		const minimumHP = Math.floor(Math.floor(2 * species.baseStats.hp + 100) * level / 100 + 10);
 		if (item === "Life Orb") {
 			targetHP = Math.floor(hp / 10) * 10 - 1;

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -5,16 +5,19 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earth Power", "Focus Blast", "Spikes", "Triple Axel", "U-turn"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Fighting", "Ground"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Close Combat", "Earthquake", "Leech Life", "Swords Dance", "Triple Axel"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Fighting", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Blizzard", "Bug Buzz", "Earth Power", "Focus Blast", "Tail Glow"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -25,11 +28,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Moonlight", "Poltergeist"],
+                "abilities": ["Triage"],
                 "teraTypes": ["Fairy", "Fighting", "Steel", "Water"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Bulk Up", "Drain Punch", "Poltergeist", "Shadow Sneak"],
+                "abilities": ["Triage"],
                 "teraTypes": ["Fairy", "Fighting", "Steel", "Water"]
             }
         ]
@@ -40,11 +45,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Energy Ball", "Overheat", "Synthesis"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fire", "Ground"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Dragon Tail", "Earth Power", "Giga Drain", "Overheat"],
+                "abilities": ["Contrary"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
@@ -55,6 +62,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Earth Power", "Encore", "Knock Off", "Rapid Spin", "Sludge Bomb", "Stealth Rock", "Tailwind", "Toxic", "Toxic Spikes", "U-turn"],
+                "abilities": ["Frisk", "Persistent"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -65,11 +73,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Energy Ball", "Fire Blast", "Paleo Wave", "Trick"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fire", "Grass", "Rock"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Energy Ball", "Fire Blast", "Meteor Beam", "Paleo Wave"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Fire", "Grass", "Rock"]
             }
         ]
@@ -80,11 +90,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Liquidation", "Recover"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Circle Throw", "Knock Off", "Recover", "Spikes"],
+                "abilities": ["Unaware"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -95,11 +107,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bullet Punch", "Close Combat", "Meteor Mash", "Poltergeist", "Strength Sap", "Trick"],
+                "abilities": ["Iron Fist"],
                 "teraTypes": ["Fairy", "Fighting", "Ghost", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defog", "Meteor Mash", "Poltergeist", "Strength Sap", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Iron Fist"],
                 "teraTypes": ["Dark", "Water"]
             }
         ]
@@ -110,11 +124,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defog", "Discharge", "Draco Meteor", "Fire Blast", "Ice Beam", "Slack Off", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Shield Dust", "Static"],
                 "teraTypes": ["Electric", "Fairy", "Steel"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Discharge", "Draco Meteor", "Fire Blast", "Ice Beam", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Shield Dust", "Static"],
                 "teraTypes": ["Electric", "Fairy", "Steel"]
             }
         ]
@@ -125,6 +141,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Facade", "Headlong Rush", "Knock Off", "Rapid Spin", "Sucker Punch", "U-turn"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -135,6 +152,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Ice Beam", "Surf", "Volt Switch", "Wild Charge"],
+                "abilities": ["Magic Guard"],
                 "teraTypes": ["Electric", "Flying"]
             }
         ]
@@ -145,6 +163,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Flash Cannon", "Focus Blast", "Nasty Plot", "Volt Switch"],
+                "abilities": ["Lightning Rod", "Volt Absorb"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -155,6 +174,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Aura Sphere", "Haze", "Hurricane", "Rapid Spin", "Roost"],
+                "abilities": ["Intimidate", "Prankster"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -165,6 +185,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Power Whip", "Shadow Claw", "Shell Smash", "Stone Edge"],
+                "abilities": ["Forewarn"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -175,11 +196,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hydro Pump", "Lava Plume", "Rapid Spin", "Recover", "Sludge Bomb", "Thunder Wave"],
+                "abilities": ["Dry Skin"],
                 "teraTypes": ["Grass", "Water"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Eruption", "Hydro Pump", "Sludge Wave", "Trick"],
+                "abilities": ["Dry Skin"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -190,16 +213,19 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bug Buzz", "Focus Blast", "Psyshock", "Tail Glow"],
+                "abilities": ["No Guard", "Weak Armor"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Blizzard", "Bug Buzz", "Focus Blast", "Hydro Pump", "Overheat", "Psychic", "Psyshock", "Thunder"],
+                "abilities": ["No Guard"],
                 "teraTypes": ["Fighting", "Fire"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Dragon Dance", "Megahorn", "Zen Headbutt"],
+                "abilities": ["No Guard"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -210,16 +236,19 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Glare", "Knock Off", "Parting Shot", "Rapid Spin", "Solar Blade", "Synthesis", "Temper Flare"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Poison", "Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Knock Off", "Solar Blade", "Sucker Punch", "Synthesis"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Poison", "Water"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Knock Off", "Rapid Spin", "Solar Blade", "Sucker Punch", "Temper Flare", "U-turn"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Fire", "Poison"]
             }
         ]
@@ -230,6 +259,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Acrobatics", "Belly Drum", "Bullet Punch", "Drain Punch"],
+                "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -240,11 +270,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Flamethrower", "Hydro Pump", "Overheat", "U-turn"],
+                "abilities": ["Analytic"],
                 "teraTypes": ["Fire", "Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Fire Blast", "Hydro Pump", "Scald", "U-turn"],
+                "abilities": ["Analytic"],
                 "teraTypes": ["Fire", "Water"]
             }
         ]
@@ -255,6 +287,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Discharge", "Encore", "Sludge Bomb", "Surf", "Taunt", "Thunderbolt"],
+                "abilities": ["Storm Drain"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -265,6 +298,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Facade", "Heavy Slam", "Wave Crash"],
+                "abilities": ["Guts"],
                 "teraTypes": ["Grass", "Normal"]
             }
         ]
@@ -275,16 +309,19 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Gunk Shot", "Knock Off", "Poison Jab", "Stone Edge", "U-turn", "Wood Hammer"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Grass"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Gunk Shot", "Knock Off", "Stealth Rock", "Stone Edge", "Toxic Spikes"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Coil", "Gunk Shot", "Stone Edge", "Wood Hammer"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -295,6 +332,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Aura Sphere", "Encore", "Focus Blast", "Moonblast", "Parting Shot", "Psychic", "Vacuum Wave"],
+                "abilities": ["Natural Cure"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -305,6 +343,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Leech Life", "Outrage", "Spirit Shackle", "Taunt", "Toxic Spikes"],
+                "abilities": ["Comatose"],
                 "teraTypes": ["Fairy", "Ghost"]
             }
         ]
@@ -315,11 +354,13 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Focus Blast", "Healing Wish", "Moonblast", "Solar Beam", "Synthesis"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Poison", "Water"]
             },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Healing Wish", "Moonblast", "Solar Beam", "Synthesis", "Tera Blast"],
+                "abilities": ["Drought"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -330,11 +371,13 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Horn Leech", "Hyper Drill", "Knock Off", "Swords Dance"],
+                "abilities": ["Galvanize"],
                 "teraTypes": ["Electric"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Double-Edge", "Horn Leech", "Rapid Spin", "Swords Dance"],
+                "abilities": ["Galvanize"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -345,16 +388,19 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bone Rush", "Bulk Up", "Flame Charge", "Morning Sun"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Grass", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bone Rush", "Bulk Up", "Flame Wheel", "Scale Shot"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Dragon"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Bone Rush", "Clear Smog", "Defog", "Flame Wheel", "Morning Sun", "Stealth Rock", "Taunt", "Toxic", "Will-O-Wisp"],
+                "abilities": ["Technician"],
                 "teraTypes": ["Grass", "Ground", "Water"]
             }
         ]
@@ -365,11 +411,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Liquidation", "Rapid Spin", "Stealth Rock", "Sticky Web", "Toxic", "U-turn"],
+                "abilities": ["Poison Heal"],
                 "teraTypes": ["Electric", "Ground"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Liquidation", "Recover", "Spiky Shield", "Toxic"],
+                "abilities": ["Poison Heal"],
                 "teraTypes": ["Electric", "Ground"]
             }
         ]
@@ -380,6 +428,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Doom Desire", "Earth Power", "Flash Cannon", "Pain Split", "Rapid Spin"],
+                "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Steel", "Water"]
             }
         ]
@@ -390,6 +439,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Defog", "Draco Meteor", "Encore", "Fire Lash", "Spikes", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Regenerator"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -400,16 +450,19 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Megahorn", "Scale Shot", "Swords Dance"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Scale Shot", "Swords Dance"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Poison"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Rush", "Earthquake", "First Impression", "U-turn"],
+                "abilities": ["Compound Eyes"],
                 "teraTypes": ["Bug", "Steel"]
             }
         ]
@@ -420,11 +473,13 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Boomburst", "Dark Pulse", "Recover", "Switcheroo", "Thunderbolt", "Toxic Spikes"],
+                "abilities": ["Color Change"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Boomburst", "Calm Mind", "Dark Pulse", "Recover"],
+                "abilities": ["Color Change"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -435,11 +490,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Body Press", "Hurricane", "Roost", "Sludge Bomb"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Body Press", "Hurricane", "Knock Off", "Roost"],
+                "abilities": ["Stamina"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -450,6 +507,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Coil", "Gunk Shot", "Roost", "Stealth Rock", "Toxic Spikes"],
+                "abilities": ["Tinted Lens"],
                 "teraTypes": ["Dark", "Flying", "Poison"]
             }
         ]
@@ -460,16 +518,19 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Body Press", "Diamond Storm", "Earthquake", "Rapid Spin"],
+                "abilities": ["Serene Grace", "Water Absorb"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Diamond Storm", "Earthquake", "Pain Split"],
+                "abilities": ["Serene Grace", "Water Absorb"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Diamond Storm", "Earthquake", "Pain Split", "Swords Dance"],
+                "abilities": ["Serene Grace", "Water Absorb"],
                 "teraTypes": ["Rock", "Steel"]
             }
         ]
@@ -480,11 +541,13 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Extreme Speed", "Flare Blitz", "Moonlight"],
+                "abilities": ["Pixilate"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Explosion", "Extreme Speed", "Overheat", "Spikes", "Will-O-Wisp"],
+                "abilities": ["Pixilate"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -495,6 +558,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Moonblast", "Recover", "Scald", "Thunder Wave"],
+                "abilities": ["Multiscale", "Rough Skin"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -505,6 +569,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Clanging Scales", "Clangorous Soul", "Flamethrower", "Sludge Wave", "Surf"],
+                "abilities": ["Armor Tail"],
                 "teraTypes": ["Fire", "Water"]
             }
         ]

--- a/data/random-battles/gen9cap/teams.ts
+++ b/data/random-battles/gen9cap/teams.ts
@@ -9,7 +9,7 @@ export class RandomCAPTeams extends RandomTeams {
 	getCAPAbility(
 		types: string[],
 		moves: Set<string>,
-		abilities: Set<string>,
+		abilities: string[],
 		counter: MoveCounter,
 		teamDetails: RandomTeamsTypes.TeamDetails,
 		species: Species,
@@ -18,16 +18,8 @@ export class RandomCAPTeams extends RandomTeams {
 		role: RandomTeamsTypes.Role,
 	): string {
 		// Hard-code abilities here
-		if (species.id === 'volkraken') return 'Analytic';
-		if (species.id === 'syclant') return 'Compound Eyes';
-		if (species.id === 'caribolt') return 'Galvanize';
-		if (species.id === 'equilibra') return 'Levitate';
-		if (species.id === 'kerfluffle') return 'Natural Cure';
 		if (species.id === 'fidgit') return moves.has('tailwind') ? 'Persistent' : 'Frisk';
-		if (species.id === 'hemogoblin') return 'Pixilate';
-		if (species.id === 'tomohawk') return 'Prankster';
-		if (species.id === 'saharaja' && moves.has('bodypress')) return 'Serene Grace';
-		if (species.id === 'cawmodore') return 'Volt Absorb';
+		if (species.id === 'tomohawk') return moves.has('haze') ? 'Prankster' : 'Intimidate';
 		// Default to regular ability selection
 		return this.getAbility(types, moves, abilities, counter, teamDetails, species, isLead, false, teraType, role);
 	}
@@ -97,8 +89,7 @@ export class RandomCAPTeams extends RandomTeams {
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const types = species.types;
-		const abilities = new Set(Object.values(species.abilities));
-		if (species.unreleasedHidden) abilities.delete(species.abilities.H);
+		const abilities = set.abilities!;
 
 		// Get moves
 		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, isDoubles, movePool, teraType!, role);

--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -538,7 +538,10 @@ export const commands: Chat.ChatCommands = {
 						} else if (([2, 3, 4, 5, 6, 7].includes(dex.gen)) && set.preferredTypes) {
 							buf += `<b>Preferred Type${Chat.plural(set.preferredTypes)}</b>: ${set.preferredTypes.join(', ')}<br/>`;
 						}
-						buf += `<b>Moves</b>: ${set.movepool.sort().map(formatMove).join(', ')}</details>`;
+						buf += `<b>Moves</b>: ${set.movepool.sort().map(formatMove).join(', ')}<br/>`;
+						if (set.abilities) {
+							buf += `<b>Abilit${Chat.plural(set.abilities, 'ies', 'y')}</b>: ${set.abilities.sort().join(', ')}</details>`;
+						}
 						setCount++;
 					}
 					movesets.push(buf);

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -508,6 +508,7 @@ namespace RandomTeamsTypes {
 	export interface RandomSetData {
 		role: Role;
 		movepool: string[];
+		abilities?: string[];
 		teraTypes?: string[];
 		preferredTypes?: string[];
 	}


### PR DESCRIPTION
This reworks ability generation in revamped Random Battles formats (Gens 3-7, Gen 9, Gen 9 doubles, Gen 9 baby, Gen 9 CAP spotlight), as follows:

- Each set now has an `abilities` section which lists the possible abilities that can be generated. The vast majority of sets only have one possible ability, so that ability will be selected. Many species have multiple sets with different abilities. For example, Yanmega has two sets, one with Tinted Lens and the other with Speed Boost.

- For sets with multiple abilities, the system determines which abilities are "allowed" based on the set of four moves generated. If there are multiple allowed abilities, it selects randomly and uniformly from them. For example, Infernape will always obtain Blaze if it has no punching moves (since Iron Fist is disallowed), but if it has a punching move, it will choose randomly between Blaze and Iron Fist.

- Weather abilities are "allowed" if the team has the requisite weather support (e.g. Drought, Drizzle). In most cases, when the weather support exists, weather abilities are 50/50 rolls with their non-weather alternatives.

- If all abilities are disallowed, weather abilities are always chosen over non-weather abilities, since they can be useful if the opponent (or the rest of your team that hasn't generated yet) brings weather. For example, Venusaur without a Grass move will be Chlorophyll and not Overgrow.

- There are way fewer hardcodes than before the rework, but some hardcodes are still necessary to prioritize one ability over another in situations where the ability is sometimes much better and sometimes much worse. For example, Drednaw with Crunch will always have Strong Jaw.

Abilities are now displayed in the `/randbats` command and checked in the random battles tests.

This update also includes some small set changes and set splits which are mainly to facilitate assigning abilities to sets.