### PR TITLE
Auctions: Formatting changes and QoL additions

### DIFF
--- a/server/chat-plugins/auction.ts
+++ b/server/chat-plugins/auction.ts
@@ -141,7 +141,7 @@ export class Auction extends Rooms.SimpleRoomGame {
 	}
 
 	generatePriceList() {
-		const draftedPlayers = Object.values(this.playerList).filter(p => p.team).sort((a, b) => b.price - a.price);
+		const draftedPlayers = Utils.sortBy(Object.values(this.playerList).filter(p => p.team), p => -p.price);
 		let buf = '';
 		for (const id in this.teams) {
 			const team = this.teams[id];
@@ -179,7 +179,7 @@ export class Auction extends Rooms.SimpleRoomGame {
 		}).join('');
 		buf += `</table></div>`;
 
-		const remainingPlayers = Object.values(this.playerList).filter(p => !p.team).sort((a, b) => a.name.localeCompare(b.name));
+		const remainingPlayers = Utils.sortBy(Object.values(this.playerList).filter(p => !p.team), p => p.name);
 		const tierArrays: {[k: string]: Player[]} = {};
 		for (const player of remainingPlayers) {
 			if (!player.tiers?.length) continue;


### PR DESCRIPTION
- Sorts names in draft pool alphabetically
- Adds additional dropdown to main display that shows current auction settings
![image](https://github.com/smogon/pokemon-showdown/assets/32044378/b08cae73-4186-46fb-b59d-1514b8987f1e)
- Adds a uhtml infobox under every highest bid to more clearly convey current bid info (taken from Scrappie)
![image](https://github.com/smogon/pokemon-showdown/assets/32044378/49bffc41-4ebc-416c-9a20-6d08367b473d)
- Adds `/overpay` command, basically an alias for `/announce OVERPAY!` that regular users can use (Scrappie command port)
- Ensures that "Guest" usernames don't appear as managers if a manager uses `/logout`