### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -5174,7 +5174,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		basePower: 90,
 		category: "Special",
 		shortDesc: "If target has boosts, steals them, +1 prio, 0 BP.",
-		desc: "This move's base power is doubled if the target has a higher number of positive stat stage changes than the user. If this move's power is doubled, a random stat, except Accuracy and Evasion, is boosted for the user by 1 stage and lowered for the target by 1 stage.",
+		desc: "If the target of this move has positive stat stage changes, this move will usually move first, and on use the attack deals no damage and instead moves all positive stat stage changes from the target to the user.",
 		name: "Adaptive Beam",
 		pp: 15,
 		priority: 0,

--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -5676,8 +5676,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 
 	// Tuthur
 	symphonieduzero: {
-		accuracy: 85,
-		basePower: 35,
+		accuracy: 100,
+		basePower: 80,
 		category: "Special",
 		shortDesc: "Deals an additional 12.5% HP at end of turn.",
 		desc: "If this move deals damage, at the end of the turn, the target will take an additional 12.5% of its maximum HP in non-attack damage if it is still on the field.",

--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -679,8 +679,7 @@
     },
     "snorlax": {
         "level": 69,
-        "moves": ["bodyslam", "thunderbolt"],
-        "essentialMoves": ["amnesia", "blizzard"],
+        "moves": ["amnesia", "blizzard", "bodyslam"],
         "exclusiveMoves": ["rest", "selfdestruct"],
         "comboMoves": ["bodyslam", "earthquake", "hyperbeam", "selfdestruct"]
     },

--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -92,6 +92,11 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["curse", "earthquake", "glare", "haze", "sludgebomb"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["curse", "earthquake", "glare", "rockslide", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -178,7 +183,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "sunnyday", "toxic"]
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "sunnyday"]
             }
         ]
     },
@@ -186,11 +191,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "doubleedge", "fireblast", "rest", "sleeptalk"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["curse", "doubleedge", "rest", "sleeptalk"]
+                "movepool": ["curse", "doubleedge", "rest", "sleeptalk", "thunder"]
             }
         ]
     },
@@ -219,11 +220,6 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["hiddenpowerbug", "spore", "swordsdance", "synthesis"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "gigadrain", "hiddenpowerbug", "spore", "synthesis"],
-                "preferredTypes": ["Bug"]
             }
         ]
     },
@@ -232,7 +228,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["gigadrain", "hiddenpowerfire", "psychic", "sleeppowder", "sludgebomb", "stunspore"],
-                "preferredTypes": ["Psychic"]
+                "preferredTypes": ["Fire", "Psychic"]
             },
             {
                 "role": "Bulky Setup",
@@ -326,7 +322,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "bodyslam", "earthquake", "lovelykiss", "return"]
+                "movepool": ["bellydrum", "earthquake", "lovelykiss", "return"]
             },
             {
                 "role": "Generalist",
@@ -340,10 +336,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["encore", "firepunch", "hiddenpowerdark", "psychic", "recover", "thunderwave"],
                 "preferredTypes": ["Fire"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["encore", "firepunch", "icepunch", "psychic", "recover", "thunderpunch"]
             }
         ]
     },
@@ -365,10 +357,6 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["hiddenpowerground", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"]
-            },
-            {
-                "role": "Generalist",
-                "movepool": ["hiddenpowerground", "razorleaf", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -448,7 +436,7 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["curse", "explosion", "fireblast", "hiddenpowerground", "sludgebomb"],
+                "movepool": ["curse", "explosion", "hiddenpowerground", "sludgebomb"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -509,10 +497,6 @@
                 "role": "Bulky Setup",
                 "movepool": ["hiddenpowerground", "protect", "return", "substitute", "surf", "swordsdance"],
                 "preferredTypes": ["Normal"]
-            },
-            {
-                "role": "Generalist",
-                "movepool": ["doubleedge", "rest", "sleeptalk", "swordsdance"]
             }
         ]
     },
@@ -531,12 +515,8 @@
     "exeggutor": {
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["hiddenpowergrass", "psychic", "stunspore", "synthesis"]
-            },
-            {
                 "role": "Fast Attacker",
-                "movepool": ["explosion", "hiddenpowerfire", "hiddenpowergrass", "psychic", "sleeppowder"]
+                "movepool": ["explosion", "hiddenpowerfire", "hiddenpowergrass", "psychic", "sleeppowder", "stunspore", "thief"]
             },
             {
                 "role": "Generalist",
@@ -815,7 +795,7 @@
     "jolteon": {
         "sets": [
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["batonpass", "growth", "hiddenpowerice", "substitute", "thunderbolt"]
             }
         ]
@@ -1152,6 +1132,10 @@
             {
                 "role": "Generalist",
                 "movepool": ["encore", "hiddenpowerflying", "leechseed", "stunspore"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["encore", "hiddenpowerflying", "sleeppowder", "stunspore"]
             }
         ]
     },
@@ -1322,12 +1306,8 @@
                 "movepool": ["curse", "glare", "hiddenpowerground", "return"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["curse", "rest", "return", "sleeptalk"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["flamethrower", "rest", "return", "sleeptalk", "thunder"]
+                "role": "Generalist",
+                "movepool": ["curse", "rest", "return", "sleeptalk", "thunder"]
             }
         ]
     },
@@ -1467,7 +1447,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["curse", "recover", "rockslide", "sandstorm", "surf", "toxic"]
+                "movepool": ["curse", "icebeam", "recover", "rockslide", "sandstorm", "surf", "toxic"]
             }
         ]
     },
