### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -588,7 +588,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "protect", "rest", "return", "swordsdance"]
+                "movepool": ["bodyslam", "earthquake", "protect", "return", "swordsdance"]
             },
             {
                 "role": "Bulky Setup",

--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -128,7 +128,7 @@
             },
             {
                 "role": "Generalist",
-                "movepool": ["earthquake", "rest", "rockslide", "sleeptalk", "swordsdance"]
+                "movepool": ["earthquake", "rest", "rockslide", "sleeptalk"]
             }
         ]
     },
@@ -186,7 +186,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "charm", "doubleedge", "fireblast", "rest", "sleeptalk"]
+                "movepool": ["bodyslam", "doubleedge", "fireblast", "rest", "sleeptalk"]
             },
             {
                 "role": "Bulky Setup",
@@ -624,10 +624,6 @@
                 "movepool": ["curse", "earthquake", "rest", "roar", "rockslide", "sleeptalk"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["curse", "earthquake", "rest", "sleeptalk"]
-            },
-            {
                 "role": "Bulky Setup",
                 "movepool": ["curse", "rest", "rockslide", "sleeptalk"]
             }
@@ -961,10 +957,6 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "hiddenpowerrock", "swordsdance", "synthesis"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hiddenpowerfire", "leechseed", "lightscreen", "razorleaf", "synthesis"]
             }
         ]
     },
@@ -1101,8 +1093,8 @@
     "bellossom": {
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["hiddenpowerfire", "leechseed", "moonlight", "razorleaf", "sleeppowder", "stunspore"]
+                "role": "Bulky Attacker",
+                "movepool": ["hiddenpowerfire", "hiddenpowerice", "leechseed", "moonlight", "razorleaf", "sleeppowder", "stunspore"]
             },
             {
                 "role": "Bulky Setup",
@@ -1403,7 +1395,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "doubleedge", "rest", "sleeptalk", "swordsdance"]
+                "movepool": ["curse", "hiddenpowerbug", "hiddenpowersteel", "rest", "sleeptalk", "swordsdance"]
             }
         ]
     },

--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -596,7 +596,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "earthquake", "rest", "sleeptalk", "thunder"]
+                "movepool": ["doubleedge", "earthquake", "rest", "sleeptalk", "surf", "thunder"]
             }
         ]
     },

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -1957,7 +1957,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "substitute"],
+                "movepool": ["calmmind", "flamethrower", "hiddenpowergrass", "substitute"],
                 "abilities": ["Pressure"]
             }
         ]

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -2080,7 +2080,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "selfdestruct", "surf", "waterspout"],
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "selfdestruct", "waterspout"],
                 "abilities": ["Water Veil"],
                 "preferredTypes": ["Ice"]
             }
@@ -3333,7 +3333,7 @@
         "level": 81,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Staller",
                 "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic", "uturn"],
                 "abilities": ["Hyper Cutter"]
             },

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -70,9 +70,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			Psychic: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Psychic') && (types.has('Fighting') || movePool.includes('calmmind'))
 			),
-			Rock: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Rock') && (species.baseStats.atk >= 95 || abilities.includes('Rock Head'))
-			),
+			Rock: (movePool, moves, abilities, types, counter, species) => (!counter.get('Rock') && species.baseStats.atk >= 80),
 			Steel: (movePool, moves, abilities, types, counter, species) => (!counter.get('Steel') && species.id === 'metagross'),
 			Water: (movePool, moves, abilities, types, counter) => !counter.get('Water'),
 		};

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -3348,12 +3348,12 @@
         "level": 77,
         "sets": [
             {
-                "role": "Staller",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "protect", "substitute", "toxic"],
                 "abilities": ["Poison Heal"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Staller",
                 "movepool": ["earthquake", "facade", "roost", "stealthrock", "stoneedge", "taunt", "toxic", "uturn"],
                 "abilities": ["Poison Heal"]
             },

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -541,6 +541,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		// Hard-code abilities here
 		if (species.id === 'marowak' && counter.get('recoil')) return 'Rock Head';
 		if (species.id === 'kingler' && counter.get('sheerforce')) return 'Sheer Force';
+		if (species.id === 'golduck' && teamDetails.rain) return 'Swift Swim';
 
 		const abilityAllowed: string[] = [];
 		// Obtain a list of abilities that are allowed (not culled)

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -83,9 +83,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			Psychic: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Psychic') && (types.has('Fighting') || movePool.includes('calmmind'))
 			),
-			Rock: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Rock') && (species.baseStats.atk >= 95 || abilities.includes('Rock Head'))
-			),
+			Rock: (movePool, moves, abilities, types, counter, species) => (!counter.get('Rock') && species.baseStats.atk >= 80),
 			Steel: (movePool, moves, abilities, types, counter, species) => (
 				!counter.get('Steel') && ['aggron', 'metagross'].includes(species.id)
 			),

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -2423,7 +2423,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["feintattack", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
+                "movepool": ["rest", "return", "sleeptalk", "suckerpunch", "superpower", "thief"],
                 "abilities": ["Contrary"],
                 "preferredTypes": ["Fighting"]
             }

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -3771,13 +3771,13 @@
         "level": 77,
         "sets": [
             {
-                "role": "Staller",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "protect", "substitute", "toxic"],
                 "abilities": ["Poison Heal"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+                "role": "Staller",
+                "movepool": ["defog", "earthquake", "knockoff", "roost", "stealthrock", "taunt", "toxic", "uturn"],
                 "abilities": ["Poison Heal"]
             },
             {
@@ -4550,7 +4550,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"],
-                "abilities": ["Mold Breaker"]
+                "abilities": ["Mold Breaker", "Sand Rush"]
             }
         ]
     },
