### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -59,22 +59,22 @@
     },
     "pidgey": {
         "level": 90,
-        "moves": ["mimic", "mirrormove", "sandattack", "substitute"],
-        "essentialMoves": ["agility", "doubleedge"],
-        "exclusiveMoves": ["quickattack", "skyattack"],
+        "moves": ["agility", "agility", "quickattack", "quickattack", "skyattack"],
+        "essentialMoves": ["doubleedge"],
+        "exclusiveMoves": ["mirrormove", "sandattack", "substitute"],
         "comboMoves": ["agility", "doubleedge", "quickattack", "skyattack"]
     },
     "pidgeotto": {
         "level": 82,
-        "moves": ["mimic", "mirrormove", "sandattack", "substitute"],
-        "essentialMoves": ["agility", "doubleedge"],
-        "exclusiveMoves": ["quickattack", "skyattack"],
+        "moves": ["agility", "agility", "quickattack", "quickattack", "skyattack"],
+        "essentialMoves": ["doubleedge"],
+        "exclusiveMoves": ["mirrormove", "sandattack", "substitute"],
         "comboMoves": ["agility", "doubleedge", "quickattack", "skyattack"]
     },
     "pidgeot": {
         "level": 76,
         "moves": ["agility", "doubleedge", "hyperbeam"],
-        "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "skyattack", "skyattack", "substitute", "quickattack", "quickattack", "quickattack"]
+        "exclusiveMoves": ["mirrormove", "reflect", "sandattack", "skyattack", "skyattack", "substitute", "quickattack", "quickattack", "quickattack"]
     },
     "rattata": {
         "level": 89,

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -423,13 +423,15 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["heatwave", "leafblade", "nightslash", "return", "uturn"],
-                "abilities": ["Inner Focus"]
+                "movepool": ["doubleedge", "heatwave", "leafblade", "nightslash", "quickattack", "uturn"],
+                "abilities": ["Inner Focus"],
+                "preferredTypes": ["Grass"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["batonpass", "leafblade", "nightslash", "return", "swordsdance"],
-                "abilities": ["Inner Focus"]
+                "abilities": ["Inner Focus"],
+                "preferredTypes": ["Grass"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -2405,7 +2405,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "recover", "signalbeam"],
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "psyshock", "recover", "signalbeam"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -4292,7 +4292,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "highjumpkick", "icepunch", "zenheadbutt"],
+                "movepool": ["crunch", "dragondance", "highjumpkick", "stoneedge", "zenheadbutt"],
                 "abilities": ["Intimidate", "Moxie"]
             },
             {

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -909,6 +909,12 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				}
 				if (skip) continue;
 
+				// Count Dry Skin as a Fire weakness
+				if (this.dex.getEffectiveness('Fire', species) === 0 && Object.values(species.abilities).includes('Dry Skin')) {
+					if (!typeWeaknesses['Fire']) typeWeaknesses['Fire'] = 0;
+					if (typeWeaknesses['Fire'] >= 3 * limitFactor) continue;
+				}
+
 				// Limit one level 100 Pokemon
 				if (!this.adjustLevel && (this.getLevel(species) === 100) && numMaxLevelPokemon >= limitFactor) {
 					continue;
@@ -945,6 +951,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 					typeDoubleWeaknesses[typeName]++;
 				}
 			}
+			// Count Dry Skin as a Fire weakness
+			if (set.ability === 'Dry Skin' && this.dex.getEffectiveness('Fire', species) === 0) typeWeaknesses['Fire']++;
 
 			// Increment level 100 counter
 			if (set.level === 100) numMaxLevelPokemon++;

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1978,7 +1978,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbuzz", "defog", "roost", "sludgebomb", "toxic", "uturn"],
+                "movepool": ["bugbuzz", "defog", "roost", "toxic", "uturn"],
                 "abilities": ["Shield Dust"]
             }
         ]
@@ -2678,7 +2678,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "psychic", "recover", "signalbeam"],
+                "movepool": ["calmmind", "psychic", "psyshock", "recover", "signalbeam"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -2837,6 +2837,12 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["agility", "earthquake", "hammerarm", "meteormash", "zenheadbutt"],
+                "abilities": ["Clear Body"],
+                "preferredTypes": ["Psychic"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "hammerarm", "honeclaws", "meteormash", "zenheadbutt"],
                 "abilities": ["Clear Body"],
                 "preferredTypes": ["Psychic"]
             }
@@ -5510,8 +5516,9 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
-                "abilities": ["Protean"]
+                "movepool": ["grassknot", "gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
+                "abilities": ["Protean"],
+                "preferredTypes": ["Poison"]
             }
         ]
     },
