### PR TITLE
Crazyhouse: Properly escape usernames

### DIFF
--- a/data/mods/partnersincrime/scripts.ts
+++ b/data/mods/partnersincrime/scripts.ts
@@ -1,3 +1,5 @@
+import {Utils} from '../../../lib';
+
 export const Scripts: ModdedBattleScriptsData = {
 	gen: 9,
 	inherit: 'gen9',
@@ -201,7 +203,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		// Please remove me once there is client support.
 		if (this.ruleTable.has('crazyhouserule')) {
 			for (const side of this.sides) {
-				let buf = `raw|${side.name}'s team:<br />`;
+				let buf = `raw|${Utils.escapeHTML(side.name)}'s team:<br />`;
 				for (const pokemon of side.pokemon) {
 					if (!buf.endsWith('<br />')) buf += '/</span>&#8203;';
 					if (pokemon.fainted) {

--- a/data/mods/trademarked/scripts.ts
+++ b/data/mods/trademarked/scripts.ts
@@ -1,3 +1,5 @@
+import {Utils} from '../../../lib';
+
 export const Scripts: ModdedBattleScriptsData = {
 	gen: 9,
 	inherit: 'gen9',
@@ -182,7 +184,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		// Please remove me once there is client support.
 		if (this.ruleTable.has('crazyhouserule')) {
 			for (const side of this.sides) {
-				let buf = `raw|${side.name}'s team:<br />`;
+				let buf = `raw|${Utils.escapeHTML(side.name)}'s team:<br />`;
 				for (const pokemon of side.pokemon) {
 					if (!buf.endsWith('<br />')) buf += '/</span>&#8203;';
 					if (pokemon.fainted) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1613,7 +1613,7 @@ export class Battle {
 		// Please remove me once there is client support.
 		if (this.ruleTable.has('crazyhouserule')) {
 			for (const side of this.sides) {
-				let buf = `raw|${side.name}'s team:<br />`;
+				let buf = `raw|${Utils.escapeHTML(side.name)}'s team:<br />`;
 				for (const pokemon of side.pokemon) {
 					if (!buf.endsWith('<br />')) buf += '/</span>&#8203;';
 					if (pokemon.fainted) {


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/unescaped-usernames-in-crazyhouse.3746267/

![image](https://github.com/smogon/pokemon-showdown/assets/23667022/937653f8-50dc-4ce9-a45e-c59c9896ad5f)

PRing because it feels kinda dumb to have to import Utils here - does the Crazyhouse implementation actually need to exist in PiC and Trademarked?