### PR TITLE
Gen 5 BW1: Ditto's Dream World ability is unreleased

### DIFF
--- a/data/mods/gen5bw1/pokedex.ts
+++ b/data/mods/gen5bw1/pokedex.ts
@@ -43,6 +43,10 @@ export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable 
 		inherit: true,
 		unreleasedHidden: true,
 	},
+	ditto: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
 	snorlax: {
 		inherit: true,
 		unreleasedHidden: true,


### PR DESCRIPTION
Impostor Ditto is only available from Hidden Grottoes in the Giant Chasm, which are only available in Black and White 2.