### PR TITLE
Shared Power: Fix source for Rest failure message

### DIFF
--- a/data/mods/sharedpower/moves.ts
+++ b/data/mods/sharedpower/moves.ts
@@ -15,23 +15,4 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			},
 		},
 	},
-	rest: {
-		inherit: true,
-		onTry(source) {
-			if (source.status === 'slp' || source.hasAbility('comatose')) return false;
-
-			if (source.hp === source.maxhp) {
-				this.add('-fail', source, 'heal');
-				return null;
-			}
-			if (source.hasAbility('insomnia')) {
-				this.add('-fail', source, '[from] ability: Insomnia', '[of] ' + source);
-				return null;
-			}
-			if (source.hasAbility('vitalspirit')) {
-				this.add('-fail', source, '[from] ability: Vital Spirit', '[of] ' + source);
-				return null;
-			}
-		},
-	},
 };

--- a/data/mods/sharedpower/moves.ts
+++ b/data/mods/sharedpower/moves.ts
@@ -33,5 +33,5 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				return null;
 			}
 		},
-	}
+	},
 };

--- a/data/mods/sharedpower/moves.ts
+++ b/data/mods/sharedpower/moves.ts
@@ -15,4 +15,23 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			},
 		},
 	},
+	rest: {
+		inherit: true,
+		onTry(source) {
+			if (source.status === 'slp' || source.hasAbility('comatose')) return false;
+
+			if (source.hp === source.maxhp) {
+				this.add('-fail', source, 'heal');
+				return null;
+			}
+			if (source.hasAbility('insomnia')) {
+				this.add('-fail', source, '[from] ability: Insomnia', '[of] ' + source);
+				return null;
+			}
+			if (source.hasAbility('vitalspirit')) {
+				this.add('-fail', source, '[from] ability: Vital Spirit', '[of] ' + source);
+				return null;
+			}
+		},
+	}
 };

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -15498,6 +15498,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				this.add('-fail', source, 'heal');
 				return null;
 			}
+			// insomnia and vital spirit checks are separate so that the message is accurate in multi-ability mods
 			if (source.hasAbility('insomnia')) {
 				this.add('-fail', source, '[from] ability: Insomnia', '[of] ' + source);
 				return null;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -15498,8 +15498,12 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				this.add('-fail', source, 'heal');
 				return null;
 			}
-			if (source.hasAbility(['insomnia', 'vitalspirit'])) {
-				this.add('-fail', source, '[from] ability: ' + source.getAbility().name, '[of] ' + source);
+			if (source.hasAbility('insomnia')) {
+				this.add('-fail', source, '[from] ability: Insomnia', '[of] ' + source);
+				return null;
+			}
+			if (source.hasAbility('vitalspirit')) {
+				this.add('-fail', source, '[from] ability: Vital Spirit', '[of] ' + source);
 				return null;
 			}
 		},


### PR DESCRIPTION
Fixes this bug report on Smogon: https://www.smogon.com/forums/threads/using-rest-with-multiple-abilities-attributes-wrong-ability.3752098/

Splits the insomnia/vital spirit check for rest into two checks for shared power, which negates the need to get the ability for the building of the protocol message.

Tested on both constructed SP and on random battles SP. The mod works differently between them, but both use this data so it works for both.