@@ -1499,11 +1479,11 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["curse", "drillpeck", "rest", "sleeptalk", "toxic"]
+                "movepool": ["curse", "drillpeck", "rest", "sleeptalk"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "drillpeck", "rest", "whirlwind"]
+                "movepool": ["curse", "drillpeck", "rest", "toxic", "whirlwind"]
             }
         ]
     },
@@ -1547,17 +1527,13 @@
     "porygon2": {
         "sets": [
             {
-                "role": "Generalist",
-                "movepool": ["icebeam", "recover", "thunderbolt", "thunderwave"]
-            },
-            {
                 "role": "Bulky Attacker",
                 "movepool": ["doubleedge", "icebeam", "recover", "thunder", "thunderwave"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "doubleedge", "icebeam", "recover", "thunderwave"]
+                "movepool": ["curse", "doubleedge", "icebeam", "recover", "thunder", "thunderwave"]
             }
         ]
     },

--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -1041,7 +1041,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["charm", "curse", "doubleedge", "fireblast", "rest", "sleeptalk"]
+                "movepool": ["curse", "doubleedge", "fireblast", "rest", "sleeptalk"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-battles/gen2/teams.ts
+++ b/data/random-battles/gen2/teams.ts
@@ -362,7 +362,6 @@ export class RandomGen2Teams extends RandomGen3Teams {
 	): string {
 		// First, the high-priority items
 		if (species.id === 'ditto') return 'Metal Powder';
-		if (species.id === 'farfetchd') return 'Stick';
 		if (species.id === 'marowak') return 'Thick Club';
 		if (species.id === 'pikachu') return 'Light Ball';
 

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -204,8 +204,13 @@
         "level": 97,
         "sets": [
             {
+                "role": "Fast Support",
+                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"],
+                "abilities": ["Cute Charm"]
+            },
+            {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "doubleedge", "fireblast", "healbell", "protect", "stealthrock", "thunderwave", "toxic", "wish"],
+                "movepool": ["bodyslam", "fireblast", "healbell", "protect", "stealthrock", "wish"],
                 "abilities": ["Cute Charm"]
             },
             {
@@ -352,7 +357,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "payback", "stoneedge"],
+                "movepool": ["bulletpunch", "dynamicpunch", "payback", "stoneedge", "toxic"],
                 "abilities": ["No Guard"]
             }
         ]
@@ -2049,9 +2054,10 @@
         "level": 92,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "encore", "explosion", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
-                "abilities": ["Liquid Ooze"]
+                "abilities": ["Liquid Ooze"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
@@ -2280,12 +2286,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["recover", "seedbomb", "stealthrock", "stoneedge", "toxic"],
-                "abilities": ["Suction Cups"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"],
+                "movepool": ["curse", "earthquake", "recover", "seedbomb", "stealthrock", "stoneedge", "swordsdance", "toxic"],
                 "abilities": ["Suction Cups"]
             }
         ]
@@ -3689,7 +3690,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
+                "movepool": ["airslash", "earthpower", "leechseed", "seedflare", "substitute", "synthesis"],
                 "abilities": ["Natural Cure"],
                 "preferredTypes": ["Flying"]
             }

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -433,7 +433,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"],
-                "abilities": ["Flash Fire", "Flame Body"]
+                "abilities": ["Flame Body", "Flash Fire"]
             },
             {
                 "role": "Wallbreaker",

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -230,8 +230,13 @@
         "level": 96,
         "sets": [
             {
+                "role": "Fast Support",
+                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"],
+                "abilities": ["Frisk"]
+            },
+            {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "doubleedge", "fireblast", "healbell", "protect", "stealthrock", "thunderwave", "toxic", "wish"],
+                "movepool": ["bodyslam", "fireblast", "healbell", "protect", "stealthrock", "wish"],
                 "abilities": ["Frisk"]
             },
             {
@@ -381,7 +386,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "payback", "stoneedge"],
+                "movepool": ["bulletpunch", "dynamicpunch", "payback", "stoneedge", "toxic"],
                 "abilities": ["No Guard"],
                 "preferredTypes": ["Rock"]
             }
@@ -428,7 +433,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"],
-                "abilities": ["Flash Fire"]
+                "abilities": ["Flash Fire", "Flame Body"]
             },
             {
                 "role": "Wallbreaker",
@@ -2099,9 +2104,10 @@
         "level": 93,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
-                "abilities": ["Liquid Ooze"]
+                "abilities": ["Liquid Ooze"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
@@ -2310,13 +2316,14 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"],
+                "movepool": ["curse", "earthquake", "recover", "seedbomb", "stoneedge", "swordsdance"],
                 "abilities": ["Storm Drain"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
-                "abilities": ["Storm Drain"]
+                "movepool": ["earthpower", "gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Storm Drain"],
+                "preferredTypes": ["Grass"]
             }
         ]
     },
@@ -3674,7 +3681,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
+                "movepool": ["airslash", "earthpower", "leechseed", "seedflare", "substitute", "synthesis"],
                 "abilities": ["Natural Cure"],
                 "preferredTypes": ["Flying"]
             }

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -472,7 +472,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"],
-                "abilities": ["Flash Fire"]
+                "abilities": ["Flame Body", "Flash Fire"]
             },
             {
                 "role": "Wallbreaker",
@@ -991,11 +991,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bodyslam", "crunch", "curse", "earthquake", "rest", "sleeptalk"],
-                "abilities": ["Thick Fat"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit"],
                 "abilities": ["Thick Fat"]
             }
         ]
