### PR TITLE
Test: Correct several format IDs

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -465,7 +465,7 @@ export class TeamValidator {
 		}
 
 		for (const rule of ruleTable.keys()) {
-			if ('!+-'.includes(rule.charAt(0))) continue;
+			if ('!+-*'.includes(rule.charAt(0))) continue;
 			const subformat = dex.formats.get(rule);
 			if (subformat.onValidateTeam && ruleTable.has(subformat.id)) {
 				problems = problems.concat(subformat.onValidateTeam.call(this, team, format, teamHas) || []);
@@ -615,7 +615,7 @@ export class TeamValidator {
 		const setSources = this.allSources(species);
 
 		for (const [rule] of ruleTable) {
-			if ('!+-'.includes(rule.charAt(0))) continue;
+			if ('!+-*'.includes(rule.charAt(0))) continue;
 			const subformat = dex.formats.get(rule);
 			if (subformat.onChangeSet && ruleTable.has(subformat.id)) {
 				problems = problems.concat(subformat.onChangeSet.call(this, set, format, setHas, teamHas) || []);
@@ -1046,7 +1046,7 @@ export class TeamValidator {
 		}
 
 		for (const [rule] of ruleTable) {
-			if ('!+-'.includes(rule.charAt(0))) continue;
+			if ('!+-*'.includes(rule.charAt(0))) continue;
 			const subformat = dex.formats.get(rule);
 			if (subformat.onValidateSet && ruleTable.has(subformat.id)) {
 				problems = problems.concat(subformat.onValidateSet.call(this, set, format, setHas, teamHas) || []);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -323,6 +323,9 @@ export class TeamValidator {
 	readonly toID: (str: any) => ID;
 	constructor(format: string | Format, dex = Dex) {
 		this.format = dex.formats.get(format);
+		if (this.format.exists === false || this.format.effectType !== 'Format') {
+			throw new Error("`format` should exist and be a format");
+		}
 		this.dex = dex.forFormat(this.format);
 		this.gen = this.dex.gen;
 		this.ruleTable = this.dex.formats.getRuleTable(this.format);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -323,8 +323,8 @@ export class TeamValidator {
 	readonly toID: (str: any) => ID;
 	constructor(format: string | Format, dex = Dex) {
 		this.format = dex.formats.get(format);
-		if (this.format.exists === false || this.format.effectType !== 'Format') {
-			throw new Error("`format` should exist and be a format");
+		if (this.format.effectType !== 'Format') {
+			throw new Error(`format should be a 'Format', but was a '${this.format.effectType}'`);
 		}
 		this.dex = dex.forFormat(this.format);
 		this.gen = this.dex.gen;

--- a/test/common.js
+++ b/test/common.js
@@ -42,7 +42,11 @@ class TestTools {
 	}
 
 	getFormat(options) {
-		if (options.formatid) return Dex.formats.get(options.formatid);
+		if (options.formatid) {
+			const format = Dex.formats.get(options.formatid);
+			if (!format.exists) throw new Error(`Unidentified format: ${options.formatid}`);
+			return format;
+		}
 
 		const gameType = Dex.toID(options.gameType || 'singles');
 		const customRules = [

--- a/test/common.js
+++ b/test/common.js
@@ -45,6 +45,7 @@ class TestTools {
 		if (options.formatid) {
 			const format = Dex.formats.get(options.formatid);
 			if (!format.exists) throw new Error(`Unidentified format: ${options.formatid}`);
+			if (format.effectType !== 'Format') throw new Error(`Has type '${format.effectType}' not 'Format': ${options.formatid}`);
 			return format;
 		}
 

--- a/test/common.js
+++ b/test/common.js
@@ -44,8 +44,7 @@ class TestTools {
 	getFormat(options) {
 		if (options.formatid) {
 			const format = Dex.formats.get(options.formatid);
-			if (!format.exists) throw new Error(`Unidentified format: ${options.formatid}`);
-			if (format.effectType !== 'Format') throw new Error(`Has type '${format.effectType}' not 'Format': ${options.formatid}`);
+			if (format.effectType !== 'Format') throw new Error(`Unidentified format: ${options.formatid}`);
 			return format;
 		}
 
@@ -78,7 +77,7 @@ class TestTools {
 		if (format) return format;
 
 		format = Dex.formats.get(formatName);
-		if (!format.exists) throw new Error(`Unidentified format: ${formatName}`);
+		if (format.effectType !== 'Format') throw new Error(`Unidentified format: ${formatName}`);
 
 		formatsCache.set(formatName, format);
 		return format;

--- a/test/common.js
+++ b/test/common.js
@@ -21,7 +21,7 @@ const DEFAULT_SEED = [0x09917, 0x06924, 0x0e1c8, 0x06af0];
 class TestTools {
 	constructor(mod = 'base') {
 		this.currentMod = mod;
-		this.dex = Dex.mod(mod);
+		this.dex = Dex.mod(mod).includeData(); // ensure that gen is initialized
 
 		this.modPrefix = this.dex.isBase ? `[gen9] ` : `[${mod}] `;
 	}

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -372,7 +372,7 @@ describe('[Gen 9] BSS Factory data should be valid (slow)', () => {
 		const genNum = 9;
 
 		for (const speciesid in setsJSON) {
-			const vType = 'battlestadiumsingles';
+			const vType = 'bssfactory';
 			let totalWeight = 0;
 			for (const set of setsJSON[speciesid].sets) {
 				totalWeight += set.weight;

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -304,8 +304,16 @@ describe('Battle Factory and BSS Factory data should be valid (slow)', () => {
 
 			for (const type in setsJSON) {
 				const typeTable = filename.includes('bss-factory-sets') ? setsJSON : setsJSON[type];
-				const vType = filename.includes('bss-factory-sets') ? `battle${genNum === 8 ? 'stadium' : 'spot'}singles` :
-					type === 'Mono' ? 'monotype' : type.toLowerCase();
+				let vType;
+				if (filename.includes('bss-factory-sets')) {
+					vType = `battle${genNum === 8 ? 'stadium' : 'spot'}singles`;
+				} else if (type === 'Mono') {
+					vType = 'monotype';
+				} else if (type === 'Uber') {
+					vType = 'ubers';
+				} else {
+					vType = type.toLowerCase();
+				}
 				for (const species in typeTable) {
 					const speciesData = typeTable[species];
 					for (const set of speciesData.sets) {

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -153,6 +153,10 @@ describe("New set format (slow)", () => {
 			filename: "gen9baby/sets",
 			roles: ["Fast Attacker", "Setup Sweeper", "Wallbreaker", "Tera Blast user", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support"],
 		},
+		"gen9randombattle@@@+cap": {
+			filename: "gen9cap/sets",
+			roles: ["Fast Attacker", "Setup Sweeper", "Wallbreaker", "Tera Blast user", "Bulky Attacker", "Bulky Setup", "Fast Bulky Setup", "Bulky Support", "Fast Support", "AV Pivot"],
+		},
 	};
 	for (const format of Object.keys(formatInfo)) {
 		const filename = formatInfo[format].filename;

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -380,7 +380,7 @@ describe('[Gen 9] BSS Factory data should be valid (slow)', () => {
 		const genNum = 9;
 
 		for (const speciesid in setsJSON) {
-			const vType = 'bssfactory';
+			const vType = 'bssregh';
 			let totalWeight = 0;
 			for (const set of setsJSON[speciesid].sets) {
 				totalWeight += set.weight;

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const assert = require('../assert');
+const common = require('../common');
 const {Utils} = require('../../dist/lib');
 const {testTeam, assertSetValidity, validateLearnset} = require('./tools');
 const {default: Dex} = require('../../dist/sim/dex');
@@ -156,10 +157,9 @@ describe("New set format (slow)", () => {
 	for (const format of Object.keys(formatInfo)) {
 		const filename = formatInfo[format].filename;
 		const setsJSON = require(`../../dist/data/random-battles/${filename}.json`);
-		const mod = filename.split('/')[0];
-		const genNum = parseInt(mod[3]);
+		const dex = common.mod(common.getFormat({formatid: format}).mod).dex; // verifies format exists
+		const genNum = dex.gen;
 		const rounds = 100;
-		const dex = Dex.forFormat(format);
 		it(`${filename}.json should have valid set data`, () => {
 			const validRoles = formatInfo[format].roles;
 			for (const [id, sets] of Object.entries(setsJSON)) {

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -152,10 +152,6 @@ describe("New set format (slow)", () => {
 			filename: "gen9baby/sets",
 			roles: ["Fast Attacker", "Setup Sweeper", "Wallbreaker", "Tera Blast user", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support"],
 		},
-		"gen9caprandombattle": {
-			filename: "gen9cap/sets",
-			roles: ["Fast Attacker", "Setup Sweeper", "Wallbreaker", "Tera Blast user", "Bulky Attacker", "Bulky Setup", "Fast Bulky Setup", "Bulky Support", "Fast Support", "AV Pivot"],
-		},
 	};
 	for (const format of Object.keys(formatInfo)) {
 		const filename = formatInfo[format].filename;

--- a/test/sim/misc/megaevolution.js
+++ b/test/sim/misc/megaevolution.js
@@ -163,7 +163,8 @@ describe('Mega Evolution', function () {
 			assertLegalButCantMega('gen9nationaldexag@@@-ndag');
 
 			// don't add it where unnecessary
-			assert.false(Dex.formats.getRuleTable(Dex.formats.get('gen4anythinggoes')).has('megarayquazaclause'));
+			const format = common.getFormat({formatid: 'gen4anythinggoes'});
+			assert.false(Dex.formats.getRuleTable(format).has('megarayquazaclause'));
 		});
 	});
 });

--- a/test/sim/misc/megaevolution.js
+++ b/test/sim/misc/megaevolution.js
@@ -163,7 +163,7 @@ describe('Mega Evolution', function () {
 			assertLegalButCantMega('gen9nationaldexag@@@-ndag');
 
 			// don't add it where unnecessary
-			assert.false(Dex.formats.getRuleTable(Dex.formats.get('gen5anythinggoes')).has('megarayquazaclause'));
+			assert.false(Dex.formats.getRuleTable(Dex.formats.get('gen4anythinggoes')).has('megarayquazaclause'));
 		});
 	});
 });

--- a/test/sim/team-validator/basic.js
+++ b/test/sim/team-validator/basic.js
@@ -81,9 +81,9 @@ describe('Team Validator', function () {
 		const team = [
 			{species: 'xerneas', ability: 'fairyaura', moves: ['snore'], ivs: {hp: 0, atk: 0, def: 0, spa: 0}, evs: {hp: 1}},
 		];
-		assert.false.legalTeam(team, 'gen8anythinggoes');
+		assert.false.legalTeam(team, 'gen9anythinggoes');
 
-		assert.legalTeam(team, 'gen8purehackmons');
+		assert.legalTeam(team, 'gen9purehackmons');
 	});
 
 	it('should reject non-existent natures', function () {
@@ -204,9 +204,9 @@ describe('Team Validator', function () {
 		const team = [
 			{species: 'corsola', ability: 'hustle', moves: ['snore', 'snore'], evs: {hp: 1}},
 		];
-		assert.false.legalTeam(team, 'gen8anythinggoes');
+		assert.false.legalTeam(team, 'gen9anythinggoes');
 
-		assert.legalTeam(team, 'gen8purehackmons');
+		assert.legalTeam(team, 'gen9purehackmons');
 	});
 
 	it('should accept VC moves only with Hidden ability and correct IVs', function () {


### PR DESCRIPTION

Found some instances where formats were being created w/ exists=false.
I made changes for the cases where a correct ID seemed obvious.
Those were:
* `gen6uber` -> `gen6ubers`
* `gen7uber` -> `gen7ubers`
* `gen9battlestadiumsingles` -> `gen9bssfactory` (test label mentions factory)
* `gen5anythinggoes` -> `gen4anythinggoes` (gen5 AG DNE)

---

<details><summary>Code for finding these</summary>

```ts
// top-level decls in ./sim/dex-formats.ts
const uniq_id = new Set();
const uniq_stack = new Set();

// ...

// inserted at bottom of Format constructor in ./sim/dex-formats.ts
if (!this.exists) {
        const stack = new Error().stack;
        if (!uniq_id.has(this.id) || !uniq_stack.has(stack)) {
                uniq_id.add(this.id);
                uniq_stack.add(stack);
                const ms = stack!.replace(/put-your-repo-path-here-or-comment-out/g, '.');
                console.log(`'${this.id}' : ${ms}`);
        }
}
```
</details>

---

Other instances of Formats where `exists == false`, may not be bugs.

<details><summary>Empty format names, seems intentional</summary>

```
'' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at Object.createBattle (./server/rooms.ts:2176:30)
    at Context.<anonymous> (./test/server/room-battle.js:27:17)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at GlobalRoomState.prepBattleRoom (./server/rooms.ts:1621:49)
    at Object.createBattle (./server/rooms.ts:2246:27)
    at Context.<anonymous> (./test/server/room-battle.js:27:17)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at new RoomBattle (./server/room-battle.ts:541:30)
    at Object.createBattle (./server/rooms.ts:2251:11)
    at Context.<anonymous> (./test/server/room-battle.js:27:17)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at new Battle (./sim/battle.ts:195:48)
    at RoomBattleStream._writeLine (./sim/battle-stream.ts:109:18)
    at RoomBattleStream._writeLines (./sim/battle-stream.ts:78:10)
    at RoomBattleStream._write (./server/room-battle.ts:1316:9)
    at RoomBattleStream.write (./lib/streams.ts:836:15)
    at new RoomBattle (./server/room-battle.ts:574:21)
    at Object.createBattle (./server/rooms.ts:2251:11)
    at Context.<anonymous> (./test/server/room-battle.js:27:17)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at new RoomBattleTimer (./server/room-battle.ts:191:30)
    at new RoomBattle (./server/room-battle.ts:599:16)
    at Object.createBattle (./server/rooms.ts:2251:11)
    at Context.<anonymous> (./test/server/room-battle.js:27:17)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at collectStats (./server/chat-plugins/randombattles/winrates.ts:176:29)
    at Object.onBattleEnd (./server/chat-plugins/randombattles/winrates.ts:169:8)
    at Object.runHandlers (./server/chat.ts:2083:11)
    at RoomBattle.end (./server/room-battle.ts:836:8)
    at RoomBattle.receive (./server/room-battle.ts:817:14)
    at RoomBattle.listen (./server/room-battle.ts:729:10)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```
</details>

<details><summary>'gen8purehackmons'</summary>

```
'gen8purehackmons' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at new TeamValidator (./sim/team-validator.ts:325:29)
    at Function.get (./sim/team-validator.ts:2845:10)
    at Function.assert.legalTeam (./test/assert.js:51:69)
    at Context.<anonymous> (./test/sim/team-validator/basic.js:86:10)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'gen8purehackmons' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at new TeamValidator (./sim/team-validator.ts:325:29)
    at Function.get (./sim/team-validator.ts:2845:10)
    at Function.assert.legalTeam (./test/assert.js:51:69)
    at Context.<anonymous> (./test/sim/team-validator/basic.js:209:10)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
```
</details>

<details><summary>'pokemontagrestrictedlegendary'</summary>

```
'pokemontagrestrictedlegendary' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at TeamValidator.validateSet (./sim/team-validator.ts:619:34)
    at TeamValidator.baseValidateTeam (./sim/team-validator.ts:416:60)
    at TeamValidator.validateTeam (./sim/team-validator.ts:345:15)
    at Function.assert.legalTeam (./test/assert.js:51:81)
    at Context.<anonymous> (./test/sim/team-validator/custom-rules.js:95:10)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'pokemontagrestrictedlegendary' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at TeamValidator.validateSet (./sim/team-validator.ts:1050:34)
    at TeamValidator.baseValidateTeam (./sim/team-validator.ts:416:60)
    at TeamValidator.validateTeam (./sim/team-validator.ts:345:15)
    at Function.assert.legalTeam (./test/assert.js:51:81)
    at Context.<anonymous> (./test/sim/team-validator/custom-rules.js:95:10)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'pokemontagrestrictedlegendary' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at TeamValidator.baseValidateTeam (./sim/team-validator.ts:469:34)
    at TeamValidator.validateTeam (./sim/team-validator.ts:345:15)
    at Function.assert.legalTeam (./test/assert.js:51:81)
    at Context.<anonymous> (./test/sim/team-validator/custom-rules.js:95:10)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'pokemontagrestrictedlegendary' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at TeamValidator.validateSet (./sim/team-validator.ts:619:34)
    at TeamValidator.baseValidateTeam (./sim/team-validator.ts:416:60)
    at TeamValidator.validateTeam (./sim/team-validator.ts:345:15)
    at assert.legalTeam (./test/assert.js:51:81)
    at Function.assert.false.<computed> [as legalTeam] (./test/assert.js:258:23)
    at Context.<anonymous> (./test/sim/team-validator/custom-rules.js:101:16)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'pokemontagrestrictedlegendary' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at TeamValidator.validateSet (./sim/team-validator.ts:1050:34)
    at TeamValidator.baseValidateTeam (./sim/team-validator.ts:416:60)
    at TeamValidator.validateTeam (./sim/team-validator.ts:345:15)
    at assert.legalTeam (./test/assert.js:51:81)
    at Function.assert.false.<computed> [as legalTeam] (./test/assert.js:258:23)
    at Context.<anonymous> (./test/sim/team-validator/custom-rules.js:101:16)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'pokemontagrestrictedlegendary' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at TeamValidator.baseValidateTeam (./sim/team-validator.ts:469:34)
    at TeamValidator.validateTeam (./sim/team-validator.ts:345:15)
    at assert.legalTeam (./test/assert.js:51:81)
    at Function.assert.false.<computed> [as legalTeam] (./test/assert.js:258:23)
    at Context.<anonymous> (./test/sim/team-validator/custom-rules.js:101:16)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
```
</details>


<details><summary>'gen9caprandombattle'</summary>

```
'gen9caprandombattle' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at ModdedDex.forFormat (./sim/dex.ts:178:28)
    at Suite.<anonymous> (./test/random-battles/all-gens.js:166:19)
    at Object.create (./node_modules/mocha/lib/interfaces/common.js:148:19)
    at context.describe.context.context (./node_modules/mocha/lib/interfaces/bdd.js:42:27)
    at Object.<anonymous> (./test/random-battles/all-gens.js:116:1)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1019:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.exports.requireOrImport (./node_modules/mocha/lib/esm-utils.js:42:12)
    at Object.exports.loadFilesAsync (./node_modules/mocha/lib/esm-utils.js:55:34)
    at singleRun (./node_modules/mocha/lib/cli/run-helpers.js:125:3)
    at Object.exports.handler (./node_modules/mocha/lib/cli/run.js:362:5)

'gen9caprandombattle' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at Teams2.getGenerator (./sim/teams.ts:620:24)
    at testTeam (./test/random-battles/tools.js:111:27)
    at Context.<anonymous> (./test/random-battles/all-gens.js:228:4)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
'gen9caprandombattle' : Error: 
    at new Format (./sim/dex-formats.ts:502:18)
    at DexFormats.get (./sim/dex-formats.ts:698:13)
    at Teams2.getGenerator (./sim/teams.ts:620:24)
    at Context.<anonymous> (./test/random-battles/all-gens.js:233:28)
    at callFn (./node_modules/mocha/lib/runnable.js:366:21)
    at Test.Runnable.run (./node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (./node_modules/mocha/lib/runner.js:677:10)
    at ./node_modules/mocha/lib/runner.js:801:12
    at next (./node_modules/mocha/lib/runner.js:594:14)
    at ./node_modules/mocha/lib/runner.js:604:7
    at next (./node_modules/mocha/lib/runner.js:486:14)
    at Immediate._onImmediate (./node_modules/mocha/lib/runner.js:572:5)
    at processImmediate (node:internal/timers:476:21)
```
</details>

