### PR TITLE
[old] Overhaul sim/dex* initialization

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -17,8 +17,9 @@ export const Scripts: ModdedBattleScriptsData = {
 	gen: 1,
 	init() {
 		for (const i in this.data.Pokedex) {
-			(this.data.Pokedex[i] as any).gender = 'N';
-			(this.data.Pokedex[i] as any).eggGroups = null;
+			const poke = this.modData('Pokedex', i);
+			poke.gender = 'N';
+			poke.eggGroups = null;
 		}
 	},
 	// BattlePokemon scripts.

--- a/data/mods/gen8linked/moves.ts
+++ b/data/mods/gen8linked/moves.ts
@@ -384,11 +384,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			if (!lastMove) return false;
 			const possibleTypes = [];
 			const attackType = lastMove.type;
-			for (const type in this.dex.data.TypeChart) {
-				if (source.hasType(type)) continue;
-				const typeCheck = this.dex.data.TypeChart[type].damageTaken[attackType];
+			for (const typeInfo of this.dex.types.all()) {
+				if (source.hasType(typeInfo.id)) continue;
+				const typeCheck = typeInfo.damageTaken[attackType];
 				if (typeCheck === 2 || typeCheck === 3) {
-					possibleTypes.push(type);
+					possibleTypes.push(typeInfo.id);
 				}
 			}
 			if (!possibleTypes.length) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -3335,7 +3335,6 @@ export const pages: Chat.PageTable = {
 };
 
 process.nextTick(() => {
-	Dex.includeData();
 	Chat.multiLinePattern.register(
 		'/htmlbox', '/quote', '/addquote', '!htmlbox', '/addhtmlbox', '/addrankhtmlbox', '/adduhtml',
 		'/changeuhtml', '/addrankuhtmlbox', '/changerankuhtmlbox', '/addrankuhtml', '/addhtmlfaq',

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -52,7 +52,7 @@ type Direction = 'less' | 'greater' | 'equal';
 const MAX_PROCESSES = 1;
 const RESULTS_MAX_LENGTH = 10;
 const MAX_RANDOM_RESULTS = 30;
-const dexesHelp = Object.keys((global.Dex?.dexes || {})).filter(x => x !== 'sourceMaps').join('</code>, <code>');
+const dexesHelp = Array.from(global.Dex?.scanMods() || []).filter(x => x !== 'sourceMaps').join('</code>, <code>');
 
 function escapeHTML(str?: string) {
 	if (!str) return '';
@@ -608,7 +608,7 @@ function getMod(target: string) {
 	const arr = target.split(',').map(x => x.trim());
 	const modTerm = arr.find(x => {
 		const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
-		return sanitizedStr.startsWith('mod=') && Dex.dexes[toID(sanitizedStr.split('=')[1])];
+		return sanitizedStr.startsWith('mod=') && Dex.mod(toID(sanitizedStr.split('=')[1]));
 	});
 	const count = arr.filter(x => {
 		const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
@@ -704,13 +704,13 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			fs.mkdirSync(`./tmp/${iso_date}`, {recursive: true});
 			const content1 = JSON.stringify(Dex.data.Aliases, null, 2);
 			fs.writeFileSync(`./tmp/${iso_date}/aliases.json`, content1);
-			const content2 = JSON.stringify(Dex.textCache, null, 2);
+			const content2 = JSON.stringify(Dex.loadTextData(), null, 2);
 			fs.writeFileSync(`./tmp/${iso_date}/text.json`, content2);
 		}
 		for (const mod_str of mod_list) {
 			console.log('now doing', mod_str);
 			const mod = Dex.mod(mod_str);
-			fs.mkdirSync(`./tmp/${iso_date}/${mod_str}`, {recursive: true});
+			if (mode === 'dump') fs.mkdirSync(`./tmp/${iso_date}/${mod_str}`, {recursive: true});
 			for (const [label, v1] of Object.entries(dedup_tables)) {
 				const v: any = v1;
 				const dataset = v.get_iter(mod);

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -625,8 +625,9 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		return {error: `You can't run searches for multiple mods.`};
 	}
 
-	const mod = Dex.mod(usedMod || 'base');
 	global.gc();
+	console.log("start:", process.memoryUsage());
+	const mod = Dex.mod(usedMod || 'base');
 	const assert = require('node:assert/strict');
 	function deepEquals(left, right) {
 		let eq = true;
@@ -681,6 +682,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			}
 			v.mod_added.set(mod_str, numNew);
 		}
+		console.log(process.memoryUsage());
+		console.log();
 	}
 	for (const [k, v] of Object.entries(dedup_tables)) {
 		for (const [id, bucket] of v.buckets) {
@@ -701,6 +704,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		v.uniq_objs.clear();
 	}
 	global.gc();
+	console.log("final:", process.memoryUsage());
+	console.log();
 	return {result: "placeholder"};
 
 

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2746,7 +2746,7 @@ function runLearn(target: string, cmd: string, canAll: boolean, formatid: string
 	}
 	let gen;
 	if (!format.exists) {
-		const dex = Dex.mod(formatid).includeData();
+		const dex = Dex.mod(formatid);
 		// can happen if you hotpatch formats without hotpatching chat
 		if (!dex) return {error: `"${formatid}" is not a supported format.`};
 
@@ -2992,7 +2992,6 @@ if (!PM.isParentProcess) {
 
 	global.Dex = require('../../sim/dex').Dex;
 	global.toID = Dex.toID;
-	Dex.includeData();
 
 	// @ts-ignore
 	require('../../lib/repl').Repl.start('dexsearch', cmd => eval(cmd)); // eslint-disable-line no-eval

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -716,7 +716,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 				const dataset = v.get_iter(mod);
 
 				if (mode === 'dump') {
-					const content = JSON.stringify(dataset, null, 2);
+					const sortedData = Utils.sortBy(Array.from(dataset), v.bucket_key);
+					const content = JSON.stringify(sortedData, null, 2);
 					fs.writeFileSync(`./tmp/${iso_date}/${mod_str}/${label}.json`, content);
 					continue;
 				}

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2418,9 +2418,10 @@ function runItemsearch(target: string, cmd: string, canAll: boolean, message: st
 		let type = "";
 
 		for (let word of searchedWords) {
-			if (word in dex.data.TypeChart) {
+			const typeInfo = dex.types.getByID(word as ID);
+			if (typeInfo.exists) {
 				if (type) return {error: "Only specify natural gift type once."};
-				type = word.charAt(0).toUpperCase() + word.slice(1);
+				type = typeInfo.name;
 			} else {
 				if (word.endsWith('bp') && word.length > 2) word = word.slice(0, -2);
 				if (Number.isInteger(Number(word))) {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -17,8 +17,7 @@ interface StoneDeltas {
 type TierShiftTiers = 'UU' | 'RUBL' | 'RU' | 'NUBL' | 'NU' | 'PUBL' | 'PU' | 'ZUBL' | 'ZU' | 'NFE' | 'LC';
 
 function getMegaStone(stone: string, mod = 'gen9'): Item | null {
-	let dex = Dex;
-	if (mod && toID(mod) in Dex.dexes) dex = Dex.mod(toID(mod));
+	const dex = (mod && Dex.mod(toID(mod))) || Dex;
 	const item = dex.items.get(stone);
 	if (!item.exists) {
 		if (toID(stone) === 'dragonascent') {
@@ -86,12 +85,11 @@ export const commands: Chat.ChatCommands = {
 		const stoneName = sep.slice(1).join('@').trim().split(',');
 		const mod = stoneName[1];
 		if (mod) {
-			if (toID(mod) in Dex.dexes) {
-				dex = Dex.mod(toID(mod));
-			} else {
+			dex = Dex.mod(toID(mod));
+			if (!dex) {
 				throw new Chat.ErrorMessage(`A mod by the name of '${mod.trim()}' does not exist.`);
 			}
-			if (dex === Dex.dexes['gen9ssb']) {
+			if (dex.currentMod === 'gen9ssb') {
 				throw new Chat.ErrorMessage(`The SSB mod supports custom elements for Mega Stones that have the capability of crashing the server.`);
 			}
 		}
@@ -203,12 +201,11 @@ export const commands: Chat.ChatCommands = {
 		const sep = target.split(',');
 		let dex = Dex;
 		if (sep[1]) {
-			if (toID(sep[1]) in Dex.dexes) {
-				dex = Dex.mod(toID(sep[1]));
-			} else {
+			dex = Dex.mod(toID(sep[1]));
+			if (!dex) {
 				throw new Chat.ErrorMessage(`A mod by the name of '${sep[1].trim()}' does not exist.`);
 			}
-			if (dex === Dex.dexes['gen9ssb']) {
+			if (dex.currentMod === 'gen9ssb') {
 				throw new Chat.ErrorMessage(`The SSB mod supports custom elements for Mega Stones that have the capability of crashing the server.`);
 			}
 		}
@@ -345,13 +342,8 @@ export const commands: Chat.ChatCommands = {
 		const args = target.split(',');
 		if (!toID(args[0])) return this.parse('/help 350cup');
 		this.runBroadcast();
-		let dex = Dex;
-		if (args[1] && toID(args[1]) in Dex.dexes) {
-			dex = Dex.dexes[toID(args[1])];
-		} else if (room?.battle) {
-			const format = Dex.formats.get(room.battle.format);
-			dex = Dex.mod(format.mod);
-		}
+		const dex = (args[1] && Dex.mod(toID(args[1]))) ||
+			(room?.battle && Dex.forFormat(room.battle.format)) || Dex;
 		const species = Utils.deepClone(dex.species.get(args[0]));
 		if (!species.exists || species.gen > dex.gen) {
 			const monName = species.gen > dex.gen ? species.name : args[0].trim();
@@ -386,13 +378,8 @@ export const commands: Chat.ChatCommands = {
 		this.runBroadcast();
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen && !args[1]) args[1] = `gen${targetGen}`;
-		let dex = Dex;
-		if (args[1] && toID(args[1]) in Dex.dexes) {
-			dex = Dex.dexes[toID(args[1])];
-		} else if (room?.battle) {
-			const format = Dex.formats.get(room.battle.format);
-			dex = Dex.mod(format.mod);
-		}
+		const dex = (args[1] && Dex.mod(toID(args[1]))) ||
+			(room?.battle && Dex.forFormat(room.battle.format)) || Dex;
 		const species = Utils.deepClone(dex.species.get(args[0]));
 		if (!species.exists || species.gen > dex.gen) {
 			const monName = species.gen > dex.gen ? species.name : args[0].trim();
@@ -599,13 +586,8 @@ export const commands: Chat.ChatCommands = {
 		this.runBroadcast();
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen && !args[1]) args[1] = `gen${targetGen}`;
-		let dex = Dex;
-		if (args[1] && toID(args[1]) in Dex.dexes) {
-			dex = Dex.dexes[toID(args[1])];
-		} else if (room?.battle) {
-			const format = Dex.formats.get(room.battle.format);
-			dex = Dex.mod(format.mod);
-		}
+		const dex = (args[1] && Dex.mod(toID(args[1]))) ||
+			(room?.battle && Dex.forFormat(room.battle.format)) || Dex;
 		const species = Utils.deepClone(dex.species.get(args[0]));
 		if (!species.exists || species.gen > dex.gen) {
 			const monName = species.gen > dex.gen ? species.name : args[0].trim();
@@ -646,12 +628,7 @@ export const commands: Chat.ChatCommands = {
 		let mod = args[1];
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen && !mod) mod = `gen${targetGen}`;
-		let dex = Dex;
-		if (mod && toID(mod) in Dex.dexes) {
-			dex = Dex.dexes[toID(mod)];
-		} else if (room?.battle) {
-			dex = Dex.forFormat(room.battle.format);
-		}
+		const dex = (mod && Dex.mod(toID(mod))) || (room?.battle && Dex.forFormat(room.battle.format)) || Dex;
 		const species = Utils.deepClone(dex.species.get(mon));
 		if (!species.exists || species.gen > dex.gen) {
 			const monName = species.gen > dex.gen ? species.name : mon.trim();
@@ -697,13 +674,8 @@ export const commands: Chat.ChatCommands = {
 		const pokemon = args[1];
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen && !args[2]) args[2] = `gen${targetGen}`;
-		let dex = Dex;
-		if (args[2] && toID(args[2]) in Dex.dexes) {
-			dex = Dex.dexes[toID(args[2])];
-		} else if (room?.battle) {
-			const format = Dex.formats.get(room.battle.format);
-			dex = Dex.mod(format.mod);
-		}
+		const dex = (args[2] && Dex.mod(toID(args[2]))) ||
+			(room?.battle && Dex.forFormat(room.battle.format)) || Dex;
 		if (!toID(nature) || !toID(pokemon)) return this.parse(`/help natureswap`);
 		this.runBroadcast();
 		const natureObj = dex.natures.get(nature);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -324,8 +324,9 @@ export abstract class MessageContext {
 			return {dex: Dex.forFormat(format), format: format, isMatch: true};
 		}
 
-		if (toID(formatOrMod) in Dex.dexes) {
-			return {dex: Dex.mod(toID(formatOrMod)).includeData(), format: null, isMatch: true};
+		const mod = Dex.mod(toID(formatOrMod));
+		if (mod) {
+			return {dex: mod.includeData(), format: null, isMatch: true};
 		}
 
 		return this.extractFormat();

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -316,7 +316,7 @@ export abstract class MessageContext {
 	}
 	extractFormat(formatOrMod?: string): {dex: ModdedDex, format: Format | null, isMatch: boolean} {
 		if (!formatOrMod) {
-			return {dex: Dex.includeData(), format: null, isMatch: false};
+			return {dex: Dex, format: null, isMatch: false};
 		}
 
 		const format = Dex.formats.get(formatOrMod);
@@ -326,7 +326,7 @@ export abstract class MessageContext {
 
 		const mod = Dex.mod(toID(formatOrMod));
 		if (mod) {
-			return {dex: mod.includeData(), format: null, isMatch: true};
+			return {dex: mod, format: null, isMatch: true};
 		}
 
 		return this.extractFormat();

--- a/server/team-validator-async.ts
+++ b/server/team-validator-async.ts
@@ -91,7 +91,7 @@ if (!PM.isParentProcess) {
 		});
 	}
 
-	global.Dex = require('../sim/dex').Dex.includeData();
+	global.Dex = require('../sim/dex').Dex;
 	global.Teams = require('../sim/teams').Teams;
 
 	// eslint-disable-next-line no-eval

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -120,20 +120,19 @@ export class DexAbilities {
 		return this.getByID(id);
 	}
 
-	getByID(id: ID): Ability {
-		if (id === '') return EMPTY_ABILITY;
-		let ability = this.abilityCache.get(id);
-		if (ability) return ability;
-
-		if (this.dex.data.Aliases.hasOwnProperty(id)) {
-			ability = this.get(this.dex.data.Aliases[id]);
-			this.abilityCache.set(id, ability);
-		} else {
-			ability = new Ability({
-				id, name: id, exists: false,
-			});
+	getByID2(id: ID): Ability | null {
+		if (id === '') return null;
+		let ability = this.abilityCache.get(id) || null;
+		if (!ability && this.dex.data.Aliases.hasOwnProperty(id)) {
+			ability = this.getByID2(toID(this.dex.data.Aliases[id]));
+			if (ability && ability.exists) this.abilityCache.set(id, ability);
 		}
 		return ability;
+	}
+
+	getByID(id: ID): Ability {
+		if (id === '') return EMPTY_ABILITY;
+		return this.getByID2(id) || new Ability({id, name: id, exists: false});
 	}
 
 	all(): readonly Ability[] {

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -1,5 +1,5 @@
 import type {PokemonEventMethods, ConditionData} from './dex-conditions';
-import {BasicEffect, toID} from './dex-data';
+import {BasicEffect, toID, assignNewFields} from './dex-data';
 import {Utils} from '../lib';
 
 interface AbilityEventMethods {
@@ -70,10 +70,7 @@ export class Ability extends BasicEffect implements Readonly<BasicEffect> {
 				this.gen = 3;
 			}
 		}
-		for (const k of Object.keys(data)) { // TODO: migrate to for..in + Object.hasOwn
-			if (k in this) continue;
-			(this as any)[k] = data[k];
-		}
+		assignNewFields(this, data);
 	}
 }
 

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -1,5 +1,6 @@
 import type {PokemonEventMethods, ConditionData} from './dex-conditions';
 import {BasicEffect, toID} from './dex-data';
+import {Utils} from '../lib';
 
 interface AbilityEventMethods {
 	onCheckShow?: (this: Battle, pokemon: Pokemon) => void;
@@ -76,6 +77,8 @@ export class Ability extends BasicEffect implements Readonly<BasicEffect> {
 	}
 }
 
+const EMPTY_ABILITY = Utils.deepFreeze(new Ability({name: '', exists: false}));
+
 export class DexAbilities {
 	readonly dex: ModdedDex;
 	readonly abilityCache = new Map<ID, Ability>();
@@ -112,12 +115,13 @@ export class DexAbilities {
 
 	get(name: string | Ability = ''): Ability {
 		if (name && typeof name !== 'string') return name;
-
-		const id = toID(name);
+		let id = '' as ID;
+		if (name) id = toID(name.trim());
 		return this.getByID(id);
 	}
 
 	getByID(id: ID): Ability {
+		if (id === '') return EMPTY_ABILITY;
 		let ability = this.abilityCache.get(id);
 		if (ability) return ability;
 

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -672,7 +672,7 @@ export class DexConditions {
 			condition = new Condition({name: id, ...this.dex.data.Conditions[id]});
 		} else if (
 			(this.dex.data.Moves.hasOwnProperty(id) && (found = this.dex.data.Moves[id]).condition) ||
-			(this.dex.data.Abilities.hasOwnProperty(id) && (found = this.dex.data.Abilities[id]).condition) ||
+			((found = this.dex.abilities.getByID(id)).exists && found.condition) ||
 			(this.dex.data.Items.hasOwnProperty(id) && (found = this.dex.data.Items[id]).condition)
 		) {
 			condition = new Condition({name: found.name || id, ...found.condition});

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -658,9 +658,11 @@ export class DexConditions {
 
 		let found;
 		if (id.startsWith('item:')) {
+			// FIXME: this is either wrong or inefficient.
 			const item = this.dex.items.getByID(id.slice(5) as ID);
 			condition = {...item, id: 'item:' + item.id as ID} as any as Condition;
 		} else if (id.startsWith('ability:')) {
+			// FIXME: this is either wrong or inefficient.
 			const ability = this.dex.abilities.getByID(id.slice(8) as ID);
 			condition = {...ability, id: 'ability:' + ability.id as ID} as any as Condition;
 		} else if (this.dex.data.Rulesets.hasOwnProperty(id)) {
@@ -672,7 +674,7 @@ export class DexConditions {
 			condition = new Condition({name: id, ...this.dex.data.Conditions[id]});
 		} else if (
 			(this.dex.data.Moves.hasOwnProperty(id) && (found = this.dex.data.Moves[id]).condition) ||
-			((found = this.dex.abilities.getByID(id)).exists && found.condition) ||
+			((found = this.dex.abilities.getByID2(id)) && found.condition) ||
 			(this.dex.data.Items.hasOwnProperty(id) && (found = this.dex.data.Items[id]).condition)
 		) {
 			condition = new Condition({name: found.name || id, ...found.condition});
@@ -684,6 +686,7 @@ export class DexConditions {
 			condition = new Condition({name: id, exists: false});
 		}
 
+		// FIXME: do you really want to be caching this unconditionally?
 		this.conditionCache.set(id, this.dex.deepFreeze(condition));
 		return condition;
 	}

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -673,7 +673,7 @@ export class DexConditions {
 			condition = new Condition({name: id, ...this.dex.data.Conditions[id]});
 		} else if (
 			(this.dex.data.Moves.hasOwnProperty(id) && (found = this.dex.data.Moves[id]).condition) ||
-			((found = this.dex.abilities.getByID2(id)) && found.condition) ||
+			(this.dex.data.Abilities.hasOwnProperty(id) && (found = this.dex.data.Abilities[id]).condition) ||
 			(this.dex.data.Items.hasOwnProperty(id) && (found = this.dex.data.Items[id]).condition)
 		) {
 			condition = new Condition({name: found.name || id, ...found.condition});

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -1,5 +1,6 @@
 import {BasicEffect, toID} from './dex-data';
 import type {SecondaryEffect, MoveEventMethods} from './dex-moves';
+import {Utils} from '../lib';
 
 export interface EventMethods {
 	onDamagingHit?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void;
@@ -633,7 +634,7 @@ export class Condition extends BasicEffect implements
 	}
 }
 
-const EMPTY_CONDITION: Condition = new Condition({name: '', exists: false});
+const EMPTY_CONDITION: Condition = Utils.deepFreeze(new Condition({name: '', exists: false}));
 
 export class DexConditions {
 	readonly dex: ModdedDex;
@@ -658,11 +659,9 @@ export class DexConditions {
 
 		let found;
 		if (id.startsWith('item:')) {
-			// FIXME: this is either wrong or inefficient.
 			const item = this.dex.items.getByID(id.slice(5) as ID);
 			condition = {...item, id: 'item:' + item.id as ID} as any as Condition;
 		} else if (id.startsWith('ability:')) {
-			// FIXME: this is either wrong or inefficient.
 			const ability = this.dex.abilities.getByID(id.slice(8) as ID);
 			condition = {...ability, id: 'ability:' + ability.id as ID} as any as Condition;
 		} else if (this.dex.data.Rulesets.hasOwnProperty(id)) {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -145,15 +145,18 @@ export class Nature extends BasicEffect implements Readonly<BasicEffect & Nature
 	readonly plus?: StatIDExceptHP;
 	readonly minus?: StatIDExceptHP;
 	constructor(data: AnyObject) {
-		super(data);
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
-		data = this;
+		super(data, false);
 
 		this.fullname = `nature: ${this.name}`;
 		this.effectType = 'Nature';
 		this.gen = 3;
 		this.plus = data.plus || undefined;
 		this.minus = data.minus || undefined;
+
+		for (const k of Object.keys(data)) { // TODO: migrate to for..in + Object.hasOwn
+			if (k in this) continue;
+			(this as any)[k] = data[k];
+		}
 	}
 }
 

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -318,7 +318,7 @@ export class DexTypes {
 	isName(name: string): boolean {
 		const id = name.toLowerCase();
 		const typeName = id.charAt(0).toUpperCase() + id.substr(1);
-		return name === typeName && this.dex.data.TypeChart.hasOwnProperty(id);
+		return name === typeName && this.typeCache.has(id as ID);
 	}
 
 	all(): readonly TypeInfo[] {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -167,38 +167,33 @@ export class DexNatures {
 	constructor(dex: ModdedDex) {
 		this.dex = dex;
 		const allCache = [];
-		for (const id in this.dex.data.Natures) {
-			allCache.push(this.getByID(id as ID));
+		for (const _id in this.dex.data.Natures) {
+			const id = _id as ID;
+			const natureData = dex.data.Natures[id];
+			const nature = new Nature(natureData);
+			if (nature.gen > dex.gen) nature.isNonstandard = 'Future';
+			this.natureCache.set(id, dex.deepFreeze(nature));
+			allCache.push(nature);
 		}
 		this.allCache = Object.freeze(allCache);
 	}
 
 	get(name: string | Nature): Nature {
 		if (name && typeof name !== 'string') return name;
-
 		return this.getByID(toID(name));
 	}
+
 	getByID(id: ID): Nature {
 		let nature = this.natureCache.get(id);
 		if (nature) return nature;
 
 		if (this.dex.data.Aliases.hasOwnProperty(id)) {
 			nature = this.get(this.dex.data.Aliases[id]);
-			if (nature.exists) {
-				this.natureCache.set(id, nature);
-			}
+			if (nature.exists) this.natureCache.set(id, nature);
 			return nature;
-		}
-		if (id && this.dex.data.Natures.hasOwnProperty(id)) {
-			const natureData = this.dex.data.Natures[id];
-			nature = new Nature(natureData);
-			if (nature.gen > this.dex.gen) nature.isNonstandard = 'Future';
 		} else {
-			nature = new Nature({name: id, exists: false});
+			return new Nature({name: id, exists: false});
 		}
-
-		if (nature.exists) this.natureCache.set(id, this.dex.deepFreeze(nature));
-		return nature;
 	}
 
 	all(): readonly Nature[] {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -162,10 +162,15 @@ export interface NatureDataTable {[natureid: IDEntry]: NatureData}
 export class DexNatures {
 	readonly dex: ModdedDex;
 	readonly natureCache = new Map<ID, Nature>();
-	allCache: readonly Nature[] | null = null;
+	allCache: readonly Nature[];
 
 	constructor(dex: ModdedDex) {
 		this.dex = dex;
+		const allCache = [];
+		for (const id in this.dex.data.Natures) {
+			allCache.push(this.getByID(id as ID));
+		}
+		this.allCache = Object.freeze(allCache);
 	}
 
 	get(name: string | Nature): Nature {
@@ -197,12 +202,6 @@ export class DexNatures {
 	}
 
 	all(): readonly Nature[] {
-		if (this.allCache) return this.allCache;
-		const natures = [];
-		for (const id in this.dex.data.Natures) {
-			natures.push(this.getByID(id as ID));
-		}
-		this.allCache = Object.freeze(natures);
 		return this.allCache;
 	}
 }

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -286,7 +286,9 @@ export class DexTypes {
 		const namesCache = [];
 		for (const _id in this.dex.data.TypeChart) {
 			const id = _id as ID;
-			const type = this.getByID(id);
+			const typeName = id.charAt(0).toUpperCase() + id.substr(1);
+			const type = new TypeInfo({name: typeName, id, ...this.dex.data.TypeChart[id]});
+			this.typeCache.set(id, this.dex.deepFreeze(type));
 			allCache.push(type);
 			if (!type.isNonstandard) namesCache.push(type.name);
 		}
@@ -300,18 +302,13 @@ export class DexTypes {
 	}
 
 	getByID(id: ID): TypeInfo {
-		let type = this.typeCache.get(id);
-		if (type) return type;
-
-		const typeName = id.charAt(0).toUpperCase() + id.substr(1);
-		if (typeName && this.dex.data.TypeChart.hasOwnProperty(id)) {
-			type = new TypeInfo({name: typeName, id, ...this.dex.data.TypeChart[id]});
-			this.typeCache.set(id, this.dex.deepFreeze(type));
-		} else {
-			type = new TypeInfo({name: typeName, id, exists: false, effectType: 'EffectType'});
-		}
-
-		return type;
+		return this.typeCache.get(id) ||
+			new TypeInfo({
+				name: id.charAt(0).toUpperCase() + id.substr(1),
+				id,
+				exists: false,
+				effectType: 'EffectType',
+			});
 	}
 
 	names(): readonly string[] {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -318,10 +318,10 @@ export class TypeInfo implements Readonly<TypeData> {
 	readonly HPdvs: SparseStatsTable;
 
 	/**
-	* If 'true' is passed for the 'canCacheFields' parameter, objects may be re-used
-	* across instances of TypeInfo. Basically, if you're going to immediately deepFreeze this,
-	* you can safely pass true.
-	*/
+	 * If 'true' is passed for the 'canCacheFields' parameter, objects may be re-used
+	 * across instances of TypeInfo. Basically, if you're going to immediately deepFreeze this,
+	 * you can safely pass true.
+	 */
 	constructor(data: AnyObject, canCacheFields = false) {
 		// initialize required fields in a consistent order bc of V8's hidden classes
 		this.id = data.id;

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -104,15 +104,17 @@ export class BasicEffect implements EffectData {
 	/** ??? */
 	sourceEffect: string;
 
-	constructor(data: AnyObject) {
-		this.exists = true;
-		Object.assign(this, data);
-
+	/**
+	 * Pass 'false' for the second parameter if you only want the declared fields of BasicEffect
+	 * to be initialized - the other properties of data will not be copied.
+	 * This is to help w/ V8 hidden classes (want to init fields in consistent order)
+	 */
+	constructor(data: AnyObject, copyOtherFields = true) {
 		this.name = Utils.getString(data.name).trim();
 		this.id = data.realMove ? toID(data.realMove) : toID(this.name); // Hidden Power hack
 		this.fullname = Utils.getString(data.fullname) || this.name;
 		this.effectType = Utils.getString(data.effectType) as EffectType || 'Condition';
-		this.exists = !!(this.exists && this.id);
+		this.exists = !!((data.exists || !('exists' in data)) && this.id);
 		this.num = data.num || 0;
 		this.gen = data.gen || 0;
 		this.shortDesc = data.shortDesc || '';
@@ -124,6 +126,13 @@ export class BasicEffect implements EffectData {
 		this.status = data.status as ID || undefined;
 		this.weather = data.weather as ID || undefined;
 		this.sourceEffect = data.sourceEffect || '';
+
+		if (copyOtherFields) {
+			for (const k of Object.keys(data)) { // TODO: migrate to for..in + Object.hasOwn
+				if (k in this) continue;
+				(this as any)[k] = data[k];
+			}
+		}
 	}
 
 	toString() {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -11,7 +11,7 @@ export interface DexTable<T> {[id: string]: T}
 
 
 /**
-* Do not expose to user input. Only populate with trusted data.
+* Do not insert user input, only populate with trusted data.
 * Populated by ./sim/dex.ts then frozen.
 */
 export const _toIDCache: Map<string, ID> = new Map();
@@ -29,10 +29,8 @@ export const _toIDCache: Map<string, ID> = new Map();
 * commonly it's used.
 */
 export function toID(text: any): ID {
-	// The sucrase transformation of optional chaining is too expensive to be used in a hot function like this.
-	/* eslint-disable @typescript-eslint/prefer-optional-chain */
 	if (typeof text === 'string') {
-	        // 99.9% case, skip checks
+	        // 99% case, skip checks
 	} else {
 	        if (text) text = text.id || text.userid || text.roomid || text;
 	        if (typeof text === 'number') text = '' + text;
@@ -43,7 +41,6 @@ export function toID(text: any): ID {
 	// Next, we often produce the same IDs many times.
 	// Otherwise, fallback to the generic case
 	return _toIDCache.get(text) || text.toLowerCase().replace(/[^a-z0-9]+/g, '') as ID;
-	/* eslint-enable @typescript-eslint/prefer-optional-chain */
 }
 
 export class BasicEffect implements EffectData {
@@ -355,6 +352,7 @@ export class TypeInfo implements Readonly<TypeData> {
 		return this.name;
 	}
 }
+const EMPTY_TYPE_INFO = Utils.deepFreeze(new TypeInfo({name: '', id: '', exists: false, effectType: 'EffectType'}));
 
 export class DexTypes {
 	readonly dex: ModdedDex;
@@ -430,6 +428,7 @@ export class DexTypes {
 	}
 
 	getByID(id: ID): TypeInfo {
+		if (id === '') return EMPTY_TYPE_INFO;
 		return this.typeCache.get(id) ||
 			new TypeInfo({
 				name: id.charAt(0).toUpperCase() + id.substr(1),

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -250,23 +250,14 @@ export class DexNatures {
 		return this.getByID(toID(name));
 	}
 
-	// TBD naming
-	// Returns null if ID is invalid
-	getByID2(id: ID): Nature | null {
-		if (id === '') return null;
-		let nature = this.natureCache.get(id) || null;
-		if (!nature && this.dex.data.Aliases.hasOwnProperty(id)) {
-			nature = this.getByID2(toID(this.dex.data.Aliases[id]));
-			// TODO: I don't think it's possible for .exists to be false here
-			// We probably have the invariant that natureCache only contains .exists=true
-			if (nature && nature.exists) this.natureCache.set(id, nature);
-		}
-		return nature;
-	}
-
 	getByID(id: ID): Nature {
 		if (id === '') return EMPTY_NATURE;
-		return this.getByID2(id) || new Nature({name: id, exists: false});
+		let nature = this.natureCache.get(id);
+		if (!nature && this.dex.data.Aliases.hasOwnProperty(id)) {
+			nature = this.getByID(toID(this.dex.data.Aliases[id]));
+			if (nature.exists) this.natureCache.set(id, nature);
+		}
+		return nature || new Nature({name: id, exists: false});
 	}
 
 	all(): readonly Nature[] {
@@ -430,14 +421,9 @@ export class DexTypes {
 		return this.getByID(toID(name));
 	}
 
-	getByID2(id: ID): TypeInfo | null {
-		if (id === '') return null;
-		return this.typeCache.get(id) || null;
-	}
-
 	getByID(id: ID): TypeInfo {
 		if (id === '') return EMPTY_TYPE_INFO;
-		return this.getByID2(id) ||
+		return this.typeCache.get(id) ||
 			new TypeInfo({
 				name: id.charAt(0).toUpperCase() + id.substr(1),
 				id,

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -522,7 +522,6 @@ export class DexFormats {
 
 	load(): this {
 		if (!this.dex.isBase) throw new Error(`This should only be run on the base mod`);
-		this.dex.includeMods();
 		if (this.formatsListCache) return this;
 
 		const formatsList = [];
@@ -566,7 +565,9 @@ export class DexFormats {
 			if (format.bestOfDefault === undefined) format.bestOfDefault = false;
 			if (format.teraPreviewDefault === undefined) format.teraPreviewDefault = false;
 			if (format.mod === undefined) format.mod = 'gen9';
-			if (!this.dex.dexes[format.mod]) throw new Error(`Format "${format.name}" requires nonexistent mod: '${format.mod}'`);
+			if (!this.dex.scanMods().has(format.mod)) {
+				throw new Error(`Format "${format.name}" requires nonexistent mod: '${format.mod}'`);
+			}
 
 			const ruleset = new Format(format);
 			this.rulesetCache.set(id, ruleset);

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -928,7 +928,7 @@ export class DexFormats {
 		}
 		const ruleid = id;
 		if (this.dex.data.Aliases.hasOwnProperty(id)) id = toID(this.dex.data.Aliases[id]);
-		const cowTypes = ['nature']; // dex.data won't work for these types, need different path
+		const cowTypes = ['nature', 'ability']; // dex.data won't work for these types, need different path
 		for (const matchType of matchTypes) {
 			if (matchType === 'item' && ruleid === 'noitem') return 'item:noitem';
 
@@ -937,6 +937,7 @@ export class DexFormats {
 				let table;
 				switch (matchType) {
 				case 'nature': table = this.dex.natures; break;
+				case 'ability': table = this.dex.abilities; break;
 				default: throw new Error('Unrecognized CoW match type.');
 				}
 				if (table.getByID(id).exists) {
@@ -949,7 +950,6 @@ export class DexFormats {
 			case 'pokemon': table = this.dex.data.Pokedex; break;
 			case 'move': table = this.dex.data.Moves; break;
 			case 'item': table = this.dex.data.Items; break;
-			case 'ability': table = this.dex.data.Abilities; break;
 			case 'pokemontag':
 				// valid pokemontags
 				const validTags = [

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -928,15 +928,28 @@ export class DexFormats {
 		}
 		const ruleid = id;
 		if (this.dex.data.Aliases.hasOwnProperty(id)) id = toID(this.dex.data.Aliases[id]);
+		const cowTypes = ['nature']; // dex.data won't work for these types, need different path
 		for (const matchType of matchTypes) {
 			if (matchType === 'item' && ruleid === 'noitem') return 'item:noitem';
+
+			// the transition period will be ugly, but temporary.
+			if (cowTypes.includes(matchType)) {
+				let table;
+				switch (matchType) {
+				case 'nature': table = this.dex.natures; break;
+				default: throw new Error('Unrecognized CoW match type.');
+				}
+				if (table.getByID(id).exists) {
+					matches.push(matchType + ':' + id);
+				}
+				continue;
+			}
 			let table;
 			switch (matchType) {
 			case 'pokemon': table = this.dex.data.Pokedex; break;
 			case 'move': table = this.dex.data.Moves; break;
 			case 'item': table = this.dex.data.Items; break;
 			case 'ability': table = this.dex.data.Abilities; break;
-			case 'nature': table = this.dex.data.Natures; break;
 			case 'pokemontag':
 				// valid pokemontags
 				const validTags = [

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -940,7 +940,7 @@ export class DexFormats {
 				case 'ability': table = this.dex.abilities; break;
 				default: throw new Error('Unrecognized CoW match type.');
 				}
-				if (table.getByID(id).exists) {
+				if (table.getByID2(id)?.exists) {
 					matches.push(matchType + ':' + id);
 				}
 				continue;

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -940,7 +940,7 @@ export class DexFormats {
 				case 'ability': table = this.dex.abilities; break;
 				default: throw new Error('Unrecognized CoW match type.');
 				}
-				if (table.getByID2(id)?.exists) {
+				if (table.getByID(id).exists) {
 					matches.push(matchType + ':' + id);
 				}
 				continue;

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -928,28 +928,16 @@ export class DexFormats {
 		}
 		const ruleid = id;
 		if (this.dex.data.Aliases.hasOwnProperty(id)) id = toID(this.dex.data.Aliases[id]);
-		const cowTypes = ['nature', 'ability']; // dex.data won't work for these types, need different path
 		for (const matchType of matchTypes) {
 			if (matchType === 'item' && ruleid === 'noitem') return 'item:noitem';
 
-			// the transition period will be ugly, but temporary.
-			if (cowTypes.includes(matchType)) {
-				let table;
-				switch (matchType) {
-				case 'nature': table = this.dex.natures; break;
-				case 'ability': table = this.dex.abilities; break;
-				default: throw new Error('Unrecognized CoW match type.');
-				}
-				if (table.getByID(id).exists) {
-					matches.push(matchType + ':' + id);
-				}
-				continue;
-			}
 			let table;
 			switch (matchType) {
 			case 'pokemon': table = this.dex.data.Pokedex; break;
 			case 'move': table = this.dex.data.Moves; break;
 			case 'item': table = this.dex.data.Items; break;
+			case 'ability': table = this.dex.data.Abilities; break;
+			case 'nature': table = this.dex.data.Natures; break;
 			case 'pokemontag':
 				// valid pokemontags
 				const validTags = [

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -1,6 +1,6 @@
 import {Utils} from '../lib';
 import type {PokemonEventMethods, ConditionData} from './dex-conditions';
-import {BasicEffect, toID} from './dex-data';
+import {BasicEffect, toID, assignNewFields} from './dex-data';
 
 interface FlingData {
 	basePower: number;
@@ -106,9 +106,7 @@ export class Item extends BasicEffect implements Readonly<BasicEffect> {
 	declare readonly onEnd?: (this: Battle, target: Pokemon) => void;
 
 	constructor(data: AnyObject) {
-		super(data);
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
-		data = this;
+		super(data, false);
 
 		this.fullname = `item: ${this.name}`;
 		this.effectType = 'Item';
@@ -152,6 +150,8 @@ export class Item extends BasicEffect implements Readonly<BasicEffect> {
 		if (this.onDrive) this.fling = {basePower: 70};
 		if (this.megaStone) this.fling = {basePower: 80};
 		if (this.onMemory) this.fling = {basePower: 50};
+
+		assignNewFields(this, data);
 	}
 }
 

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -160,10 +160,15 @@ const EMPTY_ITEM = Utils.deepFreeze(new Item({name: '', exists: false}));
 export class DexItems {
 	readonly dex: ModdedDex;
 	readonly itemCache = new Map<ID, Item>();
-	allCache: readonly Item[] | null = null;
+	allCache: readonly Item[];
 
 	constructor(dex: ModdedDex) {
 		this.dex = dex;
+		const items = [];
+		for (const id in this.dex.data.Items) {
+			items.push(this.getByID(id as ID));
+		}
+		this.allCache = Object.freeze(items);
 	}
 
 	get(name?: string | Item): Item {
@@ -209,12 +214,6 @@ export class DexItems {
 	}
 
 	all(): readonly Item[] {
-		if (this.allCache) return this.allCache;
-		const items = [];
-		for (const id in this.dex.data.Items) {
-			items.push(this.getByID(id as ID));
-		}
-		this.allCache = Object.freeze(items);
 		return this.allCache;
 	}
 }

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -1,3 +1,4 @@
+import {Utils} from '../lib';
 import type {PokemonEventMethods, ConditionData} from './dex-conditions';
 import {BasicEffect, toID} from './dex-data';
 
@@ -154,6 +155,8 @@ export class Item extends BasicEffect implements Readonly<BasicEffect> {
 	}
 }
 
+const EMPTY_ITEM = Utils.deepFreeze(new Item({name: '', exists: false}));
+
 export class DexItems {
 	readonly dex: ModdedDex;
 	readonly itemCache = new Map<ID, Item>();
@@ -165,13 +168,13 @@ export class DexItems {
 
 	get(name?: string | Item): Item {
 		if (name && typeof name !== 'string') return name;
-
-		name = (name || '').trim();
-		const id = toID(name);
+		let id = '' as ID;
+		if (name) id = toID(name.trim());
 		return this.getByID(id);
 	}
 
 	getByID(id: ID): Item {
+		if (id === '') return EMPTY_ITEM;
 		let item = this.itemCache.get(id);
 		if (item) return item;
 		if (this.dex.data.Aliases.hasOwnProperty(id)) {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -1,6 +1,6 @@
 import {Utils} from '../lib';
 import type {ConditionData} from './dex-conditions';
-import {BasicEffect, toID, assignNewFields} from './dex-data';
+import {assignNewFields, BasicEffect, toID} from './dex-data';
 
 /**
  * Describes the acceptable target(s) of a move.
@@ -573,10 +573,10 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 				}
 			}
 		}
-		if (this.category !== 'Status' && !this.zMove && !this.isZ && !this.isMax && this.id !== 'struggle') {
+		if (this.category !== 'Status' && !data.zMove && !this.isZ && !this.isMax && this.id !== 'struggle') {
 			let basePower = this.basePower;
 			this.zMove = {};
-			if (Array.isArray(this.multihit)) basePower *= 3;
+			if (Array.isArray(data.multihit)) basePower *= 3;
 			if (!basePower) {
 				this.zMove.basePower = 100;
 			} else if (basePower >= 140) {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -611,10 +611,16 @@ const EMPTY_MOVE = Utils.deepFreeze(new DataMove({name: '', exists: false}));
 export class DexMoves {
 	readonly dex: ModdedDex;
 	readonly moveCache = new Map<ID, Move>();
-	allCache: readonly Move[] | null = null;
+	allCache: readonly Move[];
 
 	constructor(dex: ModdedDex) {
 		this.dex = dex;
+		const Moves = dex.data.Moves;
+		const allCache = [];
+		for (const id in Moves) {
+			allCache.push(this.getByID(id as ID));
+		}
+		this.allCache = Object.freeze(allCache);
 	}
 
 	get(name?: string | Move): Move {
@@ -659,12 +665,6 @@ export class DexMoves {
 	}
 
 	all(): readonly Move[] {
-		if (this.allCache) return this.allCache;
-		const moves = [];
-		for (const id in this.dex.data.Moves) {
-			moves.push(this.getByID(id as ID));
-		}
-		this.allCache = Object.freeze(moves);
 		return this.allCache;
 	}
 }

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -613,6 +613,7 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 		}
 	}
 }
+const EMPTY_MOVE = Utils.deepFreeze(new DataMove({name: '', exists: false}));
 
 export class DexMoves {
 	readonly dex: ModdedDex;
@@ -625,13 +626,13 @@ export class DexMoves {
 
 	get(name?: string | Move): Move {
 		if (name && typeof name !== 'string') return name;
-
-		name = (name || '').trim();
-		const id = toID(name);
+		let id = '' as ID;
+		if (name) id = toID(name.trim());
 		return this.getByID(id);
 	}
 
 	getByID(id: ID): Move {
+		if (id === '') return EMPTY_MOVE;
 		let move = this.moveCache.get(id);
 		if (move) return move;
 		if (this.dex.data.Aliases.hasOwnProperty(id)) {

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -1,3 +1,4 @@
+import {Utils} from '../lib';
 import {toID, BasicEffect} from './dex-data';
 
 interface SpeciesAbility {
@@ -380,6 +381,7 @@ export class Learnset {
 		this.species = species;
 	}
 }
+const EMPTY_SPECIES = Utils.deepFreeze(new Species({name: '', exists: false}));
 
 export class DexSpecies {
 	readonly dex: ModdedDex;
@@ -394,17 +396,20 @@ export class DexSpecies {
 	get(name?: string | Species): Species {
 		if (name && typeof name !== 'string') return name;
 
-		name = (name || '').trim();
-		let id = toID(name);
-		if (id === 'nidoran' && name.endsWith('♀')) {
-			id = 'nidoranf' as ID;
-		} else if (id === 'nidoran' && name.endsWith('♂')) {
-			id = 'nidoranm' as ID;
+		let id = '' as ID;
+		if (name) {
+			name = name.trim();
+			id = toID(name);
+			if (id === 'nidoran' && name.endsWith('♀')) {
+				id = 'nidoranf' as ID;
+			} else if (id === 'nidoran' && name.endsWith('♂')) {
+				id = 'nidoranm' as ID;
+			}
 		}
-
 		return this.getByID(id);
 	}
 	getByID(id: ID): Species {
+		if (id === '') return EMPTY_SPECIES;
 		let species: Mutable<Species> | undefined = this.speciesCache.get(id);
 		if (species) return species;
 

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -381,7 +381,11 @@ export class Learnset {
 		this.species = species;
 	}
 }
-const EMPTY_SPECIES = Utils.deepFreeze(new Species({name: '', exists: false}));
+const EMPTY_SPECIES = Utils.deepFreeze(new Species({
+	id: '', name: '', exists: false,
+	tier: 'Illegal', doublesTier: 'Illegal',
+	natDexTier: 'Illegal', isNonstandard: 'Custom',
+}));
 
 export class DexSpecies {
 	readonly dex: ModdedDex;

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -1,5 +1,5 @@
 import {Utils} from '../lib';
-import {toID, BasicEffect} from './dex-data';
+import {assignNewFields, toID, BasicEffect} from './dex-data';
 
 interface SpeciesAbility {
 	0: string;
@@ -272,9 +272,7 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 	readonly natDexTier: TierTypes.Singles | TierTypes.Other;
 
 	constructor(data: AnyObject) {
-		super(data);
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
-		data = this;
+		super(data, false);
 
 		this.fullname = `pokemon: ${data.name}`;
 		this.effectType = 'Pokemon';
@@ -306,7 +304,7 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 			this.gender === 'N' ? {M: 0, F: 0} :
 			{M: 0.5, F: 0.5});
 		this.requiredItem = data.requiredItem || undefined;
-		this.requiredItems = this.requiredItems || (this.requiredItem ? [this.requiredItem] : undefined);
+		this.requiredItems = data.requiredItems || (this.requiredItem ? [this.requiredItem] : undefined);
 		this.baseStats = data.baseStats || {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
 		this.bst = this.baseStats.hp + this.baseStats.atk + this.baseStats.def +
 			this.baseStats.spa + this.baseStats.spd + this.baseStats.spe;
@@ -325,8 +323,8 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 		this.battleOnly = data.battleOnly || (this.isMega ? this.baseSpecies : undefined);
 		this.changesFrom = data.changesFrom ||
 			(this.battleOnly !== this.baseSpecies ? this.battleOnly : this.baseSpecies);
+		if (Array.isArray(this.changesFrom)) this.changesFrom = this.changesFrom[0];
 		this.pokemonGoData = data.pokemonGoData || undefined;
-		if (Array.isArray(data.changesFrom)) this.changesFrom = data.changesFrom[0];
 
 		if (!this.gen && this.num >= 1) {
 			if (this.num >= 906 || this.forme.includes('Paldea')) {
@@ -353,6 +351,7 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 				this.gen = 1;
 			}
 		}
+		assignNewFields(this, data);
 	}
 }
 

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -177,21 +177,21 @@ export class ModdedDex {
 		this.types = new Data.DexTypes(this);
 		this.stats = new Data.DexStats(this);
 
+		const dataCache: {[k in keyof DexTableData]?: any} = {};
+		for (const dataType of DATA_TYPES) {
+			dataCache[dataType] = this.loadDataFile(basePath, dataType);
+		}
 		if (!parentDex) {
+			dataCache['Aliases'] = this.loadDataFile(basePath, 'Aliases');
 			// Formats are inherited by mods and used by Rulesets
 			this.formats.load();
-		}
-		const dataCache: {[k in keyof DexTableData]?: any} = {};
-		for (const dataType of DATA_TYPES.concat('Aliases')) {
-			const BattleData = this.loadDataFile(basePath, dataType);
-			if (BattleData !== dataCache[dataType]) dataCache[dataType] = Object.assign(BattleData, dataCache[dataType]);
-			if (dataType === 'Rulesets' && !parentDex) {
-				for (const format of this.formats.all()) {
-					BattleData[format.id] = {...format, ruleTable: null};
-				}
+			const r = dataCache['Rulesets'];
+			for (const format of this.formats.all()) {
+				r[format.id] = {...format, ruleTable: null};
 			}
 		}
 		if (parentDex) {
+			dataCache['Aliases'] = parentDex.data['Aliases'];
 			for (const dataType of DATA_TYPES) {
 				const parentTypedData: DexTable<any> = parentDex.data[dataType];
 				const childTypedData: DexTable<any> = dataCache[dataType] || (dataCache[dataType] = {});
@@ -221,7 +221,6 @@ export class ModdedDex {
 					}
 				}
 			}
-			dataCache['Aliases'] = parentDex.data['Aliases'];
 		}
 		this.dataCache = dataCache as DexTableData;
 

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -40,6 +40,7 @@ import {Format, DexFormats} from './dex-formats';
 import {Utils} from '../lib';
 
 const BASE_MOD = 'gen9' as ID;
+const BASE_MOD_GEN = 9;
 const DATA_DIR = path.resolve(__dirname, '../data');
 const MODS_DIR = path.resolve(DATA_DIR, './mods');
 
@@ -146,6 +147,9 @@ export class ModdedDex {
 	readonly stats: Data.DexStats;
 
 	constructor(mod = 'base') {
+		if (mod in dexes) {
+			throw new Error(`Trying to construct a mod twice: ${mod}`);
+		}
 		this.isBase = (mod === 'base');
 		this.currentMod = mod;
 		this.dataDir = (this.isBase ? DATA_DIR : MODS_DIR + '/' + this.currentMod);
@@ -368,7 +372,7 @@ export class ModdedDex {
 			desc: '',
 			shortDesc: '',
 		};
-		for (let i = this.gen; i < dexes['base'].gen; i++) {
+		for (let i = this.gen; i < BASE_MOD_GEN; i++) {
 			const curDesc = entry[`gen${i}` as keyof typeof entry]?.desc;
 			const curShortDesc = entry[`gen${i}` as keyof typeof entry]?.shortDesc;
 			if (!descs.desc && curDesc) {

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -46,6 +46,13 @@ const MODS_DIR = path.resolve(DATA_DIR, './mods');
 const detectedMods: Set<string> = new Set();
 let modsScanned = false;
 const dexes: {[mod: string]: ModdedDex} = Object.create(null);
+const textCache = {
+	Pokedex: require(DATA_DIR + '/text/pokedex').PokedexText,
+	Moves: require(DATA_DIR + '/text/moves').MovesText,
+	Abilities: require(DATA_DIR + '/text/abilities').AbilitiesText,
+	Items: require(DATA_DIR + '/text/items').ItemsText,
+	Default: require(DATA_DIR + '/text/default').DefaultText,
+};
 
 type DataType =
 	'Abilities' | 'Rulesets' | 'FormatsData' | 'Items' | 'Learnsets' | 'Moves' |
@@ -122,7 +129,6 @@ export class ModdedDex {
 	modsLoaded = false; // TODO: deprecate
 
 	dataCache: DexTableData;
-	textCache: TextTableData | null;
 
 	deepClone = Utils.deepClone;
 	deepFreeze = Utils.deepFreeze;
@@ -142,8 +148,6 @@ export class ModdedDex {
 		this.isBase = (mod === 'base');
 		this.currentMod = mod;
 		this.dataDir = (this.isBase ? DATA_DIR : MODS_DIR + '/' + this.currentMod);
-
-		this.textCache = null;
 
 		const basePath = this.dataDir + '/';
 		const Scripts = this.loadDataFile(basePath, 'Scripts');
@@ -352,7 +356,7 @@ export class ModdedDex {
 				shortDesc: dataEntry.shortDesc,
 			};
 		}
-		const entry = this.loadTextData()[table][id];
+		const entry = textCache[table][id];
 		if (!entry) return null;
 		const descs = {
 			desc: '',
@@ -513,6 +517,7 @@ export class ModdedDex {
 		return {};
 	}
 
+	// TODO: deprecate
 	loadTextFile(
 		name: string, exportName: string
 	): DexTable<MoveText | ItemText | AbilityText | PokedexText | DefaultText> {
@@ -525,8 +530,7 @@ export class ModdedDex {
 		if (this.modsLoaded) return this;
 
 		for (const mod of fs.readdirSync(MODS_DIR)) {
-			if (mod in dexes) continue;
-			dexes[mod] = new ModdedDex(mod);
+			this.mod(mod);
 		}
 		this.modsLoaded = true;
 
@@ -559,16 +563,9 @@ export class ModdedDex {
 		return this;
 	}
 
+	// TODO: deprecate
 	loadTextData() {
-		if (dexes['base'].textCache) return dexes['base'].textCache;
-		dexes['base'].textCache = {
-			Pokedex: this.loadTextFile('pokedex', 'PokedexText') as DexTable<PokedexText>,
-			Moves: this.loadTextFile('moves', 'MovesText') as DexTable<MoveText>,
-			Abilities: this.loadTextFile('abilities', 'AbilitiesText') as DexTable<AbilityText>,
-			Items: this.loadTextFile('items', 'ItemsText') as DexTable<ItemText>,
-			Default: this.loadTextFile('default', 'DefaultText') as DexTable<DefaultText>,
-		};
-		return dexes['base'].textCache;
+		return textCache;
 	}
 
 	// TODO: deprecate

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -168,14 +168,6 @@ export class ModdedDex {
 		this.gen = gen;
 
 		this.formats = new DexFormats(this);
-		this.abilities = new DexAbilities(this);
-		this.items = new DexItems(this);
-		this.moves = new DexMoves(this);
-		this.species = new DexSpecies(this);
-		this.conditions = new DexConditions(this);
-		this.natures = new Data.DexNatures(this);
-		this.types = new Data.DexTypes(this);
-		this.stats = new Data.DexStats(this);
 
 		const dataCache: {[k in keyof DexTableData]?: any} = {};
 		for (const dataType of DATA_TYPES) {
@@ -226,6 +218,15 @@ export class ModdedDex {
 
 		// Execute initialization script.
 		if (this.data.Scripts.init) this.data.Scripts.init.call(this);
+
+		this.abilities = new DexAbilities(this);
+		this.items = new DexItems(this);
+		this.moves = new DexMoves(this);
+		this.species = new DexSpecies(this);
+		this.conditions = new DexConditions(this);
+		this.natures = new Data.DexNatures(this);
+		this.types = new Data.DexTypes(this);
+		this.stats = new Data.DexStats(this);
 	}
 
 	// TODO: un-getter-ify

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -191,6 +191,16 @@ export class ModdedDex {
 			for (const dataType of DATA_TYPES) {
 				const parentTypedData: DexTable<any> = parentDex.data[dataType];
 				const childTypedData: DexTable<any> = dataCache[dataType] || (dataCache[dataType] = {});
+				// if child is empty and there's no Scripts.init, there's no need to copy - just re-use.
+				let childIsEmpty = true;
+				for (const k in childTypedData) { // eslint-disable-line @typescript-eslint/no-unused-vars
+					childIsEmpty = false;
+					break;
+				}
+				if (dataType !== 'Pokedex' && childIsEmpty && !Scripts.init) {
+					dataCache[dataType] = parentTypedData;
+					continue;
+				}
 				for (const entryId in parentTypedData) {
 					if (childTypedData[entryId] === null) {
 						// null means don't inherit
@@ -221,7 +231,7 @@ export class ModdedDex {
 		this.dataCache = dataCache as DexTableData;
 
 		// Execute initialization script.
-		if (this.data.Scripts.init) this.data.Scripts.init.call(this);
+		if (Scripts.init) Scripts.init.call(this);
 
 		this.abilities = new DexAbilities(this);
 		this.items = new DexItems(this);

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -62,7 +62,6 @@ const DATA_TYPES: DataType[] = [
 	'Abilities', 'Rulesets', 'FormatsData', 'Items', 'Learnsets', 'Moves',
 	'Natures', 'Pokedex', 'Scripts', 'Conditions', 'TypeChart', 'PokemonGoData',
 ];
-const COW_DATA_TYPES: DataType[] = ['Natures', 'TypeChart'];
 
 const DATA_FILES = {
 	Abilities: 'abilities',
@@ -91,13 +90,13 @@ interface DexTableData {
 	Items: DexTable<import('./dex-items').ItemData>;
 	Learnsets: DexTable<import('./dex-species').LearnsetData>;
 	Moves: DexTable<import('./dex-moves').MoveData>;
-	Natures: Data.ModdedNatureDataTable;
+	Natures: DexTable<Data.NatureData>;
 	Pokedex: DexTable<import('./dex-species').SpeciesData>;
 	FormatsData: DexTable<import('./dex-species').SpeciesFormatsData>;
 	PokemonGoData: DexTable<import('./dex-species').PokemonGoData>;
 	Scripts: DexTable<AnyObject>;
 	Conditions: DexTable<import('./dex-conditions').ConditionData>;
-	TypeChart: Data.ModdedTypeDataTable;
+	TypeChart: DexTable<Data.TypeData>;
 }
 interface TextTableData {
 	Abilities: DexTable<AbilityText>;
@@ -190,7 +189,6 @@ export class ModdedDex {
 		if (parentDex) {
 			dataCache['Aliases'] = parentDex.data['Aliases'];
 			for (const dataType of DATA_TYPES) {
-				if (COW_DATA_TYPES.includes(dataType)) continue; // ported to CoW
 				const parentTypedData: DexTable<any> = parentDex.data[dataType];
 				const childTypedData: DexTable<any> = dataCache[dataType] || (dataCache[dataType] = {});
 				for (const entryId in parentTypedData) {
@@ -230,10 +228,8 @@ export class ModdedDex {
 		this.moves = new DexMoves(this);
 		this.species = new DexSpecies(this);
 		this.conditions = new DexConditions(this);
-		this.natures = new Data.DexNatures(this, dataCache.Natures, parentDex?.natures);
-		delete dataCache.Natures;
-		this.types = new Data.DexTypes(this, dataCache.TypeChart, parentDex?.types);
-		delete dataCache.TypeChart;
+		this.natures = new Data.DexNatures(this);
+		this.types = new Data.DexTypes(this);
 		this.stats = new Data.DexStats(this);
 	}
 
@@ -266,8 +262,6 @@ export class ModdedDex {
 	}
 
 	modData(dataType: DataType, id: string) {
-		if (COW_DATA_TYPES.includes(dataType)) throw new Error("todo: modify modData");
-		if (dataType === 'Natures' || dataType === 'TypeChart') throw new Error("unreachable, tmp for tsc");
 		if (this.isBase) return this.data[dataType][id];
 		if (this.data[dataType][id] !== this.mod(this.parentMod).data[dataType][id]) return this.data[dataType][id];
 		return (this.data[dataType][id] = Utils.deepClone(this.data[dataType][id]));

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -206,14 +206,7 @@ export class ModdedDex {
 						// null means don't inherit
 						delete childTypedData[entryId];
 					} else if (!(entryId in childTypedData)) {
-						// If it doesn't exist it's inherited from the parent data
-						if (dataType === 'Pokedex') {
-							// Pokedex entries can be modified too many different ways
-							// e.g. inheriting different formats-data/learnsets
-							childTypedData[entryId] = this.deepClone(parentTypedData[entryId]);
-						} else {
-							childTypedData[entryId] = parentTypedData[entryId];
-						}
+						childTypedData[entryId] = parentTypedData[entryId];
 					} else if (childTypedData[entryId] && childTypedData[entryId].inherit) {
 						// {inherit: true} can be used to modify only parts of the parent data,
 						// instead of overwriting entirely

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -612,6 +612,37 @@ dexes['base'] = new ModdedDex();
 dexes[BASE_MOD] = dexes['base'];
 
 export const Dex = dexes['base'];
+
+// populate _toIDCache with data from base mod.
+// It's representative enough for all other mods, so we don't need to dynamically grow the cache.
+{
+	const cache = Data._toIDCache;
+	const sources: readonly (readonly BasicEffect[])[] = [
+		Dex.species.all(), Dex.items.all(), Dex.moves.all(),
+		Dex.types.all() as any as readonly BasicEffect[], Dex.abilities.all(), Dex.natures.all(),
+	];
+	for (const source of sources) {
+		for (const effect of source) {
+			const name = effect.name;
+			if (!name) continue;
+			// we can't just use effect.id because of cases like hidden power
+			const id = toID(name);
+			const old = cache.get(name);
+			if (old === undefined) cache.set(name, id);
+			else if (old !== id) throw new Error("internal error with ID logic");
+		}
+	}
+	const aliases = Dex.data.Aliases;
+	for (const k in aliases) {
+		const name = aliases[k];
+		const id = toID(name);
+		const old = cache.get(name);
+		if (old === undefined) cache.set(name, id);
+		else if (old !== id) throw new Error("internal error with ID logic");
+	}
+	Object.freeze(cache);
+}
+
 export namespace Dex {
 	export type Species = import('./dex-species').Species;
 	export type Item = import('./dex-items').Item;

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -72,7 +72,6 @@ export class ExhaustiveRunner {
 
 	async run() {
 		const dex = Dex.forFormat(this.format);
-		dex.loadData(); // FIXME: This is required for `dex.gen` to be set properly...
 
 		const seed = this.prng.seed;
 		const pools = this.createPools(dex);

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -113,13 +113,13 @@ export class ExhaustiveRunner {
 
 	private createPools(dex: typeof Dex): Pools {
 		return {
-			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Pokedex, p => dex.species.get(p), (_, p) =>
+			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.species.all(), p =>
 				(p.name !== 'Pichu-Spiky-eared' && p.name.substr(0, 8) !== 'Pikachu-') && p.name !== 'Greninja-Bond'),
 			this.prng),
-			items: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Items, i => dex.items.get(i)), this.prng),
-			abilities: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Abilities, a => dex.abilities.get(a)), this.prng),
-			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Moves, m => dex.moves.get(m),
-				m => (m !== 'struggle' && (m === 'hiddenpower' || m.substr(0, 11) !== 'hiddenpower'))), this.prng),
+			items: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.items.all()), this.prng),
+			abilities: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.abilities.all()), this.prng),
+			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.moves.all(),
+				m => (m.id !== 'struggle' && (m.id === 'hiddenpower' || m.id.substr(0, 11) !== 'hiddenpower'))), this.prng),
 		};
 	}
 
@@ -163,16 +163,17 @@ export class ExhaustiveRunner {
 		return signatures;
 	}
 
-	private static onlyValid<T>(
-		gen: number, obj: {[key: string]: T}, getter: (k: string) => AnyObject,
-		additional?: (k: string, v: AnyObject) => boolean, nonStandard?: boolean
+	private static onlyValid(
+		gen: number, values: readonly AnyObject[],
+		additional?: (v: AnyObject) => boolean, nonStandard?: boolean
 	) {
-		return Object.keys(obj).filter(k => {
-			const v = getter(k);
-			return v.gen <= gen &&
-				(!v.isNonstandard || !!nonStandard) &&
-				(!additional || additional(k, v));
-		});
+		const keys = [];
+		for (const v of values) {
+			if (v.gen <= gen && (!v.isNonstandard || !!nonStandard) && (!additional || additional(v))) {
+				keys.push(v.id);
+			}
+		}
+		return keys;
 	}
 }
 

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -202,7 +202,7 @@ class TeamGenerator {
 		this.pools = pools;
 		this.signatures = signatures;
 
-		this.natures = Object.keys(this.dex.data.Natures);
+		this.natures = dex.natures.all().map(n => n.id);
 	}
 
 	get exhausted() {

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -114,7 +114,7 @@ export class ExhaustiveRunner {
 	private createPools(dex: typeof Dex): Pools {
 		return {
 			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.species.all(), p =>
-				(p.name !== 'Pichu-Spiky-eared' && p.name.substr(0, 8) !== 'Pikachu-') && p.name !== 'Greninja-Bond'),
+				(p.name !== 'Pichu-Spiky-eared' && !p.name!.startsWith('Pikachu-')) && p.name !== 'Greninja-Bond'),
 			this.prng),
 			items: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.items.all()), this.prng),
 			abilities: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.abilities.all()), this.prng),
@@ -164,8 +164,8 @@ export class ExhaustiveRunner {
 	}
 
 	private static onlyValid(
-		gen: number, values: readonly AnyObject[],
-		additional?: (v: AnyObject) => boolean, nonStandard?: boolean
+		gen: number, values: readonly BasicEffect[],
+		additional?: (v: BasicEffect) => boolean, nonStandard?: boolean
 	) {
 		const keys = [];
 		for (const v of values) {

--- a/test/common.js
+++ b/test/common.js
@@ -30,7 +30,7 @@ class TestTools {
 		if (cache.has(mod)) return cache.get(mod);
 
 		if (typeof mod !== 'string') throw new Error("This only supports strings");
-		if (!Dex.dexes[mod]) throw new Error(`Mod ${mod} does not exist`);
+		if (!Dex.scanMods().has(mod)) throw new Error(`Mod ${mod} does not exist`);
 
 		const moddedTestTools = new TestTools(mod);
 		cache.set(mod, moddedTestTools);

--- a/test/sim/data.js
+++ b/test/sim/data.js
@@ -131,10 +131,8 @@ describe('Dex data', function () {
 	});
 
 	it('should have valid Abilities entries', function () {
-		const Abilities = Dex.data.Abilities;
-		for (const abilityid in Abilities) {
-			const entry = Abilities[abilityid];
-			assert.equal(toID(entry.name), abilityid, `Mismatched Ability key "${abilityid}" of "${entry.name}"`);
+		for (const entry of Dex.abilities.all()) {
+			assert.equal(toID(entry.name), entry.id, `Mismatched Ability key "${entry.id}" of "${entry.name}"`);
 			assert.equal(typeof entry.num, 'number', `Ability ${entry.name} should have a number`);
 			assert.equal(typeof entry.rating, 'number', `Ability ${entry.name} should have a rating`);
 		}

--- a/test/sim/data.js
+++ b/test/sim/data.js
@@ -160,11 +160,10 @@ describe('Dex data', function () {
 	});
 
 	it('should have valid Natures entries', function () {
-		const Natures = Dex.data.Natures;
-		for (const natureid in Natures) {
-			const entry = Natures[natureid];
-			assert.equal(toID(entry.name), natureid, `Mismatched Nature key "${natureid}" of "${entry.name}"`);
-			assert.equal(!!entry.plus, !!entry.minus, `Mismatched Nature values "+${entry.plus}"/"-${entry.minus}" of "${entry.name}"`);
+		const natures = Dex.natures;
+		for (const nature of natures.all()) {
+			assert.equal(toID(nature.name), nature.id, `Mismatched Nature key "${nature.id}" of "${nature.name}"`);
+			assert.equal(!!nature.plus, !!nature.minus, `Mismatched Nature values "+${nature.plus}"/"-${nature.minus}" of "${nature.name}"`);
 		}
 	});
 

--- a/test/sim/data.js
+++ b/test/sim/data.js
@@ -131,8 +131,10 @@ describe('Dex data', function () {
 	});
 
 	it('should have valid Abilities entries', function () {
-		for (const entry of Dex.abilities.all()) {
-			assert.equal(toID(entry.name), entry.id, `Mismatched Ability key "${entry.id}" of "${entry.name}"`);
+		const Abilities = Dex.data.Abilities;
+		for (const abilityid in Abilities) {
+			const entry = Abilities[abilityid];
+			assert.equal(toID(entry.name), abilityid, `Mismatched Ability key "${abilityid}" of "${entry.name}"`);
 			assert.equal(typeof entry.num, 'number', `Ability ${entry.name} should have a number`);
 			assert.equal(typeof entry.rating, 'number', `Ability ${entry.name} should have a rating`);
 		}
@@ -158,10 +160,11 @@ describe('Dex data', function () {
 	});
 
 	it('should have valid Natures entries', function () {
-		const natures = Dex.natures;
-		for (const nature of natures.all()) {
-			assert.equal(toID(nature.name), nature.id, `Mismatched Nature key "${nature.id}" of "${nature.name}"`);
-			assert.equal(!!nature.plus, !!nature.minus, `Mismatched Nature values "+${nature.plus}"/"-${nature.minus}" of "${nature.name}"`);
+		const Natures = Dex.data.Natures;
+		for (const natureid in Natures) {
+			const entry = Natures[natureid];
+			assert.equal(toID(entry.name), natureid, `Mismatched Nature key "${natureid}" of "${entry.name}"`);
+			assert.equal(!!entry.plus, !!entry.minus, `Mismatched Nature values "+${entry.plus}"/"-${entry.minus}" of "${entry.name}"`);
 		}
 	});
 

--- a/test/sim/team-validator/basic.js
+++ b/test/sim/team-validator/basic.js
@@ -5,7 +5,6 @@ const Teams = require('../../../dist/sim/teams').Teams;
 
 describe('Team Validator', function () {
 	it('should have valid formats to work with', function () {
-		Dex.includeFormats();
 		for (const format in Dex.formatsCache) {
 			try {
 				Dex.formats.getRuleTable(Dex.formats.get(format));

--- a/tools/set-import/importer.ts
+++ b/tools/set-import/importer.ts
@@ -8,7 +8,6 @@ import * as smogon from 'smogon';
 import {Streams} from '../../lib';
 import {Dex, toID} from '../../sim/dex';
 import {TeamValidator} from '../../sim/team-validator';
-Dex.includeModData();
 
 type DeepPartial<T> = {
 	[P in keyof T]?: T[P] extends (infer I)[]

--- a/tools/simulate/index.js
+++ b/tools/simulate/index.js
@@ -37,9 +37,7 @@ if (process.argv[2]) {
 }
 
 require('child_process').execSync('node ' + __dirname + "/../../build");
-const Dex = require('../../sim/dex').Dex;
 global.Config = {allowrequestingties: false};
-Dex.includeModData();
 
 const {ExhaustiveRunner} = require('../../sim/tools/exhaustive-runner');
 const {MultiRandomRunner} = require('../../sim/tools/multi-random-runner');


### PR DESCRIPTION
# Repurposed
Lot of optimizations were explored here. They will be factored out into small PRs.

Huge thanks to slayer95 and urkerab for their feedback.

## Features
* Lower memory usage
* Better use of V8's 'hidden classes'
* More predictable loading order
* faster toID
* cached empty objects

## Bug fixes
`DexStats` now properly checks dex gen during its constructor.

## High level changes
The external API described in [DEX.md](https://github.com/smogon/pokemon-showdown/blob/master/sim/DEX.md) should be unaffected.

### Before
* Eagerly constructed mods, lazily constructed data
* Inheritance by recursive copying
* Unordered field initialization in ctors

### After
* Lazily constructed mods, eagerly constructed data
* Inheritance by Copy-on-Write
* Consistent field initialization when possible
  * Helps with 'hidden classes' in V8


## Migration guide
Applicable to code that depended on implementation details of Dex.

### `dex.loadData()`, `dex.includeFormat()`
No longer necessary, just use `dex.mod(modname)` when you need a mod.

### `dex.dexes`
No.  
Use `Dex.mod(_)` for retrieving mods and `Dex.scanMods()` to see all possible mods.