@@ -2159,7 +2154,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulkup", "bulletpunch", "closecombat", "facade", "knockoff"],
+                "movepool": ["bulletpunch", "closecombat", "facade", "fakeout", "knockoff"],
                 "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
@@ -2232,7 +2227,8 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "stoneedge", "thunderwave", "toxic"],
-                "abilities": ["Sturdy"]
+                "abilities": ["Sturdy"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2332,9 +2328,10 @@
         "level": 90,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
-                "abilities": ["Liquid Ooze"]
+                "abilities": ["Liquid Ooze"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
@@ -2554,11 +2551,6 @@
                 "role": "Fast Attacker",
                 "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower"],
                 "abilities": ["Adaptability"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "swordsdance"],
-                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -2577,13 +2569,14 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"],
+                "movepool": ["curse", "earthquake", "recover", "seedbomb", "stoneedge", "swordsdance"],
                 "abilities": ["Storm Drain"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
-                "abilities": ["Storm Drain"]
+                "movepool": ["earthpower", "gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Storm Drain"],
+                "preferredTypes": ["Grass"]
             }
         ]
     },
@@ -4098,7 +4091,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
+                "movepool": ["airslash", "earthpower", "leechseed", "seedflare", "substitute", "synthesis"],
                 "abilities": ["Natural Cure"],
                 "preferredTypes": ["Flying"]
             }
@@ -4425,9 +4418,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "playrough", "return", "superpower", "wildcharge"],
-                "abilities": ["Scrappy"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["crunch", "facade", "return", "superpower"],
+                "abilities": ["Scrappy"]
             }
         ]
     },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -3833,7 +3833,7 @@
                 "role": "Bulky Support",
                 "movepool": ["earthpower", "powergem", "stealthrock", "thunderwave", "toxic", "voltswitch"],
                 "abilities": ["Magnet Pull"],
-                "preferredTypes": ["Ground"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -3828,6 +3828,12 @@
                 "role": "Bulky Attacker",
                 "movepool": ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"],
                 "abilities": ["Magnet Pull"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["earthpower", "powergem", "stealthrock", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Magnet Pull"],
+                "preferredTypes": ["Ground"],
             }
         ]
     },

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -649,7 +649,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			return (ability === 'Solid Rock' && !!counter.get('priority')) ? 'Weakness Policy' : 'White Herb';
 		}
 		if (moves.has('psychoshift')) return 'Flame Orb';
-		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
+		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk') && species.id !== 'stoutland') {
 			return species.name === 'Conkeldurr' ? 'Flame Orb' : 'Toxic Orb';
 		}
 		if (ability === 'Magic Guard') return moves.has('counter') ? 'Focus Sash' : 'Life Orb';

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -545,7 +545,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulkup", "bulletpunch", "closecombat", "facade", "knockoff"],
+                "movepool": ["bulletpunch", "closecombat", "facade", "knockoff"],
                 "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
@@ -618,7 +618,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["flareblitz", "highhorsepower", "morningsun", "wildcharge", "willowisp"],
-                "abilities": ["Flash Fire"]
+                "abilities": ["Flame Body", "Flash Fire"]
             },
             {
                 "role": "Wallbreaker",
@@ -1207,11 +1207,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bodyslam", "crunch", "curse", "earthquake", "rest", "return", "sleeptalk"],
-                "abilities": ["Thick Fat"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit", "return"],
                 "abilities": ["Thick Fat"]
             },
             {
@@ -2392,7 +2387,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulkup", "bulletpunch", "closecombat", "facade", "knockoff"],
+                "movepool": ["bulletpunch", "closecombat", "facade", "fakeout", "knockoff"],
                 "abilities": ["Guts"],
                 "preferredTypes": ["Dark"]
             }
@@ -2463,9 +2458,10 @@
         "level": 81,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "stoneedge", "thunderwave", "toxic"],
-                "abilities": ["Sturdy"]
+                "abilities": ["Sturdy"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2570,9 +2566,10 @@
         "level": 90,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
-                "abilities": ["Liquid Ooze"]
+                "abilities": ["Liquid Ooze"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
@@ -2803,11 +2800,6 @@
                 "role": "Fast Attacker",
                 "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower"],
                 "abilities": ["Adaptability"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "swordsdance"],
-                "abilities": ["Adaptability"]
             }
         ]
     },
@@ -2826,13 +2818,14 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "recover", "seedbomb", "stoneedge", "swordsdance"],
+                "movepool": ["curse", "earthquake", "recover", "seedbomb", "stoneedge", "swordsdance"],
                 "abilities": ["Storm Drain"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
-                "abilities": ["Storm Drain"]
+                "movepool": ["earthpower", "gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
+                "abilities": ["Storm Drain"],
+                "preferredTypes": ["Grass"]
             }
         ]
     },
@@ -4151,6 +4144,12 @@
                 "role": "Bulky Attacker",
                 "movepool": ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"],
                 "abilities": ["Magnet Pull"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["earthpower", "powergem", "stealthrock", "thunderwave", "toxic", "voltswitch"],
+                "abilities": ["Magnet Pull"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -4432,7 +4431,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
+                "movepool": ["airslash", "earthpower", "leechseed", "seedflare", "substitute", "synthesis"],
                 "abilities": ["Natural Cure"],
                 "preferredTypes": ["Flying"]
             }
@@ -4783,9 +4782,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "playrough", "return", "superpower", "wildcharge"],
-                "abilities": ["Scrappy"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["crunch", "facade", "return", "superpower"],
+                "abilities": ["Scrappy"]
             }
         ]
     },
