### PR TITLE
Megas Revisited: Fix Parental Bond

### DIFF
--- a/data/mods/gen6megasrevisited/abilities.ts
+++ b/data/mods/gen6megasrevisited/abilities.ts
@@ -265,7 +265,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			if (move.category === 'Status' || move.selfdestruct || move.multihit) return;
 			if ([
 				'endeavor', 'seismictoss', 'psywave', 'nightshade', 'sonicboom', 'dragonrage',
-				'superfang', 'naturesmadness', 'bide', 'counter', 'mirrorcoat', 'metalburst'
+				'superfang', 'naturesmadness', 'bide', 'counter', 'mirrorcoat', 'metalburst',
 			].includes(move.id)) return;
 			if (!move.spreadHit && !move.isZ && !move.isMax) {
 				move.multihit = 2;

--- a/data/mods/gen6megasrevisited/abilities.ts
+++ b/data/mods/gen6megasrevisited/abilities.ts
@@ -260,6 +260,32 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		shortDesc: "On switch-in, sets Delta Stream. User takes halved damage from hazards.",
 		rating: 5,
 	},
+	parentalbond: {
+		onPrepareHit(source, target, move) {
+			if (move.category === 'Status' || move.selfdestruct || move.multihit) return;
+			if ([
+				'endeavor', 'seismictoss', 'psywave', 'nightshade', 'sonicboom', 'dragonrage',
+				'superfang', 'naturesmadness', 'bide', 'counter', 'mirrorcoat', 'metalburst'
+			].includes(move.id)) return;
+			if (!move.spreadHit && !move.isZ && !move.isMax) {
+				move.multihit = 2;
+				move.multihitType = 'parentalbond';
+			}
+		},
+		onBasePowerPriority: 7,
+		onBasePower(basePower, pokemon, target, move) {
+			if (move.multihitType === 'parentalbond' && move.hit > 1) return this.chainModify(0.5);
+		},
+		onSourceModifySecondaries(secondaries, target, source, move) {
+			if (move.multihitType === 'parentalbond' && move.id === 'secretpower' && move.hit < 2) {
+				// hack to prevent accidentally suppressing King's Rock/Razor Fang
+				return secondaries.filter(effect => effect.volatileStatus === 'flinch');
+			}
+		},
+		name: "Parental Bond",
+		rating: 4.5,
+		num: 184,
+	},
 
 	// for ngas
 	galewings: {


### PR DESCRIPTION
Parental Bond bugfix, now it doesn't work on set damage moves

(...which is the entire reason why Mega Kangaskhan is even legal in MRV and I somehow forgot to code it in because I'm dumb and somehow no one caught it in 2 years of MRV existing on our side server...)