### PR TITLE
Fix Acupressure target resolution

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2284,6 +2284,9 @@ export class Battle {
 					return target;
 				}
 				if (target.isAlly(pokemon)) {
+					if (move.target === 'adjacentAllyOrSelf' && this.gen !== 5) {
+						return pokemon;
+					}
 					// Target is a fainted ally: attack shouldn't retarget
 					return target;
 				}

--- a/test/sim/moves/acupressure.js
+++ b/test/sim/moves/acupressure.js
@@ -37,4 +37,35 @@ describe('Acupressure', function () {
 		assert.cantMove(() => battle.choose('p1', 'move acupressure 2'));
 		assert.cantMove(() => battle.choose('p1', 'move acupressure -2'));
 	});
+
+	// https://www.smogon.com/forums/threads/acupressure-targeting.3733779/post-9920405
+	it(`should redirect to the user if a targetted ally faints`, () => {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Pincurchin', moves: ['acupressure']},
+			{species: 'Flutter Mane', moves: ['memento']},
+		], [
+			{species: 'Furret', moves: ['sleeptalk']},
+			{species: 'Chien-Pao', moves: ['haze']},
+		]]);
+
+		battle.makeChoices('move acupressure -2, move memento 1', 'auto');
+		assert(Object.values(battle.p1.active[0].boosts).some(n => n === 2));
+		battle.makeChoices('move acupressure -2, pass', 'auto');
+		assert(Object.values(battle.p1.active[0].boosts).some(n => n === 2));
+	});
+
+	it(`in Gen 5, should not redirect to the uesr if a targetted ally faints`, () => {
+		battle = common.gen(5).createBattle({gameType: 'doubles'}, [[
+			{species: 'Shuckle', moves: ['acupressure']},
+			{species: 'Dugtrio', moves: ['memento']},
+		], [
+			{species: 'Marshtomp', moves: ['sleeptalk']},
+			{species: 'Nincada', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move acupressure -2, move memento 1', 'auto');
+		assert(Object.values(battle.p1.active[0].boosts).every(n => n === 0));
+		battle.makeChoices('move acupressure -2, pass', 'auto');
+		assert(Object.values(battle.p1.active[0].boosts).every(n => n === 0));
+	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/acupressure-targeting.3733779/

Technically not 100% accurate, as targetting a fainted slot in gen 4 should be disabled completely, but I think this is fine because there shouldn't be any way to revive an ally between choosing and using the move