@@ -4811,13 +4811,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Fast Support",
-                "movepool": ["acrobatics", "defog", "earthquake", "roost", "stoneedge", "uturn"],
-                "abilities": ["Defeatist"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["aquatail", "earthquake", "headsmash", "knockoff", "stealthrock", "stoneedge", "uturn"],
+                "role": "Fast Attacker",
+                "movepool": ["acrobatics", "defog", "earthquake", "knockoff", "roost", "stealthrock", "stoneedge", "uturn"],
                 "abilities": ["Defeatist"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1700,7 +1700,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "nuzzle", "spore", "stealthrock", "stickyweb", "whirlwind"],
+                "movepool": ["nuzzle", "spikes", "spore", "stealthrock", "stickyweb", "whirlwind"],
                 "abilities": ["Own Tempo"]
             }
         ]

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -246,7 +246,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			// Lunatone
 			['moonlight', 'rockpolish'],
 			// Smeargle
-			['destinybond', 'whirlwind'],
+			['nuzzle', 'whirlwind'],
 			// Liepard
 			['copycat', 'uturn'],
 			// Seviper

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -99,12 +99,8 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			Psychic: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Psychic') && (types.has('Fighting') || movePool.includes('calmmind'))
 			),
-			Rock: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Rock') && (species.baseStats.atk >= 95 || abilities.includes('Rock Head'))
-			),
-			Steel: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Steel') && species.baseStats.atk >= 100
-			),
+			Rock: (movePool, moves, abilities, types, counter, species) => (!counter.get('Rock') && species.baseStats.atk >= 80),
+			Steel: (movePool, moves, abilities, types, counter, species) => (!counter.get('Steel') && species.baseStats.atk >= 100),
 			Water: (movePool, moves, abilities, types, counter) => !counter.get('Water'),
 		};
 	}

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -583,6 +583,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.id === 'tornadus' && counter.get('Status')) return 'Prankster';
 		if (species.id === 'marowak' && counter.get('recoil')) return 'Rock Head';
 		if (species.id === 'kingler' && counter.get('sheerforce')) return 'Sheer Force';
+		if (species.id === 'golduck' && teamDetails.rain) return 'Swift Swim';
 		if (species.id === 'roserade' && counter.get('technician')) return 'Technician';
 
 		const abilityAllowed: string[] = [];

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1926,7 +1926,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "nuzzle", "spore", "stealthrock", "stickyweb", "whirlwind"],
+                "movepool": ["nuzzle", "spikes", "spore", "stealthrock", "stickyweb", "whirlwind"],
                 "abilities": ["Own Tempo"]
             }
         ]
@@ -7340,7 +7340,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "moonblast", "moongeistbeam", "psyshock", "roost"],
+                "movepool": ["calmmind", "moonblast", "moongeistbeam", "roost"],
                 "abilities": ["Shadow Shield"]
             },
             {

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -4081,13 +4081,13 @@
         "level": 79,
         "sets": [
             {
-                "role": "Staller",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "protect", "substitute", "toxic"],
                 "abilities": ["Poison Heal"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "knockoff", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+                "role": "Staller",
+                "movepool": ["defog", "earthquake", "knockoff", "roost", "stealthrock", "taunt", "toxic", "uturn"],
                 "abilities": ["Poison Heal"]
             },
             {
@@ -5174,13 +5174,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Fast Support",
-                "movepool": ["acrobatics", "defog", "earthquake", "roost", "stoneedge", "uturn"],
-                "abilities": ["Defeatist"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["aquatail", "earthquake", "headsmash", "knockoff", "stealthrock", "stoneedge", "uturn"],
+                "role": "Fast Attacker",
+                "movepool": ["acrobatics", "defog", "earthquake", "knockoff", "roost", "stealthrock", "stoneedge", "uturn"],
                 "abilities": ["Defeatist"],
                 "preferredTypes": ["Ground"]
             }
@@ -6544,6 +6539,11 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["darkestlariat", "earthquake", "fakeout", "flareblitz", "knockoff", "overheat", "uturn"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["darkestlariat", "flamecharge", "flareblitz", "swordsdance"],
                 "abilities": ["Intimidate"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -2666,7 +2666,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["feintattack", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
+                "movepool": ["rest", "return", "sleeptalk", "suckerpunch", "superpower", "thief"],
                 "abilities": ["Contrary"],
                 "preferredTypes": ["Fighting"]
             }

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -137,12 +137,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 					types.has('Fighting') || movePool.includes('psychicfangs') || movePool.includes('calmmind')
 				)
 			),
-			Rock: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Rock') && (species.baseStats.atk >= 100 || abilities.includes('Rock Head'))
-			),
-			Steel: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Steel') && species.baseStats.atk >= 100
-			),
+			Rock: (movePool, moves, abilities, types, counter, species) => (!counter.get('Rock') && species.baseStats.atk >= 80),
+			Steel: (movePool, moves, abilities, types, counter, species) => (!counter.get('Steel') && species.baseStats.atk >= 100),
 			Water: (movePool, moves, abilities, types, counter) => !counter.get('Water'),
 		};
 	}

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -349,7 +349,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			['wildcharge', 'thunderbolt'],
 			['gunkshot', 'poisonjab'],
 			[['drainpunch', 'focusblast'], ['closecombat', 'highjumpkick', 'superpower']],
