### PR TITLE
Data: Fix misspelled pokedex IDs

### DIFF
--- a/data/mods/gen5bw1/pokedex.ts
+++ b/data/mods/gen5bw1/pokedex.ts
@@ -219,7 +219,7 @@ export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable 
 		inherit: true,
 		unreleasedHidden: true,
 	},
-	lillpup: {
+	lillipup: {
 		inherit: true,
 		unreleasedHidden: true,
 	},
@@ -383,7 +383,7 @@ export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable 
 		inherit: true,
 		unreleasedHidden: true,
 	},
-	lillgant: {
+	lilligant: {
 		inherit: true,
 		unreleasedHidden: true,
 	},

--- a/data/mods/gen9ssb/pokedex.ts
+++ b/data/mods/gen9ssb/pokedex.ts
@@ -1146,7 +1146,7 @@ export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable 
 		abilities: {0: "Yellow Magic"},
 	},
 
-	ninetaleslola: {
+	ninetalesalola: {
 		inherit: true,
 		abilities: {0: "Party Up"},
 	},


### PR DESCRIPTION
Discovered while working on #10608

2 in `gen5bw1`, 1 in `gen9ssb`.

---

There are also two entries with `inherit: true` whose parent mods don't actually have a matching entry:
* `embodyaspect` in `gen9predlc`
* `flygonite` in `gen9ssb`

TBC, the inherit field sticks around at run-time - it never gets removed by `loadData` in `sim/dex.ts` because the parent mod has no such entry so you never reach that part of the code.

I couldn't just remove the `inherit` field because then Typescript complains. I think someone more familiar with `sim/` needs to put appropriate values for the fields of those two items. Or maybe they're working as intended. IDK. Just thought I'd let you know.