### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -35,7 +35,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["psychic", "sleeppowder", "stunspore", "substitute"]
+                "movepool": ["psychic", "reflect", "sleeppowder", "stunspore"]
             },
             {
                 "role": "Bulky Attacker",
@@ -1019,9 +1019,8 @@
     "crobat": {
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["haze", "hiddenpowerground", "rest", "return", "toxic"],
-                "preferredTypes": ["Normal"]
+                "role": "Bulky Attacker",
+                "movepool": ["haze", "hiddenpowerground", "rest", "toxic", "wingattack"]
             },
             {
                 "role": "Generalist",
@@ -1144,6 +1143,10 @@
             {
                 "role": "Generalist",
                 "movepool": ["agility", "batonpass", "curse", "return"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["curse", "rest", "return", "sleeptalk"]
             }
         ]
     },
@@ -1179,11 +1182,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "rest", "sleeptalk"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "earthquake", "hiddenpowerrock", "rest"]
+                "movepool": ["earthquake", "icebeam", "rest", "sleeptalk", "sludgebomb"]
             }
         ]
     },
@@ -1292,10 +1291,6 @@
             {
                 "role": "Generalist",
                 "movepool": ["explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["doubleedge", "explosion", "rapidspin", "spikes", "toxic"]
             }
         ]
     },
@@ -1426,12 +1421,12 @@
     "magcargo": {
         "sets": [
             {
-                "role": "Generalist",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "rest", "rockslide", "sleeptalk"]
+                "role": "Bulky Attacker",
+                "movepool": ["earthquake", "fireblast", "flamethrower", "hiddenpowergrass", "rest", "rockslide", "sleeptalk"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["curse", "rest", "rockslide", "sleeptalk"]
+                "movepool": ["curse", "fireblast", "flamethrower", "rest", "rockslide"]
             }
         ]
     },
@@ -1526,11 +1521,6 @@
     },
     "porygon2": {
         "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "icebeam", "recover", "thunder", "thunderwave"],
-                "preferredTypes": ["Ice"]
-            },
             {
                 "role": "Bulky Setup",
                 "movepool": ["curse", "doubleedge", "icebeam", "recover", "thunder", "thunderwave"]

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -833,13 +833,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crosschop", "fireblast", "flamethrower", "focuspunch", "hiddenpowergrass", "hiddenpowerice", "psychic", "substitute", "thunderpunch"],
+                "movepool": ["crosschop", "fireblast", "flamethrower", "focuspunch", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderpunch", "toxic"],
                 "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "psychic", "substitute", "thunderpunch"],
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderpunch"],
                 "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }
@@ -1547,12 +1547,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"],
-                "abilities": ["Sturdy"]
-            },
-            {
-                "role": "Generalist",
-                "movepool": ["explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"],
+                "movepool": ["earthquake", "explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -1917,11 +1912,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["protect", "seismictoss", "toxic", "wish"],
-                "abilities": ["Natural Cure"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["calmmind", "icebeam", "softboiled", "thunderbolt"],
                 "abilities": ["Natural Cure"]
             }
         ]
@@ -2492,7 +2482,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aromatherapy", "hiddenpowerfire", "magicalleaf", "spikes", "synthesis", "toxic"],
+                "movepool": ["hiddenpowerfire", "magicalleaf", "spikes", "synthesis"],
                 "abilities": ["Natural Cure"]
             },
             {
@@ -3070,7 +3060,7 @@
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "extremespeed", "hiddenpowerflying", "overheat", "rockslide"],
                 "abilities": ["Air Lock"],
-                "preferredTypes": ["Ground"]
+                "preferredTypes": ["Ground", "Normal"]
             }
         ]
     },
@@ -3095,7 +3085,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "firepunch", "icebeam", "psychoboost", "shadowball", "spikes", "superpower"],
+                "movepool": ["extremespeed", "firepunch", "icebeam", "psychoboost", "shadowball", "superpower"],
                 "abilities": ["Pressure"],
                 "preferredTypes": ["Fighting", "Ghost"]
             }

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -206,7 +206,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		// Add other moves you really want to have, e.g. STAB, recovery, setup.
 
 		// Enforce Seismic Toss and Spore
-		for (const moveid of ['seismictoss', 'spore']) {
+		for (const moveid of ['seismictoss', 'spikes', 'spore']) {
 			if (movePool.includes(moveid)) {
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role);

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -514,6 +514,11 @@
                 "role": "Staller",
                 "movepool": ["protect", "seismictoss", "toxic", "wish"],
                 "abilities": ["Insomnia"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["batonpass", "focusblast", "nastyplot", "psychic"],
+                "abilities": ["Insomnia"]
             }
         ]
     },
@@ -1996,7 +2001,8 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"],
-                "abilities": ["Plus"]
+                "abilities": ["Plus"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
@@ -2011,7 +2017,8 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"],
-                "abilities": ["Minus"]
+                "abilities": ["Minus"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Setup Sweeper",
@@ -2230,7 +2237,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "earthpower", "psychic", "shadowball", "substitute"],
+                "movepool": ["batonpass", "calmmind", "earthpower", "psychic", "signalbeam", "substitute"],
                 "abilities": ["Levitate"]
             },
             {
@@ -2361,9 +2368,8 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aerialace", "dragondance", "earthquake", "leafblade", "roost"],
-                "abilities": ["Chlorophyll"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["aerialace", "dragondance", "earthquake", "leafblade"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -3258,7 +3264,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowerice", "taunt", "thunderbolt"],
                 "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -3126,7 +3126,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"],
+                "movepool": ["aurasphere", "flashcannon", "nastyplot", "vacuumwave"],
                 "abilities": ["Inner Focus"]
             }
         ]
@@ -3284,7 +3284,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowerice", "taunt", "thunderbolt"],
                 "abilities": ["Flame Body", "Vital Spirit"],
                 "preferredTypes": ["Electric"]
             }
@@ -4274,7 +4274,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "spikes", "suckerpunch", "synthesis", "toxic"],
+                "movepool": ["gigadrain", "hiddenpowerfire", "spikes", "synthesis", "toxic"],
                 "abilities": ["Storm Drain", "Water Absorb"]
             },
             {

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1215,7 +1215,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["agility", "dragonpulse", "focusblast", "healbell", "thunderbolt", "voltswitch"],
+                "movepool": ["agility", "dragonpulse", "focusblast", "thunderbolt", "voltswitch"],
+                "abilities": ["Static"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["discharge", "dragonpulse", "focusblast", "healbell", "rest", "sleeptalk", "voltswitch"],
                 "abilities": ["Static"]
             }
         ]
