### PR TITLE
Change default value of FormatEffectType to Rule

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -1869,7 +1869,7 @@ export const commands: Chat.ChatCommands = {
 
 		if (!this.runBroadcast(`!formathelp ${format ? format.id : target}`)) return;
 
-		if (format && format.exists) {
+		if (format?.exists) {
 			const rules: string[] = [];
 			let rulesetHtml = '';
 			if (['Format', 'Rule', 'ValidatorRule'].includes(format.effectType)) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -1869,7 +1869,7 @@ export const commands: Chat.ChatCommands = {
 
 		if (!this.runBroadcast(`!formathelp ${format ? format.id : target}`)) return;
 
-		if (format) {
+		if (format && format.exists) {
 			const rules: string[] = [];
 			let rulesetHtml = '';
 			if (['Format', 'Rule', 'ValidatorRule'].includes(format.effectType)) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -320,7 +320,7 @@ export abstract class MessageContext {
 		}
 
 		const format = Dex.formats.get(formatOrMod);
-		if (format.effectType === 'Format' || allowRules && format.effectType === 'Rule') {
+		if (format.exists && (format.effectType === 'Format' || allowRules && format.effectType === 'Rule')) {
 			return {dex: Dex.forFormat(format), format: format, isMatch: true};
 		}
 

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -15,7 +15,7 @@ export type ModdedFormatData = FormatData | Omit<FormatData, 'name'> & {inherit:
 export interface FormatDataTable {[id: IDEntry]: FormatData}
 export interface ModdedFormatDataTable {[id: IDEntry]: ModdedFormatData}
 
-type FormatEffectType = 'Format' | 'Ruleset' | 'Rule' | 'ValidatorRule';
+type FormatEffectType = 'Condition' | 'Format' | 'Ruleset' | 'Rule' | 'ValidatorRule';
 
 /** rule, source, limit, bans */
 export type ComplexBan = [string, string, number, string[]];
@@ -480,7 +480,7 @@ export class Format extends BasicEffect implements Readonly<BasicEffect> {
 		super(data);
 
 		this.mod = Utils.getString(data.mod) || 'gen9';
-		this.effectType = Utils.getString(data.effectType) as FormatEffectType || 'Format';
+		this.effectType = Utils.getString(data.effectType) as FormatEffectType || 'Condition';
 		this.debug = !!data.debug;
 		this.rated = (typeof data.rated === 'string' ? data.rated : data.rated !== false);
 		this.gameType = data.gameType || 'singles';

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -15,7 +15,7 @@ export type ModdedFormatData = FormatData | Omit<FormatData, 'name'> & {inherit:
 export interface FormatDataTable {[id: IDEntry]: FormatData}
 export interface ModdedFormatDataTable {[id: IDEntry]: ModdedFormatData}
 
-type FormatEffectType = 'Condition' | 'Format' | 'Ruleset' | 'Rule' | 'ValidatorRule';
+type FormatEffectType = 'Format' | 'Rule' | 'ValidatorRule';
 
 /** rule, source, limit, bans */
 export type ComplexBan = [string, string, number, string[]];
@@ -480,7 +480,7 @@ export class Format extends BasicEffect implements Readonly<BasicEffect> {
 		super(data);
 
 		this.mod = Utils.getString(data.mod) || 'gen9';
-		this.effectType = Utils.getString(data.effectType) as FormatEffectType || 'Condition';
+		this.effectType = Utils.getString(data.effectType) as FormatEffectType || 'Rule';
 		this.debug = !!data.debug;
 		this.rated = (typeof data.rated === 'string' ? data.rated : data.rated !== false);
 		this.gameType = data.gameType || 'singles';


### PR DESCRIPTION
Also updates the default value in the Format constructor, ~~which doesn't actually have any runtime effect, since Format extends BasicEffect, but this commit clarifies the behavior.~~

Thanks to @larry-the-table-guy for valuable discussions leading to finding this issue.