-			['stoneedge', 'headsmash'],
 			['dracometeor', 'dragonpulse'],
 			['dragonclaw', 'outrage'],
 			['knockoff', ['darkestlariat', 'darkpulse', 'foulplay']],
@@ -775,6 +774,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'marowak' && counter.get('recoil')) return 'Rock Head';
 		if (species.id === 'sawsbuck') return moves.has('headbutt') ? 'Serene Grace' : 'Sap Sipper';
 		if (species.id === 'toucannon' && counter.get('skilllink')) return 'Skill Link';
+		if (species.id === 'golduck' && teamDetails.rain) return 'Swift Swim';
 		if (species.id === 'roserade' && counter.get('technician')) return 'Technician';
 
 		const abilityAllowed: string[] = [];
@@ -819,6 +819,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			if (species.baseSpecies === 'Arceus' && species.requiredItems) return species.requiredItems[1];
 			if (species.name === 'Raichu-Alola') return 'Aloraichium Z';
 			if (species.name === 'Decidueye') return 'Decidium Z';
+			if (species.name === 'Incineroar') return 'Incinium Z';
 			if (species.name === 'Kommo-o') return 'Kommonium Z';
 			if (species.name === 'Lunala') return 'Lunalium Z';
 			if (species.baseSpecies === 'Lycanroc') return 'Lycanium Z';

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -362,7 +362,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			// Lunatone
 			['moonlight', 'rockpolish'],
 			// Smeargle
-			['destinybond', 'whirlwind'],
+			['nuzzle', 'whirlwind'],
 			// Liepard
 			['copycat', 'uturn'],
 			// Seviper