@@ -1312,7 +1317,8 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "dazzlinggleam", "morningsun", "psychic", "psyshock", "shadowball", "trick"],
-                "abilities": ["Magic Bounce"]
+                "abilities": ["Magic Bounce"],
+                "preferredTypes": ["Fairy"]
             }
         ]
     },
@@ -2149,7 +2155,7 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["bulletpunch", "closecombat", "heavyslam", "knockoff", "stoneedge"],
-                "abilities": ["Thick Fat"],
+                "abilities": ["Guts", "Thick Fat"],
                 "preferredTypes": ["Dark"]
             },
             {
@@ -2692,13 +2698,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fireblast", "knockoff", "playrough", "protect", "pursuit", "suckerpunch", "superpower"],
-                "abilities": ["Justified"],
-                "preferredTypes": ["Fairy"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"],
+                "movepool": ["irontail", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
                 "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             }
@@ -3507,7 +3507,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"],
+                "movepool": ["aurasphere", "flashcannon", "nastyplot", "vacuumwave"],
                 "abilities": ["Inner Focus"]
             }
         ]
@@ -3693,7 +3693,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowerice", "taunt", "thunderbolt"],
                 "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }
@@ -4723,7 +4723,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "synthesis", "toxic"],
+                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "synthesis", "toxic"],
                 "abilities": ["Storm Drain", "Water Absorb"]
             },
             {

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1440,7 +1440,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["agility", "dragonpulse", "focusblast", "healbell", "thunderbolt", "voltswitch"],
+                "movepool": ["agility", "dragonpulse", "focusblast", "thunderbolt", "voltswitch"],
+                "abilities": ["Static"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["discharge", "dragonpulse", "focusblast", "healbell", "rest", "sleeptalk", "voltswitch"],
                 "abilities": ["Static"]
             }
         ]
@@ -1548,7 +1553,8 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "dazzlinggleam", "morningsun", "psychic", "psyshock", "shadowball", "trick"],
-                "abilities": ["Magic Bounce"]
+                "abilities": ["Magic Bounce"],
+                "preferredTypes": ["Fairy"]
             }
         ]
     },
@@ -2941,13 +2947,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fireblast", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower"],
-                "abilities": ["Justified"],
-                "preferredTypes": ["Fairy"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"],
+                "movepool": ["irontail", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
                 "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             }
@@ -3811,7 +3811,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "darkpulse", "flashcannon", "nastyplot", "vacuumwave"],
+                "movepool": ["aurasphere", "flashcannon", "nastyplot", "vacuumwave"],
                 "abilities": ["Inner Focus"]
             }
         ]
@@ -3997,7 +3997,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+                "movepool": ["earthquake", "fireblast", "focusblast", "hiddenpowerice", "taunt", "thunderbolt"],
                 "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }
@@ -5091,7 +5091,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "synthesis", "toxic"],
+                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "synthesis", "toxic"],
                 "abilities": ["Storm Drain", "Water Absorb"]
             },
             {
@@ -5888,6 +5888,12 @@
                 "role": "Wallbreaker",
                 "movepool": ["closecombat", "knockoff", "relicsong", "return"],
                 "abilities": ["Serene Grace"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["celebrate", "focusblast", "hypervoice", "psyshock"],
+                "abilities": ["Serene Grace"],
+                "preferredTypes": ["Normal"]
             }
         ]
     },
@@ -6672,13 +6678,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["accelerock", "drillrun", "firefang", "stoneedge", "swordsdance"],
+                "movepool": ["accelerock", "drillrun", "stoneedge", "swordsdance", "zenheadbutt"],
                 "abilities": ["Sand Rush"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["accelerock", "drillrun", "firefang", "stoneedge", "swordsdance"],
+                "movepool": ["accelerock", "drillrun", "stoneedge", "swordsdance", "zenheadbutt"],
                 "abilities": ["Sand Rush"],
                 "preferredTypes": ["Ground"]
             }
@@ -6704,13 +6710,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["accelerock", "drillrun", "firefang", "return", "stoneedge", "swordsdance"],
+                "movepool": ["accelerock", "drillrun", "return", "stoneedge", "swordsdance", "zenheadbutt"],
                 "abilities": ["Tough Claws"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["accelerock", "drillrun", "firefang", "return", "stoneedge", "swordsdance"],
+                "movepool": ["accelerock", "drillrun", "return", "stoneedge", "swordsdance", "zenheadbutt"],
                 "abilities": ["Tough Claws"],
                 "preferredTypes": ["Ground"]
             }
