### PR TITLE
Foresighters: Fix Beat Up crash

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1223,7 +1223,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'Sand Veil', 'Snow Cloak', 'King\'s Rock', 'Razor Fang', 'Baton Pass', 'Dire Claw', 'Last Respects', 'Shed Tail',
 		],
 		restricted: [
-			'Beat Up', 'Belly Drum', 'Clangorous Soul', 'Dragon Dance', 'Endeavor', 'Quiver Dance', 'Shell Smash', 'Shift Gear', 'Tail Glow', 'Tidy Up', 'Victory Dance',
+			'Belly Drum', 'Clangorous Soul', 'Dragon Dance', 'Endeavor', 'Quiver Dance', 'Shell Smash', 'Shift Gear', 'Tail Glow', 'Tidy Up', 'Victory Dance',
 		],
 		onValidateSet(set) {
 			const fsMove = this.dex.moves.get(set.moves[0]);
@@ -1243,6 +1243,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 					const moveData = this.dex.getActiveMove(move.id);
 					moveData.flags['futuremove'] = 1;
 					delete moveData.flags['protect'];
+					if (moveData.id === 'beatup') this.singleEvent('ModifyMove', moveData, null, pokemon, null, null, moveData);
 					Object.assign(t.side.slotConditions[t.position]['futuremove'], {
 						duration: 3,
 						move: moveData.id,


### PR DESCRIPTION
Note: Beat Up should not be restricted per https://www.smogon.com/forums/threads/foresighters.3735969/

Tested on input log:
```
>version 2425f1364de080346313a8917b8af0a0670d3b0a
>start {"formatid":"gen9challengecup6v6@@@foresighters,!terastalclause","seed":[48563,14448,799,11852],"rated":"Tournament battle"}
>player p1 {"name":"WooperLeTrooper","avatar":"ingo","rating":0,"seed":[55809,21582,33203,21290]}
>player p2 {"name":"articoo ☾","avatar":"#rbtt6teamchienpao","rating":0,"seed":[37796,6425,56933,50247]}
>chat ☆articoo ☾|glhf
>chat ☆WooperLeTrooper|hai articoo~
>chat ☆WooperLeTrooper|u2
>chat  Grimora|Yay wooper won
>chat  Grimora|Wooper you better clutch up this entire tourney
>chat ☆WooperLeTrooper|Nah
>chat ☆WooperLeTrooper|I'd lose
>p1 team 6, 2, 3, 4, 5, 1
>p2 team 1, 2, 3, 4, 5, 6
>p1 move beatup
>p2 move aerialace
>p1 switch 6
>p2 switch 2
>p1 move charm
>p2 move bulldoze
```