### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -1003,12 +1003,12 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bodyslam", "curse", "rest", "sleeptalk"],
-                "abilities": ["Immunity"]
+                "abilities": ["Thick Fat"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bodyslam", "curse", "earthquake", "rest"],
-                "abilities": ["Immunity"]
+                "abilities": ["Immunity", "Thick Fat"]
             }
         ]
     },

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -357,8 +357,9 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulletpunch", "dynamicpunch", "payback", "stoneedge", "toxic"],
-                "abilities": ["No Guard"]
+                "movepool": ["bulletpunch", "dynamicpunch", "earthquake", "payback", "stoneedge", "toxic"],
+                "abilities": ["No Guard"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -3876,14 +3877,10 @@
         "level": 69,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
-                "abilities": ["Multitype"]
-            },
-            {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "darkpulse", "focusblast", "judgment"],
-                "abilities": ["Multitype"]
+                "movepool": ["calmmind", "darkpulse", "focusblast", "judgment", "recover"],
+                "abilities": ["Multitype"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -66,7 +66,9 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
-			Poison: (movePool, moves, abilities, types, counter) => (!counter.get('Poison') && types.has('Grass')),
+			Poison: (movePool, moves, abilities, types, counter, species) => (
+				!counter.get('Poison') && (types.has('Grass') || species.id === 'gengar')
+			),
 			Psychic: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Psychic') && (types.has('Fighting') || movePool.includes('calmmind'))
 			),

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -386,7 +386,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulletpunch", "dynamicpunch", "payback", "stoneedge", "toxic"],
+                "movepool": ["bulletpunch", "dynamicpunch", "earthquake", "payback", "stoneedge", "toxic"],
                 "abilities": ["No Guard"],
                 "preferredTypes": ["Rock"]
             }
@@ -3095,7 +3095,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"],
+                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "willowisp"],
                 "abilities": ["Pressure"]
             }
         ]
@@ -3861,14 +3861,10 @@
         "level": 71,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
-                "abilities": ["Multitype"]
-            },
-            {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "darkpulse", "focusblast", "judgment"],
-                "abilities": ["Multitype"]
+                "movepool": ["calmmind", "darkpulse", "focusblast", "judgment", "recover"],
+                "abilities": ["Multitype"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -3880,6 +3876,11 @@
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
                 "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "earthpower", "fireblast","judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -2642,7 +2642,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["gunkshot", "knockoff", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"],
+                "movepool": ["gunkshot", "knockoff", "shadowclaw", "shadowsneak", "thunderwave", "willowisp"],
                 "abilities": ["Cursed Body", "Frisk"]
             }
         ]
@@ -3070,6 +3070,11 @@
                 "role": "Bulky Support",
                 "movepool": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
                 "abilities": ["Pressure"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "signalbeam"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3461,7 +3466,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"],
+                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "toxic", "willowisp"],
                 "abilities": ["Infiltrator"]
             }
         ]
@@ -3843,13 +3848,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "toxic", "willowisp"],
-                "abilities": ["Pressure"],
+                "abilities": ["Frisk", "Pressure"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
                 "movepool": ["earthquake", "protect", "shadowsneak", "toxic"],
-                "abilities": ["Pressure"]
+                "abilities": ["Frisk", "Pressure"]
             }
         ]
     },
@@ -3938,8 +3943,9 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "energyball", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"],
-                "abilities": ["Levitate"]
+                "movepool": ["calmmind", "healingwish", "hiddenpowerfire", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"],
+                "abilities": ["Levitate"],
+                "preferredTypes": ["Bug"]
             },
             {
                 "role": "Bulky Support",
@@ -4436,6 +4442,11 @@
                 "role": "Fast Support",
                 "movepool": ["copycat", "encore", "knockoff", "substitute", "thunderwave", "uturn"],
                 "abilities": ["Prankster"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["gunkshot", "knockoff", "playrough", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -4653,7 +4664,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "megahorn", "poisonjab", "protect", "swordsdance"],
+                "movepool": ["earthquake", "megahorn", "poisonjab", "swordsdance"],
                 "abilities": ["Speed Boost"]
             }
         ]
@@ -4820,7 +4831,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["drainpunch", "gunkshot", "haze", "painsplit", "spikes", "toxic", "toxicspikes"],
                 "abilities": ["Aftermath"]
             }
@@ -5022,7 +5033,8 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"],
-                "abilities": ["Analytic"]
+                "abilities": ["Analytic"],
+                "preferredTypes": ["Bug"]
             }
         ]
     },
@@ -5655,7 +5667,8 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "darkpulse", "psychic", "psyshock", "signalbeam", "thunderbolt"],
-                "abilities": ["Competitive"]
+                "abilities": ["Competitive"],
+                "preferredTypes": ["Bug"]
             }
         ]
     },