@@ -7319,17 +7325,20 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "flareblitz", "knockoff", "morningsun", "stoneedge", "sunsteelstrike", "zenheadbutt"],
-                "abilities": ["Full Metal Body"]
+                "abilities": ["Full Metal Body"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "flareblitz", "knockoff", "stoneedge", "sunsteelstrike", "zenheadbutt"],
-                "abilities": ["Full Metal Body"]
+                "abilities": ["Full Metal Body"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["earthquake", "flamecharge", "knockoff", "psychic", "sunsteelstrike"],
-                "abilities": ["Full Metal Body"]
+                "abilities": ["Full Metal Body"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -1427,13 +1427,13 @@
         "level": 100,
         "sets": [
             {
-                "role": "Doubles Support",
-                "movepool": ["Decorate", "Fake Out", "Follow Me", "Pollen Puff", "Tailwind"],
+                "role": "Doubles Setup Sweeper",
+                "movepool": ["Baton Pass", "No Retreat", "Population Bomb", "Spiky Shield"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]
             },
             {
-                "role": "Doubles Bulky Attacker",
+                "role": "Doubles Support",
                 "movepool": ["Decorate", "Fake Out", "Follow Me", "Tailwind"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]
@@ -1475,7 +1475,7 @@
                 "role": "Bulky Protect",
                 "movepool": ["Electroweb", "Protect", "Scald", "Snarl", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Inner Focus"],
-                "teraTypes": ["Grass"]
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -2464,15 +2464,15 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Protect"],
+                "movepool": ["Close Combat", "Extreme Speed", "Flash Cannon", "Protect"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Normal"]
             },
             {
-                "role": "Doubles Setup Sweeper",
-                "movepool": ["Aura Sphere", "Flash Cannon", "Nasty Plot", "Protect", "Vacuum Wave"],
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Rock Slide"],
                 "abilities": ["Inner Focus"],
-                "teraTypes": ["Fighting", "Steel"]
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -3963,7 +3963,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Earth Power", "Nasty Plot", "Protect", "Psychic", "Sandsear Storm", "Sludge Bomb"],
+                "movepool": ["Earth Power", "Nasty Plot", "Protect", "Psychic", "Rock Slide", "Sandsear Storm", "Sludge Bomb"],
                 "abilities": ["Sheer Force"],
                 "teraTypes": ["Ground", "Poison", "Psychic"]
             }
@@ -5192,9 +5192,9 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat"],
+                "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat", "Protect", "Rock Slide"],
                 "abilities": ["Defiant"],
-                "teraTypes": ["Dark", "Fighting", "Steel"]
+                "teraTypes": ["Dark", "Steel"]
             }
         ]
     },
@@ -6790,8 +6790,20 @@
         "level": 85,
         "sets": [
             {
+                "role": "Bulky Protect",
+                "movepool": ["Fickle Beam", "Giga Drain", "Leaf Storm", "Pollen Puff", "Protect"],
+                "abilities": ["Regenerator"],
+                "teraTypes": ["Fire", "Steel"]
+            },
+            {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Earth Power", "Fickle Beam", "Leaf Storm", "Pollen Puff", "Protect"],
+                "movepool": ["Draco Meteor", "Earth Power", "Giga Drain", "Leaf Storm"],
+                "abilities": ["Regenerator"],
+                "teraTypes": ["Fire", "Grass", "Steel"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Earth Power", "Fickle Beam", "Giga Drain", "Leaf Storm", "Pollen Puff"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Steel"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -3180,12 +3180,6 @@
                 "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Power Gem", "Rest", "Thunder Wave"],
                 "abilities": ["Magnet Pull"],
                 "teraTypes": ["Fighting"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Flash Cannon", "Power Gem", "Stealth Rock", "Thunder Wave", "Volt Switch"],
-                "abilities": ["Magnet Pull"],
-                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -4871,12 +4865,6 @@
     "carbink": {
         "level": 90,
         "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Moonblast", "Power Gem", "Spikes", "Stealth Rock"],
-                "abilities": ["Sturdy"],
-                "teraTypes": ["Fighting"]
-            },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Moonblast", "Rest", "Rock Polish"],

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -447,6 +447,12 @@
                 "movepool": ["Body Press", "Fire Blast", "Future Sight", "Ice Beam", "Psychic Noise", "Scald"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Fairy", "Fighting"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Scald", "Slack Off"],
+                "abilities": ["Regenerator"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -846,7 +852,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Dragon Dance", "Earthquake", "Freeze-Dry", "Waterfall"],
+                "movepool": ["Dragon Dance", "Earthquake", "Icicle Spear", "Waterfall"],
                 "abilities": ["Water Absorb"],
                 "teraTypes": ["Ground"]
             }
@@ -965,7 +971,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Knock Off", "U-turn"],
                 "abilities": ["Defiant"],
-                "teraTypes": ["Dark", "Fighting"]
+                "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
     },
@@ -1177,7 +1183,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Dazzling Gleam", "Discharge", "Dragon Tail", "Focus Blast", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Dazzling Gleam", "Discharge", "Focus Blast", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Static"],
                 "teraTypes": ["Fairy"]
             }
@@ -1447,7 +1453,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
+                "movepool": ["Destiny Bond", "Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Dark", "Grass"]
             },
@@ -1848,7 +1854,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Flip Turn", "Ice Beam", "Knock Off", "Roar", "Stealth Rock"],
+                "movepool": ["Earthquake", "Flip Turn", "Ice Beam", "Knock Off", "Roar", "Stealth Rock", "Yawn"],
                 "abilities": ["Damp", "Torrent"],
                 "teraTypes": ["Poison", "Steel"]
             }
@@ -2096,7 +2102,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Protect", "Sludge Bomb", "Toxic"],
-                "abilities": ["Liquid Ooze"],
+                "abilities": ["Liquid Ooze", "Sticky Hold"],
                 "teraTypes": ["Ground"]
             },
             {
@@ -2306,6 +2312,12 @@
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic", "Psychic Noise", "Psyshock", "Recover"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Poison", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Cosmic Power", "Dazzling Gleam", "Recover", "Stored Power"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -2327,7 +2339,7 @@
                 "role": "Fast Support",
                 "movepool": ["Endeavor", "Substitute", "Surf", "Whirlpool"],
                 "abilities": ["Swift Swim"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Ghost", "Ground"]
             }
         ]
     },
@@ -2619,7 +2631,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roost", "Stealth Rock", "Surf", "Yawn"],
+                "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roar", "Roost", "Stealth Rock", "Surf", "Yawn"],
                 "abilities": ["Competitive"],
                 "teraTypes": ["Flying", "Grass"]
             }
@@ -5209,7 +5221,7 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Bug Buzz", "Moonblast", "Quiver Dance", "Tera Blast"],
+                "movepool": ["Draining Kiss", "Moonblast", "Quiver Dance", "Tera Blast"],
                 "abilities": ["Shield Dust"],
                 "teraTypes": ["Ground"]
             }
@@ -5545,7 +5557,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Aura Sphere", "Flash Cannon", "Fleur Cannon", "Pain Split", "Spikes", "Volt Switch"],
+                "movepool": ["Aura Sphere", "Flash Cannon", "Fleur Cannon", "Pain Split", "Spikes", "Thunder Wave", "Volt Switch"],
                 "abilities": ["Soul-Heart"],
                 "teraTypes": ["Fairy", "Fighting", "Water"]
             },
@@ -5631,7 +5643,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Brave Bird", "Defog", "Roost", "U-turn"],
-                "abilities": ["Mirror Armor"],
+                "abilities": ["Mirror Armor", "Pressure"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -5733,7 +5745,7 @@
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Flip Turn", "Poison Jab", "Psychic Fangs", "Throat Chop", "Waterfall"],
                 "abilities": ["Swift Swim"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Water"]
             }
         ]
     },
@@ -5840,7 +5852,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat"],
                 "abilities": ["Defiant"],
-                "teraTypes": ["Dark", "Fighting", "Ghost", "Steel"]
+                "teraTypes": ["Dark", "Steel"]
             }
         ]
     },
@@ -5894,13 +5906,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute"],
+                "movepool": ["Belly Drum", "Ice Spinner", "Iron Head", "Liquidation", "Substitute", "Zen Headbutt"],
                 "abilities": ["Ice Face"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Belly Drum", "Ice Spinner", "Substitute", "Tera Blast"],
+                "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute", "Tera Blast"],
                 "abilities": ["Ice Face"],
                 "teraTypes": ["Electric", "Ground"]
             }