@@ -5853,8 +5860,8 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"],
+                "role": "AV Pivot",
+                "movepool": ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb"],
                 "abilities": ["Sap Sipper"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -2205,7 +2205,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bugbuzz", "defog", "roost", "sludgebomb", "toxic", "uturn"],
+                "movepool": ["bugbuzz", "defog", "roost", "toxic", "uturn"],
                 "abilities": ["Shield Dust"]
             }
         ]
@@ -2927,7 +2927,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "psychic", "recover", "signalbeam"],
+                "movepool": ["calmmind", "psychic", "psyshock", "recover", "signalbeam"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -3097,6 +3097,12 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["agility", "earthquake", "hammerarm", "meteormash", "zenheadbutt"],
+                "abilities": ["Clear Body"],
+                "preferredTypes": ["Psychic"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "hammerarm", "honeclaws", "meteormash", "zenheadbutt"],
                 "abilities": ["Clear Body"],
                 "preferredTypes": ["Psychic"]
             }
@@ -5943,8 +5949,9 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
-                "abilities": ["Protean"]
+                "movepool": ["grassknot", "gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
+                "abilities": ["Protean"],
+                "preferredTypes": ["Poison"]
             }
         ]
     },
@@ -6302,8 +6309,8 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"],
+                "role": "AV Pivot",
+                "movepool": ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb"],
                 "abilities": ["Sap Sipper"]
             }
         ]
@@ -7375,7 +7382,8 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["highjumpkick", "icebeam", "poisonjab", "throatchop", "uturn"],
-                "abilities": ["Beast Boost"]
+                "abilities": ["Beast Boost"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -1271,6 +1271,15 @@ export class RandomGen7Teams extends RandomGen8Teams {
 						}
 						if (skip) continue;
 
+						// Count Dry Skin/Fluffy as Fire weaknesses
+						if (
+							this.dex.getEffectiveness('Fire', species) === 0 &&
+							Object.values(species.abilities).filter(a => ['Dry Skin', 'Fluffy'].includes(a))
+						) {
+							if (!typeWeaknesses['Fire']) typeWeaknesses['Fire'] = 0;
+							if (typeWeaknesses['Fire'] >= 3 * limitFactor) continue;
+						}
+
 						// Limit four weak to Freeze-Dry
 						if (weakToFreezeDry) {
 							if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
@@ -1333,6 +1342,10 @@ export class RandomGen7Teams extends RandomGen8Teams {
 					if (this.dex.getEffectiveness(typeName, species) > 1) {
 						typeDoubleWeaknesses[typeName]++;
 					}
+				}
+				// Count Dry Skin/Fluffy as Fire weaknesses
+				if (['Dry Skin', 'Fluffy'].includes(set.ability) && this.dex.getEffectiveness('Fire', species) === 0) {
+					typeWeaknesses['Fire']++;
 				}
 				if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
 

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -2544,6 +2544,15 @@ export class RandomGen8Teams {
 				}
 				if (skip) continue;
 
+				// Count Dry Skin/Fluffy as Fire weaknesses
+				if (
+					this.dex.getEffectiveness('Fire', species) === 0 &&
+					Object.values(species.abilities).filter(a => ['Dry Skin', 'Fluffy'].includes(a))
+				) {
+					if (!typeWeaknesses['Fire']) typeWeaknesses['Fire'] = 0;
+					if (typeWeaknesses['Fire'] >= 3 * limitFactor) continue;
+				}
+
 				// Limit four weak to Freeze-Dry
 				if (weakToFreezeDry) {
 					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
@@ -2597,6 +2606,10 @@ export class RandomGen8Teams {
 				if (this.dex.getEffectiveness(typeName, species) > 1) {
 					typeDoubleWeaknesses[typeName]++;
 				}
+			}
+			// Count Dry Skin/Fluffy as Fire weaknesses
+			if (['Dry Skin', 'Fluffy'].includes(set.ability) && this.dex.getEffectiveness('Fire', species) === 0) {
+				typeWeaknesses['Fire']++;
 			}
 			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
 

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -6086,7 +6086,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Body Press", "Iron Defense", "Iron Head", "Protect"],
+                "movepool": ["Body Press", "Heavy Slam", "Iron Defense", "Protect"],
                 "abilities": ["Earth Eater"],
                 "teraTypes": ["Electric", "Fighting"]
             },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -2871,7 +2871,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aura Sphere", "Flash Cannon", "Focus Blast", "Nasty Plot", "Shadow Ball", "Vacuum Wave"],
+                "movepool": ["Aura Sphere", "Flash Cannon", "Focus Blast", "Nasty Plot", "Vacuum Wave"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Fighting"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -61,9 +61,15 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Coil", "Earthquake", "Gunk Shot", "Sucker Punch", "Trailblaze"],
+                "movepool": ["Coil", "Earthquake", "Gunk Shot", "Trailblaze"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Coil", "Earthquake", "Gunk Shot", "Sucker Punch"],
+                "abilities": ["Intimidate"],
+                "teraTypes": ["Dark", "Ground"]
             }
         ]
     },
