### PR TITLE
Clarify Special Rockruff evo time of day

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -13325,7 +13325,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Brown",
 		prevo: "Rockruff",
 		evoLevel: 25,
-		evoCondition: "from a special Rockruff",
+		evoCondition: "from a special Rockruff during the evening",
 		eggGroups: ["Field"],
 	},
 	wishiwashi: {


### PR DESCRIPTION
Rockruff with Own Tempo can only evolve during the evening which currently is not reflected in it's `evoCondition`.