### PR TITLE
[Gen 5] BW1: Remove Dream World abilities of gen 2 and 4 cover legendaries

### DIFF
--- a/data/mods/gen5bw1/pokedex.ts
+++ b/data/mods/gen5bw1/pokedex.ts
@@ -63,6 +63,14 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 		inherit: true,
 		unreleasedHidden: true,
 	},
+	lugia: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	hooh: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
 	wurmple: {
 		inherit: true,
 		unreleasedHidden: true,
@@ -184,6 +192,18 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 		unreleasedHidden: true,
 	},
 	ambipom: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	dialga: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	palkia: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	giratina: {
 		inherit: true,
 		unreleasedHidden: true,
 	},


### PR DESCRIPTION
These Pokemon only gained access to their Hidden Abilities during the release of Pokemon Dream Radar, which never released before the release of Pokemon Black and White 2.