### PR TITLE
Sim/`DexSpecies`: Deduplicate `Species` against parent mod

### DIFF
--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -414,6 +414,14 @@ export class DexSpecies {
 	}
 
 	getByID(id: ID): Species {
+		function deepStrictEqual(a: AnyObject, b: AnyObject) {
+			try {
+				require('assert').deepStrictEqual(a, b);
+				return true;
+			} catch {
+				return false;
+			}
+		}
 		if (id === '') return EMPTY_SPECIES;
 		let species: Mutable<Species> | undefined = this.speciesCache.get(id);
 		if (species) return species;
@@ -569,6 +577,13 @@ export class DexSpecies {
 				id, name: id,
 				exists: false, tier: 'Illegal', doublesTier: 'Illegal', natDexTier: 'Illegal', isNonstandard: 'Custom',
 			});
+		}
+		if (this.dex.parentMod && species.exists) {
+			const parent = this.dex.mod(this.dex.parentMod);
+			const parentSpecies = parent.species.getByID(id);
+			if (deepStrictEqual(species, parentSpecies)) {
+				species = parentSpecies;
+			}
 		}
 		if (species.exists) this.speciesCache.set(id, this.dex.deepFreeze(species));
 		return species;

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -386,8 +386,8 @@ export class Learnset {
 		this.species = species;
 	}
 }
-// TODO: remove below comment before undrafting PR
-// I would keep this inside the function, but it saves ~100/2360 ms
+
+// I would keep this 'require' inside the function, but keeping it outside saves ~100/1540 ms
 const _assertDeepEqual = require('assert').deepStrictEqual;
 function deepStrictEqual(a: AnyObject, b: AnyObject) {
 	try {
@@ -577,9 +577,12 @@ export class DexSpecies {
 			if (this.dex.gen === 3 && this.dex.abilities.get(species.abilities['1']).gen === 4) delete species.abilities['1'];
 
 			if (this.dex.parentMod) {
+				// if this species is exactly identical to parentMod's species, reuse parentMod's copy
 				const parentMod = this.dex.mod(this.dex.parentMod);
 				if (this.dex.data.Pokedex[id] === parentMod.data.Pokedex[id]) {
 					const parentSpecies = parentMod.species.getByID(id);
+					// checking tier cheaply filters out some non-matches.
+					// The construction logic is very complex so we ultimately need to do a deep equality check
 					if (species.tier === parentSpecies.tier && deepStrictEqual(species, parentSpecies)) {
 						species = parentSpecies;
 					}

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -1,5 +1,6 @@
 import {assignMissingFields, BasicEffect, toID} from './dex-data';
 import {Utils} from '../lib';
+import {isDeepStrictEqual} from 'node:util';
 
 interface SpeciesAbility {
 	0: string;
@@ -387,17 +388,6 @@ export class Learnset {
 	}
 }
 
-// I would keep this 'require' inside the function, but keeping it outside saves ~100/1540 ms
-const _assertDeepEqual = require('assert').deepStrictEqual;
-function deepStrictEqual(a: AnyObject, b: AnyObject) {
-	try {
-		_assertDeepEqual(a, b);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 export class DexSpecies {
 	readonly dex: ModdedDex;
 	readonly speciesCache = new Map<ID, Species>();
@@ -583,7 +573,7 @@ export class DexSpecies {
 					const parentSpecies = parentMod.species.getByID(id);
 					// checking tier cheaply filters out some non-matches.
 					// The construction logic is very complex so we ultimately need to do a deep equality check
-					if (species.tier === parentSpecies.tier && deepStrictEqual(species, parentSpecies)) {
+					if (species.tier === parentSpecies.tier && isDeepStrictEqual(species, parentSpecies)) {
 						species = parentSpecies;
 					}
 				}


### PR DESCRIPTION
Dedup for `Species`.

Similar to #10658. `Species` is a little more complicated so I had to change the checks a bit. 

Draft until we settle on an approach to `deepEquals`.

---

`ret size` == "Retained Size", includes the "graph it retains". So, deep size.

| stage | `DexSpecies` ret size | `Species` ret size | `allMods.species.all()` | total heap size |
| --- | --- | --- | --- | --- |
| baseline | 45325 | 42574 | 670 ms | 256 |
| dedup species | 7038 | 10822 | 1426 ms | 224 |
| use utils.isDeepStrictEqual | 7038 | 10822 | 944 ms | 224 |

52584 -> 13278 instances of `Species`, 32MB peak savings.

It is a little curious how the post-dedup snapshot attributes more of the graph to `Species` than the enclosing `DexSpecies`.

The time to create all species in all mods increased by almost 300 ms.
It was initially 2970 ms, but I was able to lessen the cost with the checks for `data` and `tier`, below.
Also, thanks to Slayer95 for suggesting to use `utils.isDeepStrictEqual` instead of the assert equivalent.

`data` rejects 5092 cases (Very rarely rejects values were actually deeply equal). 
Then, `tier` rejects 5267 cases. 
Then, `deepEqual` rejects 1557 cases. 
All the successful dedup cases also run through deepEqual. So, `deepEquals` is called ~40K times.

`isNonstandard` would only catch 93 additional cases after `tier`.
I couldn't think of any other cheap heuristics to reduce the 1557 reject cases that hit `deepEqual`.

`npm run full-test` (measured without my perf PRs for randbats) was 2% faster, so that slight increase in Species construction time seems to be offset. Yay.