### PR TITLE
Fix crash with Psych Up, Focus Energy, and Dragon Cheer

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -702,13 +702,13 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 				pokemon.boosts[i] = ally.boosts[i];
 			}
 			const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
+			// we need to be sure to remove all the overlapping crit volatiles before trying to add any
+			for (const volatile of volatilesToCopy) pokemon.removeVolatile(volatile);
 			for (const volatile of volatilesToCopy) {
 				if (ally.volatiles[volatile]) {
 					pokemon.addVolatile(volatile);
 					if (volatile === 'gmaxchistrike') pokemon.volatiles[volatile].layers = ally.volatiles[volatile].layers;
 					if (volatile === 'dragoncheer') pokemon.volatiles[volatile].hasDragonType = ally.volatiles[volatile].hasDragonType;
-				} else {
-					pokemon.removeVolatile(volatile);
 				}
 			}
 			this.add('-copyboost', pokemon, ally, '[from] ability: Costar');

--- a/data/mods/gen7pokebilities/scripts.ts
+++ b/data/mods/gen7pokebilities/scripts.ts
@@ -92,14 +92,14 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.boosts[boostName] = pokemon.boosts[boostName];
 			}
 			if (this.battle.gen >= 6) {
+				// we need to be sure to remove all the overlapping crit volatiles before trying to add any of them
 				const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
+				for (const volatile of volatilesToCopy) this.removeVolatile(volatile);
 				for (const volatile of volatilesToCopy) {
 					if (pokemon.volatiles[volatile]) {
 						this.addVolatile(volatile);
 						if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
 						if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
-					} else {
-						this.removeVolatile(volatile);
 					}
 				}
 			}

--- a/data/mods/partnersincrime/scripts.ts
+++ b/data/mods/partnersincrime/scripts.ts
@@ -382,13 +382,12 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			if (this.battle.gen >= 6) {
 				const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
+				for (const volatile of volatilesToCopy) this.removeVolatile(volatile);
 				for (const volatile of volatilesToCopy) {
 					if (pokemon.volatiles[volatile]) {
 						this.addVolatile(volatile);
 						if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
 						if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
-					} else {
-						this.removeVolatile(volatile);
 					}
 				}
 			}

--- a/data/mods/pokebilities/scripts.ts
+++ b/data/mods/pokebilities/scripts.ts
@@ -92,14 +92,14 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.boosts[boostName] = pokemon.boosts[boostName];
 			}
 			if (this.battle.gen >= 6) {
+				// we need to remove all crit volatiles before adding any crit volatiles
 				const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
+				for (const volatile of volatilesToCopy) this.removeVolatile(volatile);
 				for (const volatile of volatilesToCopy) {
 					if (pokemon.volatiles[volatile]) {
 						this.addVolatile(volatile);
 						if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
 						if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
-					} else {
-						this.removeVolatile(volatile);
 					}
 				}
 			}

