### PR TITLE
Fix invalid leave messages being sent on logout

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1031,7 +1031,7 @@ export abstract class BasicRoom {
 			const staffIntro = this.getStaffIntroMessage(user);
 			if (staffIntro) this.sendUser(user, staffIntro);
 		} else if (!user.named) {
-			this.reportJoin('l', oldid, user);
+			this.reportJoin('l', ' ' + oldid, user);
 		} else {
 			this.reportJoin('n', user.getIdentityWithStatus(this) + '|' + oldid, user);
 		}


### PR DESCRIPTION
As per PROTOCOL.md, users without a rank should have a space in place of where the rank should usually be:

> `USER` = a user, the first character being their rank (users with no rank are
> represented by a space), and the rest of the string being their username.

When the user logs out (via either /logout or clicking the "Log out" button), there is currently no space in the leave message sent.

As far as I can tell, this bug was [introduced in 2015 during a refactor](https://github.com/smogon/pokemon-showdown/commit/404520b5e1892ff66b2bea87222935279ced2ab6#diff-e8d83303f9dcd49b0865ba7f08d8b798e3b35b92d00e25eb86c257e5945feb25L1651).