@@ -6606,6 +6604,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["closecombat", "drainpunch", "earthquake", "icehammer", "stoneedge"],
                 "abilities": ["Iron Fist"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["drainpunch", "earthquake", "icehammer", "thunderpunch"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -6919,13 +6922,8 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["rest", "return", "sleeptalk", "swordsdance"],
-                "abilities": ["Battle Armor"]
-            },
-            {
                 "role": "Bulky Support",
-                "movepool": ["payback", "rest", "return", "sleeptalk", "uturn"],
+                "movepool": ["payback", "rest", "return", "sleeptalk", "swordsdance"],
                 "abilities": ["Battle Armor"]
             }
         ]

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -870,7 +870,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (moves.has('shellsmash')) {
 			return (ability === 'Solid Rock' && !!counter.get('priority')) ? 'Weakness Policy' : 'White Herb';
 		}
-		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
+		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk') && species.id !== 'stoutland') {
 			return (types.includes('Fire') || ability === 'Quick Feet' || ability === 'Toxic Boost') ? 'Toxic Orb' : 'Flame Orb';
 		}
 		if (ability === 'Magic Guard') return moves.has('counter') ? 'Focus Sash' : 'Life Orb';

--- a/data/random-battles/gen8/data.json
+++ b/data/random-battles/gen8/data.json
@@ -44,7 +44,7 @@
     },
     "pikachu": {
         "level": 92,
-        "moves": ["irontail", "knockoff", "surf", "voltswitch", "volttackle"],
+        "moves": ["knockoff", "playrough", "surf", "voltswitch", "volttackle"],
         "doublesLevel": 91,
         "doublesMoves": ["fakeout", "grassknot", "knockoff", "protect", "volttackle"]
     },
@@ -2685,7 +2685,7 @@
     },
     "zaciancrowned": {
         "level": 61,
-        "moves": ["behemothblade", "closecombat", "crunch", "playrough", "psychicfangs", "swordsdance"],
+        "moves": ["behemothblade", "closecombat", "playrough", "psychicfangs", "swordsdance"],
         "doublesLevel": 65,
         "doublesMoves": ["behemothblade", "closecombat", "playrough", "protect", "psychicfangs", "swordsdance"]
     },

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -4978,7 +4978,7 @@
               "item": ["Focus Sash"],
               "nature": "Timid",
               "evs": {"def": 4, "spa": 252, "spe": 252},
-              "teraType": ["Fairy", "Fighting", "Ghost"],
+              "teraType": ["Fairy", "Fighting"],
               "wantsTera": true,
               "ability": ["Illusion"]
           },

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -2173,7 +2173,6 @@
                   ["Curse"],
                   ["Trick Room"]
               ],
-              "gender": "F",
               "item": ["Life Orb"],
               "nature": "Adamant",
               "evs": {"hp": 36, "atk": 236, "def": 180, "spd": 4, "spe": 52},
@@ -2249,7 +2248,6 @@
                   ["Trick Room"],
                   ["Shadow Sneak"]
               ],
-              "gender": "F",
               "item": ["Covert Cloak"],
               "nature": "Adamant",
               "evs": {"hp": 36, "atk": 236, "def": 180, "spd": 4, "spe": 52},
@@ -2414,7 +2412,7 @@
           },
           {
               "species": "Basculegion",
-              "weight": 5,
+              "weight": 10,
               "moves": [
                   ["Wave Crash"],
                   ["Aqua Jet"],
@@ -2427,22 +2425,6 @@
               "evs": {"atk": 252, "spd": 4, "spe": 252},
               "teraType": ["Ghost", "Normal", "Water"],
               "ability": ["Adaptability"]
-          },
-          {
-              "species": "Basculegion",
-              "weight": 5,
-              "moves": [
-                  ["Wave Crash"],
-                  ["Aqua Jet"],
-                  ["Flip Turn", "Liquidation", "Substitute"],
-                  ["Last Respects"]
-              ],
-              "gender": "M",
-              "item": ["Life Orb"],
-              "nature": "Adamant",
-              "evs": {"atk": 252, "spd": 4, "spe": 252},
-              "teraType": ["Water"],
-              "ability": ["Swift Swim"]
           }
       ]
   },
@@ -2928,7 +2910,6 @@
                   ["Fake Out"],
                   ["Toxic Spikes"]
               ],
-              "gender": "F",
               "item": ["Air Balloon", "Focus Sash", "Normal Gem", "Red Card", "Sitrus Berry"],
               "nature": "Adamant",
               "evs": {"atk": 252, "spd": 4, "spe": 252},
@@ -2944,7 +2925,6 @@
                   ["Fake Out"],
                   ["Toxic Spikes"]
               ],
-              "gender": "F",
               "item": ["Air Balloon", "Focus Sash", "Sitrus Berry"],
               "nature": "Jolly",
               "evs": {"atk": 252, "spd": 4, "spe": 252},
@@ -2953,33 +2933,17 @@
           },
           {
               "species": "Sneasler",
-              "weight": 55,
+              "weight": 60,
               "moves": [
                   ["Dire Claw"],
                   ["Close Combat"],
                   ["Shadow Claw"],
                   ["Toxic Spikes"]
               ],
-              "gender": "F",
               "item": ["Air Balloon", "Focus Sash", "Red Card", "Sitrus Berry"],
               "nature": "Adamant",
               "evs": {"atk": 252, "spd": 4, "spe": 252},
               "teraType": ["Ghost"],
-              "ability": ["Unburden"]
-          },
-          {
-              "species": "Sneasler",
-              "weight": 5,
-              "moves": [
-                  ["Dire Claw"],
-                  ["Close Combat"],
-                  ["Swords Dance"],
-                  ["Acrobatics", "Shadow Claw"]
-              ],
-              "item": ["Grassy Seed"],
-              "nature": "Adamant",
-              "evs": {"hp": 92, "atk": 252, "def": 4, "spd": 4, "spe": 156},
-              "teraType": ["Flying", "Ghost"],
               "ability": ["Unburden"]
           }
       ]