@@ -6036,7 +6048,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Crunch", "Heavy Slam", "Iron Defense", "Stone Edge"],
                 "abilities": ["Dauntless Shield"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Ghost"]
             }
         ]
     },
@@ -6839,7 +6851,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Brave Bird", "Close Combat", "Roost", "Swords Dance", "Throat Chop"],
                 "abilities": ["Scrappy"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },
@@ -6848,9 +6860,9 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Liquidation", "Play Rough"],
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Liquidation", "Superpower"],
                 "abilities": ["Sheer Force"],
-                "teraTypes": ["Fairy", "Water"]
+                "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -316,10 +316,7 @@ export class RandomTeams {
 	 * Doesn't count bans nested inside other formats/rules.
 	 */
 	private hasDirectCustomBanlistChanges() {
-		if (
-			this.format.customRules &&
-			this.format.customRules.length === 1 && ['+cap'].includes(this.format.customRules[0])
-		) return false;
+		if (this.format.ruleTable?.has('+pokemontag:cap')) return false;
 		if (this.format.banlist.length || this.format.restricted.length || this.format.unbanlist.length) return true;
 		if (!this.format.customRules) return false;
 		for (const rule of this.format.customRules) {

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -316,6 +316,10 @@ export class RandomTeams {
 	 * Doesn't count bans nested inside other formats/rules.
 	 */
 	private hasDirectCustomBanlistChanges() {
+		if (
+			this.format.customRules &&
+			this.format.customRules.length === 1 && ['+cap'].includes(this.format.customRules[0])
+		) return false;
 		if (this.format.banlist.length || this.format.restricted.length || this.format.unbanlist.length) return true;
 		if (!this.format.customRules) return false;
 		for (const rule of this.format.customRules) {
@@ -552,6 +556,7 @@ export class RandomTeams {
 			[SPEED_SETUP, ['aquajet', 'rest', 'trickroom']],
 			['curse', ['irondefense', 'rapidspin']],
 			['dragondance', 'dracometeor'],
+			['yawn', 'roar'],
 
 			// These attacks are redundant with each other
 			[['psychic', 'psychicnoise'], ['psyshock', 'psychicnoise']],
@@ -594,8 +599,6 @@ export class RandomTeams {
 			['trick', 'uturn'],
 			// Araquanid
 			['mirrorcoat', 'hydropump'],
-			// Brute Bonnet
-			['bulletseed', 'seedbomb'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
@@ -609,6 +612,9 @@ export class RandomTeams {
 		if (!abilities.includes('Prankster')) this.incompatibleMoves(moves, movePool, 'thunderwave', 'yawn');
 
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
+		if (species.id === 'barraskewda') {
+			this.incompatibleMoves(moves, movePool, ['psychicfangs', 'crunch'], ['poisonjab', 'crunch']);
+		}
 		if (species.id === 'cyclizar') this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
@@ -773,14 +779,6 @@ export class RandomTeams {
 		if (!isDoubles && types.length === 1 && (types.includes('Normal') || types.includes('Fighting'))) {
 			if (movePool.includes('knockoff')) {
 				counter = this.addMove('knockoff', moves, types, abilities, teamDetails, species, isLead, isDoubles,
-					movePool, teraType, role);
-			}
-		}
-
-		// Enforce Flip Turn on pure Water-type Wallbreakers
-		if (types.length === 1 && types.includes('Water') && role === 'Wallbreaker') {
-			if (movePool.includes('flipturn')) {
-				counter = this.addMove('flipturn', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			}
 		}
@@ -1144,7 +1142,7 @@ export class RandomTeams {
 			species.id === 'froslass' || moves.has('populationbomb') ||
 			(ability === 'Hustle' && counter.get('setup') && !isDoubles && this.randomChance(1, 2))
 		) return 'Wide Lens';
-		if (species.id === 'smeargle') return 'Focus Sash';
+		if (species.id === 'smeargle' && !isDoubles) return 'Focus Sash';
 		if (moves.has('clangoroussoul') || (species.id === 'toxtricity' && moves.has('shiftgear'))) return 'Throat Spray';
 		if (
 			(species.baseSpecies === 'Magearna' && role === 'Tera Blast user') ||
@@ -1518,8 +1516,9 @@ export class RandomTeams {
 			if (move.damageCallback || move.damage) return true;
 			if (move.id === 'shellsidearm') return false;
 			// Magearna and doubles Dragonite, though these can work well as a general rule
-			if (move.id === 'terablast' && (
-				species.id === 'porygon2' || moves.has('shiftgear') || species.baseStats.atk > species.baseStats.spa)
+			if (
+				move.id === 'terablast' && (species.id === 'porygon2' || species.id === 'thundurus' ||
+				moves.has('shiftgear') || species.baseStats.atk > species.baseStats.spa)
 			) return false;
 			return move.category !== 'Physical' || move.id === 'bodypress' || move.id === 'foulplay';
 		});

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -46,6 +46,12 @@
                 "movepool": ["Dragon Claw", "Dragon Dance", "Iron Head", "Outrage", "Stomping Tantrum"],
                 "abilities": ["Mold Breaker"],
                 "teraTypes": ["Ground", "Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Iron Head", "Scale Shot", "Stomping Tantrum", "Swords Dance"],
+                "abilities": ["Mold Breaker"],
+                "teraTypes": ["Ground", "Steel"]
             }
         ]
     },
@@ -286,7 +292,7 @@
                 "role": "Fast Support",
                 "movepool": ["Clear Smog", "Flame Charge", "Lava Plume", "Will-O-Wisp"],
                 "abilities": ["Flame Body", "Flash Fire"],
-                "teraTypes": ["Dragon", "Fire"]
+                "teraTypes": ["Dragon"]
             }
         ]
     },
@@ -454,7 +460,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Earthquake", "Gunk Shot", "Ice Punch", "Knock Off", "Thunder Punch"],
                 "abilities": ["Iron Fist"],
-                "teraTypes": ["Dark", "Ground", "Poison"]
+                "teraTypes": ["Dark", "Electric", "Ground", "Poison"]
             }
         ]
     },
@@ -543,7 +549,7 @@
                 "role": "Fast Support",
                 "movepool": ["Bullet Seed", "Headbutt", "Synthesis", "Thunder Wave"],
                 "abilities": ["Serene Grace"],
-                "teraTypes": ["Normal"]
+                "teraTypes": ["Ghost", "Normal"]
             }
         ]
     },
@@ -565,7 +571,7 @@
         ]
     },
     "dewpider": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -580,15 +586,9 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance", "Throat Chop"],
