### PR TITLE
Fix Pursuit's interaction with Terastal in NatDex formats.

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -14919,10 +14919,14 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 					if (source.canMegaEvo || source.canUltraBurst || source.canTerastallize) {
 						for (const [actionIndex, action] of this.queue.entries()) {
 							if (action.pokemon === source) {
-								if (action.choice === 'megaEvo') this.actions.runMegaEvo(source);
-								// Also a "forme" change that happens before moves, though only possible in NatDex
-								else if (action.choice === 'terastallize') this.actions.terastallize(source);
-								else continue;
+								if (action.choice === 'megaEvo') {
+									this.actions.runMegaEvo(source);
+								} else if (action.choice === 'terastallize') {
+									// Also a "forme" change that happens before moves, though only possible in NatDex
+									this.actions.terastallize(source);
+								} else {
+									continue;
+								}
 								this.queue.list.splice(actionIndex, 1);
 								break;
 							}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -14919,16 +14919,11 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 					if (source.canMegaEvo || source.canUltraBurst || source.canTerastallize) {
 						for (const [actionIndex, action] of this.queue.entries()) {
 							if (action.pokemon === source) {
-								switch (action.choice) {
-								case 'megaEvo':
+								if (action.choice === 'megaEvo') {
 									this.actions.runMegaEvo(source);
-									break;
-								// Also a "forme" change that happens before moves, though only possible in NatDex
-								case 'terastallize':
+								} else if (action.choice === 'terastallize') {
+									// Also a "forme" change that happens before moves, though only possible in NatDex
 									this.actions.terastallize(source);
-									break;
-								default:
-									continue;
 								}
 								this.queue.list.splice(actionIndex, 1);
 								break;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -14919,12 +14919,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 					if (source.canMegaEvo || source.canUltraBurst || source.canTerastallize) {
 						for (const [actionIndex, action] of this.queue.entries()) {
 							if (action.pokemon === source) {
-								if (action.choice === 'megaEvo') {
-									this.actions.runMegaEvo(source);
-								} else if (action.choice === 'terastallize') {
-									// Also a "forme" change that happens before moves, though only possible in NatDex
-									this.actions.terastallize(source);
-								}
+								if (action.choice === 'megaEvo') this.actions.runMegaEvo(source);
+								// Also a "forme" change that happens before moves, though only possible in NatDex
+								if (action.choice === 'terastallize') this.actions.terastallize(source);
 								this.queue.list.splice(actionIndex, 1);
 								break;
 							}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -14922,6 +14922,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 								if (action.choice === 'megaEvo') this.actions.runMegaEvo(source);
 								// Also a "forme" change that happens before moves, though only possible in NatDex
 								if (action.choice === 'terastallize') this.actions.terastallize(source);
+								else continue;
 								this.queue.list.splice(actionIndex, 1);
 								break;
 							}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -14921,7 +14921,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 							if (action.pokemon === source) {
 								if (action.choice === 'megaEvo') this.actions.runMegaEvo(source);
 								// Also a "forme" change that happens before moves, though only possible in NatDex
-								if (action.choice === 'terastallize') this.actions.terastallize(source);
+								else if (action.choice === 'terastallize') this.actions.terastallize(source);
 								else continue;
 								this.queue.list.splice(actionIndex, 1);
 								break;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -14916,10 +14916,20 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 					}
 					// Run through each action in queue to check if the Pursuit user is supposed to Mega Evolve this turn.
 					// If it is, then Mega Evolve before moving.
-					if (source.canMegaEvo || source.canUltraBurst) {
+					if (source.canMegaEvo || source.canUltraBurst || source.canTerastallize) {
 						for (const [actionIndex, action] of this.queue.entries()) {
-							if (action.pokemon === source && action.choice === 'megaEvo') {
-								this.actions.runMegaEvo(source);
+							if (action.pokemon === source) {
+								switch (action.choice) {
+								case 'megaEvo':
+									this.actions.runMegaEvo(source);
+									break;
+								// Also a "forme" change that happens before moves, though only possible in NatDex
+								case 'terastallize':
+									this.actions.terastallize(source);
+									break;
+								default:
+									continue;
+								}
 								this.queue.list.splice(actionIndex, 1);
 								break;
 							}

--- a/test/sim/moves/pursuit.js
+++ b/test/sim/moves/pursuit.js
@@ -20,6 +20,21 @@ describe(`Pursuit`, function () {
 		assert.fainted(battle.p2.active[0]);
 	});
 
+	it(`should execute before the target switches out and after the user Terastallizes`, function () {
+		battle = common.gen(9).createBattle([[
+			{species: "Kingambit", ability: 'defiant', moves: ['pursuit']},
+		], [
+			{species: "Giratina", ability: 'pressure', moves: ['shadow ball']},
+			{species: "Clefable", ability: 'unaware', moves: ['calmmind']},
+		]]);
+		const giratina = battle.p2.pokemon[0];
+		const hpBeforeSwitch = giratina.hp;
+		battle.makeChoices('move Pursuit terastallize', 'switch 2');
+		const damage = hpBeforeSwitch - giratina.hp;
+		// 0 Atk Tera Dark Kingambit switching boosted Pursuit (80 BP) vs. 0 HP / 0 Def Giratina: 256-304
+		assert.bounded(damage, [256, 304], 'Actual damage: ' + damage);
+	});
+
 	it(`should continue the switch in Gen 3`, function () {
 		battle = common.gen(3).createBattle([[
 			{species: "Tyranitar", ability: 'sandstream', moves: ['pursuit']},


### PR DESCRIPTION
Currently, when triggering on a target switching out, Pursuit will go first and THEN the user will Terastallize, which is counterintuitive at the very least.