--- a/data/random-battles/gen8bdsp/data.json
+++ b/data/random-battles/gen8bdsp/data.json
@@ -123,7 +123,7 @@
         "moves": ["agility", "razorshell", "rockslide", "swordsdance", "xscissor"]
     },
     "electrode": {
-        "moves": ["explosion", "lightscreen", "taunt", "thunderbolt", "voltswitch"]
+        "moves": ["explosion", "taunt", "thunderbolt", "voltswitch"]
     },
     "exeggutor": {
         "moves": ["gigadrain", "leechseed", "psychic", "sleeppowder", "substitute"]
@@ -261,7 +261,7 @@
         "moves": ["acrobatics", "leechseed", "sleeppowder", "strengthsap", "substitute"]
     },
     "sunflora": {
-        "moves": ["energyball", "lightscreen", "sludgebomb", "synthesis"]
+        "moves": ["energyball", "leechseed", "sludgebomb", "synthesis"]
     },
     "quagsire": {
         "moves": ["earthquake", "recover", "scald", "toxic"]

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -4936,7 +4936,22 @@
       "sets": [
           {
               "species": "Gyarados",
-              "weight": 100,
+              "weight": 50,
+              "moves": [
+                  ["Taunt"],
+                  ["Iron Head", "Waterfall"],
+                  ["Earthquake"],
+                  ["Thunder Wave"]
+              ],
+              "item": ["Rocky Helmet"],
+              "nature": "Impish",
+              "evs": {"hp": 228, "atk": 4, "def": 220, "spd": 4, "spe": 52},
+              "teraType": ["Ground"],
+              "ability": ["Intimidate"]
+          },
+          {
+              "species": "Gyarados",
+              "weight": 50,
               "moves": [
                   ["Taunt"],
                   ["Iron Head", "Waterfall"],
@@ -4946,9 +4961,9 @@
               "item": ["Rocky Helmet"],
               "nature": "Impish",
               "evs": {"hp": 228, "atk": 4, "def": 220, "spd": 4, "spe": 52},
-              "teraType": ["Ground", "Steel"],
+              "teraType": ["Steel"],
               "ability": ["Intimidate"]
-          }
+          },
       ]
   },
   "pawmot": {
@@ -6077,7 +6092,24 @@
       "sets": [
           {
               "species": "Polteageist",
-              "weight": 100,
+              "weight": 50,
+              "moves": [
+                  ["Shell Smash"],
+                  ["Strength Sap"],
+                  ["Stored Power"],
+                  ["Tera Blast"]
+              ],
+              "item": ["Focus Sash"],
+              "nature": "Bold",
+              "evs": {"hp": 108, "def": 196, "spe": 204},
+              "ivs": {"atk": 0},
+              "teraType": ["Fighting", "Water"],
+              "wantsTera": true,
+              "ability": ["Weak Armor"]
+          },
+          {
+              "species": "Polteageist",
+              "weight": 50,
               "moves": [
                   ["Shell Smash"],
                   ["Strength Sap"],

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -4963,7 +4963,7 @@
               "evs": {"hp": 228, "atk": 4, "def": 220, "spd": 4, "spe": 52},
               "teraType": ["Steel"],
               "ability": ["Intimidate"]
-          },
+          }
       ]
   },
   "pawmot": {

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -3449,7 +3449,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Leaf Blade", "Protect", "Sleep Powder", "Victory Dance"],
-                "abilities": ["Chlorophyll", "Hustle"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -3900,12 +3900,6 @@
         "level": 79,
         "sets": [
             {
-                "role": "Doubles Setup Sweeper",
-                "movepool": ["Grass Knot", "Nasty Plot", "Protect", "Wildbolt Storm"],
-                "abilities": ["Prankster"],
-                "teraTypes": ["Electric", "Grass"]
-            },
-            {
                 "role": "Bulky Protect",
                 "movepool": ["Grass Knot", "Knock Off", "Protect", "Snarl", "Taunt", "Thunder Wave", "Thunderbolt"],
                 "abilities": ["Prankster"],
@@ -3916,6 +3910,12 @@
                 "movepool": ["Acrobatics", "Grass Knot", "Knock Off", "Protect", "Snarl", "Wildbolt Storm"],
                 "abilities": ["Defiant"],
                 "teraTypes": ["Electric", "Flying", "Steel"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Nasty Plot", "Protect", "Tera Blast", "Wildbolt Storm"],
+                "abilities": ["Defiant"],
+                "teraTypes": ["Flying", "Ice"]
             }
         ]
     },
@@ -3974,13 +3974,13 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Rock Slide", "Stealth Rock", "Stomping Tantrum", "Taunt", "U-turn"],
+                "movepool": ["Protect", "Rock Slide", "Stomping Tantrum", "Stone Edge", "Taunt", "U-turn"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Earthquake", "Protect", "Stone Edge", "Tera Blast"],
+                "movepool": ["Rock Slide", "Stomping Tantrum", "Stone Edge", "Tera Blast", "U-turn"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Flying"]
             }
@@ -4978,9 +4978,15 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Crunch", "Liquidation", "Protect", "Rock Slide", "Shell Smash"],
-                "abilities": ["Shell Armor", "Strong Jaw", "Swift Swim"],
-                "teraTypes": ["Dark", "Water"]
+                "movepool": ["Crunch", "Liquidation", "Rock Slide", "Shell Smash"],
+                "abilities": ["Strong Jaw"],
+                "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Doubles Bulky Setup",
+                "movepool": ["Liquidation", "Protect", "Rock Slide", "Shell Smash"],
+                "abilities": ["Shell Armor", "Swift Swim"],
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -5199,6 +5205,12 @@
                 "movepool": ["Bug Buzz", "Ice Beam", "Protect", "Quiver Dance"],
                 "abilities": ["Ice Scales"],
                 "teraTypes": ["Ground", "Water"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Ice Beam", "Protect", "Quiver Dance", "Tera Blast"],
+                "abilities": ["Ice Scales"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -6571,6 +6583,12 @@
                 "movepool": ["Close Combat", "Leaf Blade", "Protect", "Swords Dance"],
                 "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Fire", "Poison"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Close Combat", "Leaf Blade", "Protect", "Psyblade"],
+                "abilities": ["Quark Drive"],
+                "teraTypes": ["Fighting", "Fire", "Psychic"]
             },
             {
                 "role": "Doubles Wallbreaker",

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -201,8 +201,14 @@
         "level": 96,
         "sets": [
             {
+                "role": "Bulky Attacker",
+                "movepool": ["Alluring Voice", "Dazzling Gleam", "Fire Blast", "Knock Off", "Protect", "Wish"],
+                "abilities": ["Competitive"],
+                "teraTypes": ["Fire", "Poison", "Steel"]
+            },
+            {
                 "role": "Bulky Support",
-                "movepool": ["Alluring Voice", "Dazzling Gleam", "Fire Blast", "Knock Off", "Protect", "Stealth Rock", "Thunder Wave", "Wish"],
+                "movepool": ["Alluring Voice", "Dazzling Gleam", "Protect", "Stealth Rock", "Thunder Wave", "Wish"],
                 "abilities": ["Competitive"],
                 "teraTypes": ["Poison", "Steel"]
             }
@@ -651,6 +657,12 @@
                 "movepool": ["Draco Meteor", "Dragon Tail", "Flamethrower", "Giga Drain", "Knock Off"],
                 "abilities": ["Frisk"],
                 "teraTypes": ["Fire"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Dragon Pulse", "Flamethrower", "Giga Drain"],
+                "abilities": ["Harvest"],
+                "teraTypes": ["Fire", "Steel"]
             }
         ]
     },
@@ -1321,7 +1333,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Chilly Reception", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Dragon", "Fairy"]
@@ -1344,8 +1356,8 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Chilly Reception", "Fire Blast", "Psychic Noise", "Psyshock", "Slack Off", "Sludge Bomb", "Thunder Wave"],
+                "role": "Bulky Attacker",
+                "movepool": ["Chilly Reception", "Fire Blast", "Psychic Noise", "Psyshock", "Slack Off", "Sludge Bomb", "Thunder Wave", "Toxic Spikes"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Poison"]
             },
@@ -1581,8 +1593,8 @@
         "level": 86,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch", "Will-O-Wisp"],
+                "role": "Fast Attacker",
+                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
                 "abilities": ["Flash Fire"],
                 "teraTypes": ["Dark", "Fire", "Poison"]
             }
@@ -2085,7 +2097,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Gunk Shot", "Knock Off", "Swords Dance"],
                 "abilities": ["Liquid Ooze"],
-                "teraTypes": ["Dark", "Ground", "Poison"]
+                "teraTypes": ["Dark", "Ground"]
             }
         ]
     },
