### PR TITLE
Bug: desynchronization between the Battle and RoomBattle

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2812,7 +2812,7 @@ export class Battle {
 
 		if (!side.choose(input)) {
 			if (!side.choice.error) {
-				side.emitChoiceError(`Unknown error for choice: ${input}. Please save the replay and report it here: https://www.smogon.com/forums/ps-bug-report-form/.`);
+				side.emitChoiceError(`Unknown error for choice: ${input}. If you're not using a custom client, please report this as a bug.`);
 			}
 			return false;
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2810,7 +2810,12 @@ export class Battle {
 	choose(sideid: SideID, input: string) {
 		const side = this.getSide(sideid);
 
-		if (!side.choose(input)) return false;
+		if (!side.choose(input)) {
+			if (!side.choice.error) {
+				side.emitChoiceError(`Unknown error for choice ${input}. Please report save the replay and report this.`);
+			}
+			return false;
+		}
 
 		if (!side.isChoiceDone()) {
 			side.emitChoiceError(`Incomplete choice: ${input} - missing other pokemon`);

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2812,7 +2812,7 @@ export class Battle {
 
 		if (!side.choose(input)) {
 			if (!side.choice.error) {
-				side.emitChoiceError(`Unknown error for choice ${input}. Please save the replay and report it here https://www.smogon.com/forums/ps-bug-report-form/.`);
+				side.emitChoiceError(`Unknown error for choice: ${input}. Please save the replay and report it here https://www.smogon.com/forums/ps-bug-report-form/.`);
 			}
 			return false;
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2812,7 +2812,7 @@ export class Battle {
 
 		if (!side.choose(input)) {
 			if (!side.choice.error) {
-				side.emitChoiceError(`Unknown error for choice: ${input}. Please save the replay and report it here https://www.smogon.com/forums/ps-bug-report-form/.`);
+				side.emitChoiceError(`Unknown error for choice: ${input}. Please save the replay and report it here: https://www.smogon.com/forums/ps-bug-report-form/.`);
 			}
 			return false;
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2812,7 +2812,7 @@ export class Battle {
 
 		if (!side.choose(input)) {
 			if (!side.choice.error) {
-				side.emitChoiceError(`Unknown error for choice ${input}. Please report save the replay and report this.`);
+				side.emitChoiceError(`Unknown error for choice ${input}. Please save the replay and report it here https://www.smogon.com/forums/ps-bug-report-form/.`);
 			}
 			return false;
 		}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -1072,9 +1072,7 @@ export class Side {
 
 	choosePass(): boolean | Side {
 		const index = this.getChoiceIndex(true);
-		if (index >= this.active.length) {
-			return true;
-		}
+		if (index >= this.active.length) return true;
 		const pokemon: Pokemon = this.active[index];
 
 		switch (this.requestState) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -1072,7 +1072,7 @@ export class Side {
 
 	choosePass(): boolean | Side {
 		const index = this.getChoiceIndex(true);
-		if (index >= this.active.length) return true;
+		if (index >= this.active.length) return false;
 		const pokemon: Pokemon = this.active[index];
 
 		switch (this.requestState) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -1072,7 +1072,9 @@ export class Side {
 
 	choosePass(): boolean | Side {
 		const index = this.getChoiceIndex(true);
-		if (index >= this.active.length) return false;
+		if (index >= this.active.length) {
+			return this.emitChoiceError(`Can't pass: You sent more choices than unfainted Pokémon`);
+		}
 		const pokemon: Pokemon = this.active[index];
 
 		switch (this.requestState) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -1073,7 +1073,7 @@ export class Side {
 	choosePass(): boolean | Side {
 		const index = this.getChoiceIndex(true);
 		if (index >= this.active.length) {
-			return this.emitChoiceError(`Can't pass: You sent more choices than unfainted Pokémon`);
+			return true;
 		}
 		const pokemon: Pokemon = this.active[index];
 


### PR DESCRIPTION
If you have a Tatsugiri on the left and a Dondozo on the right, and you run the command `/move 1 1, pass` in the chat, the move will be registered. However, it will not execute `Battle.commitChoices()`. If you enter that command before the opponent acts, the opponent's action will trigger the `Battle.commitChoices()` method, and everything will work fine. But if you run it after the opponent has acted, the turn will never finish. If either player tries to perform another action, the server will respond with `[Invalid choice] Sorry, too late to make a different move; the next turn has already started`.

Regarding the specific issue with the trailing `pass`, I can either throw an error as it is now or change it to simply ignore it by returning `true`. Let me know which you prefer.

In case there are similar synchronization problems where the method `Battle.choose(sideid: SideID, input: string)` returns `false` but no error message is emitted, I have decided to emit an unknown error message. This is to ensure the RoomBattle remains synchronized with the Battle.

Edit: To reproduce, simply create a doubles battle with a Tatsugiri and a Dondozo (you need to put the Tatsugiri on the left). Allow the opposing player to act first, and then type `/move 1 1, pass` in the chat. You will get stuck in that turn and neither player will be able to act anymore.