### PR TITLE
GSC ZU: Ban Eevee, Beedrill, and Staryu

### DIFF
--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -42,7 +42,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	beedrill: {
-		tier: "ZU",
+		tier: "ZUBL",
 	},
 	pidgey: {
 		tier: "LC",
@@ -393,7 +393,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "PU",
 	},
 	staryu: {
-		tier: "ZU",
+		tier: "ZUBL",
 	},
 	starmie: {
 		tier: "OU",
@@ -444,7 +444,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "ZU",
 	},
 	eevee: {
-		tier: "ZU",
+		tier: "ZUBL",
 	},
 	vaporeon: {
 		tier: "OU",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/zu-old-gens-hub-gsc-quickban-slate-359.3646944/post-10274326