### PR TITLE
Dex: Don't `deepClone` Pokedex during load

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -17,8 +17,9 @@ export const Scripts: ModdedBattleScriptsData = {
 	gen: 1,
 	init() {
 		for (const i in this.data.Pokedex) {
-			(this.data.Pokedex[i] as any).gender = 'N';
-			(this.data.Pokedex[i] as any).eggGroups = null;
+			const poke = this.modData('Pokedex', i);
+			poke.gender = 'N';
+			poke.eggGroups = null;
 		}
 	},
 	// BattlePokemon scripts.

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -524,13 +524,7 @@ export class ModdedDex {
 						delete childTypedData[entryId];
 					} else if (!(entryId in childTypedData)) {
 						// If it doesn't exist it's inherited from the parent data
-						if (dataType === 'Pokedex') {
-							// Pokedex entries can be modified too many different ways
-							// e.g. inheriting different formats-data/learnsets
-							childTypedData[entryId] = this.deepClone(parentTypedData[entryId]);
-						} else {
-							childTypedData[entryId] = parentTypedData[entryId];
-						}
+						childTypedData[entryId] = parentTypedData[entryId];
 					} else if (childTypedData[entryId] && childTypedData[entryId].inherit) {
 						// {inherit: true} can be used to modify only parts of the parent data,
 						// instead of overwriting entirely


### PR DESCRIPTION
The only issue came from `gen1`'s `init` not using `modData`. After fixing that, everything just works. You can test this by deepFreezing dataCache right after running `Scripts.init` and then loading all the species for all the mods and running the test suite.