@@ -5776,7 +5789,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragondance", "earthquake", "headsmash", "outrage", "stealthrock", "superpower"],
+                "movepool": ["dragondance", "earthquake", "headsmash", "outrage", "superpower"],
                 "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -600,11 +600,6 @@
         "level": 90,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "firepunch", "stealthrock", "stoneedge", "wildcharge"],
-                "abilities": ["Magnet Pull"]
-            },
-            {
                 "role": "Wallbreaker",
                 "movepool": ["autotomize", "earthquake", "explosion", "return", "stoneedge"],
                 "abilities": ["Galvanize"],
@@ -2891,7 +2886,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["gunkshot", "knockoff", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"],
+                "movepool": ["gunkshot", "knockoff", "shadowclaw", "shadowsneak", "thunderwave", "willowisp"],
                 "abilities": ["Cursed Body", "Frisk"]
             }
         ]
@@ -3349,6 +3344,11 @@
                 "role": "Bulky Support",
                 "movepool": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
                 "abilities": ["Pressure"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "signalbeam"],
+                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3759,7 +3759,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"],
+                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "toxic", "willowisp"],
                 "abilities": ["Infiltrator"]
             }
         ]
@@ -4159,13 +4159,13 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "toxic", "willowisp"],
-                "abilities": ["Pressure"],
+                "abilities": ["Frisk", "Pressure"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
                 "movepool": ["earthquake", "protect", "shadowsneak", "toxic"],
-                "abilities": ["Pressure"]
+                "abilities": ["Frisk", "Pressure"]
             }
         ]
     },
@@ -4260,8 +4260,9 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "energyball", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"],
-                "abilities": ["Levitate"]
+                "movepool": ["calmmind", "healingwish", "hiddenpowerfire", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"],
+                "abilities": ["Levitate"],
+                "preferredTypes": ["Bug"]
             },
             {
                 "role": "Bulky Support",
@@ -4794,6 +4795,11 @@
                 "role": "Fast Support",
                 "movepool": ["copycat", "encore", "knockoff", "substitute", "thunderwave", "uturn"],
                 "abilities": ["Prankster"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["gunkshot", "knockoff", "playrough", "thunderwave"],
+                "abilities": ["Prankster"]
             }
         ]
     },
@@ -5021,7 +5027,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "megahorn", "poisonjab", "protect", "swordsdance"],
+                "movepool": ["earthquake", "megahorn", "poisonjab", "swordsdance"],
                 "abilities": ["Speed Boost"]
             }
         ]
@@ -5183,7 +5189,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["gunkshot", "haze", "painsplit", "spikes", "stompingtantrum", "toxic", "toxicspikes"],
                 "abilities": ["Aftermath"]
             }
@@ -5397,7 +5403,8 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"],
-                "abilities": ["Analytic"]
+                "abilities": ["Analytic"],
+                "preferredTypes": ["Bug"]
             }
         ]
     },
@@ -6110,7 +6117,8 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "darkpulse", "psychic", "psyshock", "signalbeam", "thunderbolt"],
-                "abilities": ["Competitive"]
+                "abilities": ["Competitive"],
+                "preferredTypes": ["Bug"]
             }
         ]
     },
@@ -6231,7 +6239,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragondance", "earthquake", "headsmash", "outrage", "stealthrock", "superpower"],
+                "movepool": ["dragondance", "earthquake", "headsmash", "outrage", "superpower"],
                 "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
             },

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -105,9 +105,9 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["High Horsepower", "Knock Off", "Leech Life", "Protect", "Stone Edge", "Swords Dance"],
+                "movepool": ["Gunk Shot", "High Horsepower", "Knock Off", "Protect", "Rapid Spin", "Stone Edge", "Swords Dance"],
                 "abilities": ["Sand Rush"],