@@ -2743,7 +2755,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Knock Off", "Low Kick", "Triple Axel", "U-turn"],
                 "abilities": ["Technician"],
-                "teraTypes": ["Ice", "Normal"]
+                "teraTypes": ["Ice"]
             },
             {
                 "role": "Wallbreaker",
@@ -2856,7 +2868,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Fire Fang", "Iron Head", "Scale Shot", "Stone Edge", "Swords Dance"],
                 "abilities": ["Rough Skin"],
-                "teraTypes": ["Dragon", "Fire", "Ground", "Steel"]
+                "teraTypes": ["Fire", "Ground", "Steel"]
             }
         ]
     },
@@ -3963,7 +3975,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Ice Spinner", "Leaf Blade", "Sleep Powder", "Victory Dance"],
-                "abilities": ["Chlorophyll", "Hustle"],
+                "abilities": ["Hustle"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4075,7 +4087,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic Noise", "Thunderbolt"],
                 "abilities": ["Shadow Tag"],
-                "teraTypes": ["Dark", "Electric", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
+                "teraTypes": ["Dark", "Electric", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Steel"]
             },
             {
                 "role": "Fast Attacker",
@@ -5521,7 +5533,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Aura Sphere", "Flash Cannon", "Fleur Cannon", "Pain Split", "Spikes", "Thunder Wave", "Volt Switch"],
+                "movepool": ["Aura Sphere", "Flash Cannon", "Fleur Cannon", "Pain Split", "Spikes", "Volt Switch"],
                 "abilities": ["Soul-Heart"],
                 "teraTypes": ["Fairy", "Fighting", "Water"]
             },
@@ -5557,7 +5569,7 @@
                 "role": "Wallbreaker",
                 "movepool": ["Gunk Shot", "High Jump Kick", "Pyro Ball", "U-turn"],
                 "abilities": ["Libero"],
-                "teraTypes": ["Fire", "Poison"]
+                "teraTypes": ["Fire"]
             },
             {
                 "role": "Fast Support",
@@ -5617,9 +5629,15 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Crunch", "Earthquake", "Liquidation", "Shell Smash", "Stone Edge"],
-                "abilities": ["Shell Armor", "Strong Jaw", "Swift Swim"],
-                "teraTypes": ["Dark", "Ground", "Water"]
+                "movepool": ["Crunch", "Liquidation", "Shell Smash", "Stone Edge"],
+                "abilities": ["Strong Jaw"],
+                "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Earthquake", "Liquidation", "Shell Smash", "Stone Edge"],
+                "abilities": ["Shell Armor", "Swift Swim"],
+                "teraTypes": ["Ground", "Water"]
             }
         ]
     },
@@ -5905,7 +5923,7 @@
                 "role": "Fast Support",
                 "movepool": ["Aura Wheel", "Parting Shot", "Protect", "Rapid Spin"],
                 "abilities": ["Hunger Switch"],
-                "teraTypes": ["Dark", "Electric"]
+                "teraTypes": ["Electric"]
             },
             {
                 "role": "Bulky Attacker",
@@ -7394,7 +7412,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Ivy Cudgel", "Knock Off", "Spikes", "Superpower", "Synthesis", "U-turn"],
+                "movepool": ["Encore", "Ivy Cudgel", "Knock Off", "Spikes", "Superpower", "Synthesis", "U-turn"],
                 "abilities": ["Defiant"],
                 "teraTypes": ["Grass"]
             },
@@ -7473,7 +7491,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Dragon Tail", "Earth Power", "Fickle Beam", "Leaf Storm"],
+                "movepool": ["Dragon Tail", "Earth Power", "Fickle Beam", "Giga Drain", "Leaf Storm"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Steel"]
             },
