### PR TITLE
Allow underleveled event Pokemon

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -804,25 +804,13 @@ export class TeamValidator {
 				isFromRBYEncounter = true;
 			}
 		}
+		let isUnderleveled;
 		if (!isFromRBYEncounter && ruleTable.has('obtainablemisc')) {
 			// FIXME: Event pokemon given at a level under what it normally can be attained at gives a false positive
 			let evoSpecies = species;
 			while (evoSpecies.prevo) {
 				if (set.level < (evoSpecies.evoLevel || 0)) {
-					if (!pokemonGoProblems || (pokemonGoProblems && pokemonGoProblems.length)) {
-						problems.push(`${name} must be at least level ${evoSpecies.evoLevel} to be evolved.`);
-						if (pokemonGoProblems && pokemonGoProblems.length) {
-							problems.push(`It failed to validate as a Pokemon from Pokemon GO because:`);
-							for (const pokemonGoProblem of pokemonGoProblems) {
-								problems.push(pokemonGoProblem);
-							}
-						}
-					} else {
-						// Pokemon from Pokemon GO can be transferred to LGPE
-						setSources.isFromPokemonGo = true;
-						setSources.sources.push('8V');
-						setSources.sourcesBefore = 0;
-					}
+					isUnderleveled = evoSpecies.name;
 					break;
 				}
 				evoSpecies = dex.species.get(evoSpecies.prevo);
@@ -837,17 +825,53 @@ export class TeamValidator {
 
 		let eventOnlyData;
 
-		if (!setSources.sourcesBefore && setSources.sources.length) {
+		if ((!setSources.sourcesBefore && setSources.sources.length) || isUnderleveled) {
 			let skippedEggSource = true;
 			const legalSources = [];
+			let evoSpecies = species;
+			if (isUnderleveled && !setSources.sources.length) {
+				while (evoSpecies.prevo) {
+					const eventData = dex.species.getLearnsetData(evoSpecies.id).eventData;
+					if (eventData) {
+						for (let eventIndex = 0; eventIndex < eventData.length; eventIndex++) {
+							const eventLevel = eventData[eventIndex].level;
+							if (eventLevel && set.level >= eventLevel) {
+								setSources.sources.push(eventData[eventIndex].generation + 'S' + eventIndex + ' ' + evoSpecies.id);
+							}
+						}
+					}
+					if (evoSpecies.name === isUnderleveled) break;
+					evoSpecies = dex.species.get(evoSpecies.prevo);
+				}
+			}
 			for (const source of setSources.sources) {
-				if (['2E', '3E'].includes(source) && set.level < 5) continue;
+				if (isUnderleveled && source.charAt(1) !== 'S') continue;
+				if (['2E', '3E'].includes(source.substr(0, 2)) && set.level < 5) continue;
 				skippedEggSource = false;
 				if (this.validateSource(set, source, setSources, outOfBattleSpecies)) continue;
 				legalSources.push(source);
 			}
+			if (pokemonGoProblems && !pokemonGoProblems.length) {
+				if (!legalSources.length) setSources.isFromPokemonGo = true;
+				legalSources.push('8V');
+			}
 			if (legalSources.length) {
 				setSources.sources = legalSources;
+			} else if (isUnderleveled) {
+				problems.push(`${name} must be at least level ${evoSpecies.evoLevel} to be evolved.`);
+				const firstEventSource = setSources.sources.filter(source => source.charAt(1) === 'S')[0];
+				if (firstEventSource) {
+					const eventProblems = this.validateSource(
+						set, firstEventSource, setSources, outOfBattleSpecies, ` to be underleveled`
+					);
+					if (eventProblems) problems.push(...eventProblems);
+				}
+				if (pokemonGoProblems) {
+					problems.push(`It failed to validate as a Pokemon from Pokemon GO because:`);
+					for (const pokemonGoProblem of pokemonGoProblems) {
+						problems.push(pokemonGoProblem);
+					}
+				}
 			} else {
 				let nonEggSource = null;
 				for (const source of setSources.sources) {

--- a/test/sim/team-validator/events.js
+++ b/test/sim/team-validator/events.js
@@ -150,12 +150,18 @@ describe('Team Validator', function () {
 		assert.false.legalTeam(team, 'gen7anythinggoes');
 	});
 
-	it.skip('should allow evolved Pokemon obtainable from events at lower levels than they could otherwise be obtained', function () {
-		const team = [
-			{species: 'dragonite', ability: 'innerfocus', moves: ['dracometeor'], evs: {hp: 1}, level: 50},
+	it('should allow evolved Pokemon obtainable from events at lower levels than they could otherwise be obtained', function () {
+		let team = [
+			{species: 'dragonite', ability: 'innerfocus', moves: ['dracometeor'], nature: 'Mild', evs: {hp: 1}, level: 50},
 			{species: 'magmar', ability: 'flamebody', moves: ['ember'], evs: {hp: 1}, level: 10},
 			{species: 'electivire', ability: 'motordrive', moves: ['quickattack'], evs: {hp: 1}, level: 10},
 		];
 		assert.legalTeam(team, 'gen4ou');
+
+		team = [
+			{species: 'mandibuzz', level: 25, ability: 'weakarmor', moves: ['pluck'], evs: {hp: 1}},
+			{species: 'volcarona', level: 35, ability: 'flamebody', moves: ['leechlife'], evs: {hp: 1}},
+		];
+		assert.legalTeam(team, 'gen5ou');
 	});
 });

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -206,6 +206,6 @@ describe('Team Validator', function () {
 			{species: 'mandibuzz', level: 25, ability: 'weakarmor', moves: ['pluck'], evs: {hp: 1}},
 			{species: 'volcarona', level: 35, ability: 'flamebody', moves: ['leechlife'], evs: {hp: 1}},
 		];
-		assert.legalTeam(team, 'gen8ou');
+		assert.legalTeam(team, 'gen5ou');
 	});
 });

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -200,12 +200,4 @@ describe('Team Validator', function () {
 		];
 		assert.false.legalTeam(team, 'gen8ou');
 	});
-
-	it('should allow underleveled event Pokemon', function () {
-		const team = [
-			{species: 'mandibuzz', level: 25, ability: 'weakarmor', moves: ['pluck'], evs: {hp: 1}},
-			{species: 'volcarona', level: 35, ability: 'flamebody', moves: ['leechlife'], evs: {hp: 1}},
-		];
-		assert.legalTeam(team, 'gen5ou');
-	});
 });

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -200,4 +200,12 @@ describe('Team Validator', function () {
 		];
 		assert.false.legalTeam(team, 'gen8ou');
 	});
+
+	it('should allow underleveled event Pokemon', function () {
+		const team = [
+			{species: 'mandibuzz', level: 25, ability: 'weakarmor', moves: ['pluck'], evs: {hp: 1}},
+			{species: 'volcarona', level: 35, ability: 'flamebody', moves: ['leechlife'], evs: {hp: 1}},
+		];
+		assert.legalTeam(team, 'gen8ou');
+	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/underleveled-evolved-pokemon-events.3747655/

If underleveled encounters are implemented as events, as suggested in [this thread](https://www.smogon.com/forums/threads/low-level-staravia-and-bibarel.3737100/), then this code will be able to allow such Pokemon as well. Currently, they're implemented in learnsets.ts without any usage due to being separate from eventData.

This also fixes an oversight from #10444 which allowed egg Pokemon under level 5 if they were a species with an associated incense and not hatched from an incense (Marill and Wobbuffet).