### PR TITLE
Dexsearch optimization

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1355,6 +1355,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			delete dex[mon];
 		}
+		console.log(pokemonSource);
 	}
 	const filters_total_time = performance.now() - filters_start_time;
 	console.log("filters total:\t", filters_total_time, "ms");

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1159,6 +1159,10 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	}
 	for (const alts of searches) {
 		if (alts.skip) continue;
+		const move_filter_start_time = performance.now();
+		const altsMoves = Object.keys(alts.moves).map(x => mod.moves.get(x));
+		move_filter_get_list_total_time += performance.now() - move_filter_start_time;
+		move_filter_total_time += performance.now() - move_filter_start_time;
 		for (const mon in dex) {
 			let matched = false;
 			if (alts.gens && Object.keys(alts.gens).length) {
@@ -1334,10 +1338,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			stat_filter_total_time += performance.now() - stat_filter_start_time;
 			if (matched) continue;
 
-			const move_filter_start_time = performance.now();
-			const mod_moves = Object.keys(alts.moves).map(x => mod.moves.get(x));
-			move_filter_get_list_total_time += performance.now() - move_filter_start_time;
-			for (const move of mod_moves) {
+			const check_moves_start_time = performance.now();
+			for (const move of altsMoves) {
 				const learn_check_start_time = performance.now();
 				if (move.gen <= mod.gen && !validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
 					move_filter_learn_check_total_time += performance.now() - learn_check_start_time;
@@ -1347,7 +1349,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 				move_filter_learn_check_total_time += performance.now() - learn_check_start_time;
 				if (!pokemonSource.size()) break;
 			}
-			move_filter_total_time += performance.now() - move_filter_start_time;
+			move_filter_total_time += performance.now() - check_moves_start_time;
 			if (matched) continue;
 
 			delete dex[mon];

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1247,7 +1247,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			}
 			if (matched) continue;
 
-
 			for (const stat in alts.stats) {
 				let monStat = 0;
 				if (stat === 'bst') {
@@ -1283,12 +1282,10 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			if (matched) continue;
 
 			for (const move of altsMoves) {
-				/** @ts-expect-error validator and pokemonSource won't be undefined if there's at least one move */
 				if (!validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
 					matched = true;
 					break;
 				}
-				/** @ts-expect-error pokemonSource won't be undefined if there's at least one move */
 				if (!pokemonSource.size()) break;
 			}
 			if (matched) continue;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1110,13 +1110,12 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	let validator;
 	let pokemonSource;
 	if (Object.values(searches).some(search => Object.keys(search.moves).length !== 0)) {
-		const format = Object.entries(Dex.data.Rulesets).find(([a, f]) => f.mod === usedMod);
-		const formatStr = format ? format[1].name : 'gen9ou';
-		const ruleTable = Dex.formats.getRuleTable(Dex.formats.get(formatStr));
+		const format = Object.entries(Dex.data.Rulesets).find(([a, f]) => f.mod === usedMod)?.[1].name || 'gen9ou';
+		const ruleTable = Dex.formats.getRuleTable(Dex.formats.get(format));
 		const additionalRules = [];
 		if (nationalSearch && !ruleTable.has('standardnatdex')) additionalRules.push('standardnatdex');
 		if (nationalSearch && ruleTable.valueRules.has('minsourcegen')) additionalRules.push('!!minsourcegen=3');
-		validator = TeamValidator.get(`${formatStr}${additionalRules.length ? `@@@${additionalRules.join(',')}` : ''}`);
+		validator = TeamValidator.get(`${format}${additionalRules.length ? `@@@${additionalRules.join(',')}` : ''}`);
 		pokemonSource = validator.allSources();
 	}
 	for (const alts of searches) {

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1135,6 +1135,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	let ability_filter_total_time = 0;
 	let forme_filter_total_time = 0;
 
+	let delete_total_time = 0;
+
 	let check_can_learn_call_count = 0;
 	// Prepare move validator and pokemonSource outside the hot loop
 	// but don't prepare them at all if there are no moves to check...
@@ -1359,7 +1361,9 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			move_filter_total_time += performance.now() - check_moves_start_time;
 			if (matched) continue;
 
+			const delete_start_time = performance.now();
 			delete dex[mon];
+			delete_total_time += performance.now() - delete_start_time;
 		}
 	}
 	const filters_total_time = performance.now() - filters_start_time;
@@ -1383,6 +1387,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	console.log("\t\tget moves:\t", move_filter_get_list_total_time, "ms");
 	console.log("\t\tlearn check:\t", move_filter_learn_check_total_time, "ms");
 	console.log("\t\tunaccounted:\t", move_filter_total_time - move_filter_get_list_total_time - move_filter_learn_check_total_time, "ms");
+	console.log("\tdelete from dex:\t", delete_total_time, "ms");
 
 	const stat = sort?.slice(0, -1);
 
@@ -1420,7 +1425,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		results.push(dex[mon].name);
 	}
 	const sort_total_time = performance.now() - sort_start_time;
-	console.log("sort", sort_total_time, "ms");
+	console.log("sort:\t", sort_total_time, "ms");
 
 	if (usedMod === 'gen7letsgo') {
 		results = results.filter(name => {
@@ -1446,6 +1451,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		results = Utils.shuffle(results).slice(0, randomOutput);
 	}
 
+	const format_result_start_time = performance.now();
 	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
 	if (results.length > 1) {
 		results.sort();
@@ -1473,9 +1479,11 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	} else {
 		resultsStr += "No Pok&eacute;mon found.";
 	}
+	const format_result_total_time = performance.now() - format_result_start_time;
 	const total_time = performance.now() - start_time;
+	console.log("format result:\t", format_result_total_time, "ms");
 	console.log("*** entire run time:\t\t\t", total_time, "ms ***");
-	console.log("*** unaccounted:\t\t\t", total_time - query_prep_total_time - filters_total_time - sort_total_time, "ms ***");
+	console.log("*** unaccounted:\t\t\t", total_time - query_prep_total_time - filters_total_time - sort_total_time - format_result_total_time, "ms ***");
 	console.log("called checkCanLearn", check_can_learn_call_count, "times");
 	if (isTest) return {results, reply: resultsStr};
 	return {reply: resultsStr};

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1282,11 +1282,11 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			if (matched) continue;
 
 			for (const move of altsMoves) {
-				if (!validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
+				if (validator && !validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
 					matched = true;
 					break;
 				}
-				if (!pokemonSource.size()) break;
+				if (pokemonSource && !pokemonSource.size()) break;
 			}
 			if (matched) continue;
 

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1135,6 +1135,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	let ability_filter_total_time = 0;
 	let forme_filter_total_time = 0;
 
+	let check_can_learn_call_count = 0;
+
 	// Prepare move validator etc outside the hot loop
 	let validator;
 	let pokemonSource;
@@ -1342,6 +1344,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			const check_moves_start_time = performance.now();
 			for (const move of altsMoves) {
 				const learn_check_start_time = performance.now();
+				check_can_learn_call_count += 1;
 				if (!validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
 					move_filter_learn_check_total_time += performance.now() - learn_check_start_time;
 					matched = true;
@@ -1467,6 +1470,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	const total_time = performance.now() - start_time;
 	console.log("*** entire run time:\t\t\t", total_time, "ms ***");
 	console.log("*** unaccounted:\t\t\t", total_time - query_prep_total_time - filters_total_time - sort_total_time, "ms ***");
+	console.log("called checkCanLearn", check_can_learn_call_count, "times");
 	if (isTest) return {results, reply: resultsStr};
 	return {reply: resultsStr};
 }

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -619,8 +619,6 @@ function getMod(target: string) {
 }
 
 function runDexsearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
-	console.log("\n\t\tnow executing:", target);
-	const start_time = performance.now();
 	const searches: DexOrGroup[] = [];
 	const {splitTarget, usedMod, count: c} = getMod(target);
 	if (c > 1) {
@@ -708,7 +706,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		return false;
 	};
 
-	const query_prep_start_time = performance.now();
 	for (const andGroup of splitTarget) {
 		const orGroup: DexOrGroup = {
 			abilities: {}, tiers: {}, doublesTiers: {}, colors: {}, 'egg groups': {}, formes: {},
@@ -1071,8 +1068,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			searches.push(orGroup);
 		}
 	}
-	const query_prep_total_time = performance.now() - query_prep_start_time;
-	console.log("query prep:\t", query_prep_total_time, "ms");
 	if (
 		showAll && searches.length === 0 && singleTypeSearch === null &&
 		megaSearch === null && gmaxSearch === null && fullyEvolvedSearch === null && sort === null
@@ -1109,7 +1104,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		Object.values(search).reduce(accumulateKeyCount, 0)
 	));
 
-	const filters_start_time = performance.now();
 	// Prepare move validator and pokemonSource outside the hot loop
 	// but don't prepare them at all if there are no moves to check...
 	// These only ever get accessed if there are moves to filter by.
@@ -1303,8 +1297,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			delete dex[mon];
 		}
 	}
-	const filters_total_time = performance.now() - filters_start_time;
-	console.log("filters total:\t", filters_total_time, "ms");
 
 	const stat = sort?.slice(0, -1);
 
@@ -1324,7 +1316,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		}
 	}
 
-	const sort_start_time = performance.now();
 	let results: string[] = [];
 	for (const mon of Object.keys(dex).sort()) {
 		if (singleTypeSearch !== null && (dex[mon].types.length === 1) !== singleTypeSearch) continue;
@@ -1341,8 +1332,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		if (dex[mon].isNonstandard === 'Gigantamax' && !allowGmax) continue;
 		results.push(dex[mon].name);
 	}
-	const sort_total_time = performance.now() - sort_start_time;
-	console.log("sort:\t\t", sort_total_time, "ms");
 
 	if (usedMod === 'gen7letsgo') {
 		results = results.filter(name => {
@@ -1366,7 +1355,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		results = Utils.shuffle(results).slice(0, randomOutput);
 	}
 
-	const format_result_start_time = performance.now();
 	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
 	if (results.length > 1) {
 		results.sort();
@@ -1386,18 +1374,10 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
 		}
 	} else if (results.length === 1) {
-		const total_time = performance.now() - start_time;
-		console.log("*** entire run time:\t\t\t", total_time, "ms ***");
-		console.log("*** unaccounted:\t\t\t", total_time - query_prep_total_time - filters_total_time - sort_total_time, "ms ***");
 		return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
 	} else {
 		resultsStr += "No Pok&eacute;mon found.";
 	}
-	const format_result_total_time = performance.now() - format_result_start_time;
-	const total_time = performance.now() - start_time;
-	console.log("format result:\t", format_result_total_time, "ms");
-	console.log("*** entire run time:\t\t\t", total_time, "ms ***");
-	console.log("*** unaccounted:\t\t\t", total_time - query_prep_total_time - filters_total_time - sort_total_time - format_result_total_time, "ms ***");
 	if (isTest) return {results, reply: resultsStr};
 	return {reply: resultsStr};
 }

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1160,7 +1160,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	for (const alts of searches) {
 		if (alts.skip) continue;
 		const move_filter_start_time = performance.now();
-		const altsMoves = Object.keys(alts.moves).map(x => mod.moves.get(x));
+		const altsMoves = Object.keys(alts.moves).map(x => mod.moves.get(x)).filter(move => move.gen <= mod.gen);
+		console.log("altsMoves size: ", Object.keys(alts.moves).length, " -> ", altsMoves.length, "(after filtering for gen)");
 		move_filter_get_list_total_time += performance.now() - move_filter_start_time;
 		move_filter_total_time += performance.now() - move_filter_start_time;
 		for (const mon in dex) {
@@ -1341,7 +1342,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			const check_moves_start_time = performance.now();
 			for (const move of altsMoves) {
 				const learn_check_start_time = performance.now();
-				if (move.gen <= mod.gen && !validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
+				if (!validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
 					move_filter_learn_check_total_time += performance.now() - learn_check_start_time;
 					matched = true;
 					break;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2391,7 +2391,7 @@ export class TeamValidator {
 		const baseSpecies = dex.species.get(originalSpecies);
 
 		const format = this.format;
-		const ruleTable = dex.formats.getRuleTable(format);
+		const ruleTable = this.ruleTable;
 		const level = set.level || 100;
 
 		let cantLearnReason = null;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2693,7 +2693,9 @@ export class TeamValidator {
 		if (!setSources.restrictiveMoves) {
 			setSources.restrictiveMoves = [];
 		}
-		setSources.restrictiveMoves.push(move.name);
+		if (!setSources.restrictiveMoves.includes(move.name)) {
+			setSources.restrictiveMoves.push(move.name);
+		}
 
 		const checkedSpecies = babyOnly ? fullLearnset[fullLearnset.length - 1].species : baseSpecies;
 		if (checkedSpecies && setSources.isFromPokemonGo &&


### PR DESCRIPTION
In short, dexsearch ~is~ was abnormally slow. A simple query like `/nds fire` took **~2 seconds** and `/nds pivot` **~4 seconds** on the prod server and my decent laptop.

This PR applies a few extremely simple fixes that address ~99% of the performance problems. **The aforementioned queries now take ~5 milliseconds and 30 milliseconds**, respectively. Far more optimizations are possible, but won't be as simple or impactful.

## Results
Below are the (very scarce) performance stats for `npm test`, running on an `i7-9750h`.
These are cheaper than `/nds`. The first test is especially slow because of the nature of JITs.

<details>
<summary>Initial</summary>

```
Before
		now executing: pivot|batonpass, mod=gen8
query prep:	 54.37550900131464 ms
dex size: 804
filters total:	 129.14655699953437 ms
	stat filters:	 0.17849896475672722 ms
	egg filters:	 0.14566901698708534 ms
	type filters:	 0.1426999494433403 ms
	resist filters:	 0.13550499826669693 ms
	weak filters:	 0.14920806139707565 ms
	ability filters: 0.12753695249557495 ms
	forme filters:	 0.12921300157904625 ms
	prepare move filters: 80.43997703120112 ms
		format:   	 74.51695001125336 ms
		ruletable:	 2.823194034397602 ms
		validator:	 2.0557279251515865 ms
		pokesource:	 0.41381001472473145 ms
	move filters:	 45.508391946554184 ms
sort:	 0.6476159989833832 ms
1421 number of unique mon objects from Dex.mod(...)
804 number of above objects that pass gen filters
total run time:			 232.11053999885917 ms
․
		now executing: pivot, mod=gen8
query prep:	 0.7473939992487431 ms
dex size: 804
filters total:	 94.04799500107765 ms
	stat filters:	 0.08011595532298088 ms
	egg filters:	 0.10512598976492882 ms
	type filters:	 0.10283003747463226 ms
	resist filters:	 0.08430599421262741 ms
	weak filters:	 0.11044797673821449 ms
	ability filters: 0.08263105899095535 ms
	forme filters:	 0.0876309834420681 ms
	prepare move filters: 75.64411291107535 ms
		format:   	 71.8328619338572 ms
		ruletable:	 1.4543550126254559 ms
		validator:	 1.648287057876587 ms
		pokesource:	 0.2687230445444584 ms
	move filters:	 16.034791000187397 ms
sort:	 0.38658300042152405 ms
1421 number of unique mon objects from Dex.mod(...)
804 number of above objects that pass gen filters
total run time:			 96.38358999788761 ms
․․․․․․․․․․․
		now executing: ice, monotype
query prep:	 0.1216839998960495 ms
dex size: 873
filters total:	 494.32178499922156 ms
	stat filters:	 0.10472292080521584 ms
	egg filters:	 0.15022199600934982 ms
	type filters:	 0.8074910305440426 ms
	resist filters:	 0.12324101477861404 ms
	weak filters:	 0.11295903846621513 ms
	ability filters: 0.10627801716327667 ms
	forme filters:	 0.10835202410817146 ms
	prepare move filters: 490.29630206152797 ms
		format:   	 76.94467301294208 ms
		ruletable:	 209.55591402947903 ms
		validator:	 202.62786000221968 ms
		pokesource:	 0.504029992967844 ms
	move filters:	 0.5825789906084538 ms
sort:	 0.08564000204205513 ms
2842 number of unique mon objects from Dex.mod(...)
1677 number of above objects that pass gen filters
total run time:			 496.44836499914527 ms
․
		now executing: ice, monotype, spe desc
query prep:	 0.1344659999012947 ms
dex size: 873
filters total:	 444.82719799876213 ms
	stat filters:	 0.09688697010278702 ms
	egg filters:	 0.1446789614856243 ms
	type filters:	 0.5860809981822968 ms
	resist filters:	 0.11443403363227844 ms
	weak filters:	 0.10183602198958397 ms
	ability filters: 0.10196587443351746 ms
	forme filters:	 0.09404192119836807 ms
	prepare move filters: 441.19286999478936 ms
		format:   	 71.15053798630834 ms
		ruletable:	 185.74913900345564 ms
		validator:	 183.20303198322654 ms
		pokesource:	 0.4670259468257427 ms
	move filters:	 0.5626690238714218 ms
sort:	 0.09177299961447716 ms
2842 number of unique mon objects from Dex.mod(...)
1677 number of above objects that pass gen filters
total run time:			 446.4883599989116 ms

		now executing: ice, monotype, hp desc
query prep:	 0.11399000138044357 ms
dex size: 873
filters total:	 446.07669800147414 ms
	stat filters:	 0.10812501609325409 ms
	egg filters:	 0.14091401174664497 ms
	type filters:	 0.6019999720156193 ms
	resist filters:	 0.1115570142865181 ms
	weak filters:	 0.10407200083136559 ms
	ability filters: 0.11563794314861298 ms
	forme filters:	 0.10732902958989143 ms
	prepare move filters: 442.34754206985235 ms
		format:   	 70.71124800294638 ms
		ruletable:	 187.70725399255753 ms
		validator:	 182.57627097144723 ms
		pokesource:	 0.4813690446317196 ms
	move filters:	 0.5883849188685417 ms
sort:	 0.05595799908041954 ms
2842 number of unique mon objects from Dex.mod(...)
1677 number of above objects that pass gen filters
total run time:			 447.76308299973607 ms
```
</details>

<details>
<summary>Latest</summary>

```
After
		now executing: pivot|batonpass, mod=gen8
query prep:	 51.89018200337887 ms
filters total:	 42.756921999156475 ms
sort:		 0.6007909998297691 ms
format result:	 0.09133599698543549 ms
*** entire run time:			 141.8944509997964 ms ***
*** unaccounted:			 46.55522000044584 ms ***
․
		now executing: pivot, mod=gen8
query prep:	 0.6547169983386993 ms
filters total:	 18.113839998841286 ms
sort:		 0.4578099995851517 ms
format result:	 0.06409899890422821 ms
*** entire run time:			 20.0837190002203 ms ***
*** unaccounted:			 0.7932530045509338 ms ***
․․․․․․․․․․․
		now executing: ice, monotype
query prep:	 0.13084299862384796 ms
filters total:	 0.772537000477314 ms
sort:		 0.04282499849796295 ms
format result:	 0.018077000975608826 ms
*** entire run time:			 1.8486009985208511 ms ***
*** unaccounted:			 0.8843189999461174 ms ***
․
		now executing: ice, monotype, spe desc
query prep:	 0.07613600045442581 ms
filters total:	 0.6047910004854202 ms
sort:		 0.03371300548315048 ms
format result:	 0.08656799793243408 ms
*** entire run time:			 1.2767650038003922 ms ***
*** unaccounted:			 0.47555699944496155 ms ***

		now executing: ice, monotype, hp desc
query prep:	 0.055977001786231995 ms
filters total:	 0.6282810047268867 ms
sort:		 0.02927199751138687 ms
format result:	 0.04599300026893616 ms
*** entire run time:			 1.1314250007271767 ms ***
*** unaccounted:			 0.3719019964337349 ms ***
```

</details>

(I go by 'ThereRNoNamesLeft' on Showdown)