@@ -7485,7 +7503,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Earth Power", "Fickle Beam", "Leaf Storm", "Recover"],
+                "movepool": ["Draco Meteor", "Earth Power", "Fickle Beam", "Leaf Storm"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Dragon", "Steel"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1447,7 +1447,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Destiny Bond", "Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
+                "movepool": ["Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Grass"]
             },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1180,6 +1180,12 @@
                 "movepool": ["Agility", "Dazzling Gleam", "Focus Blast", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Static"],
                 "teraTypes": ["Electric", "Fairy"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Dazzling Gleam", "Discharge", "Focus Blast", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Static"],
+                "teraTypes": ["Fairy"]
             }
         ]
     },

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -133,7 +133,7 @@ const NO_LEAD_POKEMON = [
 	'Zacian', 'Zamazenta',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
-	'Basculegion', 'Houndstone', 'Roaring Moon', 'Zacian', 'Zamazenta',
+	'Basculegion', 'Houndstone', 'Iron Bundle', 'Roaring Moon', 'Zacian', 'Zamazenta',
 ];
 
 const DEFENSIVE_TERA_BLAST_USERS = [
@@ -1030,7 +1030,7 @@ export class RandomTeams {
 			return (species.id === 'thundurus' && !!counter.get('Status'));
 		case 'Hydration': case 'Swift Swim':
 			return !teamDetails.rain;
-		case 'Iron Fist': case 'Skill Link': case 'Strong Jaw':
+		case 'Iron Fist': case 'Skill Link':
 			return !counter.get(toID(ability));
 		case 'Overgrow':
 			return !counter.get('Grass');
@@ -1071,7 +1071,7 @@ export class RandomTeams {
 		if (species.id === 'swampert' && (counter.get('Water') || moves.has('flipturn'))) return 'Torrent';
 		if (species.id === 'toucannon' && counter.get('skilllink')) return 'Skill Link';
 		if (abilities.includes('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
-		if (abilities.includes('Strong Jaw') && counter.get('strongjaw')) return 'Strong Jaw';
+		if (species.id === 'golduck' && teamDetails.rain) return 'Swift Swim';
 
 		// ffa abilities that differ from doubles
 		if (this.format.gameType === 'freeforall') {
@@ -1265,11 +1265,11 @@ export class RandomTeams {
 		if (
 			(offensiveRole || (role === 'Tera Blast user' && (species.baseStats.spe >= 80 || moves.has('trickroom')))) &&
 			(!moves.has('fakeout') || species.id === 'ambipom') && !moves.has('incinerate') &&
-			(!moves.has('uturn') || types.includes('Bug') || species.baseStats.atk >= 120 || ability === 'Libero') &&
+			(!moves.has('uturn') || types.includes('Bug') || ability === 'Libero') &&
 			((!moves.has('icywind') && !moves.has('electroweb')) || species.id === 'ironbundle')
 		) {
 			return (
-				(ability === 'Quark Drive' || ability === 'Protosynthesis') &&
+				(ability === 'Quark Drive' || ability === 'Protosynthesis') && !isLead &&
 				['firstimpression', 'uturn', 'voltswitch'].every(m => !moves.has(m)) && species.id !== 'ironvaliant'
 			) ? 'Booster Energy' : 'Life Orb';
 		}

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1269,8 +1269,8 @@ export class RandomTeams {
 			((!moves.has('icywind') && !moves.has('electroweb')) || species.id === 'ironbundle')
 		) {
 			return (
-				(ability === 'Quark Drive' || ability === 'Protosynthesis') && !isLead &&
-				['firstimpression', 'uturn', 'voltswitch'].every(m => !moves.has(m)) && species.id !== 'ironvaliant'
+				(ability === 'Quark Drive' || ability === 'Protosynthesis') && !isLead && species.id !== 'ironvaliant' &&
+				['dracometeor', 'firstimpression', 'uturn', 'voltswitch'].every(m => !moves.has(m)) &&
 			) ? 'Booster Energy' : 'Life Orb';
 		}
 		if (isLead && (species.id === 'glimmora' ||

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1270,7 +1270,7 @@ export class RandomTeams {
 		) {
 			return (
 				(ability === 'Quark Drive' || ability === 'Protosynthesis') && !isLead && species.id !== 'ironvaliant' &&
-				['dracometeor', 'firstimpression', 'uturn', 'voltswitch'].every(m => !moves.has(m)) &&
+				['dracometeor', 'firstimpression', 'uturn', 'voltswitch'].every(m => !moves.has(m))
 			) ? 'Booster Energy' : 'Life Orb';
 		}
 		if (isLead && (species.id === 'glimmora' ||

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1,6 +1,6 @@
 {
     "aipom": {
-        "level": 5,
+        "level": 6,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -123,7 +123,7 @@
         ]
     },
     "bergmite": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -728,7 +728,7 @@
         ]
     },
     "duskull": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1247,7 +1247,7 @@
         ]
     },
     "happiny": {
-        "level": 9,
+        "level": 8,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1331,7 +1331,7 @@
         ]
     },
     "houndour": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1342,7 +1342,7 @@
         ]
     },
     "igglybuff": {
-        "level": 9,
+        "level": 8,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1635,7 +1635,7 @@
         ]
     },
     "mareep": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1837,7 +1837,7 @@
         ]
     },
     "nacli": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2043,7 +2043,7 @@
         ]
     },
     "poliwag": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2172,7 +2172,7 @@
         ]
     },
     "rellor": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2227,7 +2227,7 @@
         ]
     },
     "rookidee": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2434,7 +2434,7 @@
         ]
     },
     "shellder": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2579,7 +2579,7 @@
         ]
     },
     "skwovet": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2935,7 +2935,7 @@
         ]
     },
     "tarountula": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3091,7 +3091,7 @@
         ]
     },
     "tynamo": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Tera Blast user",
@@ -3236,7 +3236,7 @@
         ]
     },
     "wingull": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Fast Support",

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -894,7 +894,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Air Slash", "Defog", "Double-Edge", "Heat Wave", "Roost", "Taunt", "U-turn"],
+                "movepool": ["Brave Bird", "Defog", "Double-Edge", "Heat Wave", "Roost", "Taunt", "U-turn"],
                 "abilities": ["Gale Wings"],
                 "teraTypes": ["Steel"]
             }
@@ -3200,20 +3200,14 @@
         "level": 6,
         "sets": [
             {
-                "role": "Fast Support",
-                "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Moonblast"],
-                "abilities": ["Snow Warning"],
-                "teraTypes": ["Steel", "Water"]
-            },
-            {
                 "role": "Setup Sweeper",
-                "movepool": ["Aurora Veil", "Blizzard", "Moonblast", "Nasty Plot"],
+                "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Nasty Plot"],
                 "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Blizzard", "Moonblast", "Nasty Plot", "Tera Blast"],