--- a/data/mods/trademarked/scripts.ts
+++ b/data/mods/trademarked/scripts.ts
@@ -284,13 +284,13 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			if (this.battle.gen >= 6) {
 				const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
+				// we need to remove all the crit volatiles before adding any crit volatile
+				for (const volatile of volatilesToCopy) this.removeVolatile(volatile);
 				for (const volatile of volatilesToCopy) {
 					if (pokemon.volatiles[volatile]) {
 						this.addVolatile(volatile);
 						if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
 						if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
-					} else {
-						this.removeVolatile(volatile);
 					}
 				}
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -14542,14 +14542,16 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			for (i in target.boosts) {
 				source.boosts[i] = target.boosts[i];
 			}
+
 			const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
+			// we need to remove all crit stage volatiles first; otherwise copying e.g. dragoncheer onto a mon with focusenergy
+			// will crash the server (since addVolatile fails due to overlap, leaving the source mon with no hasDragonType to set)
+			for (const volatile of volatilesToCopy) source.removeVolatile(volatile);
 			for (const volatile of volatilesToCopy) {
 				if (target.volatiles[volatile]) {
 					source.addVolatile(volatile);
 					if (volatile === 'gmaxchistrike') source.volatiles[volatile].layers = target.volatiles[volatile].layers;
 					if (volatile === 'dragoncheer') source.volatiles[volatile].hasDragonType = target.volatiles[volatile].hasDragonType;
-				} else {
-					source.removeVolatile(volatile);
 				}
 			}
 			this.add('-copyboost', source, target, '[from] move: Psych Up');

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1274,14 +1274,14 @@ export class Pokemon {
 			this.boosts[boostName] = pokemon.boosts[boostName];
 		}
 		if (this.battle.gen >= 6) {
+			// we need to remove all of the overlapping crit volatiles before adding any of them
 			const volatilesToCopy = ['dragoncheer', 'focusenergy', 'gmaxchistrike', 'laserfocus'];
+			for (const volatile of volatilesToCopy) this.removeVolatile(volatile);
 			for (const volatile of volatilesToCopy) {
 				if (pokemon.volatiles[volatile]) {
 					this.addVolatile(volatile);
 					if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
 					if (volatile === 'dragoncheer') this.volatiles[volatile].hasDragonType = pokemon.volatiles[volatile].hasDragonType;
-				} else {
-					this.removeVolatile(volatile);
 				}
 			}
 		}

--- a/test/sim/abilities/costar.js
+++ b/test/sim/abilities/costar.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Costar', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should copy the teammate\'s crit ratio on activation', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Smeargle', level: 1, moves: ['sleeptalk', 'focusenergy']},
+			{species: 'Suicune', level: 1, moves: ['sleeptalk']},
+			{species: 'Flamigo', level: 1, ability: 'costar', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Suicune', level: 1, moves: ['sleeptalk']},
+			{species: 'pikachu', level: 1, moves: ['sleeptalk']},
+			{species: 'weezinggalar', level: 1, ability: 'neutralizinggas', moves: ['sleeptalk']},
+		]});
+
+		battle.makeChoices('move focusenergy, move sleeptalk', 'move sleeptalk, move sleeptalk');
+		battle.makeChoices('move sleeptalk, switch flamigo', 'move sleeptalk, move sleeptalk');
+
+		const flamigo = battle.p1.active[1];
+		assert(flamigo.volatiles['focusenergy'], "Costar should copy volatile crit modifiers.");
+
+		battle.makeChoices('switch suicune, move sleeptalk', 'switch weezinggalar, move sleeptalk');
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'switch suicune, move sleeptalk');
+		assert(!flamigo.volatiles['focusenergy'], "Costar should copy having no volatile crit modifiers when re-activated.");
+	});
+
+	it('should copy both positive and negative stat changes', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Suicune', level: 1, moves: ['sleeptalk']},
+			{species: 'Smeargle', level: 1, moves: ['sleeptalk', 'shellsmash']},
+			{species: 'Flamigo', level: 1, ability: 'costar', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Suicune', level: 1, moves: ['sleeptalk']},
+			{species: 'Suicune', level: 1, moves: ['sleeptalk']},
+		]});
+
+
+		battle.makeChoices('move sleeptalk, move shellsmash', 'move sleeptalk, move sleeptalk');
+		battle.makeChoices('switch flamigo, move sleeptalk', 'move sleeptalk, move sleeptalk');
+
+		const flamigo = battle.p1.active[0];
+		assert.statStage(flamigo, 'atk', 2, "A pokemon should copy the target's positive stat changes (atk) when switching in with Costar.");
+		assert.statStage(flamigo, 'spa', 2, "A pokemon should copy the target's positive stat changes (spa) when switching in with Costar.");
+		assert.statStage(flamigo, 'spe', 2, "A pokemon should copy the target's positive stat changes (spe) when switching in with Costar.");
+		assert.statStage(flamigo, 'def', -1, "A pokemon should copy the target's negative stat changes (def) when switching in with Costar.");
+		assert.statStage(flamigo, 'spd', -1, "A pokemon should copy the target's negative stat changes (spd) when switching in with Costar.");
+	});
+});
+

--- a/test/sim/moves/dragoncheer.js
+++ b/test/sim/moves/dragoncheer.js
@@ -113,6 +113,26 @@ describe('Dragon Cheer', function () {
 		battle.makeChoices('move bubble, move sleeptalk', 'auto');
 	});
 
+	it(`should be copied by Psych Up, using the target's Dragon Cheer level and replacing the user's current critical hit stage`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'milotic', moves: ['dragoncheer', 'psychup', 'bubble', 'focusenergy']},
+			{species: 'comfey', moves: ['sleeptalk']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'wobbuffet', moves: ['sleeptalk']},
+		]]);
+
+		battle.onEvent(
+			'ModifyCritRatio', battle.format, -99,
+			(critRatio) => assert.equal(critRatio, 2)
+		);
+
+		battle.makeChoices('move focusenergy, move sleeptalk', 'auto');
+		battle.makeChoices('move dragoncheer -2, move sleeptalk', 'auto');
+		battle.makeChoices('move psychup -2, move sleeptalk', 'auto');
+		battle.makeChoices('move bubble, move sleeptalk', 'auto');
+	});
+
 	it(`should be copied by Transform, using the target's Dragon Cheer level`, function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'milotic', moves: ['dragoncheer', 'transform']},


### PR DESCRIPTION
If a pokemon under the effect of `focus energy` tries to copy the `dragon cheer` effect, the server crashes. Removing the possible crit stage modifiers first protects against `dragon cheer` trying to set the property of a volatile that was never successfully added.

I didn't test this for faithfulness against the in-game behavior.

Replication instructions:
start a local server.
create two doubles teams. One must have a mon that can use both `focus energy` and `psych up`, e.g. hydreigon. The other must have a pokemon that can use `dragon cheer`. Challenge yourself with the two teams.
Turn 1: use `dragon cheer` and `focus energy`
Turn 2: use `psych up` from the mon under `focus energy`, targeting the opposing mon under the effect of `dragon cheer`

