### PR TITLE
[Gen 5] BW1: Update tiers

### DIFF
--- a/data/mods/gen5bw1/formats-data.ts
+++ b/data/mods/gen5bw1/formats-data.ts
@@ -41,6 +41,9 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	hippowdon: {
 		tier: "UUBL",
 	},
+	toxicroak: {
+		tier: "OU",
+	},
 	snover: {
 		tier: "UUBL",
 	},
@@ -66,6 +69,9 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "OU",
 	},
 	mienshao: {
+		tier: "OU",
+	},
+	hydreigon: {
 		tier: "OU",
 	},
 	virizion: {


### PR DESCRIPTION
Move Hydreigon and Toxicroak out of OU by technicality, since that is a distinction given to OU Pokemon after the generation had ended. It is the same reason why other Pokemon that are OU by technicality in Gen 5 OU are not listed as such in this mod.