+                "movepool": ["Aurora Veil", "Blizzard", "Nasty Plot", "Tera Blast"],
                 "abilities": ["Snow Warning"],
                 "teraTypes": ["Ground"]
             }

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -54,7 +54,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Aqua Jet", "Belly Drum", "Facade", "Substitute"],
+                "movepool": ["Aqua Jet", "Belly Drum", "Body Slam", "Facade"],
                 "abilities": ["Huge Power"],
                 "teraTypes": ["Water"]
             }
@@ -552,7 +552,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Crunch", "Outrage", "Roar", "Thunder Wave", "Work Up"],
+                "movepool": ["Crunch", "Outrage", "Thunder Wave", "Work Up"],
+                "abilities": ["Hustle"],
+                "teraTypes": ["Poison"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Crunch", "Outrage", "Roar", "Thunder Wave"],
                 "abilities": ["Hustle"],
                 "teraTypes": ["Poison"]
             }
@@ -1018,7 +1024,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Iron Head", "Scale Shot", "Swords Dance"],
                 "abilities": ["Rough Skin"],
-                "teraTypes": ["Dragon", "Ground", "Steel"]
+                "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Fast Attacker",
@@ -1357,19 +1363,19 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Burning Jealousy", "Dark Pulse", "Draining Kiss", "Nasty Plot", "Thunder Wave"],
+                "movepool": ["Burning Jealousy", "Dark Pulse", "Dazzling Gleam", "Nasty Plot", "Thunder Wave"],
                 "abilities": ["Prankster"],
                 "teraTypes": ["Dark", "Fairy", "Fire"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Dazzling Gleam", "Light Screen", "Parting Shot", "Reflect", "Taunt", "Thunder Wave"],
+                "movepool": ["Dazzling Gleam", "Draining Kiss", "Light Screen", "Parting Shot", "Reflect", "Taunt", "Thunder Wave"],
                 "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Dark Pulse", "Dazzling Gleam", "Parting Shot", "Sucker Punch", "Taunt", "Thunder Wave"],
+                "movepool": ["Dark Pulse", "Dazzling Gleam", "Draining Kiss", "Parting Shot", "Sucker Punch", "Taunt", "Thunder Wave"],
                 "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             }
@@ -1503,9 +1509,9 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Flare Blitz", "Leech Life", "Trailblaze"],
+                "movepool": ["Flare Blitz", "Leech Life", "Swords Dance", "Trailblaze"],
                 "abilities": ["Intimidate"],