@@ -551,7 +557,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Destiny Bond", "Encore", "Focus Blast", "Shadow Ball", "Sludge Wave", "Toxic Spikes", "Will-O-Wisp"],
+                "movepool": ["Encore", "Focus Blast", "Shadow Ball", "Sludge Wave", "Toxic Spikes", "Will-O-Wisp"],
                 "abilities": ["Cursed Body"],
                 "teraTypes": ["Fighting", "Ghost"]
             }
@@ -596,7 +602,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Energy Ball", "Leaf Storm", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Giga Drain", "Leaf Storm", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Aftermath", "Soundproof", "Static"],
                 "teraTypes": ["Electric", "Grass"]
             },
@@ -940,7 +946,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Discharge", "Heat Wave", "Hurricane", "Roost", "U-turn", "Volt Switch"],
+                "movepool": ["Discharge", "Heat Wave", "Hurricane", "Roost", "Thunderbolt", "U-turn"],
                 "abilities": ["Static"],
                 "teraTypes": ["Electric", "Steel"]
             }
@@ -1018,7 +1024,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Knock Off", "Psychic", "Stealth Rock", "Taunt", "Toxic Spikes", "U-turn", "Will-O-Wisp"],
+                "movepool": ["Encore", "Knock Off", "Psychic", "Psychic Noise", "Stealth Rock", "Toxic Spikes", "U-turn", "Will-O-Wisp"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Dark", "Fairy", "Steel"]
             },
@@ -1312,7 +1318,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Chilly Reception", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Dragon", "Fairy", "Water"]
+                "teraTypes": ["Dragon", "Fairy"]
             },
             {
                 "role": "Wallbreaker",
@@ -1324,7 +1330,7 @@
                 "role": "Fast Support",
                 "movepool": ["Chilly Reception", "Future Sight", "Scald", "Slack Off"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Dragon", "Fairy", "Water"]
+                "teraTypes": ["Dragon", "Fairy"]
             }
         ]
     },
@@ -1589,13 +1595,13 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Outrage", "Waterfall", "Wave Crash"],
                 "abilities": ["Sniper", "Swift Swim"],
-                "teraTypes": ["Dragon", "Water"]
+                "teraTypes": ["Water"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Dance", "Iron Head", "Outrage", "Wave Crash"],
                 "abilities": ["Sniper", "Swift Swim"],
-                "teraTypes": ["Dragon", "Steel", "Water"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -2223,7 +2229,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aqua Jet", "Crabhammer", "Dragon Dance", "Knock Off", "Swords Dance"],
+                "movepool": ["Aqua Jet", "Crabhammer", "Dragon Dance", "Knock Off"],
                 "abilities": ["Adaptability"],
                 "teraTypes": ["Water"]
             }
@@ -2476,7 +2482,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Fire Punch", "Healing Wish", "Iron Head", "Protect", "U-turn", "Wish"],
+                "movepool": ["Healing Wish", "Iron Head", "Protect", "Psychic", "U-turn", "Wish"],
                 "abilities": ["Serene Grace"],
                 "teraTypes": ["Water"]
             }
@@ -2861,7 +2867,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Aura Sphere", "Flash Cannon", "Focus Blast", "Nasty Plot", "Shadow Ball", "Vacuum Wave"],
                 "abilities": ["Inner Focus"],
-                "teraTypes": ["Fighting", "Ghost"]
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -3471,7 +3477,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Air Slash", "Earth Power", "Rest", "Seed Flare"],
+                "movepool": ["Air Slash", "Earth Power", "Seed Flare", "Synthesis"],
                 "abilities": ["Natural Cure"],
                 "teraTypes": ["Grass", "Ground", "Steel"]
             },
@@ -3497,6 +3503,12 @@
                 "movepool": ["Air Slash", "Leech Seed", "Seed Flare", "Substitute"],
                 "abilities": ["Serene Grace"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Air Slash", "Earth Power", "Seed Flare", "Synthesis"],
+                "abilities": ["Serene Grace"],
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -3804,7 +3816,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Scald", "Wild Charge"],
+                "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Scald", "Sucker Punch", "Wild Charge"],
                 "abilities": ["Reckless"],
                 "teraTypes": ["Dark", "Electric", "Fire", "Water"]
             },