Sample crash log/replay below:
```
CRASH: TypeError: Cannot set properties of undefined (setting 'hasDragonType')
    at Battle.onHit (/.../pokemon-showdown/data/moves.ts:14550:65)
    at Battle.singleEvent (/.../pokemon-showdown/sim/battle.ts:585:25)
    at BattleActions.runMoveEffects (/.../pokemon-showdown/sim/battle-actions.ts:1305:31)
    at BattleActions.spreadMoveHit (/.../pokemon-showdown/sim/battle-actions.ts:1118:17)
    at BattleActions.hitStepMoveHitLoop (/.../pokemon-showdown/sim/battle-actions.ts:953:44)
    at BattleActions.trySpreadMoveHit (/.../pokemon-showdown/sim/battle-actions.ts:612:79)
    at BattleActions.useMoveInner (/.../pokemon-showdown/sim/battle-actions.ts:529:22)
    at BattleActions.useMove (/.../pokemon-showdown/sim/battle-actions.ts:386:27)
    at BattleActions.runMove (/.../pokemon-showdown/sim/battle-actions.ts:322:33)
    at Battle.runAction (/.../pokemon-showdown/sim/battle.ts:2548:17)

Additional information:
  chunk = >p2 move 1 2,move 2
  inputLog = 
>version 8ac3035eb2f1e9c09b4abf7277f02e6311032cc0
>start {"formatid":"gen9doublesou","seed":[36206,60552,37751,22375],"rated":"Rated battle"}
>player p1 {"name":"local","avatar":"266","team":"Roaring Moon|||Protosynthesis|DragonCheer,DragonDance||1,,,,,|N|,0,,,,|||,,,,,Dragon]Dragonite|||InnerFocus|DragonCheer,DragonDance||1,,,,,|F|,0,,,,|||,,,,,Dragon","rating":1072}
>player p2 {"name":"local2","avatar":"169","team":"Clefable|||CuteCharm|PsychUp,PlayRough||1,,,,,|M||||,,,,,Fairy]Cresselia|||Levitate|Safeguard,Protect||1,,,,,|F|,0,,,,|||,,,,,Psychic]Hydreigon|||Levitate|PsychUp,FocusEnergy||1,,,,,|F|,0,,,,|||,,,,,Dark","rating":1076}
>p1 team 1, 2
>p2 team 3, 2, 1
>p1 move dragoncheer -2, move dragondance
>p2 move focusenergy, move protect
>p1 move dragondance, move dragoncheer -1
>p2 move psychup +2, move protect
  log = 
|t:|1727364917
|gametype|doubles
|player|p1|local|266|1072
|player|p2|local2|169|1076
|teamsize|p1|2
|teamsize|p2|3
|gen|9
|tier|[Gen 9] Doubles OU
|rated|
|rule|Species Clause: Limit one of each Pokémon
|rule|OHKO Clause: OHKO moves are banned
|rule|Evasion Moves Clause: Evasion moves are banned
|rule|Gravity Sleep Clause: The combination of sleep-inducing moves with imperfect accuracy and Gravity or Gigantamax Orbeetle are banned
|rule|Endless Battle Clause: Forcing endless battles is banned
|rule|HP Percentage Mod: HP is shown in percentages
|clearpoke
|poke|p1|Roaring Moon|
|poke|p1|Dragonite, F|
|poke|p2|Clefable, M|
|poke|p2|Cresselia, F|
|poke|p2|Hydreigon, F|
|teampreview
|
|t:|1727364923
|start
|switch|p1a: Roaring Moon|Roaring Moon|351/351
|switch|p1b: Dragonite|Dragonite, F|323/323
|switch|p2a: Hydreigon|Hydreigon, F|325/325
|switch|p2b: Cresselia|Cresselia, F|381/381
|turn|1
|
|t:|1727364933
|move|p2b: Cresselia|Protect|p2b: Cresselia
|-singleturn|p2b: Cresselia|Protect
|move|p1a: Roaring Moon|Dragon Cheer|p1b: Dragonite
|-start|p1b: Dragonite|move: Dragon Cheer
|move|p2a: Hydreigon|Focus Energy|p2a: Hydreigon
|-start|p2a: Hydreigon|move: Focus Energy
|move|p1b: Dragonite|Dragon Dance|p1b: Dragonite
|-boost|p1b: Dragonite|atk|1
|-boost|p1b: Dragonite|spe|1
|
|upkeep
|turn|2
|
|t:|1727364945
|move|p2b: Cresselia|Protect||[still]
|-fail|p2b: Cresselia
|move|p1b: Dragonite|Dragon Cheer|p1a: Roaring Moon
|-start|p1a: Roaring Moon|move: Dragon Cheer
|move|p1a: Roaring Moon|Dragon Dance|p1a: Roaring Moon
|-boost|p1a: Roaring Moon|atk|1
|-boost|p1a: Roaring Moon|spe|1
|move|p2a: Hydreigon|Psych Up|p1b: Dragonite
```