### PR TITLE
Handle 25 hour days correctly

### DIFF
--- a/server/chat-plugins/daily-spotlight.ts
+++ b/server/chat-plugins/daily-spotlight.ts
@@ -52,7 +52,7 @@ function nextDaily() {
 
 const midnight = new Date();
 midnight.setHours(24, 0, 0, 0);
-let timeout = setTimeout(nextDaily, midnight.valueOf() - Date.now());
+let timeout = setTimeout(nextDaily, midnight.getTime() - Date.now());
 
 export async function renderSpotlight(roomid: RoomID, key: string, index: number) {
 	let imgHTML = '';

--- a/server/chat-plugins/seasons.ts
+++ b/server/chat-plugins/seasons.ts
@@ -228,8 +228,7 @@ export function rollTimer() {
 	void updateBadgeholders();
 	const time = Date.now();
 	const next = new Date();
-	next.setHours(next.getHours() + 1);
-	next.setMinutes(0, 0, 0);
+	next.setHours(next.getHours() + 1, 0, 0, 0);
 	updateTimeout = setTimeout(() => rollTimer(), next.getTime() - time);
 
 	const discussionRoom = Rooms.search('seasondiscussion');

--- a/server/private-messages/index.ts
+++ b/server/private-messages/index.ts
@@ -140,8 +140,8 @@ export const PrivateMessages = new class {
 		if (!PM.isParentProcess) return null!;
 		const time = Date.now();
 		// even though we expire once a week atm, we check once a day
-		const nextMidnight = new Date(time + 24 * 60 * 60 * 1000);
-		nextMidnight.setHours(0, 0, 1);
+		const nextMidnight = new Date();
+		nextMidnight.setHours(24, 0, 0, 0);
 		if (this.clearInterval) clearTimeout(this.clearInterval);
 		this.clearInterval = setTimeout(() => {
 			void this.clearOffline();

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -327,8 +327,8 @@ export class Roomlog {
 			log.setupRoomlogStream();
 		}
 		const time = Date.now();
-		const nextMidnight = new Date(time + 24 * 60 * 60 * 1000);
-		nextMidnight.setHours(0, 0, 1);
+		const nextMidnight = new Date();
+		nextMidnight.setHours(24, 0, 0, 0);
 		Roomlogs.rollLogTimer = setTimeout(() => Roomlog.rollLogs(), nextMidnight.getTime() - time);
 	}
 	truncate() {


### PR DESCRIPTION
`server/chat-plugins/daily-spotlight.ts` shows how to correctly find next midnight, although it uses `valueOf` instead of `getTime` which I assume would be preferred, so I updated that.

`server/chat-plugins/seasons.ts` doesn't make use of all four arguments to `setHours` when it could, so I fixed that while I was checking for misuses of `setHours`.

`server/private-messages/index.ts` and `server/roomlogs.ts` both try to find next midnight by adding 86400 seconds and then rewinding to 00:00:01, but this doesn't work in days with DST transitions as they don't have 24 hours, so I ported the code from `server/chat-plugins/daily-spotlight.ts`.