+                "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Arena Trap"],
-                "teraTypes": ["Fairy", "Ground", "Rock"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Earthquake", "Stone Edge", "Tera Blast", "Throat Chop"],
-                "abilities": ["Arena Trap"],
-                "teraTypes": ["Fairy", "Grass"]
+                "teraTypes": ["Ground", "Rock"]
             }
         ]
     },
@@ -647,9 +647,15 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Earthquake", "Poison Jab", "Rapid Spin", "Rock Slide", "Swords Dance"],
+                "movepool": ["Earthquake", "Rapid Spin", "Rock Slide", "Swords Dance"],
                 "abilities": ["Mold Breaker", "Sand Rush"],
-                "teraTypes": ["Ground", "Poison", "Rock"]
+                "teraTypes": ["Ground", "Rock"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Poison Jab", "Rapid Spin", "Swords Dance"],
+                "abilities": ["Mold Breaker", "Sand Rush"],
+                "teraTypes": ["Ground", "Poison"]
             }
         ]
     },
@@ -807,7 +813,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Moonlight", "Psychic", "Sleep Powder", "Stun Spore"],
                 "abilities": ["Harvest"],
-                "teraTypes": ["Dark", "Poison"]
+                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },
@@ -816,9 +822,9 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Double-Edge", "Haze", "Hypnosis", "Ice Beam", "Waterfall"],
+                "movepool": ["Haze", "Hypnosis", "Ice Beam", "Scale Shot", "Waterfall"],
                 "abilities": ["Adaptability"],
-                "teraTypes": ["Ice", "Normal"]
+                "teraTypes": ["Dragon", "Ice"]
             }
         ]
     },
@@ -827,9 +833,9 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Encore", "Flamethrower", "Psychic", "Will-O-Wisp"],
+                "movepool": ["Calm Mind", "Encore", "Flamethrower", "Mud Shot", "Psychic", "Will-O-Wisp"],
                 "abilities": ["Blaze"],
-                "teraTypes": ["Dragon", "Fairy"]
+                "teraTypes": ["Dragon", "Fairy", "Ground"]
             }
         ]
     },
@@ -862,7 +868,7 @@
                 "role": "Fast Support",
                 "movepool": ["Alluring Voice", "Ice Beam", "Surf", "Thief", "U-turn"],
                 "abilities": ["Storm Drain", "Swift Swim"],
-                "teraTypes": ["Fairy", "Water"]
+                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -1058,7 +1064,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Nasty Plot", "Power Gem", "Shadow Ball", "Substitute"],
                 "abilities": ["Run Away"],
-                "teraTypes": ["Fairy", "Ghost"]
+                "teraTypes": ["Ghost", "Rock"]
             },
             {
                 "role": "Tera Blast user",
@@ -1164,7 +1170,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Drain Punch", "Gunk Shot", "Poison Jab", "Shadow Sneak"],
                 "abilities": ["Poison Touch"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -1230,7 +1236,7 @@
         ]
     },
     "gulpin": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1320,13 +1326,13 @@
                 "role": "Wallbreaker",
                 "movepool": ["Dragon Pulse", "Flip Turn", "Ice Beam", "Surf"],
                 "abilities": ["Sniper", "Swift Swim"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Dragon", "Water"]
             },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Pulse", "Ice Beam", "Rain Dance", "Surf"],
                 "abilities": ["Swift Swim"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Dragon", "Water"]
             }
         ]
     },
@@ -1404,6 +1410,12 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Outrage"],
+                "abilities": ["Bulletproof"],
+                "teraTypes": ["Ground", "Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earthquake", "Iron Head", "Scale Shot", "Swords Dance"],
                 "abilities": ["Bulletproof"],
                 "teraTypes": ["Ground", "Steel"]
             }
@@ -1560,7 +1572,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Belly Drum", "Cross Chop", "Mach Punch", "Temper Flare", "Thunder Punch"],
+                "movepool": ["Belly Drum", "Cross Chop", "Fire Punch", "Mach Punch", "Thunder Punch"],
                 "abilities": ["Flame Body", "Vital Spirit"],
                 "teraTypes": ["Fighting"]
             },
@@ -1763,9 +1775,9 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bullet Seed", "Knock Off", "Tail Slap", "Tidy Up", "Triple Axel"],
+                "movepool": ["Bullet Seed", "Knock Off", "Tail Slap", "Tidy Up"],
                 "abilities": ["Skill Link"],
-                "teraTypes": ["Grass", "Ice", "Normal"]
+                "teraTypes": ["Grass", "Normal"]
             }
         ]
     },
@@ -1793,7 +1805,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Earthquake", "Heavy Slam", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Stamina"],
-                "teraTypes": ["Fighting", "Ground", "Steel"]
+                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },
@@ -1852,7 +1864,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Air Slash", "Defog", "Draco Meteor", "Heat Wave", "Hurricane", "Roost", "U-turn"],
+                "movepool": ["Defog", "Draco Meteor", "Heat Wave", "Hurricane", "Roost", "U-turn"],
                 "abilities": ["Infiltrator"],
                 "teraTypes": ["Fairy", "Steel"]
             }
@@ -1864,6 +1876,12 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Pain Split", "Power Gem", "Thunder Wave"],
+                "abilities": ["Magnet Pull"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Pain Split", "Power Gem", "Stealth Rock", "Thunder Wave", "Volt Switch"],
                 "abilities": ["Magnet Pull"],
                 "teraTypes": ["Fighting"]
             }
@@ -1965,7 +1983,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Gunk Shot", "Ice Shard", "Knock Off", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Pickup"],
-                "teraTypes": ["Dark", "Ground", "Poison"]
+                "teraTypes": ["Dark", "Poison"]
             }
         ]
     },
@@ -2006,12 +2024,6 @@
     "pikipek": {
         "level": 6,
         "sets": [
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Acrobatics", "Bullet Seed", "Flame Charge", "Knock Off", "Swords Dance"],
-                "abilities": ["Pickup", "Skill Link"],
-                "teraTypes": ["Flying", "Grass", "Steel"]
-            },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Bullet Seed", "Knock Off", "Roost", "Swords Dance", "U-turn"],
@@ -2055,7 +2067,7 @@
                 "role": "Tera Blast user",
                 "movepool": ["Belly Drum", "Body Slam", "Tera Blast", "Waterfall"],
                 "abilities": ["Swift Swim", "Water Absorb"],
-                "teraTypes": ["Fire", "Ground"]
+                "teraTypes": ["Dragon", "Fire", "Ground"]
             }
         ]
     },
