### PR TITLE
Refactor LetsGo rulesets

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3385,7 +3385,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		name: "[Gen 7 Let's Go] OU",
 		mod: 'gen7letsgo',
 		searchShow: false,
-		ruleset: ['Adjust Level = 50', 'Obtainable', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Team Preview', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod'],
+		ruleset: ['Standard'],
 		banlist: ['Uber'],
 	},
 	{

--- a/data/mods/gen7letsgo/rulesets.ts
+++ b/data/mods/gen7letsgo/rulesets.ts
@@ -1,0 +1,10 @@
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
+	standard: {
+		inherit: true,
+		ruleset: ['Adjust Level = 50', 'Obtainable', 'Team Preview', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod'],
+	},
+	standarddoubles: {
+		inherit: true,
+		ruleset: ['Adjust Level = 50', 'Obtainable', 'Team Preview', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod'],
+	},
+};


### PR DESCRIPTION
It basically just adds 'Adjust Level = 50' to [Gen 7 Let's Go] Doubles OU.