@@ -4114,6 +4126,12 @@
                 "movepool": ["Clear Smog", "Giga Drain", "Sludge Bomb", "Spore", "Toxic"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Giga Drain", "Sludge Bomb", "Spore", "Stomping Tantrum"],
+                "abilities": ["Regenerator"],
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -4229,7 +4247,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Triple Axel", "U-turn"],
+                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "U-turn"],
                 "abilities": ["Reckless"],
                 "teraTypes": ["Fighting"]
             },
@@ -4758,7 +4776,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Flip Turn", "Focus Blast", "Sludge Wave", "Toxic", "Toxic Spikes"],
+                "movepool": ["Draco Meteor", "Dragon Tail", "Flip Turn", "Focus Blast", "Sludge Wave", "Toxic", "Toxic Spikes"],
                 "abilities": ["Adaptability"],
                 "teraTypes": ["Fighting"]
             }
@@ -4820,7 +4838,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Moonblast", "Rest", "Rock Polish"],
-                "abilities": ["Clear Body"],
+                "abilities": ["Clear Body", "Sturdy"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4830,9 +4848,9 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Knock Off", "Power Whip", "Scald", "Sludge Bomb", "Thunderbolt"],
+                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Knock Off", "Power Whip", "Scald", "Sludge Bomb"],
                 "abilities": ["Sap Sipper"],
-                "teraTypes": ["Electric", "Fire", "Grass", "Ground", "Poison", "Water"]
+                "teraTypes": ["Fire", "Grass", "Ground", "Poison", "Water"]
             }
         ]
     },
@@ -5094,9 +5112,15 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Drain Punch", "Earthquake", "Ice Hammer", "Knock Off"],
+                "movepool": ["Close Combat", "Drain Punch", "Earthquake", "Gunk Shot", "Ice Hammer", "Knock Off"],
                 "abilities": ["Iron Fist"],
                 "teraTypes": ["Fighting", "Ground"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Drain Punch", "Earthquake", "Ice Hammer", "Knock Off"],
+                "abilities": ["Iron Fist"],
+                "teraTypes": ["Fighting", "Ground", "Water"]
             }
         ]
     },
@@ -5699,7 +5723,7 @@
         "sets": [
             {
                 "role": "Tera Blast user",
-                "movepool": ["Giga Drain", "Shadow Ball", "Shell Smash", "Stored Power", "Strength Sap", "Tera Blast"],
+                "movepool": ["Shadow Ball", "Shell Smash", "Stored Power", "Strength Sap", "Tera Blast"],
                 "abilities": ["Cursed Body"],
                 "teraTypes": ["Fighting"]
             },
@@ -7310,6 +7334,12 @@
                 "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off"],
                 "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Drain Punch", "Gunk Shot", "High Horsepower", "Knock Off", "Psychic Fangs"],
+                "abilities": ["Toxic Chain"],
+                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -7429,12 +7459,6 @@
                 "movepool": ["Body Press", "Draco Meteor", "Dragon Tail", "Flash Cannon", "Stealth Rock", "Thunder Wave", "Thunderbolt"],
                 "abilities": ["Stamina"],
                 "teraTypes": ["Fighting"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Aura Sphere", "Draco Meteor", "Flash Cannon", "Thunderbolt"],
-                "abilities": ["Stamina"],
-                "teraTypes": ["Dragon", "Electric", "Fighting"]
             }
         ]
     },