@@ -2122,7 +2134,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Ice Beam", "Nasty Plot", "Surf", "Trailblaze"],
                 "abilities": ["Cloud Nine", "Swift Swim"],
-                "teraTypes": ["Steel", "Water"]
+                "teraTypes": ["Grass", "Steel", "Water"]
             }
         ]
     },
@@ -2289,7 +2301,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Crunch", "Earthquake", "Fire Fang", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Intimidate"],
-                "teraTypes": ["Dark", "Ground"]
+                "teraTypes": ["Dark", "Flying", "Ground"]
             }
         ]
     },
@@ -2345,7 +2357,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Flare Blitz", "Gunk Shot", "High Jump Kick", "U-turn"],
                 "abilities": ["Libero"],
-                "teraTypes": ["Fighting", "Fire", "Poison"]
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -2401,7 +2413,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Flip Turn", "Haze", "Icicle Spear", "Surf", "Thief"],
                 "abilities": ["Thick Fat"],
-                "teraTypes": ["Poison", "Steel", "Water"]
+                "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Fast Support",
@@ -2427,7 +2439,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Electroweb", "Giga Drain", "Lunge", "Sticky Web", "Synthesis"],
+                "movepool": ["Giga Drain", "Iron Defense", "Lunge", "Sticky Web", "Synthesis"],
                 "abilities": ["Chlorophyll", "Swarm"],
                 "teraTypes": ["Ghost"]
             }
@@ -2552,7 +2564,7 @@
                 "role": "Tera Blast user",
                 "movepool": ["Giga Drain", "Shadow Ball", "Shell Smash", "Tera Blast", "Will-O-Wisp"],
                 "abilities": ["Cursed Body"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fairy", "Fighting"]
             }
         ]
     },
@@ -2601,18 +2613,18 @@
         ]
     },
     "slowpoke": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Curse", "Earthquake", "Fire Blast", "Liquidation", "Slack Off", "Thunder Wave", "Zen Headbutt"],
+                "role": "Bulky Attacker",
+                "movepool": ["Curse", "Liquidation", "Slack Off", "Thunder Wave", "Zen Headbutt"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
     },
     "slowpokegalar": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2701,7 +2713,7 @@
         ]
     },
     "snorunt": {
-        "level": 8,
+        "level": 7,
         "sets": [
             {
                 "role": "Fast Support",
@@ -2774,7 +2786,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Knock Off", "Megahorn", "Poison Jab", "Sticky Web", "Sucker Punch", "Toxic Spikes"],
                 "abilities": ["Insomnia", "Swarm"],
-                "teraTypes": ["Dark", "Steel"]
+                "teraTypes": ["Dark", "Ghost", "Steel"]
             }
         ]
     },
@@ -2796,7 +2808,7 @@
                 "role": "Wallbreaker",
                 "movepool": ["Bullet Seed", "Play Rough", "Shadow Claw", "Sucker Punch", "U-turn"],
                 "abilities": ["Protean"],
-                "teraTypes": ["Fairy", "Grass"]
+                "teraTypes": ["Grass"]
             }
         ]
     },
@@ -2846,7 +2858,7 @@
         ]
     },
     "stunky": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Fast Support",
@@ -2874,7 +2886,7 @@
                 "role": "Fast Support",
                 "movepool": ["Bug Buzz", "Giga Drain", "Hydro Pump", "Ice Beam", "Sticky Web"],
                 "abilities": ["Swift Swim"],
-                "teraTypes": ["Ground", "Steel", "Water"]
+                "teraTypes": ["Ghost", "Ground", "Steel", "Water"]
             }
         ]
     },
@@ -2999,10 +3011,10 @@
         "level": 7,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Encore", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
                 "abilities": ["Pickpocket"],
-                "teraTypes": ["Fairy", "Water"]
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -3125,7 +3137,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Gunk Shot", "Iron Head", "Parting Shot", "Taunt", "Toxic Spikes"],
                 "abilities": ["Overcoat"],
-                "teraTypes": ["Poison", "Steel", "Water"]
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -3220,7 +3232,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Hurricane", "Roost", "Thunder Wave", "Thunderbolt", "U-turn"],
                 "abilities": ["Volt Absorb"],
-                "teraTypes": ["Electric", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -3315,7 +3327,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Burning Jealousy", "Knock Off", "Sludge Bomb", "Trick", "U-turn"],
                 "abilities": ["Illusion"],
-                "teraTypes": ["Dark", "Poison"]
+                "teraTypes": ["Poison"]
             },
             {
                 "role": "Setup Sweeper",
@@ -3338,7 +3350,7 @@
                 "role": "Tera Blast user",
                 "movepool": ["Bitter Malice", "Burning Jealousy", "Nasty Plot", "Tera Blast", "Will-O-Wisp"],
                 "abilities": ["Illusion"],
-                "teraTypes": ["Fairy"]
+                "teraTypes": ["Fairy", "Fighting"]
             }
         ]
     }

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -57,6 +57,9 @@ export class RandomBabyTeams extends RandomTeams {
 		this.moveEnforcementCheckers['Bug'] = (movePool, moves, abilities, types, counter) => (
 			!counter.get('Bug')
 		);
+		this.moveEnforcementCheckers['Grass'] = (movePool, moves, abilities, types, counter, species) => (
+			!counter.get('Grass') && species.id !== 'rowlet'
+		);
 	}
 
 
@@ -488,7 +491,6 @@ export class RandomBabyTeams extends RandomTeams {
 		if (ability === 'Guts' && moves.has('facade')) return 'Flame Orb';
 		if (ability === 'Quick Feet') return 'Toxic Orb';
 
-		if (types.includes('Bug') && types.includes('Flying')) return 'Heavy-Duty Boots';
 		if (['Harvest', 'Ripen', 'Unburden'].includes(ability) || moves.has('bellydrum')) return 'Oran Berry';
 	}
 

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -68,7 +68,7 @@
         ]
     },
     "stratagem": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -102,18 +102,18 @@
         ]
     },
     "kitsunoh": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Bullet Punch", "Close Combat", "Meteor Mash", "Poltergeist", "Strength Sap", "Trick"],
-                "abilities": ["Iron Fist"],
-                "teraTypes": ["Fairy", "Fighting", "Ghost", "Steel"]
+                "movepool": ["Close Combat", "Defog", "Encore", "Meteor Mash", "Poltergeist", "Strength Sap", "Trick", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Trace"],
+                "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Meteor Mash", "Poltergeist", "Strength Sap", "U-turn", "Will-O-Wisp"],
-                "abilities": ["Iron Fist"],
+                "movepool": ["Defog", "Encore", "Meteor Mash", "Poltergeist", "Strength Sap", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Trace"],
                 "teraTypes": ["Dark", "Water"]
             }
         ]