-                "teraTypes": ["Bug", "Dark", "Rock"]
+                "teraTypes": ["Poison", "Rock"]
             },
             {
                 "role": "Doubles Bulky Attacker",
@@ -3683,13 +3683,13 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Iron Head", "Protect", "Scale Shot", "Swords Dance"],
-                "abilities": ["Mold Breaker"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Dragon", "Fighting", "Steel"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Dragon Claw", "First Impression", "Iron Head", "Protect"],
-                "abilities": ["Mold Breaker"],
+                "abilities": ["Unnerve"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -5652,7 +5652,7 @@
             },
             {
                 "role": "Offensive Protect",
-                "movepool": ["Flower Trick", "Knock Off", "Pollen Puff", "Protect", "Sucker Punch", "Taunt"],
+                "movepool": ["Flower Trick", "Knock Off", "Protect", "Sucker Punch", "Taunt"],
                 "abilities": ["Overgrow"],
                 "teraTypes": ["Poison"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -6847,8 +6847,14 @@
         "level": 77,
         "sets": [
             {
+                "role": "Doubles Setup Sweeper",
+                "movepool": ["Close Combat", "Mighty Cleave", "Protect", "Swords Dance"],
+                "abilities": ["Quark Drive"],
+                "teraTypes": ["Fighting"]
+            },
+            {
                 "role": "Offensive Protect",
-                "movepool": ["Close Combat", "Mighty Cleave", "Protect", "Swords Dance", "Zen Headbutt"],
+                "movepool": ["Close Combat", "Mighty Cleave", "Protect", "Zen Headbutt"],
                 "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -89,7 +89,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Alluring Voice", "Encore", "Focus Blast", "Grass Knot", "Nasty Plot", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Alluring Voice", "Encore", "Focus Blast", "Grass Knot", "Knock Off", "Nasty Plot", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Lightning Rod"],
                 "teraTypes": ["Grass", "Water"]
             },
@@ -178,20 +178,8 @@
         "level": 78,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Aurora Veil", "Blizzard", "Encore", "Moonblast"],
-                "abilities": ["Snow Warning"],
-                "teraTypes": ["Steel", "Water"]
-            },
-            {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Aurora Veil", "Blizzard", "Moonblast", "Nasty Plot"],
-                "abilities": ["Snow Warning"],
-                "teraTypes": ["Steel", "Water"]
-            },
-            {
                 "role": "Fast Support",
-                "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Moonblast"],
+                "movepool": ["Aurora Veil", "Blizzard", "Encore", "Freeze-Dry", "Moonblast", "Nasty Plot"],
                 "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             }
@@ -342,9 +330,15 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Head Smash", "Morning Sun", "Wild Charge"],
+                "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Head Smash", "Wild Charge"],
                 "abilities": ["Rock Head"],
-                "teraTypes": ["Rock"]
+                "teraTypes": ["Fire", "Normal", "Rock"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Extreme Speed", "Flare Blitz", "Head Smash", "Morning Sun"],
+                "abilities": ["Rock Head"],
+                "teraTypes": ["Fire", "Grass", "Normal", "Rock"]
             }
         ]
     },
@@ -1226,6 +1220,12 @@
                 "movepool": ["Aqua Jet", "Belly Drum", "Liquidation", "Play Rough"],
                 "abilities": ["Huge Power"],
                 "teraTypes": ["Water"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Aqua Jet", "Knock Off", "Liquidation", "Play Rough"],
+                "abilities": ["Huge Power"],
+                "teraTypes": ["Dragon", "Steel", "Water"]
             }
         ]
     },
@@ -1840,12 +1840,6 @@
                 "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Protect", "Stone Edge", "Swords Dance"],
                 "abilities": ["Speed Boost"],
                 "teraTypes": ["Dark", "Fighting"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Fire Blast", "Knock Off", "Protect"],
-                "abilities": ["Speed Boost"],
-                "teraTypes": ["Dark", "Fighting", "Fire"]
             }
         ]
     },
@@ -1864,7 +1858,7 @@
         "level": 95,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Bulky Attacker",
                 "movepool": ["Crunch", "Play Rough", "Poison Fang", "Sucker Punch", "Taunt", "Throat Chop"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Fairy", "Poison"]
@@ -2295,6 +2289,12 @@
                 "movepool": ["Air Slash", "Leech Seed", "Protect", "Substitute"],
                 "abilities": ["Harvest"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Dance", "Dual Wingbeat", "Earthquake", "Leaf Blade", "Synthesis"],
+                "abilities": ["Harvest"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -2421,7 +2421,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Aura Sphere", "Calm Mind", "Draco Meteor", "Psyshock", "Recover"],
+                "movepool": ["Calm Mind", "Draco Meteor", "Psyshock", "Recover"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
             }
@@ -3135,6 +3135,12 @@
                 "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Knock Off", "Stealth Rock"],
                 "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Ice"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Trailblaze"],
+                "abilities": ["Thick Fat"],
+                "teraTypes": ["Grass"]
             }
         ]
     },
@@ -3505,6 +3511,12 @@
                 "movepool": ["Dark Pulse", "Focus Blast", "Hypnosis", "Nasty Plot", "Sludge Bomb", "Substitute"],
                 "abilities": ["Bad Dreams"],
                 "teraTypes": ["Poison"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Dark Pulse", "Focus Blast", "Sludge Bomb", "Trick"],
+                "abilities": ["Bad Dreams"],
+                "teraTypes": ["Poison"]
             }
         ]
     },
@@ -3569,16 +3581,10 @@
         "level": 73,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Calm Mind", "Earth Power", "Ice Beam", "Judgment"],
