### PR TITLE
Fix interaction of Psych Up and Transform with Dragon Cheer

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -701,11 +701,12 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			for (i in ally.boosts) {
 				pokemon.boosts[i] = ally.boosts[i];
 			}
-			const volatilesToCopy = ['focusenergy', 'gmaxchistrike', 'laserfocus'];
+			const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
 			for (const volatile of volatilesToCopy) {
 				if (ally.volatiles[volatile]) {
 					pokemon.addVolatile(volatile);
 					if (volatile === 'gmaxchistrike') pokemon.volatiles[volatile].layers = ally.volatiles[volatile].layers;
+					if (volatile === 'dragoncheer') pokemon.volatiles[volatile].hasDragonType = ally.volatiles[volatile].hasDragonType;
 				} else {
 					pokemon.removeVolatile(volatile);
 				}

--- a/data/mods/gen7pokebilities/scripts.ts
+++ b/data/mods/gen7pokebilities/scripts.ts
@@ -92,11 +92,12 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.boosts[boostName] = pokemon.boosts[boostName];
 			}
 			if (this.battle.gen >= 6) {
-				const volatilesToCopy = ['focusenergy', 'gmaxchistrike', 'laserfocus'];
+				const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
 				for (const volatile of volatilesToCopy) {
 					if (pokemon.volatiles[volatile]) {
 						this.addVolatile(volatile);
 						if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
+						if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
 					} else {
 						this.removeVolatile(volatile);
 					}

--- a/data/mods/partnersincrime/scripts.ts
+++ b/data/mods/partnersincrime/scripts.ts
@@ -386,6 +386,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					if (pokemon.volatiles[volatile]) {
 						this.addVolatile(volatile);
 						if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
+						if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
 					} else {
 						this.removeVolatile(volatile);
 					}

--- a/data/mods/pokebilities/scripts.ts
+++ b/data/mods/pokebilities/scripts.ts
@@ -92,11 +92,12 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.boosts[boostName] = pokemon.boosts[boostName];
 			}
 			if (this.battle.gen >= 6) {
-				const volatilesToCopy = ['focusenergy', 'gmaxchistrike', 'laserfocus'];
+				const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
 				for (const volatile of volatilesToCopy) {
 					if (pokemon.volatiles[volatile]) {
 						this.addVolatile(volatile);
 						if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
+						if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
 					} else {
 						this.removeVolatile(volatile);
 					}

--- a/data/mods/trademarked/scripts.ts
+++ b/data/mods/trademarked/scripts.ts
@@ -288,6 +288,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					if (pokemon.volatiles[volatile]) {
 						this.addVolatile(volatile);
 						if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
+						if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
 					} else {
 						this.removeVolatile(volatile);
 					}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -14565,11 +14565,12 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			for (i in target.boosts) {
 				source.boosts[i] = target.boosts[i];
 			}
-			const volatilesToCopy = ['focusenergy', 'gmaxchistrike', 'laserfocus'];
+			const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
 			for (const volatile of volatilesToCopy) {
 				if (target.volatiles[volatile]) {
 					source.addVolatile(volatile);
 					if (volatile === 'gmaxchistrike') source.volatiles[volatile].layers = target.volatiles[volatile].layers;
+					if (volatile === 'dragoncheer') source.volatiles[volatile].hasDragonType = target.volatiles[volatile].hasDragonType;
 				} else {
 					source.removeVolatile(volatile);
 				}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1279,6 +1279,7 @@ export class Pokemon {
 				if (pokemon.volatiles[volatile]) {
 					this.addVolatile(volatile);
 					if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
+					if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
 				} else {
 					this.removeVolatile(volatile);
 				}

--- a/test/sim/moves/dragoncheer.js
+++ b/test/sim/moves/dragoncheer.js
@@ -66,19 +66,6 @@ describe('Dragon Cheer', function () {
 		assert(battle.log.some(line => line.startsWith('|-fail'))); // second trigger
 	});
 
-	it('should not proc throat spray (is not a sound-based move)', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
-			{species: 'dragapult', item: 'throatspray', moves: ['dragoncheer']},
-			{species: 'kingdra', moves: ['splash']},
-		], [
-			{species: 'dragapult', moves: ['splash']},
-			{species: 'dragapult', moves: ['splash']},
-		]]);
-
-		battle.makeChoices('auto', 'auto');
-		assert(battle.log.every(line => !line.startsWith('|-activate')));
-	});
-
 	it('should not increase ratio if affected Pokemon turns into a Dragon Type after Dragon Cheer', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'dragapult', moves: ['dragoncheer', 'splash']},
@@ -105,5 +92,43 @@ describe('Dragon Cheer', function () {
 
 		battle.makeChoices();
 		assert(battle.log.some(line => !line.startsWith('|-fail')));
+	});
+
+	it(`should be copied by Psych Up, using the target's Dragon Cheer level`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'milotic', moves: ['dragoncheer', 'psychup', 'bubble']},
+			{species: 'kingdra', moves: ['sleeptalk']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'wobbuffet', moves: ['sleeptalk']},
+		]]);
+
+		battle.onEvent(
+			'ModifyCritRatio', battle.format, -99,
+			(critRatio) => assert.equal(critRatio, 3)
+		);
+
+		battle.makeChoices('move dragoncheer -2, move sleeptalk', 'auto');
+		battle.makeChoices('move psychup -2, move sleeptalk', 'auto');
+		battle.makeChoices('move bubble, move sleeptalk', 'auto');
+	});
+
+	it(`should be copied by Transform, using the target's Dragon Cheer level`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'milotic', moves: ['dragoncheer', 'transform']},
+			{species: 'kingdra', moves: ['sleeptalk', 'bubble']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'wobbuffet', moves: ['sleeptalk']},
+		]]);
+
+		battle.onEvent(
+			'ModifyCritRatio', battle.format, -99,
+			(critRatio) => assert.equal(critRatio, 3)
+		);
+
+		battle.makeChoices('move dragoncheer -2, move sleeptalk', 'auto');
+		battle.makeChoices('move transform -2, move sleeptalk', 'auto');
+		battle.makeChoices('move bubble, move sleeptalk', 'auto');
 	});
 });


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/dragon-cheer-and-psych-up.3735685/

It also fixes the interaction of Transform with Dragon Cheer so that Transform / Psych Up are copying the current Dragon Cheer crit boost level (before, I'm pretty sure they were defaulting to whatever type the user of Transform / Psych Up was).

I also removed a pointless test for checking if Dragon Cheer was a sound move.