### PR TITLE
Add Gen 3 Draft

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -477,7 +477,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen3',
 		searchShow: false,
 		ruleset: ['Standard Draft', 'Swagger Clause', 'DryPass Clause', '!Team Preview'],
-		banlist: ['King\'s Rock', 'Quick Claw', 'Assist']
+		banlist: ['King\'s Rock', 'Quick Claw', 'Assist'],
 	},
 
 	// OM of the Month


### PR DESCRIPTION
Gen 3 draft format is needed for a Smogon Draft League tournament.

https://www.smogon.com/forums/threads/adv-cup-signups.3752743/