### PR TITLE
Test: Remove repeated `JSON.stringify`s in `assertSetValidity`

### DIFF
--- a/test/random-battles/tools.js
+++ b/test/random-battles/tools.js
@@ -123,6 +123,7 @@ function testTeam(options, test) {
 function assertSetValidity(format, set) {
 	const dex = Dex.forFormat(format);
 	const species = dex.species.get(set.species || set.name);
+	const setString = JSON.stringify(set);
 
 	// According to Random Battles room staff, we should not ensure that HP IVs are valid for
 	// BSS formats. This is because level 100 Pokémon can be hypertrained
@@ -132,25 +133,25 @@ function assertSetValidity(format, set) {
 			.validateStats(set, species, new PokemonSources())
 			// Suppress errors about mistaken EV quantities
 			.filter(f => !f.includes(' EVs'));
-		assert.equal(valid.length, 0, `Invalid stats: ${valid} (set: ${JSON.stringify(set)})`);
+		assert.equal(valid.length, 0, `Invalid stats: ${valid} (set: ${setString})`);
 	}
 
 	// We check `dex.gen` here because Format#gen is 0 in the current gen, while ModdedDex#gen is never 0.
-	assert(species.exists, `The species "${species.name}" does not exist. (set: ${JSON.stringify(set)})`);
-	assert(species.gen <= dex.gen, `The species "${species.name}" is from a newer generation. (set: ${JSON.stringify(set)})`);
+	assert(species.exists, `The species "${species.name}" does not exist. (set: ${setString})`);
+	assert(species.gen <= dex.gen, `The species "${species.name}" is from a newer generation. (set: ${setString})`);
 
 	if (set.item) {
 		const item = dex.items.get(set.item);
-		assert(item.exists, `The item "${item.name}" does not exist. (set: ${JSON.stringify(set)})`);
-		assert(item.gen <= dex.gen, `The item "${item.name}" is from a newer generation. (set: ${JSON.stringify(set)})`);
+		assert(item.exists, `The item "${item.name}" does not exist. (set: ${setString})`);
+		assert(item.gen <= dex.gen, `The item "${item.name}" is from a newer generation. (set: ${setString})`);
 	}
 
 	if (set.ability && set.ability !== 'None') {
 		const ability = dex.abilities.get(set.ability);
-		assert(ability.exists, `The ability "${ability.name}" does not exist. (set: ${JSON.stringify(set)})`);
-		assert(ability.gen <= dex.gen, `The ability "${ability.name}" is from a newer generation. (set: ${JSON.stringify(set)})`);
+		assert(ability.exists, `The ability "${ability.name}" does not exist. (set: ${setString})`);
+		assert(ability.gen <= dex.gen, `The ability "${ability.name}" is from a newer generation. (set: ${setString})`);
 	} else {
-		assert(dex.gen < 3, `This set does not have an ability, but is intended for use in Gen 3 or later. (set: ${JSON.stringify(set)})`);
+		assert(dex.gen < 3, `This set does not have an ability, but is intended for use in Gen 3 or later. (set: ${setString})`);
 	}
 
 	// Arceus plate check
@@ -163,7 +164,7 @@ function assertSetValidity(format, set) {
 		assert(set.item.endsWith(' Plate'), `${species.name} doesn't have a Plate (got "${set.item}" instead)`);
 	}
 
-	assert(set.moves.filter(m => m.startsWith('hiddenpower')).length <= 1, `This set has multiple Hidden Power moves. (set: ${JSON.stringify(set)})`);
+	assert(set.moves.filter(m => m.startsWith('hiddenpower')).length <= 1, `This set has multiple Hidden Power moves. (set: ${setString})`);
 }
 
 /**


### PR DESCRIPTION
While working on #10616 , I've observed that several seconds are spent building strings in `assertSetValidity` from `./test/random-battles/tools.js`.

Stats:
249K calls

| stage | time (ms) |
| --- | --- |
| Baseline | 6858 |
| Pull out `JSON.stringify` | **3673** |
| Replace all strings with `''` | 2770 |

So, you can save up to another 1s by lazily constructing the strings. I decided to pass on that.

3 seconds doesn't seem like a lot right now, but with my local copy of #10616, I'm at ~135 seconds total. So, it adds up. And it's an easy change.

I could not produce similar gains for the other functions in that file, so I left them alone.