### PR TITLE
Sim/`DexMoves`: Deduplicate `DataMove` against parent mod

### DIFF
--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -656,13 +656,14 @@ export class DexMoves {
 				(move as any).isNonstandard = 'Future';
 			}
 			if (this.dex.parentMod) {
-				const parent = this.dex.mod(this.dex.parentMod);
-				const parentMove = parent.moves.getByID(id);
-				if (moveData === parent.data.Moves[id] &&
-				    move.isNonstandard === parentMove.isNonstandard &&
-				    move.desc === parentMove.desc &&
-				    move.shortDesc === parentMove.shortDesc) {
-					move = parentMove;
+				const parentMod = this.dex.mod(this.dex.parentMod);
+				if (moveData === parentMod.data.Moves[id]) {
+					const parentMove = parentMod.moves.getByID(id);
+					if (move.isNonstandard === parentMove.isNonstandard &&
+					    move.desc === parentMove.desc &&
+					    move.shortDesc === parentMove.shortDesc) {
+						move = parentMove;
+					}
 				}
 			}
 		} else {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -656,6 +656,7 @@ export class DexMoves {
 				(move as any).isNonstandard = 'Future';
 			}
 			if (this.dex.parentMod) {
+				// If move is exactly identical to parentMod's move, reuse parentMod's copy
 				const parentMod = this.dex.mod(this.dex.parentMod);
 				if (moveData === parentMod.data.Moves[id]) {
 					const parentMove = parentMod.moves.getByID(id);

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -655,6 +655,16 @@ export class DexMoves {
 			if (move.gen > this.dex.gen) {
 				(move as any).isNonstandard = 'Future';
 			}
+			if (this.dex.parentMod) {
+				const parent = this.dex.mod(this.dex.parentMod);
+				const parentMove = parent.moves.getByID(id);
+				if (moveData === parent.data.Moves[id] &&
+				    move.isNonstandard === parentMove.isNonstandard &&
+				    move.desc === parentMove.desc &&
+				    move.shortDesc === parentMove.shortDesc) {
+					move = parentMove;
+				}
+			}
 		} else {
 			move = new DataMove({
 				name: id, exists: false,


### PR DESCRIPTION
Dedup for `DataMove`.
	
`ret size`: Retained Size column in Chrome dev tools memory tab. "Size of the object plus the graph it retains"

| stage | `DexMoves` ret size | `DataMove` ret size | `allMods.moves.all()` | total heap size |
| --- | ---- | ----- | --- | --- |
| Baseline | 24.345 MB | 22.747 MB | 475 ms | 260 MB |
| dedup moves | 3.3 MB | 3.0 MB | 402 ms | 240 MB |

36344 -> 4968 instances of `DataMove`.

I was really shocked to find that it loads faster - it's running **more** code.
I'm guessing the 86% dedup rate means that so much less memory (which now never leaves the 'young gen') had to be copied by the GC, so maybe that's where the time savings come from? 
The first couple paragraphs of [this v8 blogpost](https://v8.dev/blog/orinoco-parallel-scavenger) explain the role of the young gen in GCs.

[Earlier tests](https://github.com/smogon/pokemon-showdown/pull/10549#issuecomment-2407772806) indicate that this strategy can, at best, yield 4739 instances of `DataMove`, and Chrome's UI indicates that there are 4968 instances of DataMove. That test was over a month ago, so maybe some mods changed? Anyway, we're in the right ballpark. Oh, the other cause could be overuse of `modData`, which does a deep copy. The earlier test uses deep equality but this impl uses shallow equality (much cheaper, but has false negatives (safe for correctness)). Maybe there's some script that calls `modData` but doesn't actually modify the move. Not a big deal atm.

---

You can save a further 15% in time (and <1 MB) by also doing this:

```ts
all(): readonly Move[] {
        if (this.allCache) return this.allCache;
        // BEGIN NEW
        if (this.dex.parentMod) {
                const parent = this.dex.mod(this.dex.parentMod);
                if (this.dex.data.Moves === parent.data.Moves && this.dex.gen === parent.gen) {
                        this.allCache = parent.moves.all();
                        this.moveCache = parent.moves.moveCache;
                        return this.allCache;
                }
        }
        // END NEW
        const moves = [];
        for (const id in this.dex.data.Moves) {
                moves.push(this.getByID(id as ID));
        }
        this.allCache = Object.freeze(moves);
        return this.allCache;
}
```

I left it out bc imo this is a better fit for when all objects are constructed during DexMoves constructor, but that requires lazy mod loading. Constructing all the objects upfront in DexMoves' ctor keeps the logic in one place, and is likely to be faster.

---

<details><summary>bench code</summary>

Inserted at the bottom of `sim/dex.ts`

```ts
// const v8 = require('v8'); // uncomment the two v8 lines to do a heap snapshot which you can inspect with Chrome.
Dex.includeMods();
Dex.includeModData();
for (const e of ['abilities', 'species', 'moves', 'items', 'types', 'natures']) {
        const start = performance.now();
        for (const d in dexes) {
                if (d === 'base') continue;
                const m = dexes[d];
                m[e].all();
        }
        console.log(e, performance.now() - start);
}
// v8.writeHeapSnapshot();
throw new Error('stop early');
```

</details>

---

<details><summary>load time for all other Dex component</summary>

Note: in a similar PR I left in the `v8.writeHeapSnapshot` calls when measuring the time 
for `.all()`s. For whatever reason, that noticeably slows down the `.all()`s. So, that's
why these numbers add up to a much smaller time than the total time recorded in the other PR.

Time in milliseconds.
These times were consistent with repeated runs.

```
// without dedup
abilities 96.11295000091195
species 713.9901599995792
moves 475.5642639994621
items 132.09175600111485
types 1.7992599979043007
natures 2.300714001059532

// with dedup (this PR)
abilities 96.6237739995122
species 716.0696760006249
moves 402.00951999798417
items 131.15769999846816
types 1.6965250000357628
natures 2.189902000129223


// also with same-gen dedup in .all() 
abilities 95.16279899701476
species 700.7795180007815
moves 343.8259319998324
items 127.67007499933243
types 1.6952290013432503
natures 2.1241800002753735
```

</details>