-                "abilities": ["Multitype"],
-                "teraTypes": ["Ground"]
-            },
-            {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Recover"],
+                "movepool": ["Calm Mind", "Earth Power", "Fire Blast", "Judgment", "Recover"],
                 "abilities": ["Multitype"],
-                "teraTypes": ["Fire"]
+                "teraTypes": ["Fire", "Ground"]
             }
         ]
     },
@@ -3598,15 +3604,15 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Earthquake", "Extreme Speed", "Gunk Shot", "Outrage", "Swords Dance"],
+                "movepool": ["Extreme Speed", "Flare Blitz", "Heavy Slam", "Outrage", "Swords Dance"],
                 "abilities": ["Multitype"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Fire"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Dragon Dance", "Earthquake", "Gunk Shot", "Outrage"],
+                "movepool": ["Dragon Dance", "Flare Blitz", "Heavy Slam", "Outrage"],
                 "abilities": ["Multitype"],
-                "teraTypes": ["Ground", "Poison"]
+                "teraTypes": ["Fire", "Steel"]
             },
             {
                 "role": "Fast Bulky Setup",
@@ -4826,6 +4832,12 @@
                 "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "U-turn", "Water Pulse"],
                 "abilities": ["Mega Launcher"],
                 "teraTypes": ["Dark", "Dragon", "Fighting"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "U-turn", "Water Pulse"],
+                "abilities": ["Mega Launcher"],
+                "teraTypes": ["Dragon"]
             }
         ]
     },
