### PR TITLE
Properly validate cosmetic forms in learnsetDomain

### DIFF
--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -578,7 +578,7 @@ export class DexSpecies {
 		const movePool = new Set<ID>();
 		for (const {species, learnset} of this.getFullLearnset(id)) {
 			for (const moveid in learnset) {
-				eggMovesOnly = this.eggMovesOnly(species, this.get(id));
+				if (!eggMovesOnly) eggMovesOnly = this.eggMovesOnly(species, this.get(id));
 				if (eggMovesOnly) {
 					if (learnset[moveid].some(source => source.startsWith('9E'))) {
 						movePool.add(moveid as ID);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2779,6 +2779,9 @@ export class TeamValidator {
 		nextSpecies = baseSpecies;
 		let speciesCount = 0;
 		if (!tradebackEligible) {
+			if (!dex.species.getLearnsetData(nextSpecies.id).learnset) {
+				nextSpecies = dex.species.get(nextSpecies.changesFrom || nextSpecies.baseSpecies);
+			}
 			while (nextSpecies) {
 				for (let gen = nextSpecies.gen; gen <= dex.gen; gen++) {
 					/**

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -209,6 +209,7 @@ describe('Team Validator', function () {
 
 		team = [
 			{species: 'incineroar', ability: 'blaze', moves: ['knockoff', 'partingshot'], evs: {hp: 1}},
+			{species: 'shelloseast', ability: 'stickyhold', moves: ['infestation', 'stringshot'], evs: {hp: 1}},
 		];
 		assert.legalTeam(team, 'gen8ou');
 	});


### PR DESCRIPTION
https://www.smogon.com/forums/threads/shellos-east-has-weird-incompatible-moves-in-gen-9-natdex-draft.3752399/

Using the same logic that getFullLearnset uses.

Also fixes getMovePool so that the two different places that change eggMovesOnly do not override each other.