### PR TITLE
Sim/`DexItems`: Deduplicate `Item` against parent mod

### DIFF
--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -199,6 +199,16 @@ export class DexItems {
 			if (item.gen > this.dex.gen) {
 				(item as any).isNonstandard = 'Future';
 			}
+			if (this.dex.parentMod) {
+				const parent = this.dex.mod(this.dex.parentMod);
+				const parentItem = parent.items.getByID(id);
+				if (itemData === parent.data.Items[id] &&
+				    item.isNonstandard === parentItem.isNonstandard &&
+				    item.desc === parentItem.desc &&
+				    item.shortDesc === parentItem.shortDesc) {
+					item = parentItem;
+				}
+			}
 		} else {
 			item = new Item({name: id, exists: false});
 		}

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -200,13 +200,15 @@ export class DexItems {
 				(item as any).isNonstandard = 'Future';
 			}
 			if (this.dex.parentMod) {
+				// If this item is exactly identical to parentMod's item, reuse parentMod's copy
 				const parent = this.dex.mod(this.dex.parentMod);
-				const parentItem = parent.items.getByID(id);
-				if (itemData === parent.data.Items[id] &&
-				    item.isNonstandard === parentItem.isNonstandard &&
-				    item.desc === parentItem.desc &&
-				    item.shortDesc === parentItem.shortDesc) {
-					item = parentItem;
+				if (itemData === parent.data.Items[id]) {
+					const parentItem = parent.items.getByID(id);
+					if (item.isNonstandard === parentItem.isNonstandard &&
+					    item.desc === parentItem.desc &&
+					    item.shortDesc === parentItem.shortDesc) {
+						item = parentItem;
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Dedup for `Items`.

Very similar to #10658.

|   stage  | \`DexItems\` ret size | \`Items\` ret size | \`allMods.items.all()\` | total heap size |
| -------- | --------------------: | -----------------: | ----------------------: | --------------: |
| baseline | 8714 KB | 7485 KB | 125 ms | 256 MB |
| w/ dedup | 1445 KB |  830 KB | 102 ms | 250 MB |

19876 -> 2173 instances of \`Item\`, 6MB peak savings.