@@ -147,7 +147,7 @@
         ]
     },
     "krilowatt": {
-        "level": 85,
+        "level": 84,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -158,11 +158,11 @@
         ]
     },
     "voodoom": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aura Sphere", "Dark Pulse", "Flash Cannon", "Focus Blast", "Nasty Plot", "Volt Switch"],
+                "movepool": ["Aura Sphere", "Dark Pulse", "Flash Cannon", "Focus Blast", "Nasty Plot", "Vacuum Wave", "Volt Switch"],
                 "abilities": ["Lightning Rod", "Volt Absorb"],
                 "teraTypes": ["Steel"]
             }
@@ -265,7 +265,7 @@
         ]
     },
     "volkraken": {
-        "level": 83,
+        "level": 82,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -293,7 +293,7 @@
         ]
     },
     "naviathan": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -304,7 +304,7 @@
         ]
     },
     "crucibelle": {
-        "level": 87,
+        "level": 86,
         "sets": [
             {
                 "role": "AV Pivot",
@@ -366,7 +366,7 @@
         ]
     },
     "caribolt": {
-        "level": 83,
+        "level": 81,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -445,7 +445,7 @@
         ]
     },
     "miasmaw": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -553,7 +553,7 @@
         ]
     },
     "cresceidon": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -112,7 +112,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Encore", "Meteor Mash", "Poltergeist", "Strength Sap", "U-turn", "Will-O-Wisp"],
+                "movepool": ["Defog", "Meteor Mash", "Poltergeist", "Strength Sap", "U-turn", "Will-O-Wisp"],
                 "abilities": ["Trace"],
                 "teraTypes": ["Dark", "Water"]
             }