@@ -3943,7 +3907,6 @@
                   ["Hammer Arm", "Low Kick", "Taunt"],
                   ["Thunder Wave"]
               ],
-              "gender": "M",
               "item": ["Focus Sash"],
               "nature": "Adamant",
               "evs": {"atk": 252, "def": 4, "spe": 252},
@@ -4571,49 +4534,13 @@
                   ["Roost"],
                   ["Taunt", "Toxic"],
                   ["U-turn"],
-                  ["Charm", "Play Rough"]
+                  ["Play Rough"]
               ],
               "item": ["Leftovers"],
               "nature": "Careful",
               "evs": {"hp": 252, "spd": 220, "spe": 36},
               "teraType": ["Flying", "Water"],
               "ability": ["Toxic Chain"]
-          }
-      ]
-  },
-  "pelipper": {
-      "weight": 3,
-      "sets": [
-          {
-              "species": "Pelipper",
-              "weight": 70,
-              "moves": [
-                  ["U-turn"],
-                  ["Hydro Pump", "Surf"],
-                  ["Ice Beam"],
-                  ["Hurricane", "Roost"]
-              ],
-              "item": ["Damp Rock"],
-              "nature": "Quiet",
-              "evs": {"hp": 252, "def": 4, "spa": 252},
-              "ivs": {"spe": 0},
-              "teraType": ["Grass", "Ground", "Steel"],
-              "ability": ["Drizzle"]
-          },
-          {
-              "species": "Pelipper",
-              "weight": 30,
-              "moves": [
-                  ["U-turn"],
-                  ["Hydro Pump", "Surf"],
-                  ["Ice Beam"],
-                  ["Hurricane"]
-              ],
-              "item": ["Choice Specs", "Damp Rock"],
-              "nature": "Modest",
-              "evs": {"spa": 252, "spd": 4, "spe": 252},
-              "teraType": ["Flying", "Grass", "Ground", "Steel", "Water"],
-              "ability": ["Drizzle"]
           }
       ]
   },
@@ -5058,7 +4985,7 @@
       "sets": [
           {
               "species": "Drifblim",
-              "weight": 95,
+              "weight": 100,
               "moves": [
                   ["Minimize"],
                   ["Substitute"],
@@ -5066,22 +4993,6 @@
                   ["Air Slash", "Shadow Ball", "Stockpile", "Strength Sap", "Will-O-Wisp"]
               ],
               "item": ["Kee Berry", "Sitrus Berry"],
-              "nature": "Timid",
-              "evs": {"def": 164, "spd": 92, "spe": 252},
-              "ivs": {"atk": 0},
-              "teraType": ["Dark", "Normal", "Water"],
-              "ability": ["Unburden"]
-          },
-          {
-              "species": "Drifblim",
-              "weight": 5,
-              "moves": [
-                  ["Minimize"],
-                  ["Substitute"],
-                  ["Baton Pass"],
-                  ["Air Slash", "Shadow Ball", "Stockpile", "Strength Sap", "Will-O-Wisp"]
-              ],
-              "item": ["Grassy Seed"],
               "nature": "Timid",
               "evs": {"def": 164, "spd": 92, "spe": 252},
               "ivs": {"atk": 0},

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -4544,6 +4544,26 @@
           }
       ]
   },
+  "pelipper": {
+    "weight": 3,
+    "sets": [
+        {
+            "species": "Pelipper",
+            "weight": 100,
+            "moves": [
+                ["U-turn"],
+                ["Hydro Pump"],
+                ["Ice Beam"],
+                ["Hurricane"]
+            ],
+            "item": ["Choice Specs"],
+            "nature": "Modest",
+            "evs": {"spa": 252, "spd": 4, "spe": 252},
+            "teraType": ["Flying", "Grass", "Ground", "Steel", "Water"],
+            "ability": ["Drizzle"]
+        }
+    ]
+},
   "rotomheat": {
       "weight": 3,
       "sets": [

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -1456,7 +1456,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Heal Pulse", "Helping Hand", "Seismic Toss", "Soft-Boiled", "Thunder Wave"],
+                "movepool": ["Heal Pulse", "Helping Hand", "Hyper Voice", "Protect", "Seismic Toss", "Soft-Boiled", "Thunder Wave"],
                 "abilities": ["Healer"],
                 "teraTypes": ["Fairy", "Ghost", "Poison"]
             }
@@ -1641,7 +1641,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Hurricane", "Hydro Pump", "Muddy Water", "Tailwind", "Wide Guard"],
+                "movepool": ["Hurricane", "Hydro Pump", "Muddy Water", "Protect", "Tailwind", "Wide Guard"],
                 "abilities": ["Drizzle"],
                 "teraTypes": ["Ground", "Steel"]
             }
