### PR TITLE
Gen 1: fix Hyper Beam recharge interactions with partial trapping moves

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -80,7 +80,12 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		self: {
 			volatileStatus: 'partialtrappinglock',
 		},
-		// FIXME: onBeforeMove(pokemon, target) {target.removeVolatile('mustrecharge')}
+		onTryMove(source, target) {
+			if (target.volatiles['mustrecharge']) {
+				target.removeVolatile('mustrecharge');
+				this.hint("In Gen 1, partial trapping moves negate the recharge turn of Hyper Beam, even if they miss.", true);
+			}
+		},
 		onHit(target, source) {
 			/**
 			 * The duration of the partially trapped must be always renewed to 2
@@ -136,7 +141,12 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		self: {
 			volatileStatus: 'partialtrappinglock',
 		},
-		// FIXME: onBeforeMove(pokemon, target) {target.removeVolatile('mustrecharge')}
+		onTryMove(source, target) {
+			if (target.volatiles['mustrecharge']) {
+				target.removeVolatile('mustrecharge');
+				this.hint("In Gen 1, partial trapping moves negate the recharge turn of Hyper Beam, even if they miss.", true);
+			}
+		},
 		onHit(target, source) {
 			/**
 			 * The duration of the partially trapped must be always renewed to 2
@@ -314,7 +324,12 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		self: {
 			volatileStatus: 'partialtrappinglock',
 		},
-		// FIXME: onBeforeMove(pokemon, target) {target.removeVolatile('mustrecharge')}
+		onTryMove(source, target) {
+			if (target.volatiles['mustrecharge']) {
+				target.removeVolatile('mustrecharge');
+				this.hint("In Gen 1, partial trapping moves negate the recharge turn of Hyper Beam, even if they miss.", true);
+			}
+		},
 		onHit(target, source) {
 			/**
 			 * The duration of the partially trapped must be always renewed to 2
@@ -939,7 +954,12 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		self: {
 			volatileStatus: 'partialtrappinglock',
 		},
-		// FIXME: onBeforeMove(pokemon, target) {target.removeVolatile('mustrecharge')}
+		onTryMove(source, target) {
+			if (target.volatiles['mustrecharge']) {
+				target.removeVolatile('mustrecharge');
+				this.hint("In Gen 1, partial trapping moves negate the recharge turn of Hyper Beam, even if they miss.", true);
+			}
+		},
 		onHit(target, source) {
 			/**
 			 * The duration of the partially trapped must be always renewed to 2

--- a/test/sim/moves/hyperbeam.js
+++ b/test/sim/moves/hyperbeam.js
@@ -51,4 +51,46 @@ describe(`Hyper Beam`, function () {
 		battle.makeChoices();
 		assert.cantMove(() => battle.choose('p1', 'move tackle'));
 	});
+
+	it(`[Gen 1] Partial trapping moves negate recharge turns (recharging Pokemon is slower))`, function () {
+		battle = common.gen(1).createBattle({forceRandomChance: true}, [[
+			{species: 'cloyster', moves: ['surf', 'clamp']},
+		], [
+			{species: 'snorlax', moves: ['hyperbeam']},
+		]]);
+		// All moves hit
+		battle.makeChoices();
+		assert(battle.p2.active[0].volatiles['mustrecharge']);
+		battle.makeChoices('move clamp', 'auto');
+		assert.false(battle.p2.active[0].volatiles['mustrecharge']);
+		assert(battle.p2.active[0].volatiles['partiallytrapped']);
+	});
+
+	it(`[Gen 1] Partial trapping moves negate recharge turns (recharging Pokemon is faster)`, function () {
+		battle = common.gen(1).createBattle({forceRandomChance: true}, [[
+			{species: 'cloyster', moves: ['clamp']},
+		], [
+			{species: 'aerodactyl', moves: ['hyperbeam']},
+		]]);
+		// All moves hit
+		battle.makeChoices();
+		assert.false.fullHP(battle.p1.active[0]);
+		assert.false(battle.p2.active[0].volatiles['mustrecharge']);
+		assert(battle.p2.active[0].volatiles['partiallytrapped']);
+	});
+
+	it(`[Gen 1] Hyper Beam automatic selection glitch`, function () {
+		battle = common.gen(1).createBattle({seed: [0, 0, 1, 0]}, [[
+			{species: 'cloyster', moves: ['surf', 'clamp']},
+		], [
+			{species: 'snorlax', moves: ['hyperbeam']},
+		]]);
+		// All moves hit in the first turn
+		battle.makeChoices();
+		assert(battle.p2.active[0].volatiles['mustrecharge']);
+		// Clamp misses, the forced Hyper Beam hits
+		battle.makeChoices('move clamp', 'auto');
+		assert.false(battle.p2.active[0].volatiles['partiallytrapped']);
+		assert(battle.p2.active[0].volatiles['mustrecharge']);
+	});
 });


### PR DESCRIPTION
Partial trapping moves negate the recharge turn of Hyper Beam, regardless of whether they hit or miss. 

Also implements the [Hyper Beam automatic selection glitch](https://glitchcity.wiki/wiki/Hyper_Beam_automatic_selection_glitch): if a faster partial trapping move misses against a recharging Pokemon, the recharging Pokemon will automatically use Hyper Beam (and if Hyper Beam has 0 PP, it will underflow to 63 PP).