### PR TITLE
Formats: Remove leading space in ' ND LC'

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2229,7 +2229,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'Sleep Clause Mod', 'Forme Clause', 'Z-Move Clause', 'Terastal Clause', 'Mega Rayquaza Clause',
 		],
 		banlist: [
-			'ND Uber', 'ND AG', 'ND OU', 'ND UUBL', 'ND UU', 'ND RUBL', 'ND RU', 'ND NFE', ' ND LC',
+			'ND Uber', 'ND AG', 'ND OU', 'ND UUBL', 'ND UU', 'ND RUBL', 'ND RU', 'ND NFE', 'ND LC',
 			'Battle Bond', 'Moody', 'Shadow Tag', 'Berserk Gene', 'King\'s Rock', 'Quick Claw', 'Razor Fang', 'Acupressure', 'Last Respects',
 		],
 		unbanlist: [


### PR DESCRIPTION
There shouldn't have been any bugs since things should run it through `toID` first, but it seems better to be consistent.

I didn't find any similar typos in the rest of the file.