@@ -2630,13 +2630,13 @@
         "level": 87,
         "sets": [
             {
-                "role": "Doubles Setup Sweeper",
-                "movepool": ["Blizzard", "Calm Mind", "Freeze-Dry", "Shadow Ball"],
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Blizzard", "Freeze-Dry", "Mud Shot", "Protect"],
                 "abilities": ["Ice Body"],
-                "teraTypes": ["Ghost", "Ice"]
+                "teraTypes": ["Ground"]
             },
             {
-                "role": "Doubles Wallbreaker",
+                "role": "Doubles Setup Sweeper",
                 "movepool": ["Blizzard", "Calm Mind", "Freeze-Dry", "Mud Shot"],
                 "abilities": ["Ice Body"],
                 "teraTypes": ["Ground"]
@@ -4635,8 +4635,20 @@
         "level": 85,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
+                "role": "Doubles Bulky Setup",
                 "movepool": ["Liquidation", "Lunge", "Protect", "Sticky Web", "Wide Guard"],
+                "abilities": ["Water Bubble"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Doubles Support",
+                "movepool": ["Liquidation", "Leech Life", "Protect", "Sticky Web", "Wide Guard"],
+                "abilities": ["Water Bubble"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Hydro Pump", "Liquidation", "Protect", "Sticky Web", "Wide Guard"],
                 "abilities": ["Water Bubble"],
                 "teraTypes": ["Water"]
             }
@@ -5989,6 +6001,12 @@
                 "movepool": ["Psychic", "Revival Blessing", "Struggle Bug", "Trick Room"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Bug Buzz", "Psychic", "Revival Blessing", "Trick Room"],
+                "abilities": ["Synchronize"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -6468,7 +6486,7 @@
         "sets": [
             {
                 "role": "Choice Item user",
-                "movepool": ["Dazzling Gleam", "Focus Blast", "Make It Rain", "Psychic", "Shadow Ball", "Thunderbolt", "Trick"],
+                "movepool": ["Dazzling Gleam", "Focus Blast", "Make It Rain", "Shadow Ball", "Thunderbolt", "Trick"],
                 "abilities": ["Good as Gold"],
                 "teraTypes": ["Fairy", "Steel"]
             },
@@ -6477,6 +6495,12 @@
                 "movepool": ["Make It Rain", "Nasty Plot", "Protect", "Shadow Ball"],
                 "abilities": ["Good as Gold"],
                 "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Dazzling Gleam", "Focus Blast", "Make It Rain", "Protect", "Shadow Ball"],
+                "abilities": ["Good as Gold"],
+                "teraTypes": ["Fairy", "Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -4642,7 +4642,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Liquidation", "Leech Life", "Protect", "Sticky Web", "Wide Guard"],
+                "movepool": ["Leech Life", "Liquidation", "Protect", "Sticky Web", "Wide Guard"],
                 "abilities": ["Water Bubble"],
                 "teraTypes": ["Water"]
             },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -2725,15 +2725,15 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Crunch", "Flip Turn", "Ice Spinner", "Low Kick", "Wave Crash"],
+                "movepool": ["Crunch", "Flip Turn", "Ice Spinner", "Wave Crash"],
                 "abilities": ["Water Veil"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Crunch", "Ice Spinner", "Low Kick", "Wave Crash"],
+                "movepool": ["Bulk Up", "Crunch", "Ice Spinner", "Wave Crash"],
                 "abilities": ["Water Veil"],
-                "teraTypes": ["Dark", "Fighting", "Ice", "Steel", "Water"]
+                "teraTypes": ["Dark", "Steel", "Water"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -4375,7 +4375,7 @@
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bug Buzz", "Fiery Dance", "Fire Blast", "Giga Drain", "Morning Sun", "Quiver Dance"],
                 "abilities": ["Flame Body", "Swarm"],
-                "teraTypes": ["Fire", "Grass"]
+                "teraTypes": ["Fire", "Grass", "Steel"]
             },
             {
                 "role": "Tera Blast user",

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -201,14 +201,8 @@
         "level": 96,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Alluring Voice", "Dazzling Gleam", "Fire Blast", "Knock Off", "Protect", "Wish"],
-                "abilities": ["Competitive"],
-                "teraTypes": ["Fire", "Poison", "Steel"]
-            },
-            {
                 "role": "Bulky Support",
-                "movepool": ["Alluring Voice", "Dazzling Gleam", "Protect", "Stealth Rock", "Thunder Wave", "Wish"],
+                "movepool": ["Alluring Voice", "Dazzling Gleam", "Fire Blast", "Knock Off", "Protect", "Thunder Wave", "Wish"],
                 "abilities": ["Competitive"],
                 "teraTypes": ["Poison", "Steel"]
             }
@@ -576,7 +570,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic Noise", "Thunder Wave", "Toxic"],
                 "abilities": ["Insomnia"],
-                "teraTypes": ["Dark", "Steel"]
+                "teraTypes": ["Dark", "Fairy", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
@@ -1183,7 +1177,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Dazzling Gleam", "Discharge", "Focus Blast", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Dazzling Gleam", "Discharge", "Dragon Tail", "Focus Blast", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Static"],
                 "teraTypes": ["Fairy"]
             }
@@ -1665,6 +1659,12 @@
                 "movepool": ["Ceaseless Edge", "Spore", "Stealth Rock", "Sticky Web", "Whirlwind"],
                 "abilities": ["Own Tempo"],
                 "teraTypes": ["Ghost"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Population Bomb", "Power Trip", "Shell Smash", "Spore"],
+                "abilities": ["Technician"],
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -2000,7 +2000,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Bullet Punch", "Close Combat", "Facade", "Headlong Rush", "Knock Off"],
+                "movepool": ["Bullet Punch", "Close Combat", "Facade", "Fake Out", "Headlong Rush", "Knock Off"],
                 "abilities": ["Guts"],
                 "teraTypes": ["Normal"]
             },
@@ -2392,7 +2392,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Curse", "Iron Defense", "Iron Head", "Rest"],
+                "movepool": ["Body Press", "Iron Defense", "Iron Head", "Rest"],
                 "abilities": ["Clear Body"],
                 "teraTypes": ["Fighting"]
             },
@@ -2473,7 +2473,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Ascent", "Dragon Dance", "Earthquake", "Outrage"],
                 "abilities": ["Air Lock"],
-                "teraTypes": ["Flying"]
+                "teraTypes": ["Flying", "Steel"]
             },
             {
                 "role": "Fast Attacker",
@@ -2485,7 +2485,7 @@
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Ascent", "Earthquake", "Scale Shot", "Swords Dance"],
                 "abilities": ["Air Lock"],
-                "teraTypes": ["Dragon", "Flying"]
+                "teraTypes": ["Dragon", "Flying", "Steel"]
             }
         ]
     },
@@ -2551,7 +2551,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Cosmic Power", "Night Shade", "Recover", "Spikes", "Stealth Rock", "Taunt"],
+                "movepool": ["Cosmic Power", "Night Shade", "Recover", "Stored Power"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Steel"]
             },
@@ -2559,7 +2559,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Knock Off", "Psychic Noise", "Recover", "Spikes", "Stealth Rock", "Teleport"],
                 "abilities": ["Pressure"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Dark", "Fairy", "Steel"]
             },
             {
                 "role": "Bulky Setup",
@@ -2903,6 +2903,12 @@
                 "movepool": ["Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind"],
                 "abilities": ["Sand Stream"],
                 "teraTypes": ["Dragon", "Rock", "Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Curse", "Earthquake", "Slack Off", "Stone Edge"],
+                "abilities": ["Sand Stream"],
+                "teraTypes": ["Rock", "Steel"]
             }
         ]
     },