@@ -7455,9 +7479,9 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Draco Meteor", "Earth Power", "Fickle Beam", "Leaf Storm"],
+                "movepool": ["Earth Power", "Fickle Beam", "Leaf Storm", "Recover"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Dragon"]
+                "teraTypes": ["Dragon", "Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -60,13 +60,13 @@
                 "teraTypes": ["Dark", "Ground"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Coil", "Earthquake", "Gunk Shot", "Trailblaze"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Grass", "Ground"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Coil", "Earthquake", "Gunk Shot", "Sucker Punch"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Ground"]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1904,7 +1904,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Hurricane", "Hydro Pump", "Surf", "U-turn"],
+                "movepool": ["Hurricane", "Hydro Pump", "U-turn", "Weather Ball"],
                 "abilities": ["Drizzle"],
                 "teraTypes": ["Flying", "Water"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1232,7 +1232,7 @@
                 "teraTypes": ["Steel", "Water"]
             },
             {
-                "role": "Bulky Attacker",
+                "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Hydro Pump", "Ice Beam", "Weather Ball"],
                 "abilities": ["Drizzle"],
                 "teraTypes": ["Water"]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -60,10 +60,10 @@
                 "teraTypes": ["Dark", "Ground"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Coil", "Earthquake", "Gunk Shot", "Trailblaze"],
                 "abilities": ["Intimidate"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Grass", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
@@ -1230,6 +1230,12 @@
                 "movepool": ["Encore", "Haze", "Hydro Pump", "Hypnosis", "Ice Beam", "Rest", "Surf"],
                 "abilities": ["Drizzle"],
                 "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Focus Blast", "Hydro Pump", "Ice Beam", "Weather Ball"],
+                "abilities": ["Drizzle"],
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -3493,7 +3499,7 @@
         "level": 73,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Fast Attacker",
                 "movepool": ["Air Slash", "Dazzling Gleam", "Earth Power", "Seed Flare"],
                 "abilities": ["Serene Grace"],
                 "teraTypes": ["Flying", "Grass"]

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1678,6 +1678,15 @@ export class RandomTeams {
 				}
 				if (skip) continue;
 
+				// Count Dry Skin/Fluffy as Fire weaknesses
+				if (
+					this.dex.getEffectiveness('Fire', species) === 0 &&
+					Object.values(species.abilities).filter(a => ['Dry Skin', 'Fluffy'].includes(a))
+				) {
+					if (!typeWeaknesses['Fire']) typeWeaknesses['Fire'] = 0;
+					if (typeWeaknesses['Fire'] >= 3 * limitFactor) continue;
+				}
+
 				// Limit four weak to Freeze-Dry
 				if (weakToFreezeDry) {
 					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
@@ -1745,6 +1754,10 @@ export class RandomTeams {
 				if (this.dex.getEffectiveness(typeName, species) > 1) {
 					typeDoubleWeaknesses[typeName]++;
 				}
+			}
+			// Count Dry Skin/Fluffy as Fire weaknesses
+			if (['Dry Skin', 'Fluffy'].includes(set.ability) && this.dex.getEffectiveness('Fire', species) === 0) {
+				typeWeaknesses['Fire']++;
 			}
 			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
 

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1067,7 +1067,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Dazzling Gleam", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball", "Thunderbolt"],
+                "movepool": ["Dazzling Gleam", "Nasty Plot", "Psychic", "Shadow Ball", "Thunderbolt"],
                 "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Fairy", "Ghost"]
             },
@@ -1101,7 +1101,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Dazzling Gleam", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock"],
+                "movepool": ["Mud Shot", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock"],
                 "abilities": ["Toxic Debris"],
                 "teraTypes": ["Ghost", "Grass"]
             }
@@ -1279,13 +1279,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind", "Yawn"],
-                "abilities": ["Sand Stream"],
-                "teraTypes": ["Dragon", "Rock", "Steel"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Curse", "Earthquake", "Slack Off", "Stone Edge"],
+                "movepool": ["Curse", "Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind", "Yawn"],
                 "abilities": ["Sand Stream"],
                 "teraTypes": ["Dragon", "Rock", "Steel"]
             }
@@ -1752,7 +1746,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Acid Armor", "Draining Kiss", "Recover", "Stored Power"],
+                "movepool": ["Acid Armor", "Dazzling Gleam", "Draining Kiss", "Recover", "Stored Power"],
                 "abilities": ["Aroma Veil"],
                 "teraTypes": ["Fairy", "Steel"]
             }
@@ -2198,7 +2192,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Close Combat", "Crunch", "Earthquake", "Ice Punch", "Swords Dance"],
+                "movepool": ["Close Combat", "Copycat", "Crunch", "Earthquake", "Ice Punch", "Swords Dance"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Dark", "Fighting", "Ground"]
             }
@@ -2259,7 +2253,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Brave Bird", "Close Combat", "Hone Claws", "Roost"],
+                "movepool": ["Aerial Ace", "Bulk Up", "Close Combat", "Roost"],
                 "abilities": ["Hustle"],
                 "teraTypes": ["Fighting"]
             }
@@ -3001,7 +2995,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Encore", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
-                "abilities": ["Mold Breaker", "Pickpocket"],
+                "abilities": ["Pickpocket"],
                 "teraTypes": ["Fairy", "Water"]
             }
         ]
@@ -3310,7 +3304,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Crunch", "Double-Edge", "Stomping Tantrum", "U-turn", "Yawn"],
                 "abilities": ["Adaptability", "Stakeout"],
