### PR TITLE
Pokemoves: Fix validation

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -507,19 +507,19 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'Arceus', 'Annihilape', 'Calyrex-Ice', 'Calyrex-Shadow', 'Chi-Yu', 'Chien-Pao', 'Darkrai', 'Deoxys-Base', 'Deoxys-Attack', 'Dialga', 'Dialga-Origin',
 			'Dragapult', 'Espathra', 'Eternatus', 'Flutter Mane', 'Giratina', 'Giratina-Origin', 'Groudon', 'Hoopa-Unbound', 'Ho-Oh', 'Iron Bundle', 'Koraidon',
 			'Kyogre', 'Kyurem-Black', 'Kyurem-White', 'Lugia', 'Lunala', 'Magearna', 'Mewtwo', 'Miraidon', 'Necrozma-Dawn-Wings', 'Necrozma-Dusk-Mane', 'Palafin',
-			'Palkia', 'Palkia-Origin', 'Rayquaza', 'Reshiram', 'Regieleki', 'Shaymin-Sky', 'Solgaleo', 'Spectrier', 'Urshifu-Base', 'Urshifu-Rapid-Strike', 'Zacian',
+			'Palkia', 'Palkia-Origin', 'Rayquaza', 'Reshiram', 'Regieleki', 'Shaymin-Sky', 'Solgaleo', 'Spectrier', 'Urshifu', 'Urshifu-Rapid-Strike', 'Zacian',
 			'Zacian-Crowned', 'Zamazenta-Crowned', 'Zekrom', 'Arena Trap', 'Moody', 'Shadow Tag', 'King\'s Rock', 'Razor Fang', 'Baton Pass', 'Last Respects',
 			'Shed Tail',
 		],
 		restricted: [
 			'Araquanid', 'Avalugg-Hisui', 'Baxcalibur', 'Beartic', 'Breloom', 'Brute Bonnet', 'Cacnea', 'Cacturne', 'Chandelure', 'Conkeldurr', 'Copperajah', 'Crabominable',
-			'Cubchoo', 'Dewpider', 'Diglett', 'Diglett-Alola', 'Dragonite', 'Dugtrio', 'Dugtrio-Alola', 'Enamorus-Base', 'Enamorus-Therian', 'Espeon', 'Excadrill', 'Flareon',
+			'Cubchoo', 'Dewpider', 'Diglett', 'Diglett-Alola', 'Dragonite', 'Dugtrio', 'Dugtrio-Alola', 'Enamorus', 'Enamorus-Therian', 'Espeon', 'Excadrill', 'Flareon',
 			'Froslass', 'Gabite', 'Garchomp', 'Gengar', 'Gholdengo', 'Gible', 'Glaceon', 'Glastrier', 'Glimmora', 'Great Tusk', 'Grimer', 'Hatterene', 'Haxorus', 'Heatran',
 			'Hoopa-Base', 'Iron Hands', 'Iron Leaves', 'Iron Moth', 'Iron Thorns', 'Iron Valiant', 'Keldeo', 'Kingambit', 'Kleavor', 'Kyurem', 'Landorus-Therian', 'Latios',
-			'Magearna', 'Magnezone', 'Mamoswine', 'Medicham', 'Meditite', 'Meloetta-Base', 'Meloetta-Pirouette', 'Metagross', 'Muk', 'Munkidori', 'Necrozma', 'Ninetales-Alola',
-			'Okidogi', 'Polteageist', 'Porygon-Z', 'Primarina', 'Raging Bolt', 'Rampardos', 'Regigigas', 'Rhydon', 'Rhyperior', 'Roaring Moon', 'Salamence', 'Sandshrew',
-			'Sandshrew-Alola', 'Sandslash', 'Sandslash-Alola', 'Scizor', 'Skuntank', 'Slaking', 'Slither Wing', 'Sneasler', 'Stunky', 'Terapagos-Stellar', 'Terrakion',
-			'Thundurus-Therian', 'Tyranitar', 'Ursaluna-Base', 'Ursaluna-Bloodmoon', 'Ursaring', 'Vikavolt', 'Volcanion', 'Volcarona', 'Vulpix-Alola', 'Yanma', 'Yanmega',
+			'Magearna', 'Magnezone', 'Mamoswine', 'Medicham', 'Meditite', 'Meloetta', 'Metagross', 'Muk', 'Munkidori', 'Necrozma', 'Ninetales-Alola', 'Okidogi', 'Polteageist',
+			'Porygon-Z', 'Primarina', 'Raging Bolt', 'Rampardos', 'Regigigas', 'Rhydon', 'Rhyperior', 'Roaring Moon', 'Salamence', 'Sandshrew', 'Sandshrew-Alola', 'Sandslash',
+			'Sandslash-Alola', 'Scizor', 'Skuntank', 'Slaking', 'Slither Wing', 'Sneasler', 'Stunky', 'Terapagos-Stellar', 'Terrakion', 'Thundurus-Therian', 'Tyranitar',
+			'Ursaluna-Base', 'Ursaluna-Bloodmoon', 'Ursaring', 'Vikavolt', 'Volcanion', 'Volcarona', 'Vulpix-Alola', 'Yanma', 'Yanmega',
 		],
 		validateSet(set, teamHas) {
 			let pokemoves = 0;
@@ -529,7 +529,9 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 				for (const [i, moveid] of set.moves.entries()) {
 					const pokemove = this.dex.species.get(moveid);
 					if (!pokemove.exists) continue;
-					if (pokemove.isNonstandard && !this.ruleTable.has(`+pokemontag:${this.toID(pokemove.isNonstandard)}`)) {
+					if (pokemove.isNonstandard &&
+						 !(this.ruleTable.has(`+pokemontag:${this.toID(pokemove.isNonstandard)}`) || this.ruleTable.has(`+pokemon:${pokemove.id}`) ||
+							this.ruleTable.has(`+basepokemon:${this.toID(pokemove.baseSpecies)}`))) {
 						problems.push(`${pokemove.isNonstandard} Pok\u00e9mon are not allowed to be used as Pokemoves.`);
 					}
 					if (this.ruleTable.isRestrictedSpecies(pokemove) || this.ruleTable.isBannedSpecies(pokemove)) {

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -530,7 +530,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 					const pokemove = this.dex.species.get(moveid);
 					if (!pokemove.exists) continue;
 					if (pokemove.isNonstandard &&
-						 !(this.ruleTable.has(`+pokemontag:${this.toID(pokemove.isNonstandard)}`) || this.ruleTable.has(`+pokemon:${pokemove.id}`) ||
+						!(this.ruleTable.has(`+pokemontag:${this.toID(pokemove.isNonstandard)}`) ||
+							this.ruleTable.has(`+pokemon:${pokemove.id}`) ||
 							this.ruleTable.has(`+basepokemon:${this.toID(pokemove.baseSpecies)}`))) {
 						problems.push(`${pokemove.isNonstandard} Pok\u00e9mon are not allowed to be used as Pokemoves.`);
 					}

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -513,13 +513,13 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		],
 		restricted: [
 			'Araquanid', 'Avalugg-Hisui', 'Baxcalibur', 'Beartic', 'Breloom', 'Brute Bonnet', 'Cacnea', 'Cacturne', 'Chandelure', 'Conkeldurr', 'Copperajah', 'Crabominable',
-			'Cubchoo', 'Darkrai', 'Dewpider', 'Diglett', 'Diglett-Alola', 'Dragonite', 'Dugtrio', 'Dugtrio-Alola', 'Enamorus-Base', 'Enamorus-Therian', 'Espeon', 'Excadrill',
-			'Flareon', 'Froslass', 'Gabite', 'Garchomp', 'Gengar', 'Gholdengo', 'Gible', 'Glaceon', 'Glastrier', 'Glimmora', 'Great Tusk', 'Grimer', 'Hatterene', 'Haxorus',
-			'Heatran', 'Hoopa-Base', 'Iron Hands', 'Iron Leaves', 'Iron Moth', 'Iron Thorns', 'Iron Valiant', 'Keldeo', 'Kingambit', 'Kleavor', 'Kyurem', 'Landorus-Therian',
-			'Latios', 'Magearna', 'Magnezone', 'Mamoswine', 'Medicham', 'Meditite', 'Meloetta-Base', 'Meloetta-Pirouette', 'Metagross', 'Muk', 'Munkidori', 'Necrozma',
-			'Ninetales-Alola', 'Okidogi', 'Palafin-Hero', 'Polteageist', 'Porygon-Z', 'Primarina', 'Raging Bolt', 'Rampardos', 'Regigigas', 'Rhydon', 'Rhyperior', 'Roaring Moon',
-			'Salamence', 'Sandshrew', 'Sandshrew-Alola', 'Sandslash', 'Sandslash-Alola', 'Scizor', 'Skuntank', 'Slaking', 'Slither Wing', 'Sneasler', 'Stunky', 'Terapagos-Stellar',
-			'Terrakion', 'Thundurus-Therian', 'Tyranitar', 'Ursaluna-Base', 'Ursaluna-Bloodmoon', 'Ursaring', 'Vikavolt', 'Volcanion', 'Volcarona', 'Vulpix-Alola', 'Yanma', 'Yanmega',
+			'Cubchoo', 'Dewpider', 'Diglett', 'Diglett-Alola', 'Dragonite', 'Dugtrio', 'Dugtrio-Alola', 'Enamorus-Base', 'Enamorus-Therian', 'Espeon', 'Excadrill', 'Flareon',
+			'Froslass', 'Gabite', 'Garchomp', 'Gengar', 'Gholdengo', 'Gible', 'Glaceon', 'Glastrier', 'Glimmora', 'Great Tusk', 'Grimer', 'Hatterene', 'Haxorus', 'Heatran',
+			'Hoopa-Base', 'Iron Hands', 'Iron Leaves', 'Iron Moth', 'Iron Thorns', 'Iron Valiant', 'Keldeo', 'Kingambit', 'Kleavor', 'Kyurem', 'Landorus-Therian', 'Latios',
+			'Magearna', 'Magnezone', 'Mamoswine', 'Medicham', 'Meditite', 'Meloetta-Base', 'Meloetta-Pirouette', 'Metagross', 'Muk', 'Munkidori', 'Necrozma', 'Ninetales-Alola',
+			'Okidogi', 'Polteageist', 'Porygon-Z', 'Primarina', 'Raging Bolt', 'Rampardos', 'Regigigas', 'Rhydon', 'Rhyperior', 'Roaring Moon', 'Salamence', 'Sandshrew',
+			'Sandshrew-Alola', 'Sandslash', 'Sandslash-Alola', 'Scizor', 'Skuntank', 'Slaking', 'Slither Wing', 'Sneasler', 'Stunky', 'Terapagos-Stellar', 'Terrakion',
+			'Thundurus-Therian', 'Tyranitar', 'Ursaluna-Base', 'Ursaluna-Bloodmoon', 'Ursaring', 'Vikavolt', 'Volcanion', 'Volcarona', 'Vulpix-Alola', 'Yanma', 'Yanmega',
 		],
 		validateSet(set, teamHas) {
 			let pokemoves = 0;


### PR DESCRIPTION
Darkrai is already in the banlist, so it being also restricted was messing things up a bit.
Palafin-Hero being restricted was redundant as Palafin is banned as a whole.