@@ -3982,7 +3988,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Ice Spinner", "Leaf Blade", "Sleep Powder", "Victory Dance"],
                 "abilities": ["Hustle"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },
@@ -4048,7 +4054,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Dragon Dance", "Knock Off", "Poison Jab"],
-                "abilities": ["Intimidate", "Moxie"],
+                "abilities": ["Intimidate"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -5888,13 +5894,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Belly Drum", "Ice Spinner", "Iron Head", "Liquidation", "Substitute", "Zen Headbutt"],
+                "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute"],
                 "abilities": ["Ice Face"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute", "Tera Blast"],
+                "movepool": ["Belly Drum", "Ice Spinner", "Substitute", "Tera Blast"],
                 "abilities": ["Ice Face"],
                 "teraTypes": ["Electric", "Ground"]
             }
@@ -6675,7 +6681,7 @@
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Lumina Crash", "Shadow Ball", "U-turn"],
                 "abilities": ["Speed Boost"],
-                "teraTypes": ["Fairy", "Ghost", "Psychic"]
+                "teraTypes": ["Fairy", "Psychic"]
             },
             {
                 "role": "Fast Bulky Setup",
@@ -7249,7 +7255,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Heavy Slam", "Ruination", "Spikes", "Stealth Rock", "Throat Chop"],
+                "movepool": ["Earthquake", "Heavy Slam", "Payback", "Ruination", "Spikes", "Stealth Rock"],
                 "abilities": ["Vessel of Ruin"],
                 "teraTypes": ["Ghost", "Poison", "Steel"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -553,13 +553,13 @@
                 "role": "Wallbreaker",
                 "movepool": ["Focus Blast", "Nasty Plot", "Shadow Ball", "Sludge Wave", "Trick"],
                 "abilities": ["Cursed Body"],
-                "teraTypes": ["Fighting", "Ghost"]
+                "teraTypes": ["Dark", "Fighting", "Ghost"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Encore", "Focus Blast", "Shadow Ball", "Sludge Wave", "Toxic Spikes", "Will-O-Wisp"],
                 "abilities": ["Cursed Body"],
-                "teraTypes": ["Fighting", "Ghost"]
+                "teraTypes": ["Dark", "Fighting", "Ghost"]
             }
         ]
     },

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1140,11 +1140,11 @@ export class RandomTeams {
 		if (role === 'AV Pivot') return 'Assault Vest';
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'regieleki') return 'Magnet';
-		if (species.id === 'smeargle') return 'Focus Sash';
 		if (
 			species.id === 'froslass' || moves.has('populationbomb') ||
 			(ability === 'Hustle' && counter.get('setup') && !isDoubles && this.randomChance(1, 2))
 		) return 'Wide Lens';