-                "teraTypes": ["Ground", "Normal"]
+                "teraTypes": ["Normal"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -735,6 +735,13 @@ export class RandomBabyTeams extends RandomTeams {
 				}
 				if (skip) continue;
 
+				// Count Dry Skin/Fluffy as Fire weaknesses
+				if (
+					this.dex.getEffectiveness('Fire', species) === 0 &&
+					Object.values(species.abilities).filter(a => ['Dry Skin', 'Fluffy'].includes(a)) &&
+					typeWeaknesses.get('Fire') >= 3 * limitFactor
+				) continue;
+
 				// Limit four weak to Freeze-Dry
 				if (weakToFreezeDry) {
 					if (typeWeaknesses.get('Freeze-Dry') >= 4 * limitFactor) continue;
@@ -769,6 +776,10 @@ export class RandomBabyTeams extends RandomTeams {
 				if (this.dex.getEffectiveness(typeName, species) > 1) {
 					typeDoubleWeaknesses.add(typeName);
 				}
+			}
+			// Count Dry Skin/Fluffy as Fire weaknesses
+			if (['Dry Skin', 'Fluffy'].includes(set.ability) && this.dex.getEffectiveness('Fire', species) === 0) {
+				typeWeaknesses.add('Fire');
 			}
 			if (weakToFreezeDry) typeWeaknesses.add('Freeze-Dry');
 

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -622,7 +622,9 @@ export class RandomBabyTeams extends RandomTeams {
 			const move = this.dex.moves.get(m);
 			if (move.damageCallback || move.damage) return true;
 			if (move.id === 'shellsidearm') return false;
-			if (move.id === 'terablast' && species.baseStats.atk > species.baseStats.spa) return false;
+			if (move.id === 'terablast' && (
+				species.id === 'porygon' || species.baseStats.atk > species.baseStats.spa)
+			) return false;
 			return move.category !== 'Physical' || move.id === 'bodypress' || move.id === 'foulplay';
 		});
 

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -16,9 +16,9 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Blizzard", "Bug Buzz", "Earth Power", "Focus Blast", "Tail Glow"],
-                "abilities": ["Compound Eyes"],
-                "teraTypes": ["Fighting", "Ground"]
+                "movepool": ["Bug Buzz", "Earth Power", "Ice Beam", "Tail Glow"],
+                "abilities": ["Mountaineer"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -40,7 +40,7 @@
         ]
     },
     "pyroak": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -61,7 +61,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earth Power", "Encore", "Knock Off", "Rapid Spin", "Sludge Bomb", "Stealth Rock", "Tailwind", "Toxic", "Toxic Spikes", "U-turn"],
+                "movepool": ["Earth Power", "Encore", "Rapid Spin", "Sludge Bomb", "Spikes", "Stealth Rock", "Tailwind", "Toxic Spikes", "U-turn"],
                 "abilities": ["Frisk", "Persistent"],
                 "teraTypes": ["Flying", "Steel"]
             }
@@ -85,11 +85,11 @@
         ]
     },
     "arghonaut": {
-        "level": 78,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Drain Punch", "Liquidation", "Recover"],
+                "movepool": ["Bulk Up", "Drain Punch", "Recover", "Waterfall"],
                 "abilities": ["Unaware"],
                 "teraTypes": ["Steel"]
             },
@@ -102,7 +102,7 @@
         ]
     },
     "kitsunoh": {
-        "level": 79,
+        "level": 80,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -208,7 +208,7 @@
         ]
     },
     "aurumoth": {
-        "level": 77,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -231,7 +231,7 @@
         ]
     },
     "malaconda": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -254,7 +254,7 @@
         ]
     },
     "cawmodore": {
-        "level": 77,
+        "level": 75,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -265,7 +265,7 @@
         ]
     },
     "volkraken": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -349,7 +349,7 @@
         ]
     },
     "jumbao": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Support",
@@ -361,7 +361,7 @@
                 "role": "Tera Blast user",
                 "movepool": ["Healing Wish", "Moonblast", "Solar Beam", "Synthesis", "Tera Blast"],
                 "abilities": ["Drought"],
-                "teraTypes": ["Fire"]
+                "teraTypes": ["Fire", "Ground"]
             }
         ]
     },
@@ -370,7 +370,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Horn Leech", "Hyper Drill", "Knock Off", "Swords Dance"],
+                "movepool": ["Horn Leech", "Hyper Drill", "Knock Off", "Quick Attack", "Swords Dance"],
                 "abilities": ["Galvanize"],
                 "teraTypes": ["Electric"]
             },
@@ -383,7 +383,7 @@
         ]
     },
     "smokomodo": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -406,7 +406,7 @@
         ]
     },
     "snaelstrom": {
-        "level": 81,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -440,7 +440,7 @@
                 "role": "Fast Support",
                 "movepool": ["Defog", "Draco Meteor", "Encore", "Fire Lash", "Spikes", "Thunder Wave", "Will-O-Wisp"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Steel", "Water"]
+                "teraTypes": ["Fairy", "Steel"]
             }
         ]
     },