@@ -5571,6 +5583,12 @@
                 "movepool": ["Grassy Glide", "High Horsepower", "Knock Off", "Swords Dance", "U-turn", "Wood Hammer"],
                 "abilities": ["Grassy Surge"],
                 "teraTypes": ["Grass"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Grassy Glide", "High Horsepower", "U-turn", "Wood Hammer"],
+                "abilities": ["Grassy Surge"],
+                "teraTypes": ["Grass", "Poison", "Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -2291,7 +2291,7 @@
                 "teraTypes": ["Steel"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Dual Wingbeat", "Earthquake", "Leaf Blade", "Synthesis"],
                 "abilities": ["Harvest"],
                 "teraTypes": ["Ground"]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -179,7 +179,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Aurora Veil", "Blizzard", "Encore", "Freeze-Dry", "Moonblast", "Nasty Plot"],
+                "movepool": ["Aurora Veil", "Blizzard", "Encore", "Moonblast", "Nasty Plot"],
+                "abilities": ["Snow Warning"],
+                "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Moonblast", "Nasty Plot"],
                 "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             }

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1338,7 +1338,7 @@ export class RandomTeams {
 		if (moves.has('substitute')) return 'Leftovers';
 		if (
 			moves.has('stickyweb') && isLead &&
-			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) >= 235
+			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 235
 		) return 'Focus Sash';
 		if (this.dex.getEffectiveness('Rock', species) >= 1) return 'Heavy-Duty Boots';
 		if (

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -213,7 +213,7 @@ export class RandomTeams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (
-				movePool.includes('freezedry') || movePool.includes('blizzard') || !counter.get('Ice')
+				(movePool.includes('freezedry') && movePool.includes('icebeam')) || !counter.get('Ice')
 			),
 			Normal: (movePool, moves, types, counter) => (movePool.includes('boomburst') || movePool.includes('hypervoice')),
 			Poison: (movePool, moves, abilities, types, counter) => {
@@ -221,10 +221,8 @@ export class RandomTeams {
 				return !counter.get('Poison');
 			},
 			Psychic: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => {
-				if (counter.get('Psychic')) return false;
-				if (movePool.includes('calmmind') || abilities.includes('Strong Jaw')) return true;
-				if (isDoubles && movePool.includes('psychicfangs')) return true;
-				return abilities.includes('Psychic Surge') || ['Bug', 'Electric', 'Fighting', 'Fire', 'Grass', 'Poison'].some(m => types.includes(m));
+				if ((types.includes('Steel') || types.includes('Water')) && !movePool.includes('psychicfangs')) return false;
+				return !counter.get('Psychic');
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
 			Steel: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => (
@@ -484,6 +482,7 @@ export class RandomTeams {
 		if (teamDetails.screens && movePool.length >= this.maxMoveCount + 2) {
 			if (movePool.includes('reflect')) this.fastPop(movePool, movePool.indexOf('reflect'));
 			if (movePool.includes('lightscreen')) this.fastPop(movePool, movePool.indexOf('lightscreen'));
+			if (movePool.includes('auroraveil')) this.fastPop(movePool, movePool.indexOf('auroraveil'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
 		if (teamDetails.stickyWeb) {
@@ -602,7 +601,7 @@ export class RandomTeams {
 
 		if (!types.includes('Ice')) this.incompatibleMoves(moves, movePool, 'icebeam', 'icywind');
 
-		if (!isDoubles) this.incompatibleMoves(moves, movePool, ['taunt', 'strengthsap'], 'encore');
+		if (!isDoubles) this.incompatibleMoves(moves, movePool, 'taunt', 'encore');
 
 		if (!types.includes('Dark') && teraType !== 'Dark') this.incompatibleMoves(moves, movePool, 'knockoff', 'suckerpunch');
 
@@ -616,6 +615,7 @@ export class RandomTeams {
 		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
 		if (species.id === 'coalossal') this.incompatibleMoves(moves, movePool, 'flamethrower', 'overheat');
+		if (!isDoubles && species.id === 'jumpluff') this.incompatibleMoves(moves, movePool, 'encore', 'strengthsap');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.
@@ -746,8 +746,8 @@ export class RandomTeams {
 				movePool, teraType, role);
 		}
 
-		// Enforce Night Shade, Revelation Dance, Revival Blessing, and Sticky Web
-		for (const moveid of ['nightshade', 'revelationdance', 'revivalblessing', 'stickyweb']) {
+		// Enforce Blizzard, Night Shade, Revelation Dance, Revival Blessing, and Sticky Web
+		for (const moveid of ['blizzard', 'nightshade', 'revelationdance', 'revivalblessing', 'stickyweb']) {
 			if (movePool.includes(moveid)) {
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
@@ -768,6 +768,14 @@ export class RandomTeams {
 			}
 			if (movePool.includes('defog')) {
 				counter = this.addMove('defog', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+					movePool, teraType, role);
+			}
+		}
+
+		// Enforce Aurora Veil if the team doesn't already have screens
+		if (!teamDetails.screens) {
+			if (movePool.includes('auroraveil')) {
+				counter = this.addMove('auroraveil', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			}
 		}
@@ -1326,7 +1334,10 @@ export class RandomTeams {
 		}
 		if (species.id === 'golem') return (counter.get('speedsetup')) ? 'Weakness Policy' : 'Custap Berry';
 		if (moves.has('substitute')) return 'Leftovers';
-		if (moves.has('stickyweb') && species.id !== 'araquanid' && isLead) return 'Focus Sash';
+		if (
+			moves.has('stickyweb') && isLead &&
+			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) >= 235
+		) return 'Focus Sash';
 		if (this.dex.getEffectiveness('Rock', species) >= 1) return 'Heavy-Duty Boots';
 		if (
 			(moves.has('chillyreception') || (
@@ -1490,7 +1501,10 @@ export class RandomTeams {
 			if ((moves.has('substitute') && ['Sitrus Berry', 'Salac Berry'].includes(item))) {
 				// Two Substitutes should activate Sitrus Berry
 				if (hp % 4 === 0) break;
-			} else if ((moves.has('bellydrum') || moves.has('filletaway')) && (item === 'Sitrus Berry' || ability === 'Gluttony')) {
+			} else if (
+				(moves.has('bellydrum') || moves.has('filletaway') || moves.has('shedtail')) &&
+				(item === 'Sitrus Berry' || ability === 'Gluttony')
+			) {
 				// Belly Drum should activate Sitrus Berry
 				if (hp % 2 === 0) break;
 			} else if (moves.has('substitute') && moves.has('endeavor')) {
@@ -1501,7 +1515,7 @@ export class RandomTeams {
 				if (srWeakness <= 0 || ability === 'Regenerator' || ['Leftovers', 'Life Orb'].includes(item)) break;
 				if (item !== 'Sitrus Berry' && hp % (4 / srWeakness) > 0) break;
 				// Minimise number of Stealth Rock switch-ins to activate Sitrus Berry
-				if (item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;
+				if (!isDoubles && item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;
 			}
 			evs.hp -= 4;
 		}

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -775,11 +775,9 @@ export class RandomTeams {
 		}
 
 		// Enforce Aurora Veil if the team doesn't already have screens
-		if (!teamDetails.screens) {
-			if (movePool.includes('auroraveil')) {
-				counter = this.addMove('auroraveil', moves, types, abilities, teamDetails, species, isLead, isDoubles,
-					movePool, teraType, role);
-			}
+		if (!teamDetails.screens && movePool.includes('auroraveil')) {
+			counter = this.addMove('auroraveil', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+				movePool, teraType, role);
 		}
 
 		// Enforce Knock Off on pure Normal- and Fighting-types in singles

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -212,16 +212,15 @@ export class RandomTeams {
 				)
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
-			Ice: (movePool, moves, abilities, types, counter) => (
-				(movePool.includes('freezedry') && movePool.includes('icebeam')) || !counter.get('Ice')
-			),
+			Ice: (movePool, moves, abilities, types, counter) => (!counter.get('Ice')),
 			Normal: (movePool, moves, types, counter) => (movePool.includes('boomburst') || movePool.includes('hypervoice')),
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (types.includes('Ground')) return false;
 				return !counter.get('Poison');
 			},
 			Psychic: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => {
-				if ((types.includes('Steel') || types.includes('Water')) && !movePool.includes('psychicfangs')) return false;
+				if ((isDoubles || species.id === 'bruxish') && movePool.includes('psychicfangs')) return false;
+				if (['Dark', 'Steel', 'Water'].some(m => types.includes(m))) return false;
 				return !counter.get('Psychic');
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
@@ -743,6 +742,12 @@ export class RandomTeams {
 		// Enforce Facade if Guts is a possible ability
 		if (movePool.includes('facade') && abilities.includes('Guts')) {
 			counter = this.addMove('facade', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+				movePool, teraType, role);
+		}
+
+		// Enforce Freeze-Dry if Ice Beam and Freeze-Dry are possible moves
+		if (movePool.includes('freezedry') && movePool.includes('icebeam')) {
+			counter = this.addMove('freezedry', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 				movePool, teraType, role);
 		}
 

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -212,7 +212,9 @@ export class RandomTeams {
 				)
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
-			Ice: (movePool, moves, abilities, types, counter) => (!counter.get('Ice')),
+			Ice: (movePool, moves, abilities, types, counter) => (
+				movePool.includes('freezedry') || movePool.includes('blizzard') || !counter.get('Ice')
+			),
 			Normal: (movePool, moves, types, counter) => (movePool.includes('boomburst') || movePool.includes('hypervoice')),
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (types.includes('Ground')) return false;
@@ -745,14 +747,8 @@ export class RandomTeams {
 				movePool, teraType, role);
 		}
 
-		// Enforce Freeze-Dry if Ice Beam and Freeze-Dry are possible moves
-		if (movePool.includes('freezedry') && movePool.includes('icebeam')) {
-			counter = this.addMove('freezedry', moves, types, abilities, teamDetails, species, isLead, isDoubles,
-				movePool, teraType, role);
-		}
-
-		// Enforce Blizzard, Night Shade, Revelation Dance, Revival Blessing, and Sticky Web
-		for (const moveid of ['blizzard', 'nightshade', 'revelationdance', 'revivalblessing', 'stickyweb']) {
+		// Enforce Night Shade, Revelation Dance, Revival Blessing, and Sticky Web
+		for (const moveid of ['nightshade', 'revelationdance', 'revivalblessing', 'stickyweb']) {
 			if (movePool.includes(moveid)) {
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -219,7 +219,7 @@ export class RandomTeams {
 				return !counter.get('Poison');
 			},
 			Psychic: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => {
-				if ((isDoubles || species.id === 'bruxish') && movePool.includes('psychicfangs')) return false;
+				if ((isDoubles || species.id === 'bruxish') && movePool.includes('psychicfangs')) return true;
 				if (['Dark', 'Steel', 'Water'].some(m => types.includes(m))) return false;
 				return !counter.get('Psychic');
 			},

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -480,11 +480,12 @@ export class RandomTeams {
 			.map(move => move.id);
 
 		// Team-based move culls
-		if (teamDetails.screens && movePool.length >= this.maxMoveCount + 2) {
-			if (movePool.includes('reflect')) this.fastPop(movePool, movePool.indexOf('reflect'));
-			if (movePool.includes('lightscreen')) this.fastPop(movePool, movePool.indexOf('lightscreen'));
+		if (teamDetails.screens) {
 			if (movePool.includes('auroraveil')) this.fastPop(movePool, movePool.indexOf('auroraveil'));
-			if (moves.size + movePool.length <= this.maxMoveCount) return;
+			if (movePool.length >= this.maxMoveCount + 2) {
+				if (movePool.includes('reflect')) this.fastPop(movePool, movePool.indexOf('reflect'));
+				if (movePool.includes('lightscreen')) this.fastPop(movePool, movePool.indexOf('lightscreen'));
+			}
 		}
 		if (teamDetails.stickyWeb) {
 			if (movePool.includes('stickyweb')) this.fastPop(movePool, movePool.indexOf('stickyweb'));
@@ -799,7 +800,7 @@ export class RandomTeams {
 
 		// Enforce moves in doubles
 		if (isDoubles) {
-			const doublesEnforcedMoves = ['auroraveil', 'mortalspin', 'spore'];
+			const doublesEnforcedMoves = ['mortalspin', 'spore'];
 			for (const moveid of doublesEnforcedMoves) {
 				if (movePool.includes(moveid)) {
 					counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -186,7 +186,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Horn Leech", "Shadow Claw", "Stone Edge", "Victory Dance"],
                 "abilities": ["Forewarn"],
-                "teraTypes": ["Rock", "Water"]
+                "teraTypes": ["Fairy", "Rock", "Water"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -230,7 +230,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Blizzard", "Bug Buzz", "Focus Blast", "Hydro Pump", "Overheat", "Psychic", "Psyshock", "Thunder"],
+                "movepool": ["Bug Buzz", "Focus Blast", "Hydro Pump", "Overheat", "Psychic", "Psyshock", "Thunder"],
                 "abilities": ["No Guard"],
                 "teraTypes": ["Fighting", "Fire"]
             },

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -230,7 +230,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Bug Buzz", "Focus Blast", "Hydro Pump", "Overheat", "Psychic", "Psyshock", "Thunder"],
+                "movepool": ["Blizzard", "Bug Buzz", "Focus Blast", "Hydro Pump", "Overheat", "Psychic", "Psyshock", "Thunder"],
                 "abilities": ["No Guard"],
                 "teraTypes": ["Fighting", "Fire"]
             },

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -196,7 +196,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Horn Leech", "Pain Split", "Power Whip", "Shadow Claw", "Sticky Web", "Toxic Spikes", "Will-O-Wisp"],
+                "movepool": ["Horn Leech", "Pain Split", "Power Whip", "Shadow Claw", "Shadow Sneak", "Sticky Web", "Toxic Spikes", "Will-O-Wisp"],
                 "abilities": ["Forewarn"],
                 "teraTypes": ["Fairy", "Water"]
             }

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -112,7 +112,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Meteor Mash", "Poltergeist", "Strength Sap", "U-turn", "Will-O-Wisp"],
+                "movepool": ["Defog", "Encore", "Meteor Mash", "Poltergeist", "Strength Sap", "U-turn", "Will-O-Wisp"],
                 "abilities": ["Trace"],
                 "teraTypes": ["Dark", "Water"]
             }
@@ -180,13 +180,25 @@
         ]
     },
     "necturna": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Power Whip", "Shadow Claw", "Shell Smash", "Stone Edge"],
+                "role": "Bulky Setup",
+                "movepool": ["Horn Leech", "Shadow Claw", "Stone Edge", "Victory Dance"],
                 "abilities": ["Forewarn"],
-                "teraTypes": ["Rock"]
+                "teraTypes": ["Rock", "Water"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Horn Leech", "Pain Split", "Rage Fist", "Toxic Spikes", "Will-O-Wisp"],
+                "abilities": ["Forewarn"],
+                "teraTypes": ["Fairy", "Water"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Horn Leech", "Pain Split", "Power Whip", "Shadow Claw", "Sticky Web", "Toxic Spikes", "Will-O-Wisp"],
+                "abilities": ["Forewarn"],
+                "teraTypes": ["Fairy", "Water"]
             }
         ]
     },

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -252,7 +252,8 @@ describe("New set format (slow)", () => {
 							const stealthRock = Math.floor(i / 2) % 2;
 							const stickyWeb = Math.floor(i / 4) % 2;
 							const spikes = Math.floor(i / 8) % 2;
-							const teamDetails = {rapidSpin, stealthRock, stickyWeb, spikes};
+							const screens = Math.floor(i / 2) % 2;
+							const teamDetails = {rapidSpin, stealthRock, stickyWeb, spikes, screens};
 							// randomMoveset() deletes moves from the movepool, so recreate it every time
 							const movePool = set.movepool.map(m => (m.startsWith('hiddenpower') ? m : dex.moves.get(m).id));
 							let moveSet;


### PR DESCRIPTION
Welcome to the AV update. Merge as soon as convenient.

**Gen 9 Random Battle**:
-Tropius now runs an additional set of Setup Sweeper with Dual Wingbeat, Dragon Dance, Earthquake, and Leaf Blade/Synthesis, with Tera Ground and a Sitrus Berry.
-Clawitzer now runs an additional set of AV Pivot with the same moves as Choice Specs but only Tera Dragon.
-Azumarill now runs an additional set of AV Pivot with Aqua Jet, Liquidation, Play Rough, and Knock Off with Tera Dragon/Steel/Water.
-Rillaboom now runs an additional set of AV Pivot with Grassy Glide, Wood Hammer, High Horsepower, and U-turn with Tera Grass/Steel/Poison.
-Mamoswine now runs an additional set of AV Pivot with Ice Shard, Icicle Crash, Earthquake, and Trailblaze with Tera Grass.
-Darkrai now runs an additional set of Wallbreaker with Dark Pulse, Focus Blast, Sludge Bomb, and Trick with Choice Specs and Tera Poison.
-Hisuian Arcanine's sets have been adjusted: the Fast Attacker set no longer runs Morning Sun and is Tera Rock/Fire/Normal, and there is a new Bulky Attacker set with Morning Sun and without Close Combat or Wild Charge with Tera Rock/Fire/Normal/Grass.
-Mixed Fire Blast Blaziken no longer exists. It is now always Swords Dance.
-Lead Spidops and Vikavolt no longer get Focus Sash because they're too bulky. Only webs setters with a combined base HP, Def, and SpD of 234 or lower will get focus sash in the lead slot now.
-Aurora Veil now always generates on Pokemon that can run it. Additionally, if the team already has screens or Aurora Veil, Aurora Veil will not be generated on these Pokemon. As such:
--AV Abomasnow now only exists if the team has screens.
--Alolan Ninetales's sets have been mostly merged together and it can now run stuff like plot 3 atks or plot encore if the team already has screens. Freeze Dry is more common than Nasty Plot or Encore.
-Wallbreaker Mightyena has been changed to Bulky Attacker. It now gets Leftovers instead of Life Orb. That's all this change does.
-Arceus-Bug's sets have been merged together and Ice Beam has been removed. It now always gets Recover and rolls between Tera Ground Earth Power and Tera Fire Fire Blast.
-Psychic STAB enforcement has been simplified significantly. Psychic STAB is now forced on Wallbreaker Oranguru as a result.
-Latias: -Aura Sphere (now always gets Recover)
-arceus-dragon (all sets): -earthquake, -tera ground, -gunk shot, -tera poison, +flare blitz, +tera fire, +heavy slam, +tera steel (though the tera steel's only on set 2)
-Fast Support Raichu: +Knock Off

**Gen 9 CAP Random Battle**:
-A hardcode for Jumpluff has been reworked, so now we can add Encore to bulky Kitsunoh.
-Necturna now has Sketch again. As such, its sets are entirely revamped:
--A Bulky Setup set with Victory Dance, Horn Leech, Shadow Claw, and Stone Edge with Tera Fairy/Rock/Water and Leftovers.
--A Bulky Attacker set with Rage Fist, Horn Leech, Pain Split, and Will-o-Wisp/Toxic Spikes with Tera Fairy/Water and Leftovers.
--A Bulky Support set with Sticky Web, Shadow Claw, Horn Leech/Power Whip, and Pain Split/Will-O-Wisp/Toxic Spikes/Shadow Sneak with Tera Fairy/Water and Leftovers.
--Its level has been reduced from 82 to 80.

**Gen 9 Random Doubles**:
-Pokemon no longer ever lower their HP to maximize Stealth Rock switch-ins with Sitrus Berry. Belly Drum, Fillet Away, and Shed Tail still get even HP.
-Meowscarada no longer runs Pollen Puff on its Life Orb set.
-Swords Dance Sandslash: -Leech Life, -Tera Bug, -Tera Dark, +Gunk Shot, +Tera Poison, +Rapid Spin
-Iron Boulder's sets have been split between Swords Dance and Zen Headbutt for technical reasons.

**Old Gens**:
-In Gens 5-7, Spiritomb now runs Foul Play instead of Dark Pulse again.
-In Gens 6-7, Spiritomb now runs Toxic on its Bulky Attacker set.
-In Gens 6-7, Dusknoir now runs Frisk half the time.
-In Gens 6-7, Garbodor's role has been changed to Bulky Attacker to enforce a second attack.
-In Gens 6-7, Scolipede no longer runs Protect.
-In Gens 6-7, Mesprit, Beheeyem, and Meowstic-F now always run Signal Beam.
-In Gens 6-7, Deoxys-Defense now runs a Calm Mind set with Psychic/Psyshock, Focus Blast/Signal Beam, and Recover.
-In Gens 6-7, Liepard now runs a Fast Attacker set with Thunder Wave, Gunk Shot, Knock Off, and Play Rough with a Life Orb.
-In Gens 6-7, Fast Attacker Mesprit no longer runs Ice Beam or Energy Ball.
-In Gens 6-7, Tyrantrum no longer runs Stealth Rock.
-In Gens 6-7, regular Banette no longer runs Taunt.
-In Gen 7, Alolan Golem no longer runs Magnet Pull.
-In Gens 4-5, Machamp now runs Earthquake.
-In Gens 4-5, Arceus-Psychic's sets have been merged and it now runs Judgment, Focus Blast, Calm Mind, and Dark Pulse/Recover.
-In Gen 5, Arceus-Rock now runs an additional set of Calm Mind with Earth Power/Fire Blast and Recover.
-In Gen 4, Machamp now always runs Payback.
-In Gen 4, Gengar now always runs Poison STAB.
-In Gen 3, Snorlax now runs Thick Fat on its Rest sets. the Chesto Berry set still sometimes runs Immunity.