### PR TITLE
LGPE: Update Tier for Charizard-Mega-Y to RUBL

### DIFF
--- a/data/mods/gen7letsgo/formats-data.ts
+++ b/data/mods/gen7letsgo/formats-data.ts
@@ -28,7 +28,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		doublesTier: "DOU",
 	},
 	charizardmegay: {
-		tier: "RU",
+		tier: "RUBL",
 		doublesTier: "DOU",
 	},
 	squirtle: {


### PR DESCRIPTION
Charizard-Mega-Y quickbanned to RUBL.
https://www.smogon.com/forums/threads/lgpe-ru-zard-y-quickbanned.3696384/#post-10258917