### PR TITLE
BattleSearch: Fix pathological regex

### DIFF
--- a/server/chat-plugins/battlesearch.ts
+++ b/server/chat-plugins/battlesearch.ts
@@ -46,10 +46,12 @@ export async function runBattleSearch(userids: ID[], month: string, tierid: ID, 
 	if (useRipgrep) {
 		// Matches non-word (including _ which counts as a word) characters between letters/numbers
 		// in a user's name so the userid can case-insensitively be matched to the name.
-		const regexString = userids.map(id => `(?=.*?("p(1|2)":"${[...id].join('[^a-zA-Z0-9]*')}[^a-zA-Z0-9]*"))`).join('');
+		// We want to be order-insensitive for the player IDs. This union is much cheaper than using PCRE.
+		const userUnion = userids.map(id => `${[...id].join('[^a-zA-Z0-9]*')}[^a-zA-Z0-9]*`).join('|');
+		const regexString = userids.map(id => `(.*?("p(1|2)":"(${userUnion})"))`).join('');
 		let output;
 		try {
-			output = await ProcessManager.exec(['rg', '-i', regexString, '--no-line-number', '-P', '-tjson', ...files]);
+			output = await ProcessManager.exec(['rg', '-i', regexString, '--no-line-number', '-tjson', ...files]);
 		} catch {
 			return results;
 		}


### PR DESCRIPTION
PCRE lookahead was causing the regex to be pathologically slow.

The lookahead was introduced by #7801 , the purpose of which I (eventually) inferred to be to handle out-of-order player IDs.
I.e., you do `/battlesearch alice, bob` and also want to match battles where p1 was bob and p2 was alice.

---

Cases I've tested: `files with no matches`, and `search 1 ID w/ matches in either slot`, and `search 2 ID w/ matches in either order`.

---

Measured perf on directory with 500K files, 8GB, all non-matches.
Low-end cacheless NVMe SSD.

File cache was cleared each run with `echo 3 | sudo tee /proc/sys/vm/drop_caches`.  

Before: 100% CPU usage, 1MB/s disk read.  
After: 20% CPU usage, 500MB/s disk read.

```
$ rg --version
ripgrep 14.1.1 (rev 4649aa9700)

features:+pcre2
simd(compile):+SSE2,-SSSE3,-AVX2
simd(runtime):+SSE2,+SSSE3,+AVX2

PCRE2 10.43 is available (JIT is available)
```

---

When testing, I had to disable a couple permission checks, disable ripgrep's gitignore behavior and import `Monitor` to actually be able to run this. Those changes are visible at https://github.com/larry-the-table-guy/pokemon-showdown/commit/b519ef64acf28e16348f35d8c3aa3b7a3e085f58 . That is the code I tested and measured with, and then I copied the relevant changes to this PR branch.

---

`Chatlog` was also touched by #7801, but it seems that feature has since been moved to a DB, so IDK if it's worth changing that one as well.