+		if (species.id === 'smeargle') return 'Focus Sash';
 		if (moves.has('clangoroussoul') || (species.id === 'toxtricity' && moves.has('shiftgear'))) return 'Throat Spray';
 		if (
 			(species.baseSpecies === 'Magearna' && role === 'Tera Blast user') ||


### PR DESCRIPTION
This is a smaller update, for everything except gen 2 oddly. 9 has some wacky stuff though.

**Gen 9 Random Battle:**
-Smeargle now has a second set of Setup Sweeper with Population Bomb, Spore, Shell Smash, and Power Trip with a Wide Lens and Tera Normal. Yes, really. It can live a hit with how high its level is.
-Hippowdon now has a second set of Bulky Setup with Curse, EdgeQuake, and Slack Off with Tera Rock/Steel.
-Sitrus Berry Eiscue no longer exists. It no longer runs Liquidation on Tera Blast and no longer runs Zen Headbutt or Iron Head on non-Tera Blast. It is always Salac Berry Substitute now.
-Night Shade Deoxys-Defense no longer runs hazards or taunt, and is instead just Night Shade, Cosmic Power, Stored Power, and Recover.
-Floatzel: -Low Kick (both sets), -Tera Ice, -Tera Fighting
-AV Ampharos: +Dragon Tail
-Bulky Attacker Ting-Lu: -Throat Chop, +Payback
-Guts Hariyama: +Fake Out
-Registeel: -Curse
-Hisuian Lilligant: +Tera Steel
-Bulky Support Hypno: +Tera Fairy
-non-Extreme Speed Rayquazas: +Tera Steel
-Specs Espathra: -Tera Ghost
-Bulky Support Deoxys-Defense: +Tera Dark, +Tera Fairy
-Both Gengar sets: +Tera Dark
-non-Tera Blast Volcarona: +Tera Steel

Per winrate analysis:
-Wigglytuff's previous changes have been reverted; it now runs just one set, no longer always has WishTect, and no longer runs Tera Fire. In addition, it no longer runs Stealth Rock.
-Moxie Scrafty no longer exists.

**Super Staff Bros Ultimate**:
-Symphonie du Zero, the move of Tuthur's Scream Tail, will now be 80 bp and 100 accuracy again. Specifically requested that I include it here by Hizo.
-Adaptive Beam's description is more accurate to how it works now.

**Doubles:**
-Araquanid now has three sets with one move's difference between the three of them. It now rolls between Leech Life, Lunge, and Hydro Pump as its second attack.
-Glaceon's Shadow Ball set has been changed to Tera Ground Mud Shot + Protect + Blizzard + Freeze-Dry.
-Gholdengo: -Psychic, added set 3 of Offensive Protect with STABs, Protect, Dazzling Gleam, and Focus Blast with Tera Steel/Fairy.
-Pelipper: +Protect
-Blissey: +Hyper Voice, +Protect
-Rabsca: +Set 2 with Bug Buzz over Struggle Bug

**Oldgens:**
-In Gen 8, Pikachu now runs Play rough over Iron Tail
-In Gen 8, Zacian-Crowned no longer runs Crunch.
-In Gens 4-7, Shaymin now runs Synthesis over Rest
-In Gens 4-7, Swalot's Bulky Support set is now Bulky Attacker and it always runs Earthquake.
-In Gens 4-7, Cradily now runs a ground move on its sets.
-In Gens 5-7, Rapidash can now run Flame Body when it has Leftovers.
-In Gens 6-7, Guts Hariyama runs Fake Out over Bulk Up.
-In Gens 6-7, Crawdaunt no longer runs Swords Dance.
-In Gens 6-7, Probopass now runs a second set with Power Gem over Flash Cannon.
-In Gens 6-7, Stoutland now runs Facade and no longer runs Play Rough or Wild Charge.
-In Gens 6-7, Snorlax no longer runs Assault Vest.
-In Gens 6-7, Mega Aggron now always runs Earthquake
-In Gen 7, Machamp no longer runs Bulk Up with Guts.
-In Gen 7, Crabominable now runs an AV Pivot set.
-In Gen 7, Type: Null no longer runs U-turn.
-In Gens 4-5, Wigglytuff now runs status-inducing moves with Double-Edge and non-status-inducing moves with Body Slam.
-In Gens 4-5, Machamp now runs Toxic over Bulk Up.
-In Gen 2, Kingler no longer runs its RestTalk set.
-In Gen 2, Exeggutor no longer runs its Synthesis set. Its Fast Attacker set now has Stun Spore and Thief.
-In Gen 2, Farfetch'd now runs Leftovers.
-In Gen 2, Victreebel now only runs its Swords Dance set.
-In Gen 2, Belly Drum Poliwrath no longer runs Body Slam.
-In Gen 2, Ninetales no longer runs Toxic.
-In Gen 2, Jolteon now always runs HP Ice.
-In Gen 2, non-Curse Venomoth now always runs HP Fire.
-In Gen 2, Muk no longer runs Fire Blast
-In Gen 2, Parasect now only runs Swords Dance sets.
-In Gen 2, Arbok now runs a third set of sludge bomb, earthquake, rock slide, glare, and curse. It will always get Earthquake.
-In Gen 2, Bulky Support Alakazam no longer exists.
-In Gen 2, Wigglytuff no longer runs Fire Blast and Body Slam, and it now runs Thunder.
-In Gen 2, Jumpluff now runs a third set with HP Flying, Encore, Sleep Powder, and Stun Spore.
-In Gen 2, Dunsparce no longer runs Flamethrower and some of its sets have been merged as a result.
-In Gen 2, Corsola now runs Ice Beam.
-In Gen 2, Skarmory no longer runs Toxic with RestTalk and now runs it with Curse instead.
-In Gen 2, Porygon2 will always run Double-Edge and the Curse set can run Thunder.
-In Gen 2, Togetic no longer runs Charm.
-In Gen 1, Amnesia snorlax now always runs Body Slam instead of rolling between Body Slam and Thunderbolt.

**BSS Factory:**
-Pelipper is now only Choice Specs with Hydro Pump. It no longer runs Surf or Damp Rock.
-Basculegion no longer runs Swift Swim
-Mimikyu and Sneasler no longer have inconsistent gender restrictions.
-Sneasler and Drifblim no longer run Grassy Seed.
-Fezandipiti now will always get an actual real attack.
-Hisuian Zoroark will no longer get Tera Blast Ghost.