-                "teraTypes": ["Bug", "Dragon", "Fire"]
+                "teraTypes": ["Bug", "Fire", "Grass"]
             },
             {
                 "role": "Bulky Attacker",
@@ -1748,7 +1754,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Acid Armor", "Dazzling Gleam", "Draining Kiss", "Recover", "Stored Power"],
                 "abilities": ["Aroma Veil"],
-                "teraTypes": ["Fairy", "Steel"]
+                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },
@@ -2193,7 +2199,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Copycat", "Crunch", "Earthquake", "Ice Punch", "Swords Dance"],
-                "abilities": ["Inner Focus"],
+                "abilities": ["Inner Focus", "Prankster"],
                 "teraTypes": ["Dark", "Fighting", "Ground"]
             }
         ]

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -431,7 +431,9 @@ export class RandomBabyTeams extends RandomTeams {
 
 		// Hard-code abilities here
 		if (species.id === 'rowlet' && counter.get('Grass')) return 'Overgrow';
+		if (species.id === 'riolu') return moves.has('copycat') ? 'Prankster' : 'Inner Focus';
 		if (species.id === 'pikipek' && counter.get('skilllink')) return 'Skill Link';
+		if (species.id === 'psyduck' && teamDetails.rain) return 'Swift Swim';
 
 		const abilityAllowed: string[] = [];
 		// Obtain a list of abilities that are allowed (not culled)

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -488,9 +488,7 @@ export class RandomBabyTeams extends RandomTeams {
 		if (ability === 'Guts' && moves.has('facade')) return 'Flame Orb';
 		if (ability === 'Quick Feet') return 'Toxic Orb';
 
-		if (
-			this.dex.getEffectiveness('Rock', species) >= 2 && this.dex.getEffectiveness('Ground', species) >= 0
-		) return 'Heavy-Duty Boots';
+		if (types.includes('Bug') && types.includes('Flying')) return 'Heavy-Duty Boots';
 		if (['Harvest', 'Ripen', 'Unburden'].includes(ability) || moves.has('bellydrum')) return 'Oran Berry';
 	}
 


### PR DESCRIPTION
**Gen 9 Random Battle**:
-Exeggutor-Alola runs a third set: Bulky Setup with CM, Dragon Pulse, Giga Drain, Flamethrower, Tera Fire/Steel with Harvest and Sitrus Berry.
-Wigglytuff is set split so that it always runs Wish + Protect; it can now run Tera Fire alongside Fire Blast.
-Drednaw is set split so that Crunch is always Tera Dark, and to simplify Strong Jaw code.
-Ampharos runs an AV set with Discharge/Thunderbolt, Dazzling Gleam, Focus Blast, and Volt Switch.
-Lilligant-Hisui is always Hustle. It can no longer obtain Chlorophyll even alongside a sun setter.
-AV Hydrapple: +Giga Drain, rolling with Leaf Storm.
-WB Hydrapple: -Recover, +Draco Meteor (-LO, +specs), since previous changes results in a significant winrate drop.
-Houndoom: -wisp, and no longer has Nasty Plot forced, since previous changes results in a significant winrate drop.

Minor set and tera type adjustments:
-CM Gothitelle: -Tera Psychic.
-Cinderace: -Tera Poison.
-Morpeko: -Tera Dark.
-Fast Support Ogerpon: +Encore.
-SD Garchomp: -Tera Dragon.
-CB Ambipom: -Tera Normal, it is always Tera Ice with Triple Axel.
-SD Swalot: -Tera Poison.
-Bulky Attacker Magearna: -Thunder Wave.
-Slowking, Slowking-Galar: change Bulky Support to Bulky Attacker.
-Slowking-Galar: +Toxic Spikes.
-Qwilfish: -Destiny Bond.

**Gen 9 Random Doubles Battle**:
-Booster Energy can no longer generate in the lead slots. Iron Bundle can no longer generate in the lead slots, since it is reliant on Booster Energy.
-Drednaw is set split so that Crunch is always Tera Dark, and to simplify Strong Jaw code.
-Lilligant-Hisui is always Hustle. It can no longer obtain Chlorophyll even alongside a sun setter.
-Thundurus's Nasty Plot set is Tera Blast Flying/Ice instead of Grass Knot. It is also Defiant so that it can sometimes take advantage of physical Tera Blast.
-Support Landorus-Therian: -Stealth Rock, +Protect, +Stone Edge.
-Tera Blast Flying Landorus-Therian is AV with Stomping Tantrum, U-turn, and Rock Slide/Stone Edge.
-Frosmoth runs a Tera Blast Ground set.
-Iron Leaves runs a Protect 3 attacks set with Booster Energy.

**Baby Random Battle**:
-Milcery: -Tera Fairy, +Tera Poison.
-Setup Litten: -Bulk Up, +Swords Dance, -Tera Dragon, +Tera Grass.
-Bulky Setup Gible: -Tera Dragon.
-Azurill: -Substitute, +Body Slam.
-Deino's set has been split so that it no longer gets both Roar and Work Up.
-Riolu gets Prankster with Copycat and Inner Focus otherwise.
-Setup Sweeper Impidimp: -Draining Kiss, +Dazzling Gleam.
-other Impidimp sets: +Draining Kiss.
-Bulky Support Fletchling: -Air Slash, +Brave Bird.
-Vulpix-Alola no longer runs Moonblast since we discovered that it is not a Fairy type.
-Larvesta runs Eviolite instead of Heavy-Duty Boots; Yanma and Scyther run Heavy-Duty Boots instead of Eviolite.
-Some Pokemon have had their levels adjusted. Specifically: Bergmite, Duskull, Happiny, Houndour, Igglybuff, Mareep, Nacli, Poliwag, Rellor, Rookidee, Shellder, Skwovet, Tarountula, Tynamo, Wingull have been nerfed by -1 level, and Aipom has been buffed by +1 level.

**BDSP Random Battle**:
-Electrode: -Light Screen.
-Sunflora: -Light Screen, +Leech Seed.

**Gen 7 Random Battle**:
-Incineroar runs a setup set with Swords Dance, Flame Charge, Flare Blitz, and Darkest Lariat with Incinium Z.
-Bulky Attacker Lunala: -Psyshock.

**Gen 6 Random Battle**:
-Excadrill can now run Sand Rush if the team has a sand setter, fixing an oversight in a previous update.

**Gen 6-7 Random Battle**:
-Archeops' sets have been merged so that it always runs Acrobatics, Stone Edge, and Earthquake. It no longer runs Aqua Tail or Head Smash.
-Spinda: -Feint Attack, +Thief.
-Smeargle: -Destiny Bond, +Spikes.

**Gen 4 Random Battle**:
-Wailord no longer runs Surf and always runs Hydro Pump.

**Gen 4-7 Random Battle**:
-Bulky Support Gliscor has its role changed to Staller to enforce Toxic. In Gens 6-7, Defog is now added to the set, since it would no longer be forced.
-Rock STAB enforcement has been simplified; Rock STAB is enforced on all species with base Attack at least 80.

**Gen 3 Random Battle**:
-SubCM Entei no longer runs HP Ice, since HP Grass is much better.

**Gen 2 Random Battle**:
-Sandslash and Rhydon no longer run mono-EQ sets that can't touch Flying types.
-Wigglytuff no longer runs Charm.
-Meganium's non-SD set is removed.
-Scizor's Bulky Setup set now runs HP Bug/Steel as its one attacking move instead of Double-Edge which is walled by Ghost types.
-Bellossom's Bulky Support set has been role changed to Bulky Attacker to force coverage, which is either HP Fire or the newly added HP Ice.
-Lickitung's Bulky Attacker set can run Surf.
-Lickitung's Setup Sweeper set will no longer run Rest/Mint Berry, and can run Body Slam.

In all randomized formats in generations 5-9, Golduck (and Psyduck in baby rands) is hardcoded to always be Swift Swim if the team has generated a rain setter before.

**BSS Factory**:
-Gyarados will always have Earthquake when it is Tera Ground.
-Polteageist will sometimes have Weak Armor, instead of always being Cursed Body.