@@ -468,7 +468,7 @@
         ]
     },
     "chromera": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -491,13 +491,13 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Body Press", "Hurricane", "Roost", "Sludge Bomb"],
                 "abilities": ["Stamina"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Body Press", "Hurricane", "Knock Off", "Roost"],
                 "abilities": ["Stamina"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },
@@ -506,9 +506,9 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Brave Bird", "Coil", "Gunk Shot", "Roost", "Stealth Rock", "Toxic Spikes"],
+                "movepool": ["Brave Bird", "Coil", "Gunk Shot", "Roost", "Toxic Spikes"],
                 "abilities": ["Tinted Lens"],
-                "teraTypes": ["Dark", "Flying", "Poison"]
+                "teraTypes": ["Flying", "Poison", "Steel"]
             }
         ]
     },
@@ -528,15 +528,15 @@
                 "teraTypes": ["Fighting"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Diamond Storm", "Earthquake", "Pain Split", "Swords Dance"],
+                "role": "Bulky Setup",
+                "movepool": ["Diamond Storm", "Earthquake", "Pain Split", "Rapid Spin", "Swords Dance"],
                 "abilities": ["Serene Grace", "Water Absorb"],
                 "teraTypes": ["Rock", "Steel"]
             }
         ]
     },
     "hemogoblin": {
-        "level": 77,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -559,7 +559,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Moonblast", "Recover", "Scald", "Thunder Wave"],
                 "abilities": ["Multiscale", "Rough Skin"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9cap/teams.ts
+++ b/data/random-battles/gen9cap/teams.ts
@@ -35,7 +35,7 @@ export class RandomCAPTeams extends RandomTeams {
 		teraType: string,
 		role: RandomTeamsTypes.Role,
 	) {
-		// Placeholder in case we need to hardcode items for CAP mons.
+		if (ability === 'Mountaineer') return 'Life Orb';
 	}
 
 	getLevel(

--- a/data/random-battles/gen9cap/teams.ts
+++ b/data/random-battles/gen9cap/teams.ts
@@ -273,6 +273,15 @@ export class RandomCAPTeams extends RandomTeams {
 				}
 				if (skip) continue;
 
+				// Count Dry Skin/Fluffy as Fire weaknesses
+				if (
+					this.dex.getEffectiveness('Fire', species) === 0 &&
+					Object.values(species.abilities).filter(a => ['Dry Skin', 'Fluffy'].includes(a))
+				) {
+					if (!typeWeaknesses['Fire']) typeWeaknesses['Fire'] = 0;
+					if (typeWeaknesses['Fire'] >= 3 * limitFactor) continue;
+				}
+
 				// Limit four weak to Freeze-Dry
 				if (weakToFreezeDry) {
 					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
@@ -334,6 +343,10 @@ export class RandomCAPTeams extends RandomTeams {
 				if (this.dex.getEffectiveness(typeName, species) > 1) {
 					typeDoubleWeaknesses[typeName]++;
 				}
+			}
+			// Count Dry Skin/Fluffy as Fire weaknesses
+			if (['Dry Skin', 'Fluffy'].includes(set.ability) && this.dex.getEffectiveness('Fire', species) === 0) {
+				typeWeaknesses['Fire']++;
 			}
 			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
 

--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -540,8 +540,9 @@ export const commands: Chat.ChatCommands = {
 						}
 						buf += `<b>Moves</b>: ${set.movepool.sort().map(formatMove).join(', ')}<br/>`;
 						if (set.abilities) {
-							buf += `<b>Abilit${Chat.plural(set.abilities, 'ies', 'y')}</b>: ${set.abilities.sort().join(', ')}</details>`;
+							buf += `<b>Abilit${Chat.plural(set.abilities, 'ies', 'y')}</b>: ${set.abilities.sort().join(', ')}`;
 						}
+						buf += '</details>';
 						setCount++;
 					}
 					movesets.push(buf);


### PR DESCRIPTION
Fluffy and Dry Skin now count as fire weaknesses.

Gen 9 changes that reduce the rate of Choice items will be marked with (__*__).

**Gen 9 Random Battle:**
-Crabominable now has an additional set of AV Pivot with Drain Punch, Ice Hammer, Knock Off, and Earthquake with Tera Ground/Fighting/Water and an Assault Vest. (__*__)
-Politoed now has an additional set of Fast Attacker with Weather Ball, Hydro Pump, Ice Beam, and Focus Blast with Choice Scarf or Choice Specs and Tera Water.
-Arbok's Coil set has been split into two. Trailblaze can now sometimes run Tera Grass, and Sucker Punch can now sometimes run Tera Dark. (__*__)
-Shaymin-Sky now has an additional set with Synthesis, three attacks, and Heavy-Duty Boots. (__*__)
-Amoonguss now has an additional set of Bulky Attacker with Stomping Tantrum.
-Okidogi now has an additional set of AV Pivot with Drain Punch, Gunk Shot, Knock Off, and a roll between Psychic Fangs and High Horsepower, with Tera Dark and an Assault Vest.
-Archaludon's Choice Scarf and Choice Specs set has been removed. (__*__)
-Dragalge: +Dragon Tail. When rolled, Dragon Tail will grant Assault Vest on it. (__*__)
-Wallbreaker Hydrapple: -Draco Meteor, +Recover; Now runs Life Orb 3 Atks Recover instead of Choice Specs. (__*__)
-Electrode-H: -Energy Ball, +Giga Drain; Can no longer run Choice Specs. (__*__)
-Shaymin (Land): -Rest, +Synthesis
-Crawdaunt: -Swords Dance
-Wallbreaker Mienshao: -Triple Axel, +Stone Edge
-AV Pivot Emboar: +Sucker Punch
-Jirachi (the set that gets Scarf sometimes): -Fire Punch, +Psychic
-Tera Blast Polteageist: -Giga Drain
-Goodra: -Thunderbolt
-Specs Pelipper: -Surf, +Weather Ball
-Support Mew: -Taunt, +Psychic Noise
-Support Slowking sets: -Tera Water
-Iron Head Kingdra: -Tera Dragon, -Tera Water
-Waterfall Kingdra: -Tera Dragon

Due to winrate analysis, the following changes have been made:
-Zapdos: -Volt Switch, +Thunderbolt
-Lucario: -Tera Ghost, -Shadow Ball
-Iron Defense Carbink: +Sturdy (rolls with Clear Body)
-Gengar: -Destiny Bond
-Wallbreaker Crabominable: +Gunk Shot

**Gen 9 CAP Random Battle:**
-Tail Glow Syclant now runs Mountaineer with a Life Orb and no longer runs inaccurate moves.
-Setup Sweeper Saharaja: +Rapid Spin, change role to Bulky Setup to give it Leftovers instead of Life Orb.
-Fidgit: +Spikes, -Knock Off, -Toxic
-Arghonaut: -Liquidation, +Waterfall
-Tera Blast Jumbao: +Tera Ground
-Setup Sweeper Caribolt: +Quick Attack
-All Venomicon (Prologue) sets: +Tera Steel
-Venomicon-Epilogue: -Tera Dark, -Stealth Rock
-Cresceidon: +Tera Poison
-Astrolotl: -Tera Water, +Tera Fairy

Arghonaut level 78 -> 80
Smokomodo level 82 -> 83
Aurumoth level 77 -> 78
Malaconda level 84 -> 85
Hemogoblin level 77 -> 78
Kitsunoh level 79 -> 80
Pyroak level 86 -> 85
Jumbao level 84 -> 83
Volkraken level 84 -> 83
Snaelstrom level 81 -> 80
Cawmodore level 77 -> 75
Chromera level 84 -> 82

**Doubles:**
Iron Defense Orthworm: -Iron Head, +Heavy Slam

**Baby:**
-Tera Blast Porygon now runs Attack investment.
-Riolu: +Copycat
-Glimmet: -Dazzling Gleam, +Mud Shot
-Milcery: +Dazzling Gleam
-Yungoos: -Tera Ground
-Hippopotas's sets have been merged into one. Curse is less common now.
-Tinkatink: -Mold Breaker (now is only Pickpocket)
-Girafarig: -Psyshock
-Rufflet: -Hone Claws, -Brave Bird, +Aerial Ace, +Bulk Up

**Old Gens:**
-In Gens 5-7, Calm Mind Chimecho can now run Psyshock.
-In Gens 6-7, Goodra is now AV Pivot and no longer runs Thunderbolt, Choice Scarf, or Choice Specs.
-In Gens 6-7, Protean Greninja will now always run Gunk Shot and can run Grass Knot.
-In Gens 6-7, Support Dustox no longer runs Sludge Bomb.
-In Gen 7, Pheromosa now always runs Throat Chop.
-In Gen 5, Scrafty now runs Stone Edge instead of Ice Punch.
-In Gen 4, non-SD Farfetch'd now runs Double-Edge and Quick Attack instead of Return, and all Farfetch'd sets now always have Leaf Blade.
-In Gen 1, the Pidgey line no longer runs Mimic, and the ones that aren't Pidgeot now run Agility less often.