### PR TITLE
Convert noSketch to move flag

### DIFF
--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -728,7 +728,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sketch: {
 		inherit: true,
-		flags: {bypasssub: 1, failencore: 1, noassist: 1},
+		flags: {bypasssub: 1, failencore: 1, noassist: 1, nosketch: 1},
 		onHit() {
 			// Sketch always fails in Link Battles
 			this.add('-nothing');

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -231,7 +231,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	explosion: {
 		inherit: true,
-		noSketch: true,
+		flags: {protect: 1, mirror: 1, metronome: 1, noparentalbond: 1, nosketch: 1},
 	},
 	flail: {
 		inherit: true,
@@ -402,14 +402,12 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	metronome: {
 		inherit: true,
-		flags: {failencore: 1},
-		noSketch: true,
+		flags: {failencore: 1, nosketch: 1},
 	},
 	mimic: {
 		inherit: true,
 		accuracy: 100,
-		noSketch: true,
-		flags: {protect: 1, bypasssub: 1, allyanim: 1, failencore: 1, noassist: 1},
+		flags: {protect: 1, bypasssub: 1, allyanim: 1, failencore: 1, noassist: 1, nosketch: 1},
 	},
 	mindreader: {
 		inherit: true,
@@ -436,7 +434,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mirrormove: {
 		inherit: true,
-		flags: {metronome: 1, failencore: 1},
+		flags: {metronome: 1, failencore: 1, nosketch: 1},
 		onHit(pokemon) {
 			const noMirror = ['metronome', 'mimic', 'mirrormove', 'sketch', 'sleeptalk', 'transform'];
 			const target = pokemon.side.foe.active[0];
@@ -449,7 +447,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			}
 			this.actions.useMove(lastMove, pokemon);
 		},
-		noSketch: true,
 	},
 	mist: {
 		num: 54,
@@ -727,7 +724,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	selfdestruct: {
 		inherit: true,
-		noSketch: true,
+		flags: {protect: 1, mirror: 1, metronome: 1, noparentalbond: 1, nosketch: 1},
 	},
 	sketch: {
 		inherit: true,
@@ -757,7 +754,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sleeptalk: {
 		inherit: true,
-		flags: {failencore: 1, nosleeptalk: 1},
+		flags: {failencore: 1, nosleeptalk: 1, nosketch: 1},
 		onHit(pokemon) {
 			const moves = [];
 			for (const moveSlot of pokemon.moveSlots) {
@@ -772,7 +769,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			if (!randomMove) return false;
 			this.actions.useMove(randomMove, pokemon);
 		},
-		noSketch: true,
 	},
 	solarbeam: {
 		inherit: true,
@@ -934,7 +930,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	transform: {
 		inherit: true,
-		noSketch: true,
+		flags: {bypasssub: 1, metronome: 1, failencore: 1, nosketch: 1},
 	},
 	triattack: {
 		inherit: true,

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -582,7 +582,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sketch: {
 		inherit: true,
-		flags: {bypasssub: 1, failencore: 1, noassist: 1, failmimic: 1},
+		flags: {bypasssub: 1, failencore: 1, noassist: 1, failmimic: 1, nosketch: 1},
 	},
 	sleeptalk: {
 		inherit: true,
@@ -640,7 +640,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	struggle: {
 		inherit: true,
-		flags: {contact: 1, protect: 1, noassist: 1, failencore: 1, failmimic: 1},
+		flags: {contact: 1, protect: 1, noassist: 1, failencore: 1, failmimic: 1, nosketch: 1},
 		accuracy: 100,
 		recoil: [1, 4],
 		struggleRecoil: false,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1387,13 +1387,15 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sketch: {
 		inherit: true,
-		flags: {bypasssub: 1, allyanim: 1, failencore: 1, noassist: 1, failcopycat: 1, failinstruct: 1, failmimic: 1},
+		flags: {
+			bypasssub: 1, allyanim: 1, failencore: 1, noassist: 1,
+			failcopycat: 1, failinstruct: 1, failmimic: 1, nosketch: 1,
+		},
 		onHit(target, source) {
-			const disallowedMoves = ['chatter', 'sketch', 'struggle'];
 			if (source.transformed || !target.lastMove || target.volatiles['substitute']) {
 				return false;
 			}
-			if (disallowedMoves.includes(target.lastMove.id) || source.moves.includes(target.lastMove.id)) {
+			if (target.lastMove.flags['nosketch'] || source.moves.includes(target.lastMove.id)) {
 				 return false;
 			}
 			const sketchIndex = source.moves.indexOf('sketch');
@@ -1472,7 +1474,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	struggle: {
 		inherit: true,
 		flags: {
-			contact: 1, protect: 1, failencore: 1, failmefirst: 1, noassist: 1, failcopycat: 1, failinstruct: 1, failmimic: 1,
+			contact: 1, protect: 1, failencore: 1, failmefirst: 1,
+			noassist: 1, failcopycat: 1, failinstruct: 1, failmimic: 1, nosketch: 1,
 		},
 		onModifyMove(move) {
 			move.type = '???';

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -111,7 +111,10 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			chance: 10,
 			volatileStatus: 'confusion',
 		},
-		flags: {protect: 1, sound: 1, distance: 1, noassist: 1, failcopycat: 1, failmefirst: 1, nosleeptalk: 1, failmimic: 1},
+		flags: {
+			protect: 1, sound: 1, distance: 1, noassist: 1, failcopycat: 1,
+			failmefirst: 1, nosleeptalk: 1, failmimic: 1, nosketch: 1,
+		},
 	},
 	conversion: {
 		inherit: true,

--- a/data/mods/gen8/moves.ts
+++ b/data/mods/gen8/moves.ts
@@ -126,7 +126,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	darkvoid: {
 		inherit: true,
 		isNonstandard: "Past",
-		noSketch: false,
+		flags: {protect: 1, reflectable: 1, mirror: 1, metronome: 1},
 	},
 	doubleironbash: {
 		inherit: true,
@@ -234,7 +234,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	hyperspacefury: {
 		inherit: true,
 		isNonstandard: "Past",
-		noSketch: false,
+		flags: {mirror: 1, bypasssub: 1},
 	},
 	hyperspacehole: {
 		inherit: true,

--- a/data/mods/gen8/moves.ts
+++ b/data/mods/gen8/moves.ts
@@ -91,7 +91,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		flags: {
 			protect: 1, mirror: 1, sound: 1, distance: 1, bypasssub: 1,
-			noassist: 1, failcopycat: 1, failinstruct: 1, failmefirst: 1, nosleeptalk: 1, failmimic: 1,
+			noassist: 1, failcopycat: 1, failinstruct: 1, failmefirst: 1, nosleeptalk: 1, failmimic: 1, nosketch: 1,
 		},
 	},
 	copycat: {

--- a/data/mods/gen9dlc1/moves.ts
+++ b/data/mods/gen9dlc1/moves.ts
@@ -42,7 +42,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	darkvoid: {
 		inherit: true,
-		noSketch: false,
+		flags: {protect: 1, reflectable: 1, mirror: 1, metronome: 1},
 	},
 	decorate: {
 		inherit: true,
@@ -90,7 +90,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	hyperspacefury: {
 		inherit: true,
-		noSketch: false,
+		flags: {mirror: 1, bypasssub: 1},
 	},
 	iceburn: {
 		inherit: true,
@@ -140,7 +140,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	revivalblessing: {
 		inherit: true,
-		noSketch: false,
+		flags: {heal: 1},
 	},
 	rockwrecker: {
 		inherit: true,

--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -1401,8 +1401,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		name: "(╯°o°）╯︵ ┻━┻",
 		pp: 10,
 		priority: 0,
-		flags: {protect: 1, failcopycat: 1},
-		noSketch: true,
+		flags: {protect: 1, failcopycat: 1, nosketch: 1},
 		onTryMove() {
 			this.attrLastMove('[still]');
 		},
@@ -3763,7 +3762,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		desc: "User copies opponents signature move and adds it to its own movepool, replacing this move. The user then uses the copied move immediately and gains the Imprison condition, preventing foes from using moves in the user's moveset. The PP of the copied move will be adjusted to match the PP the copied signature move is supposed to have. If the copied custom move would fail if used in this manner, Plagiarism fails and the user boosts all stats by 1 stage, except Accuracy and Evasion.",
 		pp: 5,
 		priority: 1,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1, failmimic: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1, failmimic: 1, nosketch: 1},
 		onTry(source) {
 			if (source.m.usedPlagiarism) {
 				this.hint("Plagiarism only works once per switch-in.");
@@ -3778,7 +3777,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			const sigMoveName = ssbSets[(target.illusion || target).name].signatureMove;
 			const move = this.dex.getActiveMove(sigMoveName);
 			if (!target || this.queue.willSwitch(target) || target.beingCalledBack ||
-				move.flags['failcopycat'] || move.noSketch) {
+				move.flags['failcopycat'] || move.flags['nosketch']) {
 				this.boost({spa: 1, spd: 1, spe: 1}, source, source, m);
 				return;
 			}
@@ -3802,7 +3801,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			source.addVolatile('imprison', source);
 			source.m.usedPlagiarism = true;
 		},
-		noSketch: true,
 		secondary: null,
 		target: "normal",
 		type: "Dark",
@@ -4349,8 +4347,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		desc: "If the user is Volcarona, this move is Ice-type and, after dealing damage, transforms the user into a Snow Warning Frosmoth with Blizzard, Chilly Reception, and Aurora Veil. If the user is Frosmoth, this move is Fire-type and, after dealing damage, transforms the user into a Drought Volcarona with Torch Song, Morning Sun, and Solar Beam. This move fails if the user is neither Frosmoth nor Volcarona.",
 		pp: 10,
 		priority: 0,
-		flags: {protect: 1, mirror: 1, failcopycat: 1},
-		noSketch: true,
+		flags: {protect: 1, mirror: 1, failcopycat: 1, nosketch: 1},
 		onTryMove() {
 			this.attrLastMove('[still]');
 		},

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -2086,8 +2086,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		name: "Magikarp's Revenge",
 		pp: 10,
 		priority: 0,
-		flags: {contact: 1, recharge: 1, protect: 1, mirror: 1, heal: 1, metronome: 1},
-		noSketch: true,
+		flags: {contact: 1, recharge: 1, protect: 1, mirror: 1, heal: 1, metronome: 1, nosketch: 1},
 		drain: [1, 2],
 		onTry(pokemon) {
 			if (pokemon.species.name !== 'Magikarp') {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2438,8 +2438,8 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 20,
 		priority: 0,
 		flags: {
-			protect: 1, mirror: 1, sound: 1, distance: 1, bypasssub: 1, nosleeptalk: 1,
-			noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
+			protect: 1, mirror: 1, sound: 1, distance: 1, bypasssub: 1,
+			nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
 		},
 		secondary: {
 			chance: 100,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1498,9 +1498,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 10,
 		priority: 0,
 		flags: {
-			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1,
+			failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
 		},
-		noSketch: true,
 		secondary: {
 			chance: 30,
 			status: 'brn',
@@ -2438,10 +2438,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 20,
 		priority: 0,
 		flags: {
-			protect: 1, mirror: 1, sound: 1, distance: 1, bypasssub: 1,
-			nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			protect: 1, mirror: 1, sound: 1, distance: 1, bypasssub: 1, nosleeptalk: 1,
+			noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
 		},
-		noSketch: true,
 		secondary: {
 			chance: 100,
 			volatileStatus: 'confusion',
@@ -2729,9 +2728,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 10,
 		priority: 0,
 		flags: {
-			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1,
+			failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
 		},
-		noSketch: true,
 		secondary: {
 			chance: 30,
 			status: 'par',
@@ -3466,7 +3465,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		name: "Dark Void",
 		pp: 10,
 		priority: 0,
-		flags: {protect: 1, reflectable: 1, mirror: 1, metronome: 1},
+		flags: {protect: 1, reflectable: 1, mirror: 1, metronome: 1, nosketch: 1},
 		status: 'slp',
 		onTry(source, target, move) {
 			if (source.species.name === 'Darkrai' || move.hasBounced) {
@@ -3476,7 +3475,6 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			this.hint("Only a Pokemon whose form is Darkrai can use this move.");
 			return null;
 		},
-		noSketch: true,
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Dark",
@@ -9478,7 +9476,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		name: "Hyperspace Fury",
 		pp: 5,
 		priority: 0,
-		flags: {mirror: 1, bypasssub: 1},
+		flags: {mirror: 1, bypasssub: 1, nosketch: 1},
 		breaksProtect: true,
 		onTry(source) {
 			if (source.species.name === 'Hoopa-Unbound') {
@@ -9499,7 +9497,6 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				def: -1,
 			},
 		},
-		noSketch: true,
 		secondary: null,
 		target: "normal",
 		type: "Dark",
@@ -11051,9 +11048,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 10,
 		priority: 0,
 		flags: {
-			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1,
+			failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
 		},
-		noSketch: true,
 		secondary: {
 			chance: 30,
 			volatileStatus: 'confusion',
@@ -13253,9 +13250,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 10,
 		priority: 0,
 		flags: {
-			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1,
+			failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
 		},
-		noSketch: true,
 		secondary: {
 			chance: 30,
 			status: 'psn',
@@ -15666,7 +15663,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 1,
 		noPPBoosts: true,
 		priority: 0,
-		flags: {heal: 1},
+		flags: {heal: 1, nosketch: 1},
 		onTryHit(source) {
 			if (!source.side.pokemon.filter(ally => ally.fainted).length) {
 				return false;
@@ -15681,7 +15678,6 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			duration: 1,
 			// reviving implemented in side.ts, kind of
 		},
-		noSketch: true,
 		secondary: null,
 		target: "self",
 		type: "Normal",
@@ -17192,12 +17188,13 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		noPPBoosts: true,
 		priority: 0,
 		flags: {
-			bypasssub: 1, allyanim: 1, failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			bypasssub: 1, allyanim: 1, failencore: 1, nosleeptalk: 1, noassist: 1,
+			failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
 		},
 		onHit(target, source) {
 			const move = target.lastMove;
 			if (source.transformed || !move || source.moves.includes(move.id)) return false;
-			if (move.noSketch || move.isZ || move.isMax) return false;
+			if (move.flags['nosketch'] || move.isZ || move.isMax) return false;
 			const sketchIndex = source.moves.indexOf('sketch');
 			if (sketchIndex < 0) return false;
 			const sketchedMove = {
@@ -17213,7 +17210,6 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			source.baseMoveSlots[sketchIndex] = sketchedMove;
 			this.add('-activate', source, 'move: Sketch', move.name);
 		},
-		noSketch: true,
 		secondary: null,
 		target: "normal",
 		type: "Normal",
@@ -18930,9 +18926,8 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		priority: 0,
 		flags: {
 			contact: 1, protect: 1,
-			failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
 		},
-		noSketch: true,
 		onModifyMove(move, pokemon, target) {
 			move.type = '???';
 			this.add('-activate', pokemon, 'move: Struggle');
@@ -20003,7 +19998,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		name: "Tera Starstorm",
 		pp: 5,
 		priority: 0,
-		flags: {protect: 1, mirror: 1, noassist: 1, failcopycat: 1, failmimic: 1},
+		flags: {protect: 1, mirror: 1, noassist: 1, failcopycat: 1, failmimic: 1, nosketch: 1},
 		onModifyType(move, pokemon) {
 			if (pokemon.species.name === 'Terapagos-Stellar') {
 				move.type = 'Stellar';
@@ -20017,7 +20012,6 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				move.target = 'allAdjacentFoes';
 			}
 		},
-		noSketch: true,
 		secondary: null,
 		target: "normal",
 		type: "Normal",
@@ -21617,9 +21611,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 10,
 		priority: 0,
 		flags: {
-			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			protect: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1,
+			failcopycat: 1, failmimic: 1, failinstruct: 1, nosketch: 1,
 		},
-		noSketch: true,
 		secondary: {
 			chance: 10,
 			status: 'slp',

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -5746,8 +5746,11 @@ export const MovesText: {[id: IDEntry]: MoveText} = {
 	},
 	sketch: {
 		name: "Sketch",
-		desc: "This move is permanently replaced by the last move used by the target. The copied move has the maximum PP for that move. Fails if the target has not made a move, if the user has Transformed, or if the move is Chatter, Sketch, Struggle, or any move the user knows.",
+		desc: "This move is permanently replaced by the last move used by the target. The copied move has the maximum PP for that move. Fails if the target has not made a move, if the user has Transformed, or if the move is Blazing Torque, Combat Torque, Dark Void, Hyperspace Fury, Magical Torque, Noxious Torque, Revival Blessing, Sketch, Struggle, Tera Starstorm, Wicked Torque, or any move the user knows.",
 		shortDesc: "Permanently copies the last move target used.",
+		gen8: {
+			desc: "This move is permanently replaced by the last move used by the target. The copied move has the maximum PP for that move. Fails if the target has not made a move, if the user has Transformed, or if the move is Chatter, Sketch, Struggle, or any move the user knows.",
+		},
 		gen3: {
 			desc: "This move is permanently replaced by the last move used by the target. The copied move has the maximum PP for that move. Fails if the target has not made a move, if the user has Transformed, or if the move is Sketch, Struggle, or any move the user knows.",
 		},

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -363,7 +363,7 @@ export const commands: Chat.ChatCommands = {
 			`- <code>zmove</code>, <code>max</code>, or <code>gmax</code> as parameters will search for Z-Moves, Max Moves, and G-Max Moves respectively.<br/>` +
 			`- Move targets must be preceded with <code>targets </code>; e.g. <code>targets user</code> searches for moves that target the user.<br/>` +
 			`- Valid move targets are: one ally, user or ally, one adjacent opponent, all Pokemon, all adjacent Pokemon, all adjacent opponents, user and allies, user's side, user's team, any Pokemon, opponent's side, one adjacent Pokemon, random adjacent Pokemon, scripted, and user.<br/>` +
-			`- Valid flags are: allyanim, bypasssub (bypasses Substitute), bite, bullet, cantusetwice, charge, contact, dance, defrost, distance (can target any Pokemon in Triples), failcopycat, failencore, failinstruct, failmefirst, failmimic, futuremove, gravity, heal, highcrit, instruct, metronome, mimic, mirror (reflected by Mirror Move), mustpressure, multihit, noassist, nonsky, noparentalbond, nosleeptalk, ohko, pivot, pledgecombo, powder, priority, protect, pulse, punch, recharge, recovery, reflectable, secondary, slicing, snatch, sound, and wind.<br/>` +
+			`- Valid flags are: allyanim, bypasssub (bypasses Substitute), bite, bullet, cantusetwice, charge, contact, dance, defrost, distance (can target any Pokemon in Triples), failcopycat, failencore, failinstruct, failmefirst, failmimic, futuremove, gravity, heal, highcrit, instruct, metronome, mimic, mirror (reflected by Mirror Move), mustpressure, multihit, noassist, nonsky, noparentalbond, nosketch, nosleeptalk, ohko, pivot, pledgecombo, powder, priority, protect, pulse, punch, recharge, recovery, reflectable, secondary, slicing, snatch, sound, and wind.<br/>` +
 			`- <code>protection</code> as a parameter will search protection moves like Protect, Detect, etc.<br/>` +
 			`- A search that includes <code>!protect</code> will show all moves that bypass protection.<br/>` +
 			`</details><br/>` +
@@ -1389,8 +1389,8 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 	const allFlags = [
 		'allyanim', 'bypasssub', 'bite', 'bullet', 'cantusetwice', 'charge', 'contact', 'dance', 'defrost', 'distance', 'failcopycat', 'failencore',
 		'failinstruct', 'failmefirst', 'failmimic', 'futuremove', 'gravity', 'heal', 'metronome', 'mirror', 'mustpressure', 'noassist', 'nonsky',
-		'noparentalbond', 'nosleeptalk', 'pledgecombo', 'powder', 'protect', 'pulse', 'punch', 'recharge', 'reflectable', 'slicing', 'snatch', 'sound',
-		'wind',
+		'noparentalbond', 'nosketch', 'nosleeptalk', 'pledgecombo', 'powder', 'protect', 'pulse', 'punch', 'recharge', 'reflectable', 'slicing',
+		'snatch', 'sound', 'wind',
 
 		// Not flags directly from move data, but still useful to sort by
 		'highcrit', 'multihit', 'ohko', 'protection', 'secondary',

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -50,6 +50,7 @@ interface MoveFlags {
 	noassist?: 1; // Cannot be selected by Assist.
 	nonsky?: 1; // Prevented from being executed or selected in a Sky Battle.
 	noparentalbond?: 1; // Cannot be made to hit twice via Parental Bond.
+	nosketch?: 1; // Cannot be copied by Sketch
 	nosleeptalk?: 1; // Cannot be selected by Sleep Talk.
 	pledgecombo?: 1; // Gems will not activate. Cannot be redirected by Storm Drain / Lightning Rod.
 	powder?: 1; // Has no effect on Pokemon which are Grass-type, have the Ability Overcoat, or hold Safety Goggles.
@@ -273,7 +274,6 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	// ---------------
 	hasCrashDamage?: boolean;
 	isConfusionSelfHit?: boolean;
-	noSketch?: boolean;
 	stallingMove?: boolean;
 	baseMove?: ID;
 }
@@ -476,8 +476,6 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 	declare readonly critModifier?: number;
 	/** Forces the move to get STAB even if the type doesn't match. */
 	readonly forceSTAB: boolean;
-	/** True if it can't be copied with Sketch. */
-	readonly noSketch: boolean;
 
 	readonly volatileStatus?: ID;
 
@@ -520,7 +518,6 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 		this.damage = data.damage!;
 		this.spreadHit = data.spreadHit || false;
 		this.forceSTAB = !!data.forceSTAB;
-		this.noSketch = !!data.noSketch;
 		this.volatileStatus = typeof data.volatileStatus === 'string' ? (data.volatileStatus as ID) : undefined;
 
 		if (this.category !== 'Status' && !this.maxMove && this.id !== 'struggle') {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -50,7 +50,7 @@ interface MoveFlags {
 	noassist?: 1; // Cannot be selected by Assist.
 	nonsky?: 1; // Prevented from being executed or selected in a Sky Battle.
 	noparentalbond?: 1; // Cannot be made to hit twice via Parental Bond.
-	nosketch?: 1; // Cannot be copied by Sketch
+	nosketch?: 1; // Cannot be copied by Sketch.
 	nosleeptalk?: 1; // Cannot be selected by Sleep Talk.
 	pledgecombo?: 1; // Gems will not activate. Cannot be redirected by Storm Drain / Lightning Rod.
 	powder?: 1; // Has no effect on Pokemon which are Grass-type, have the Ability Overcoat, or hold Safety Goggles.

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -602,7 +602,7 @@ export class DexSpecies {
 					// Smeargle time
 					// A few moves like Dark Void were made unSketchable in a generation later than when they were introduced
 					// However, this has only happened in a gen where transfer moves are unavailable
-					const sketchables = this.dex.moves.all().filter(m => !m.noSketch && !m.isNonstandard);
+					const sketchables = this.dex.moves.all().filter(m => !m.flags['nosketch'] && !m.isNonstandard);
 					for (const move of sketchables) {
 						movePool.add(move.id);
 					}

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2444,7 +2444,7 @@ export class TeamValidator {
 			if (moveid === 'sketch') {
 				sketch = true;
 			} else if (learnset['sketch']) {
-				if (move.noSketch || move.isZ || move.isMax) {
+				if (move.flags['nosketch'] || move.isZ || move.isMax) {
 					cantLearnReason = `can't be Sketched.`;
 				} else if (move.gen > 7 && !canSketchPostGen7Moves &&
 					(dex.gen === 8 ||


### PR DESCRIPTION
As of DLC2, Scarlet/Violet have a proper move flag for moves that can't be Sketched. This converts the old flag we were using to a standard move flag.

I also corrected a very minor bug of Chatter being flagged as not Sketchable in 9, as well as updated Sketch's descriptions.