### PR TITLE
RBY CAP: Give Probosicle's signature move the right category

### DIFF
--- a/data/mods/gen1rbycap/moves.ts
+++ b/data/mods/gen1rbycap/moves.ts
@@ -74,7 +74,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	icicle: {
 		accuracy: 100,
 		basePower: 70,
-		category: "Physical",
+		category: "Special",
 		shortDesc: "High critical hit ratio.",
 		name: "Icicle",
 		pp: 15,


### PR DESCRIPTION
Quickfix, Icicle was accidentally made physical when it should be Special like all other Ice moves