### PR TITLE
Fix prevo/evo move incompatibilities

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1116,7 +1116,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		if (nationalSearch && !ruleTable.has('standardnatdex')) additionalRules.push('standardnatdex');
 		if (nationalSearch && ruleTable.valueRules.has('minsourcegen')) additionalRules.push('!!minsourcegen=3');
 		validator = TeamValidator.get(`${format}${additionalRules.length ? `@@@${additionalRules.join(',')}` : ''}`);
-		pokemonSource = validator.allSources();
 	}
 	for (const alts of searches) {
 		if (alts.skip) continue;
@@ -1282,6 +1281,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			if (matched) continue;
 
 			for (const move of altsMoves) {
+				pokemonSource = validator?.allSources();
 				if (validator && !validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
 					matched = true;
 					break;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -107,6 +107,11 @@ export class PokemonSources {
 	 */
 	eventOnlyMinSourceGen?: number;
 	/**
+	 * A list of movepools, identified by gen and species, which moves can be pulled from.
+	 * Used to deal with compatibility issues for prevo/evo-exclusive moves
+	 */
+	learnsetDomain?: string[] | null;
+	/**
 	 * Some Pokemon evolve by having a move in their learnset (like Piloswine
 	 * with Ancient Power). These can only carry three other moves from their
 	 * prevo, because the fourth move must be the evo move. This restriction
@@ -263,6 +268,13 @@ export class PokemonSources {
 				this.pomegEggMoves = other.pomegEggMoves;
 			} else {
 				this.pomegEggMoves.push(...other.pomegEggMoves);
+			}
+		}
+		if (other.learnsetDomain) {
+			if (!this.learnsetDomain) {
+				this.learnsetDomain = other.learnsetDomain;
+			} else {
+				this.learnsetDomain.filter(source => other.learnsetDomain?.includes(source));
 			}
 		}
 		if (this.possiblyLimitedEggMoves && !this.sourcesBefore) {
@@ -2417,6 +2429,7 @@ export class TeamValidator {
 		const format = this.format;
 		const ruleTable = this.ruleTable;
 		const level = set.level || 100;
+		const canLearnSpecies: ID[] = [];
 
 		let cantLearnReason = null;
 
@@ -2425,6 +2438,7 @@ export class TeamValidator {
 		let blockedHM = false;
 
 		let babyOnly = '';
+		let minLearnGen = dex.gen;
 
 		// This is a pretty complicated algorithm
 
@@ -2508,6 +2522,12 @@ export class TeamValidator {
 				//   teach it, and transfer it to the current gen.)
 
 				const learnedGen = parseInt(learned.charAt(0));
+				if (setSources.learnsetDomain && !setSources.learnsetDomain.includes(learnedGen + species.id)) {
+					if (!cantLearnReason) {
+						cantLearnReason = `is incompatible with ${(setSources.restrictiveMoves || []).join(', ')}.`;
+					}
+					continue;
+				}
 				if (learnedGen < this.minSourceGen) {
 					if (!cantLearnReason) {
 						cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${this.minSourceGen}.`;
@@ -2522,9 +2542,6 @@ export class TeamValidator {
 				}
 
 				if (formeCantInherit && (learned.charAt(1) !== 'E' || learnedGen < 9)) continue;
-
-				// redundant
-				if (learnedGen <= moveSources.sourcesBefore) continue;
 
 				if (
 					baseSpecies.evoRegion === 'Alola' && checkingPrevo && learnedGen >= 8 &&
@@ -2608,7 +2625,7 @@ export class TeamValidator {
 								setSources.babyOnly = babyOnly;
 							}
 						}
-						if (!moveSources.moveEvoCarryCount) return null;
+						if (!moveSources.moveEvoCarryCount && !setSources.babyOnly) return null;
 					}
 					// past-gen level-up, TM, or tutor moves:
 					//   available as long as the source gen was or was before this gen
@@ -2669,6 +2686,8 @@ export class TeamValidator {
 					}
 					moveSources.add(learned);
 				}
+				if (!canLearnSpecies.includes(species.id)) canLearnSpecies.push(species.id);
+				minLearnGen = Math.min(minLearnGen, learnedGen);
 			}
 			if (ruleTable.has('mimicglitch') && species.gen < 5) {
 				// include the Mimic Glitch when checking this mon's learnset
@@ -2751,6 +2770,32 @@ export class TeamValidator {
 						}
 					}
 				}
+			}
+		}
+
+		let nextSpecies;
+		nextSpecies = baseSpecies;
+		let speciesCount = 0;
+		if (!tradebackEligible) {
+			while (nextSpecies) {
+				for (let gen = nextSpecies.gen; gen <= dex.gen; gen++) {
+					/**
+					 * Case 1: The species can learn the move - allow moves of the species from all gens
+					 * Case 2: Both prevo and evo can learn the move - same as case 1
+					 * Case 3: Prevo-only move - allow moves of the species from the min gen and later
+					 * Case 4: Evo-only move - allow moves of the species from the max gen and before
+					*/
+					if (canLearnSpecies.includes(nextSpecies.id) ||
+						(0 < speciesCount && speciesCount < canLearnSpecies.length) ||
+						(speciesCount === 0 && gen >= minLearnGen) ||
+						(speciesCount === canLearnSpecies.length && gen <= moveSources.sourcesBefore)
+					) {
+						if (!moveSources.learnsetDomain) moveSources.learnsetDomain = [];
+						moveSources.learnsetDomain.push(gen + nextSpecies.id);
+					}
+				}
+				if (canLearnSpecies.includes(nextSpecies.id)) speciesCount++;
+				nextSpecies = dex.species.learnsetParent(nextSpecies);
 			}
 		}
 

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -200,4 +200,11 @@ describe('Team Validator', function () {
 		];
 		assert.false.legalTeam(team, 'gen8ou');
 	});
+
+	it('should disallow certain combinations of prevo/evo-exclusive moves', function () {
+		const team = [
+			{species: 'slowking', ability: 'oblivious', moves: ['counter', 'slackoff'], evs: {hp: 1}},
+		];
+		assert.false.legalTeam(team, 'gen7ou');
+	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/slowking-counter-slack-off.3751437/

The idea I had with this change is to find all the possible "evolution paths" a Pokemon can have through generations (eg. if a Slowpoke evolved to Slowking in Gen 4, it can have all Slowpoke moves from Gen 4 and earlier, and all Slowking moves from Gen 4 and later). So for the Slowking in the bug report, if it knows Slack Off, then all of the possible evolution paths includes anything that doesn't have Slowking in Gen 3, and conversely, having Counter would include all evolution paths that don't have Slowpoke in Gen 4 and later. Since having one of the two moves would exclude the other move from their "learnset domains", having both Counter and Slack Off means there is no possible evolution path that includes both moves, and as such it would be illegal. This logic is not applicable in formats with Gen 1-2 tradeback, and as such, learnset domains will not be generated at all in such formats (although this may need to be revisited for Gen 8-9's transfer system).

This also fixes https://www.smogon.com/forums/threads/dexsearch-with-natdex-has-different-results-based-on-param-order.3751467/