--- a/sim/teams.ts
+++ b/sim/teams.ts
@@ -624,7 +624,7 @@ export const Teams = new class Teams {
 			TeamGenerator = require(`../data/mods/gen9ssb/random-teams`).default;
 		} else if (toID(format).includes('gen9babyrandombattle')) {
 			TeamGenerator = require(`../data/random-battles/gen9baby/teams`).default;
-		} else if (toID(format).includes('gen9randombattle') && format.customRules?.includes('+cap')) {
+		} else if (toID(format).includes('gen9randombattle') && format.ruleTable?.has('+pokemontag:cap')) {
 			TeamGenerator = require(`../data/random-battles/gen9cap/teams`).default;
 		} else {
 			TeamGenerator = require(`../data/random-battles/${format.mod}/teams`).default;

--- a/sim/teams.ts
+++ b/sim/teams.ts
@@ -624,11 +624,7 @@ export const Teams = new class Teams {
 			TeamGenerator = require(`../data/mods/gen9ssb/random-teams`).default;
 		} else if (toID(format).includes('gen9babyrandombattle')) {
 			TeamGenerator = require(`../data/random-battles/gen9baby/teams`).default;
-		} else if (
-				// when removing cap rands ladder, remove the line below and collapse
-				toID(format).includes('gen9caprandombattle') ||
-				(toID(format).includes('gen9randombattle') && format.customRules?.includes('+cap'))
-			) {
+		} else if (toID(format).includes('gen9randombattle') && format.customRules?.includes('+cap')) {
 			TeamGenerator = require(`../data/random-battles/gen9cap/teams`).default;
 		} else {
 			TeamGenerator = require(`../data/random-battles/${format.mod}/teams`).default;

--- a/sim/teams.ts
+++ b/sim/teams.ts
@@ -624,7 +624,11 @@ export const Teams = new class Teams {
 			TeamGenerator = require(`../data/mods/gen9ssb/random-teams`).default;
 		} else if (toID(format).includes('gen9babyrandombattle')) {
 			TeamGenerator = require(`../data/random-battles/gen9baby/teams`).default;
-		} else if (toID(format).includes('gen9caprandombattle')) {
+		} else if (
+				// when removing cap rands ladder, remove the line below and collapse
+				toID(format).includes('gen9caprandombattle') ||
+				(toID(format).includes('gen9randombattle') && format.customRules?.includes('+cap'))
+			) {
 			TeamGenerator = require(`../data/random-battles/gen9cap/teams`).default;
 		} else {
 			TeamGenerator = require(`../data/random-battles/${format.mod}/teams`).default;


### PR DESCRIPTION
Please merge before end of month if you can. No worries if you can't.

**Gen 9 Random Battle:**
-Chimecho now runs a third set of Cosmic Power, Stored Power, Dazzling Gleam, and Recover with Tera Steel.
-Bulky Attacker (non-Iron Defense) Probopass and Carbink no longer exist.
-Tera Blast Thundurus-Incarnate now gets Attack investment for when Defiant procs.
-Corviknight: +Pressure (rolled with Mirror Armor)
-Protect Swalot: +Sticky Hold (rolled with Liquid Ooze)
-Dragon Dance Lapras: -Freeze-Dry, +Icicle Spear (now gets Dice instead of Boots)
-QD Ribombee: -Bug Buzz, +Draining Kiss
-Swampert: +Yawn
-Empoleon: +Roar
-Sheer Force Cetitan: -Tera Fairy, -Play Rough, +Superpower. Will now always get Liquidation.
-Zamazenta-Crowned: +Tera Ghost
-Luvdisc: +Tera Ground
-Galarian Zapdos: +Tera Steel
-Setup Sweeper Flamigo: +Tera Steel
-Falinks: -Tera Ghost, -Tera Fighting
-Barraskewda: +Tera Water

Winrate-based reversions:
-Qwilfish is regaining Destiny Bond.
-Magearna is regaining Thunder Wave.
-Ampharos is losing Dragon Tail.
-Eiscue is regaining Zen Headbutt and Iron Head on non-Tera Blast and Liquidation on Tera Blast, thus also giving it Sitrus back.

Technical:
-Roar and Yawn can't generate together.
-A hardcode for Brute Bonnet was removed.
-A hardcode for Barraskewda was changed to a simpler, more straightforward one.

**Gen 9 Random Doubles**
-Lucario's sets have been changed to one mixed attacking set with Close Combat, Flash Cannon, Extreme Speed, and Protect and one Choice Band set with CC, Espeed, Mash, and Rock Slide.
-Smeargle's first set has been changed to Population Bomb, Spiky Shield, No Retreat, and Baton Pass with a Wide Lens. Smeargle's other set with Decorate now runs Sitrus Berry instead of Focus Sash.
-Hydrapple's sets have been changed significantly. It now has a Bulky Protect set with Pollen Puff, Fickle Beam, and Giga Drain/Leaf Storm, a Choice Specs Wallbreaker set with Earth Power, Draco Meteor, Leaf Storm, and Giga Drain, and an Assault Vest Bulky Attacker set with Fickle Beam, Giga Drain/Leaf Storm, Pollen Puff, and Earth Power. AV is only Tera Steel, the others are Tera Fire/Steel.
-Landorus: +Rock Slide (will not coincide with Nasty Plot)
-Falinks: +Rock Slide, +Protect, -Tera Fighting
-Bulky Protect Raikou: -Tera Grass, +Tera Water (Raikou will no longer get three electric moves)

**Gen 9 CAP Random Battle**
-This format will still exist after the spotlight has ended. This patch allows CAP rands to be created by adding the rule "+cap" to a Gen 9 Random Battle tournament or challenge. This has been tested and Hecate and Hizo helped me with the code.
-Level balancing has occurred. Caribolt, Kitsunoh, and Naviathan have lost two levels, and Stratagem, Crucibelle, Cresceidon, Volkraken, Miasmaw, and Voodoom have lost one level.
-Fast Attacker Kitsunoh: -Iron Fist, -Bullet Punch, -Tera Ghost, -Tera Steel, -Tera Fairy, +Trace, +U-turn (Now always gets Close Combat)
-Bulky Attacker Kitsunoh: -Iron Fist, +Trace, +Encore
-Voodoom: +Vacuum Wave
-Changes to Chuggalong will happen when its nerfs are implemented onsite.

**Gen 9 Baby Random Battle**
-Grass-type STAB is now enforced on all dual-typed Grass-types except Rowlet.
-Heavy-Duty Boots no longer exists in this format in any capacity.
-Nosepass now has a Bulky Attacker set with Volt Switch and Stealth Rock, in addition to its preexisting Iron Defense set.
-Drilbur has been split up between Rock Slide and Poison Jab; it now always gets Rapid Spin.
-Axew and Jangmo-o now run a second set each with Eviolite Swords Dance + Scale Shot.
-Tera Blast Drilbur no longer exists. Drilbur's other set no longer runs Throat Chop or Tera Fairy and will now always get Stone Edge.
-Acrobatics Pikipek no longer exists.
-Tinkatink's role has been change to Bulky Attacker. It will now always have Knock Off.
-Sewaddle: -Electroweb, +Iron Defense (Iron Defense will only be rolled if the team already has a sticky web user.)
-Slowpoke: All moves removed except Curse, Slack Off, Liquidation, Zen Headbutt, and Thunder Wave.
-BD Magby: -Temper Flare, +Fire Punch
-Fennekin: +Tera Ground, +Mud Shot
-Noibat: -Air Slash
-Minccino: -Triple Axel, -Tera Ice
-Feebas: -Tera Normal, -Double Edge, +Tera Dragon, +Scale Shot
-Surskit, Deerling, and Spinarak: +Tera Ghost
-Setup Psyduck: +Tera Grass
-Horsea and Tera Blast Poliwag: +Tera Dragon
-Tera Blast Sinistea: +Tera Fairy
-Sandile: +Tera Flying
-Tera Blast Zorua-H: +Tera Fighting
-Bulky Attacker Zorua: -Tera Dark
-Crabrawler: +Tera Electric
-Varoom: -Tera Steel, -Tera Poison
-Tinkatink: -Tera Fairy
-Charcadet: -Tera Fire
-Wattrel: -Tera Electric
-Seel, Finneon: -Tera Water
-Phanpy, Mudbray: -Tera Ground
-Setup Sweeper Gimmighoul-Roaming: -Tera Fairy, +Tera Rock
-Exeggcute: -Tera Dark, +Tera Steel
-Grimer: +Tera Dark
-Fast Attacker Scorbunny: -Tera Poison, -Tera Fighting
-Sprigatito: -Tera Fairy

**Old Gens:**
-In Gens 4-7, Magmortar no longer runs Hidden Power Grass or Substitute and can now run Taunt.
-In Gens 5-7, Maractus no longer runs Sucker Punch.
-In Gens 5-7, Lucario no longer runs Dark Pulse.
-In Gens 6-7, Mega Ampharos now has a set split where one set runs Agility and Thunderbolt and the other runs Discharge and RestTalk or Heal Bell.
-In Gens 6-7, Mega Absol has lost Fire Blast, gained Iron Tail, and merged its sets together
-In Gens 6-7, Espeon now always gets Dazzlilng Gleam.
-In Gen 7, Meloetta now runs a Z-Celebrate set with its usual three special attacks.
-In Gen 7, Solgaleo now always runs Earthquake.
-In Gen 7, Lycanroc and Lycanroc-Dusk now run Zen Headbutt instead of Fire Fang.
-In Gen 6, AV Hariyama can sometimes roll Guts on its AV Pivot set.
-In Gen 4, Tropius no longer runs Roost on its setup set.
-In Gen 4, CM Lunatone now runs Signal Beam instead of Shadow Ball.
-In Gen 4, Plusle and Minun now always run HP Ice.
-In Gen 4, Hypno now has a third set with Nasty Plot and Baton Pass.
-In Gen 3, Spikes is now enforced on all sets that have the move.
-In Gen 3, Deoxys (normal) no longer runs Spikes.
-In Gen 3, Forretress's sets were merged because Spikes is forced now and we wouldn't have to worry about Choice Band existing anymore.
-In Gen 3, Blissey no longer runs its setup set.
-In Gen 3, Magmar no longer runs Psychic and non-setup Magmar can now run Toxic.
-In Gen 3, Wallbreaker Rayquaza now always runs Extreme Speed.
-In Gen 2, Forretress's double-edge set no longer exists.
-In Gen 2, Porygon2's non-Curse set no longer exists.
-In Gen 2, Aipom now runs a second set with RestTalk, Curse, and Return.
-In Gen 2, Crobat now runs Wing Attack instead of Return and always runs HP Ground.
-In Gen 2, Magcargo's Generalist role has been changed to Bulky Attacker to enforce a second attack and that set now has Earthquake. Its other set now runs Fire Blast or Flamethrower instead of Sleep Talk.
-In Gen 2, Fast Attacker Butterfree now runs Reflect instead of Substitute
-In Gen 2, Belly Drum Quagsire no longer exists and Bulky Attacker Quagsire now sometimes runs Sludge Bomb.