### PR TITLE
Auto-deny unregistered users in IP appeals

### DIFF
--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1414,6 +1414,14 @@ export const textTickets: {[k: string]: TextTicketInfo} = {
 					"Apologies for the inconvenience. It should expire in a few days.",
 				];
 			}
+
+			if (!user.registered) {
+				return [
+					"Because this account isn't registered (with a password), we cannot verify your identity.",
+					"Please come back with a different account you've registered in the past.",
+				];
+			}
+
 			return true;
 		},
 		async onSubmit(ticket, text, user) {


### PR DESCRIPTION
This sort of works, but the way this gets interpreted is wrong:
![image](https://github.com/user-attachments/assets/f7d0690f-09fc-4610-bbaa-6b0688397b23)

I assume this happens for the markshared blacklist message too.