### PR TITLE
Items: Add descriptions for Strange Ball

### DIFF
--- a/data/text/items.ts
+++ b/data/text/items.ts
@@ -1767,7 +1767,7 @@ export const ItemsText: {[id: IDEntry]: ItemText} = {
 	},
 	strangeball: {
 		name: "Strange Ball",
-		shortDesc: "Placeholder if caught in Pokéball not in current game."
+		shortDesc: "Placeholder if caught in Poke Ball not in current game.",
 	},
 	strawberrysweet: {
 		name: "Strawberry Sweet",

--- a/data/text/items.ts
+++ b/data/text/items.ts
@@ -1765,6 +1765,10 @@ export const ItemsText: {[id: IDEntry]: ItemText} = {
 		name: "Stone Plate",
 		shortDesc: "Holder's Rock-type attacks have 1.2x power. Judgment is Rock type.",
 	},
+	strangeball: {
+		name: "Strange Ball",
+		shortDesc: "Placeholder if caught in Pokéball not in current game."
+	},
 	strawberrysweet: {
 		name: "Strawberry Sweet",
 		shortDesc: "Evolves Milcery into Alcremie when held and spun around.",


### PR DESCRIPTION
I think this is the only item that doesn't have a description? Was adding types for ps-client and found this

https://bulbapedia.bulbagarden.net/wiki/Strange_Ball for reference