### PR TITLE
Preload data when using Dex.mod

### DIFF
--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -165,7 +165,7 @@ export class ModdedDex {
 
 	mod(mod: string | undefined): ModdedDex {
 		if (!dexes['base'].modsLoaded) dexes['base'].includeMods();
-		return dexes[mod || 'base'];
+		return dexes[mod || 'base'].includeData();
 	}
 
 	forGen(gen: number) {

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -6,8 +6,8 @@ describe('Mod loader', function () {
 	it('should always provide accurate gen information', function () {
 		{
 			const Dex = require('./../../dist/sim/dex').Dex;
-			assert.equal(Dex.forFormat('gen1randombattle').gen, 1);
 			assert.equal(Dex.mod('gen2').gen, 2);
+			assert.equal(Dex.forFormat('gen1randombattle').gen, 1);
 		}
 	});
 

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -3,6 +3,14 @@
 const assert = require('./../assert');
 
 describe('Mod loader', function () {
+	it('should always provide accurate gen information', function () {
+		{
+			const Dex = require('./../../dist/sim/dex').Dex;
+			assert.equal(Dex.forFormat('gen1randombattle').gen, 1);
+			assert.equal(Dex.mod('gen2').gen, 2);
+		}
+	});
+
 	it('should work fine in any order', function () {
 		{
 			const Dex = require('./../../dist/sim/dex').Dex;


### PR DESCRIPTION
With the initial introduction fo TypeScript at 3716f36, ``Dex.mod``, and ``Dex.format`` (nowadays ``Dex.forFormat``) no longer ensured that the data cache has been filled.

Newer lazy-loading getter APIs were introduced, which were intended to be used as a replacement for direct access to the loaded data (``dataCache``).

However, these APIs were either not effective or not properly used., as reflected by 43ef4d9, which reverted ``Dex.forFormat`` to its full capabilities.

Nevertheless, ``Dex.mod`` was left untouched, which results in a footgun where ``Dex.forFormat('gen1randbats').gen == 1``, but ``Dex.mod('gen1').gen == 9`` - when ran from different processes.

This commit brings back ``Dex.mod`` to its original behavior, so that gen information is always there when it's needed.

Thanks to @larry-the-table-guy for reporting this issue.