### PR TITLE
Dex: share dataCache entries when possible

### DIFF
--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -518,6 +518,16 @@ export class ModdedDex {
 			for (const dataType of DATA_TYPES) {
 				const parentTypedData: DexTable<any> = parentDex.data[dataType];
 				const childTypedData: DexTable<any> = dataCache[dataType] || (dataCache[dataType] = {});
+				// if child is empty and there's no Scripts.init, there's no need to copy, just re-use.
+				let childIsEmpty = true;
+				for (const k in childTypedData) { // eslint-disable-line @typescript-eslint/no-unused-vars
+					childIsEmpty = false;
+					break;
+				}
+				if (dataType !== 'Pokedex' && childIsEmpty && !Scripts.init) {
+					dataCache[dataType] = parentTypedData;
+					continue;
+				}
 				for (const entryId in parentTypedData) {
 					if (childTypedData[entryId] === null) {
 						// null means don't inherit


### PR DESCRIPTION
Spinoff of https://github.com/smogon/pokemon-showdown/pull/10549

Yet another simple change. Saves about 9 MB. That number could also be BS. Heap snapshot soon (TM).

Benchmark: 
```ts
console.log(process.memoryUsage());
const start = performance.now();
Dex.includeMods();
Dex.includeModData();
console.log(performance.now() - start);
console.log(process.memoryUsage());
```

Before:
```
{
  rss: 72876032,
  heapTotal: 21819392,
  heapUsed: 14359032,
  external: 2136062,
  arrayBuffers: 379495
}
1201.6942330002785
{
  rss: 343375872,
  heapTotal: 253513728,
  heapUsed: 227047504,     <--------
  external: 2141831,
  arrayBuffers: 341063
}
```

After:
```
{
  rss: 72695808,
  heapTotal: 22081536,
  heapUsed: 14419336,
  external: 2143886,
  arrayBuffers: 387319
}
1196.5219890028238
{
  rss: 325799936,
  heapTotal: 251940864,
  heapUsed: 218888848,     <--------
  external: 2178386,
  arrayBuffers: 327882
}

```

Further savings will come from removing the unconditional deep copying of Pokedex.  
It's OK if modData does a deep copy as needed, but to do it for every single entry of Pokedex is too much.

---

<details><summary>click for long list of mods that share dataCache entries with their parent</summary>

```
fullpotential Rulesets
fullpotential FormatsData
fullpotential Items
fullpotential Learnsets
fullpotential Moves
fullpotential Natures
fullpotential Conditions
fullpotential TypeChart
fullpotential PokemonGoData
gen8 Natures
gen8 Conditions
gen8 PokemonGoData
gen7 Learnsets
gen7 Natures
gen7 Conditions
gen7 TypeChart
gen7 PokemonGoData
gen6 Rulesets
gen6 Natures
gen6 PokemonGoData
gen5 Learnsets
gen5 Natures
gen5 PokemonGoData
gen4 Learnsets
gen4 Natures
gen4 TypeChart
gen4 PokemonGoData
gen2 Abilities
gen2 Natures
gen1jpn Abilities
gen1jpn FormatsData
gen1jpn Items
gen1jpn Learnsets
gen1jpn Natures
gen1rbycap Abilities
gen1rbycap Rulesets
gen1rbycap Items
gen1rbycap Natures
gen1stadium Abilities
gen1stadium Items
gen1stadium Learnsets
gen1stadium Natures
gen2stadium2 Abilities
gen2stadium2 FormatsData
gen2stadium2 Learnsets
gen2stadium2 Natures
gen4pt Abilities
gen4pt Rulesets
gen4pt Items
gen4pt Moves
gen4pt Natures
gen4pt Conditions
gen4pt TypeChart
gen4pt PokemonGoData
gen5bw1 Abilities
gen5bw1 Rulesets
gen5bw1 Moves
gen5bw1 Natures
gen5bw1 Conditions
gen5bw1 TypeChart
gen5bw1 PokemonGoData
gen6xy Abilities
gen6xy Rulesets
gen6xy Natures
gen6xy Conditions
gen6xy TypeChart
gen6xy PokemonGoData
gen7pokebilities Rulesets
gen7pokebilities FormatsData
gen7pokebilities Items
gen7pokebilities Learnsets
gen7pokebilities Natures
gen7pokebilities Conditions
gen7pokebilities TypeChart
gen7pokebilities PokemonGoData
gen7sm Abilities
gen7sm Rulesets
gen7sm Natures
gen7sm Conditions
gen7sm TypeChart
gen7sm PokemonGoData
gen8bdsp Rulesets
gen8bdsp Natures
gen8bdsp Conditions
gen8bdsp TypeChart
gen8bdsp PokemonGoData
gen8dlc1 Natures
gen8dlc1 Conditions
gen8dlc1 TypeChart
gen8dlc1 PokemonGoData
gen8linked Abilities
gen8linked Rulesets
gen8linked FormatsData
gen8linked Learnsets
gen8linked Natures
gen8linked TypeChart
gen8linked PokemonGoData
gen9dlc1 Rulesets
gen9dlc1 Natures
gen9dlc1 Scripts
gen9dlc1 Conditions
gen9dlc1 PokemonGoData
gen9predlc Rulesets
gen9predlc Natures
gen9predlc Conditions
gen9predlc TypeChart
gen9predlc PokemonGoData
gen9ssb FormatsData
gen9ssb Learnsets
gen9ssb Natures
gen9ssb PokemonGoData
partnersincrime Rulesets
partnersincrime FormatsData
partnersincrime Learnsets
partnersincrime Natures
partnersincrime Conditions
partnersincrime TypeChart
partnersincrime PokemonGoData
pokebilities Rulesets
pokebilities FormatsData
pokebilities Items
pokebilities Learnsets
pokebilities Natures
pokebilities Conditions
pokebilities TypeChart
pokebilities PokemonGoData
pokemoves Rulesets
pokemoves FormatsData
pokemoves Items
pokemoves Learnsets
pokemoves Natures
pokemoves Conditions
pokemoves TypeChart
pokemoves PokemonGoData
randomroulette Abilities
randomroulette Rulesets
randomroulette FormatsData
randomroulette Items
randomroulette Learnsets
randomroulette Moves
randomroulette Natures
randomroulette Conditions
randomroulette TypeChart
randomroulette PokemonGoData
sharedpower Rulesets
sharedpower FormatsData
sharedpower Items
sharedpower Learnsets
sharedpower Natures
sharedpower Conditions
sharedpower TypeChart
sharedpower PokemonGoData
sharingiscaring Abilities
sharingiscaring Rulesets
sharingiscaring FormatsData
sharingiscaring Learnsets
sharingiscaring Natures
sharingiscaring TypeChart
sharingiscaring PokemonGoData
trademarked Abilities
trademarked Rulesets
trademarked FormatsData
trademarked Items
trademarked Learnsets
trademarked Moves
trademarked Natures
trademarked Conditions
trademarked TypeChart
trademarked PokemonGoData
```
</details>