### PR TITLE
Megas Revisited: Fix Mega BSTs over +100

### DIFF
--- a/data/mods/gen6megasrevisited/pokedex.ts
+++ b/data/mods/gen6megasrevisited/pokedex.ts
@@ -87,7 +87,7 @@ export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable 
 	sceptilemega: {
 		inherit: true,
 		types: ["Grass", "Dragon"],
-		baseStats: {hp: 75, atk: 95, def: 79, spa: 145, spd: 99, spe: 142},
+		baseStats: {hp: 70, atk: 95, def: 79, spa: 145, spd: 99, spe: 142},
 		abilities: {0: "Armor Tail"},
 	},
 	swampertmega: {
@@ -156,7 +156,7 @@ export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable 
 	ampharosmega: {
 		inherit: true,
 		types: ["Electric", "Dragon"],
-		baseStats: {hp: 90, atk: 95, def: 95, spa: 165, spd: 115, spe: 55},
+		baseStats: {hp: 90, atk: 95, def: 95, spa: 165, spd: 110, spe: 55},
 		abilities: {0: "Mega Launcher"},
 	},
 	gyaradosmega: {


### PR DESCRIPTION
Extremely minor bug fix for Megas Revisited, Mega Sceptile has +5 HP which it's not supposed to have and Mega Ampharos has +5 SpD that it wasn't supposed to have, resulting in BSTs that were above +100. 