### PR TITLE
Dex/`loadData`: Merge objects w/ spread syntax

### DIFF
--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -535,10 +535,7 @@ export class ModdedDex {
 						delete childTypedData[entryId].inherit;
 
 						// Merge parent into children entry, preserving existing childs' properties.
-						for (const key in parentTypedData[entryId]) {
-							if (key in childTypedData[entryId]) continue;
-							childTypedData[entryId][key] = parentTypedData[entryId][key];
-						}
+						childTypedData[entryId] = {...parentTypedData[entryId], ...childTypedData[entryId]};
 					}
 				}
 			}


### PR DESCRIPTION
Results in fewer object shapes.

Similar to #10608. Smaller effect, but very easy change.

`loadData` and `construct all` are in milliseconds.
`heap 1` is MB after loading data for all mods (`after`)
`heap 2` is MB after constructing objects for all mods (`aftest`)


| Stage            | loadData | construct all | heap 1 | heap 2 |
| ---------------- | -------- | ------------- | ------ | ------ |
| Baseline         |     1261 |          3421 |    174 |    277 |
| just loadData (this PR)    |     1265 |          3052 |    171 |    268 |
| just field order (other PR) |     1274 |          2197 |    174 |    263 |
| both PRs            |     1264 |          2064 |    171 |    260 |

---

<details><summary>Benchmark code</summary>

Inserted at bottom of `./sim/dex.ts`

```ts
const v8 = require('v8');
v8.writeHeapSnapshot(); // before
const start1 = performance.now();
Dex.includeMods();
Dex.includeModData();
const loaded_data_t = performance.now();
v8.writeHeapSnapshot(); // after
const start2 = performance.now();
for (const d in dexes) {
        if (d === 'base') continue;
        const m = dexes[d];
        m.species.all();
        m.moves.all();
        m.items.all();
        m.abilities.all();
        m.types.all();
        m.natures.all();
}
const constructed_t = performance.now();
v8.writeHeapSnapshot(); // aftest

console.log('loadDatas', loaded_data_t - start1);
console.log('constructors', constructed_t - start2);
throw new Error('stop early');
```
</details>