### PR TITLE
Dex*: Cache empty objects

### DIFF
--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -1,5 +1,6 @@
 import type {PokemonEventMethods, ConditionData} from './dex-conditions';
 import {BasicEffect, toID} from './dex-data';
+import {Utils} from '../lib';
 
 interface AbilityEventMethods {
 	onCheckShow?: (this: Battle, pokemon: Pokemon) => void;
@@ -66,6 +67,8 @@ export class Ability extends BasicEffect implements Readonly<BasicEffect> {
 	}
 }
 
+const EMPTY_ABILITY = Utils.deepFreeze(new Ability({id: '', name: '', exists: false}));
+
 export class DexAbilities {
 	readonly dex: ModdedDex;
 	readonly abilityCache = new Map<ID, Ability>();
@@ -77,12 +80,12 @@ export class DexAbilities {
 
 	get(name: string | Ability = ''): Ability {
 		if (name && typeof name !== 'string') return name;
-
-		const id = toID(name);
+		const id = toID(name.trim());
 		return this.getByID(id);
 	}
 
 	getByID(id: ID): Ability {
+		if (id === '') return EMPTY_ABILITY;
 		let ability = this.abilityCache.get(id);
 		if (ability) return ability;
 

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -1,3 +1,4 @@
+import {Utils} from '../lib';
 import {BasicEffect, toID} from './dex-data';
 import type {SecondaryEffect, MoveEventMethods} from './dex-moves';
 
@@ -633,7 +634,7 @@ export class Condition extends BasicEffect implements
 	}
 }
 
-const EMPTY_CONDITION: Condition = new Condition({name: '', exists: false});
+const EMPTY_CONDITION: Condition = Utils.deepFreeze(new Condition({name: '', exists: false}));
 
 export class DexConditions {
 	readonly dex: ModdedDex;
@@ -651,7 +652,7 @@ export class DexConditions {
 	}
 
 	getByID(id: ID): Condition {
-		if (!id) return EMPTY_CONDITION;
+		if (id === '') return EMPTY_CONDITION;
 
 		let condition = this.conditionCache.get(id);
 		if (condition) return condition;

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -145,6 +145,8 @@ export class Nature extends BasicEffect implements Readonly<BasicEffect & Nature
 	}
 }
 
+const EMPTY_NATURE = Utils.deepFreeze(new Nature({name: '', exists: false}));
+
 export interface NatureData {
 	name: string;
 	plus?: StatIDExceptHP;
@@ -167,10 +169,10 @@ export class DexNatures {
 
 	get(name: string | Nature): Nature {
 		if (name && typeof name !== 'string') return name;
-
 		return this.getByID(toID(name));
 	}
 	getByID(id: ID): Nature {
+		if (id === '') return EMPTY_NATURE;
 		let nature = this.natureCache.get(id);
 		if (nature) return nature;
 
@@ -274,6 +276,8 @@ export class TypeInfo implements Readonly<TypeData> {
 	}
 }
 
+const EMPTY_TYPE_INFO = Utils.deepFreeze(new TypeInfo({name: '', id: '', exists: false, effectType: 'EffectType'}));
+
 export class DexTypes {
 	readonly dex: ModdedDex;
 	readonly typeCache = new Map<ID, TypeInfo>();
@@ -290,6 +294,7 @@ export class DexTypes {
 	}
 
 	getByID(id: ID): TypeInfo {
+		if (id === '') return EMPTY_TYPE_INFO;
 		let type = this.typeCache.get(id);
 		if (type) return type;
 

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -1,5 +1,6 @@
 import type {PokemonEventMethods, ConditionData} from './dex-conditions';
 import {BasicEffect, toID} from './dex-data';
+import {Utils} from '../lib';
 
 interface FlingData {
 	basePower: number;
@@ -154,6 +155,8 @@ export class Item extends BasicEffect implements Readonly<BasicEffect> {
 	}
 }
 
+const EMPTY_ITEM = Utils.deepFreeze(new Item({name: '', exists: false}));
+
 export class DexItems {
 	readonly dex: ModdedDex;
 	readonly itemCache = new Map<ID, Item>();
@@ -165,13 +168,12 @@ export class DexItems {
 
 	get(name?: string | Item): Item {
 		if (name && typeof name !== 'string') return name;
-
-		name = (name || '').trim();
-		const id = toID(name);
+		const id = name ? toID(name.trim()) : '' as ID;
 		return this.getByID(id);
 	}
 
 	getByID(id: ID): Item {
+		if (id === '') return EMPTY_ITEM;
 		let item = this.itemCache.get(id);
 		if (item) return item;
 		if (this.dex.data.Aliases.hasOwnProperty(id)) {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -614,6 +614,8 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 	}
 }
 
+const EMPTY_MOVE = Utils.deepFreeze(new DataMove({name: '', exists: false}));
+
 export class DexMoves {
 	readonly dex: ModdedDex;
 	readonly moveCache = new Map<ID, Move>();
@@ -625,13 +627,12 @@ export class DexMoves {
 
 	get(name?: string | Move): Move {
 		if (name && typeof name !== 'string') return name;
-
-		name = (name || '').trim();
-		const id = toID(name);
+		const id = name ? toID(name.trim()) : '' as ID;
 		return this.getByID(id);
 	}
 
 	getByID(id: ID): Move {
+		if (id === '') return EMPTY_MOVE;
 		let move = this.moveCache.get(id);
 		if (move) return move;
 		if (this.dex.data.Aliases.hasOwnProperty(id)) {

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -1,3 +1,4 @@
+import {Utils} from '../lib';
 import {toID, BasicEffect} from './dex-data';
 
 interface SpeciesAbility {
@@ -355,6 +356,12 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 	}
 }
 
+const EMPTY_SPECIES = Utils.deepFreeze(new Species({
+	id: '', name: '', exists: false,
+	tier: 'Illegal', doublesTier: 'Illegal',
+	natDexTier: 'Illegal', isNonstandard: 'Custom',
+}));
+
 export class Learnset {
 	readonly effectType: 'Learnset';
 	/**
@@ -394,17 +401,21 @@ export class DexSpecies {
 	get(name?: string | Species): Species {
 		if (name && typeof name !== 'string') return name;
 
-		name = (name || '').trim();
-		let id = toID(name);
-		if (id === 'nidoran' && name.endsWith('♀')) {
-			id = 'nidoranf' as ID;
-		} else if (id === 'nidoran' && name.endsWith('♂')) {
-			id = 'nidoranm' as ID;
+		let id = '' as ID;
+		if (name) {
+			name = name.trim();
+			id = toID(name);
+			if (id === 'nidoran' && name.endsWith('♀')) {
+				id = 'nidoranf' as ID;
+			} else if (id === 'nidoran' && name.endsWith('♂')) {
+				id = 'nidoranm' as ID;
+			}
 		}
-
 		return this.getByID(id);
 	}
+
 	getByID(id: ID): Species {
+		if (id === '') return EMPTY_SPECIES;
 		let species: Mutable<Species> | undefined = this.speciesCache.get(id);
 		if (species) return species;
 


### PR DESCRIPTION
Use cached, deep frozen instances for lookups with empty IDs.

For me, `npm test` went from 16s to 10s.

Spun off from [this](https://github.com/smogon/pokemon-showdown/pull/10549#issuecomment-2403851844)

I also tried `./sim/dex-formats', but got this error.
```
  2116 passing (10s)
  87 pending
  1 failing

  1) Simulator abstraction layer features
       Battle
         should not get players out of sync in rated battles on rename:
     TypeError: Cannot assign to read only property 'ruleTable' of object '[object Object]'
      at DexFormats.getRuleTable (sim/dex-formats.ts:899:24)
      at Object.createBattle (server/rooms.ts:2188:32)
      at Context.<anonymous> (test/server/room-battle.js:27:17)
      at processImmediate (node:internal/timers:476:21)

```

And empty names are rarely passed to DexFormats.get(), at least during `npm run full-test`.