### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -241,13 +241,12 @@
     },
     "meowth": {
         "level": 85,
-        "moves": ["bodyslam", "bubblebeam", "slash"],
-        "exclusiveMoves": ["thunder", "thunderbolt"]
+        "moves": ["bodyslam", "bubblebeam", "slash", "thunderbolt"]
     },
     "persian": {
         "level": 73,
         "moves": ["bodyslam", "bubblebeam", "slash"],
-        "exclusiveMoves": ["hyperbeam", "hyperbeam", "thunder", "thunderbolt"]
+        "exclusiveMoves": ["hyperbeam", "thunderbolt"]
     },
     "psyduck": {
         "level": 89,
@@ -272,8 +271,8 @@
     },
     "growlithe": {
         "level": 89,
-        "moves": ["agility", "flamethrower", "reflect"],
-        "essentialMoves": ["bodyslam", "fireblast"]
+        "moves": ["agility", "bodyslam", "fireblast"],
+        "exclusiveMoves": ["flamethrower", "reflect"]
     },
     "arcanine": {
         "level": 75,
@@ -288,14 +287,13 @@
     "poliwhirl": {
         "level": 79,
         "moves": ["amnesia", "blizzard", "surf"],
-        "exclusiveMoves": ["counter", "hypnosis", "hypnosis", "hypnosis", "psychic"]
+        "exclusiveMoves": ["hypnosis", "hypnosis", "hypnosis", "psychic"]
     },
     "poliwrath": {
         "level": 74,
-        "moves": ["blizzard", "bodyslam", "earthquake", "submission"],
-        "essentialMoves": ["surf"],
-        "exclusiveMoves": ["hypnosis", "hypnosis", "hypnosis", "psychic"],
-        "comboMoves": ["amnesia", "blizzard"]
+        "moves": ["bodyslam", "earthquake", "hypnosis", "submission"],
+        "essentialMoves": ["blizzard", "surf"],
+        "comboMoves": ["amnesia", "blizzard", "hypnosis", "surf"]
     },
     "abra": {
         "level": 84,
@@ -458,12 +456,12 @@
     "drowzee": {
         "level": 84,
         "moves": ["hypnosis", "psychic", "thunderwave"],
-        "exclusiveMoves": ["counter", "reflect", "rest", "seismictoss", "seismictoss"]
+        "exclusiveMoves": ["counter", "rest", "seismictoss", "seismictoss"]
     },
     "hypno": {
         "level": 72,
         "moves": ["hypnosis", "psychic", "thunderwave"],
-        "exclusiveMoves": ["counter", "reflect", "rest", "rest", "seismictoss", "seismictoss"]
+        "exclusiveMoves": ["counter", "rest", "rest", "seismictoss", "seismictoss"]
     },
     "krabby": {
         "level": 89,

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -1451,19 +1451,15 @@
         "level": 90,
         "sets": [
             {
-                "role": "Berry Sweeper",
-                "movepool": ["drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "substitute"],
-                "abilities": ["Insomnia"]
-            },
-            {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball"],
                 "abilities": ["Insomnia"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "thunderwave", "toxic"],
-                "abilities": ["Insomnia"]
+                "movepool": ["drillpeck", "hiddenpowerground", "pursuit", "shadowball", "thunderwave", "toxic"],
+                "abilities": ["Insomnia"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -1803,7 +1799,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["drillpeck", "protect", "rest", "spikes", "toxic"],
+                "movepool": ["drillpeck", "protect", "spikes", "toxic"],
                 "abilities": ["Keen Eye"]
             },
             {

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -121,6 +121,10 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
+		if (teamDetails.spikes && teamDetails.spikes >= 2) {
+			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 		if (teamDetails.statusCure) {
 			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
 			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -980,14 +980,19 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "icepunch", "return", "waterfall"],
-                "abilities": ["Torrent"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["dragondance", "earthquake", "icepunch", "waterfall"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "earthquake", "icepunch", "return", "swordsdance", "waterfall"],
+                "movepool": ["aquajet", "return", "swordsdance", "waterfall"],
                 "abilities": ["Torrent"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["aquajet", "earthquake", "icepunch", "superpower", "waterfall"],
+                "abilities": ["Torrent"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -3203,7 +3208,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["explosion", "flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt"],
+                "movepool": ["explosion", "flashcannon", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerice", "thunderbolt"],
                 "abilities": ["Magnet Pull"]
             },
             {

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1018,14 +1018,19 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "icepunch", "superpower", "waterfall"],
-                "abilities": ["Torrent"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["dragondance", "earthquake", "icepunch", "waterfall"],
+                "abilities": ["Torrent"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "earthquake", "icepunch", "superpower", "swordsdance", "waterfall"],
+                "movepool": ["aquajet", "return", "swordsdance", "waterfall"],
                 "abilities": ["Torrent"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["aquajet", "earthquake", "icepunch", "superpower", "waterfall"],
+                "abilities": ["Torrent"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -2882,8 +2887,13 @@
                 "abilities": ["Anticipation", "Overcoat"]
             },
             {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerground", "hiddenpowerrock", "leafstorm", "psychic", "signalbeam"],
+                "abilities": ["Anticipation", "Overcoat"]
+            },
+            {
                 "role": "Staller",
-                "movepool": ["gigadrain", "protect", "signalbeam", "synthesis", "toxic"],
+                "movepool": ["gigadrain", "hiddenpowerground", "protect", "toxic"],
                 "abilities": ["Anticipation", "Overcoat"]
             }
         ]
@@ -3232,8 +3242,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerice", "thunderbolt", "voltswitch"],
                 "abilities": ["Magnet Pull"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Analytic"]
             }
         ]
     },
@@ -4421,13 +4436,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "signalbeam", "trickroom"],
-                "abilities": ["Magic Guard"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"],
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "signalbeam"],
                 "abilities": ["Magic Guard"]
             }
         ]
@@ -4581,7 +4591,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "psychic", "signalbeam", "thunderbolt", "trick", "trickroom"],
+                "movepool": ["hiddenpowerfighting", "psychic", "recover", "signalbeam", "thunderbolt", "trick", "trickroom"],
                 "abilities": ["Analytic"]
             }
         ]

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -811,7 +811,10 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 
 		// Minimize confusion damage, including if Foul Play is its only physical attack
-		if ((!counter.get('Physical') || (counter.get('Physical') <= 1 && moves.has('foulplay'))) && !moves.has('transform')) {
+		if (
+			(!counter.get('Physical') || (counter.get('Physical') <= 1 && (moves.has('foulplay') || moves.has('rapidspin')))) &&
+			!moves.has('transform')
+		) {
 			evs.atk = 0;
 			ivs.atk = hasHiddenPower ? (ivs.atk || 31) - 28 : 0;
 		}

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1640,7 +1640,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+                "movepool": ["darkpulse", "fireblast", "nastyplot", "sludgebomb", "suckerpunch"],
                 "abilities": ["Flash Fire"]
             }
         ]
@@ -1650,7 +1650,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"],
+                "movepool": ["darkpulse", "fireblast", "nastyplot", "sludgebomb", "taunt"],
                 "abilities": ["Flash Fire"]
             }
         ]
@@ -3250,8 +3250,13 @@
                 "abilities": ["Anticipation", "Overcoat"]
             },
             {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerground", "hiddenpowerrock", "leafstorm", "psychic", "signalbeam"],
+                "abilities": ["Anticipation", "Overcoat"]
+            },
+            {
                 "role": "Staller",
-                "movepool": ["gigadrain", "protect", "signalbeam", "synthesis", "toxic"],
+                "movepool": ["gigadrain", "hiddenpowerground", "protect", "toxic"],
                 "abilities": ["Anticipation", "Overcoat"]
             }
         ]
@@ -3641,8 +3646,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "movepool": ["flashcannon", "hiddenpowerground", "thunderbolt", "voltswitch"],
                 "abilities": ["Magnet Pull"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["flashcannon", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Analytic"]
             }
         ]
     },
@@ -4888,13 +4898,8 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trickroom"],
-                "abilities": ["Magic Guard"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"],
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "signalbeam"],
                 "abilities": ["Magic Guard"]
             }
         ]
@@ -5048,7 +5053,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"],
+                "movepool": ["hiddenpowerfighting", "psychic", "psyshock", "recover", "signalbeam", "thunderbolt", "trick", "trickroom"],
                 "abilities": ["Analytic"],
                 "preferredTypes": ["Bug"]
             }

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -809,7 +809,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 		// Minimize confusion damage, including if Foul Play is its only physical attack
 		if (
-			(!counter.get('Physical') || (counter.get('Physical') <= 1 && moves.has('foulplay'))) &&
+			(!counter.get('Physical') || (counter.get('Physical') <= 1 && (moves.has('foulplay') || moves.has('rapidspin')))) &&
 			!moves.has('copycat') && !moves.has('transform')
 		) {
 			evs.atk = 0;

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -807,18 +807,14 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "flamethrower", "gigadrain", "leafstorm", "trickroom"],
-                "abilities": ["Frisk"]
-            },
-            {
-                "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "flamethrower", "gigadrain", "leafstorm"],
                 "abilities": ["Frisk"]
             },
             {
-                "role": "AV Pivot",
-                "movepool": ["dracometeor", "flamethrower", "gigadrain", "knockoff"],
-                "abilities": ["Frisk"]
+                "role": "Fast Attacker",
+                "movepool": ["dracometeor", "dragontail", "flamethrower", "knockoff", "moonlight", "sleeppowder", "stunspore", "woodhammer"],
+                "abilities": ["Harvest"],
+                "preferredTypes": ["Fire"]
             }
         ]
     },
@@ -1866,7 +1862,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+                "movepool": ["darkpulse", "fireblast", "nastyplot", "sludgebomb", "suckerpunch"],
                 "abilities": ["Flash Fire"]
             }
         ]
@@ -1876,7 +1872,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"],
+                "movepool": ["darkpulse", "fireblast", "nastyplot", "sludgebomb", "taunt"],
                 "abilities": ["Flash Fire"]
             }
         ]
@@ -3529,6 +3525,16 @@
                 "role": "Setup Sweeper",
                 "movepool": ["bugbuzz", "energyball", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "quiverdance"],
                 "abilities": ["Anticipation", "Overcoat"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["bugbuzz", "hiddenpowerground", "hiddenpowerrock", "leafstorm", "psychic"],
+                "abilities": ["Anticipation", "Overcoat"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["gigadrain", "hiddenpowerground", "protect", "toxic"],
+                "abilities": ["Anticipation", "Overcoat"]
             }
         ]
     },
@@ -3942,8 +3948,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "movepool": ["flashcannon", "hiddenpowerground", "thunderbolt", "voltswitch"],
                 "abilities": ["Magnet Pull"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["flashcannon", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Analytic"]
             }
         ]
     },
@@ -5253,13 +5264,8 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trickroom"],
-                "abilities": ["Magic Guard"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"],
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recover", "signalbeam"],
                 "abilities": ["Magic Guard"]
             }
         ]
@@ -5425,7 +5431,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"],
+                "movepool": ["hiddenpowerfighting", "psychic", "psyshock", "recover", "signalbeam", "thunderbolt", "trick", "trickroom"],
                 "abilities": ["Analytic"],
                 "preferredTypes": ["Bug"]
             }
@@ -5713,7 +5719,7 @@
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["calmmind", "focusblast", "gigadrain", "hiddenpowerrock"],
+                "movepool": ["closecombat", "leafblade", "stoneedge", "swordsdance"],
                 "abilities": ["Justified"],
                 "preferredTypes": ["Fighting"]
             }
@@ -6628,7 +6634,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bugbuzz", "energyball", "roost", "thunderbolt", "voltswitch"],
+                "movepool": ["bugbuzz", "discharge", "energyball", "roost", "toxic", "voltswitch"],
                 "abilities": ["Levitate"],
                 "preferredTypes": ["Bug"]
             }

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -1076,7 +1076,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		// Minimize confusion damage, including if Foul Play is its only physical attack
 		if (
-			(!counter.get('Physical') || (counter.get('Physical') <= 1 && moves.has('foulplay'))) &&
+			(!counter.get('Physical') || (counter.get('Physical') <= 1 && (moves.has('foulplay') || moves.has('rapidspin')))) &&
 			!moves.has('copycat') && !moves.has('transform')
 		) {
 			evs.atk = 0;

--- a/data/random-battles/gen8/data.json
+++ b/data/random-battles/gen8/data.json
@@ -928,7 +928,7 @@
     },
     "latias": {
         "level": 80,
-        "moves": ["calmmind", "dracometeor", "healingwish", "mysticalfire", "psychic", "roost"],
+        "moves": ["calmmind", "dracometeor", "healingwish", "mysticalfire", "psyshock", "roost"],
         "doublesLevel": 82,
         "doublesMoves": ["calmmind", "dracometeor", "healpulse", "mysticalfire", "psyshock", "roost", "tailwind"]
     },
@@ -2155,7 +2155,7 @@
     },
     "silvallypoison": {
         "level": 83,
-        "moves": ["defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "toxic"],
+        "moves": ["defog", "flamethrower", "multiattack", "partingshot", "surf", "toxic"],
         "doublesLevel": 88,
         "doublesMoves": ["flamethrower", "grasspledge", "multiattack", "partingshot", "snarl", "tailwind"]
     },
@@ -2263,7 +2263,7 @@
     },
     "buzzwole": {
         "level": 75,
-        "moves": ["closecombat", "darkestlariat", "dualwingbeat", "ironhead", "leechlife", "stoneedge"],
+        "moves": ["closecombat", "darkestlariat", "dualwingbeat", "earthquake", "leechlife", "stoneedge"],
         "doublesLevel": 80,
         "doublesMoves": ["closecombat", "darkestlariat", "dualwingbeat", "ironhead", "leechlife", "stoneedge"],
         "noDynamaxMoves": ["bulkup", "closecombat", "darkestlariat", "leechlife", "poisonjab", "roost", "stoneedge"]

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -4354,13 +4354,13 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Hurricane", "Protect", "Tailwind"],
-                "abilities": ["Infiltrator"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Dragon", "Fire", "Steel"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Draco Meteor", "Flamethrower", "Hurricane", "Protect", "Tailwind"],
-                "abilities": ["Infiltrator"],
+                "abilities": ["Frisk"],
                 "teraTypes": ["Dragon", "Fire", "Steel"]
             }
         ]
@@ -6646,13 +6646,13 @@
                 "role": "Doubles Support",
                 "movepool": ["Matcha Gotcha", "Rage Powder", "Shadow Ball", "Trick Room"],
                 "abilities": ["Hospitality"],
-                "teraTypes": ["Grass", "Water"]
+                "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Matcha Gotcha", "Protect", "Shadow Ball"],
                 "abilities": ["Hospitality"],
-                "teraTypes": ["Grass", "Water"]
+                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -6712,7 +6712,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Follow Me", "Horn Leech", "Knock Off", "Spiky Shield"],
+                "movepool": ["Follow Me", "Ivy Cudgel", "Knock Off", "Spiky Shield"],
                 "abilities": ["Defiant"],
                 "teraTypes": ["Grass"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1077,7 +1077,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Eruption", "Fire Blast", "Focus Blast", "Scorching Sands"],
-                "abilities": ["Flash Fire"],
+                "abilities": ["Blaze", "Flash Fire"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -1151,7 +1151,7 @@
                 "role": "Fast Support",
                 "movepool": ["Knock Off", "Megahorn", "Poison Jab", "Sticky Web", "Sucker Punch", "Toxic Spikes"],
                 "abilities": ["Insomnia", "Swarm"],
-                "teraTypes": ["Ghost", "Steel"]
+                "teraTypes": ["Ghost"]
             }
         ]
     },
@@ -1549,6 +1549,17 @@
             }
         ]
     },
+    "piloswine": {
+        "level": 85,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Roar", "Stealth Rock"],
+                "abilities": ["Thick Fat"],
+                "teraTypes": ["Dragon", "Poison"]
+            }
+        ]
+    },
     "delibird": {
         "level": 100,
         "sets": [
@@ -1721,12 +1732,6 @@
                 "movepool": ["Calm Mind", "Scald", "Shadow Ball", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Electric", "Water"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Calm Mind", "Scald", "Substitute", "Tera Blast", "Thunderbolt"],
-                "abilities": ["Pressure"],
-                "teraTypes": ["Ice"]
             }
         ]
     },
@@ -2309,7 +2314,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic", "Psychic Noise", "Psyshock", "Recover"],
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic Noise", "Psyshock", "Recover"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Poison", "Steel"]
             },
@@ -2575,9 +2580,9 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic", "Psychic Noise", "Psyshock", "Recover"],
+                "movepool": ["Calm Mind", "Focus Blast", "Psychic Noise", "Psyshock", "Recover"],
                 "abilities": ["Pressure"],
-                "teraTypes": ["Dark", "Fighting", "Steel"]
+                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },
@@ -2754,7 +2759,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Clear Smog", "Earthquake", "Ice Beam", "Recover", "Stealth Rock", "Surf"],
+                "movepool": ["Clear Smog", "Earthquake", "Ice Beam", "Recover", "Spikes", "Stealth Rock", "Surf"],
                 "abilities": ["Storm Drain"],
                 "teraTypes": ["Poison", "Steel"]
             },
@@ -2979,7 +2984,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Dire Claw", "Gunk Shot", "Swords Dance", "Throat Chop", "U-turn"],
+                "movepool": ["Close Combat", "Dire Claw", "Gunk Shot", "Throat Chop", "U-turn"],
                 "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark", "Fighting"]
             },
@@ -3075,10 +3080,10 @@
                 "teraTypes": ["Bug"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["Air Slash", "Bug Buzz", "Hypnosis", "U-turn"],
-                "abilities": ["Tinted Lens"],
-                "teraTypes": ["Bug"]
+                "role": "Tera Blast user",
+                "movepool": ["Air Slash", "Bug Buzz", "Protect", "Tera Blast"],
+                "abilities": ["Speed Boost"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -3530,7 +3535,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Air Slash", "Earth Power", "Healing Wish", "Seed Flare"],
+                "movepool": ["Air Slash", "Dazzling Gleam", "Earth Power", "Seed Flare"],
                 "abilities": ["Serene Grace"],
                 "teraTypes": ["Flying", "Grass"]
             },
@@ -5226,7 +5231,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Accelerock", "Close Combat", "Crunch", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance", "Taunt"],
+                "movepool": ["Accelerock", "Close Combat", "Crunch", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance"],
                 "abilities": ["Sand Rush"],
                 "teraTypes": ["Fighting"]
             }
@@ -5427,9 +5432,15 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Drain Punch", "Play Rough", "Shadow Claw", "Shadow Sneak", "Swords Dance", "Wood Hammer"],
+                "movepool": ["Drain Punch", "Play Rough", "Shadow Sneak", "Swords Dance", "Wood Hammer"],
                 "abilities": ["Disguise"],
-                "teraTypes": ["Fairy", "Fighting", "Ghost", "Grass"]
+                "teraTypes": ["Fairy", "Fighting", "Grass"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Play Rough", "Shadow Claw", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Disguise"],
+                "teraTypes": ["Fairy", "Ghost"]
             }
         ]
     },
@@ -5821,10 +5832,16 @@
         "level": 89,
         "sets": [
             {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
+                "abilities": ["Tough Claws"],
+                "teraTypes": ["Fighting"]
+            },
+            {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
-                "abilities": ["Steely Spirit", "Tough Claws"],
-                "teraTypes": ["Fighting", "Steel"]
+                "abilities": ["Steely Spirit"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -5979,7 +5996,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Draco Meteor", "Flash Cannon", "Iron Defense", "Stealth Rock", "Thunder Wave"],
+                "movepool": ["Body Press", "Draco Meteor", "Dragon Tail", "Flash Cannon", "Iron Defense", "Stealth Rock", "Thunder Wave"],
                 "abilities": ["Light Metal"],
                 "teraTypes": ["Fighting"]
             }
@@ -6691,8 +6708,8 @@
         "level": 91,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Bug Buzz", "Earth Power", "Psychic", "Revival Blessing", "Trick Room"],
+                "role": "Wallbreaker",
+                "movepool": ["Bug Buzz", "Earth Power", "Psychic", "Recover", "Revival Blessing", "Trick Room"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Steel"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1472,6 +1472,11 @@
                 "movepool": ["Aqua Jet", "Crunch", "Gunk Shot", "Liquidation", "Swords Dance"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Water"]
+            }, {
+                "role": "Setup Sweeper",
+                "movepool": ["Crunch", "Gunk Shot", "Scale Shot", "Swords Dance"],
+                "abilities": ["Intimidate"],
+                "teraTypes": ["Dragon"]
             }
         ]
     },
@@ -6069,7 +6074,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Crunch", "Heavy Slam", "Iron Defense", "Stone Edge"],
+                "movepool": ["Body Press", "Crunch", "Heavy Slam", "Iron Defense", "Stone Edge", "Substitute"],
                 "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Fighting", "Ghost"]
             }

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1535,9 +1535,9 @@ export class RandomTeams {
 			const move = this.dex.moves.get(m);
 			if (move.damageCallback || move.damage) return true;
 			if (move.id === 'shellsidearm') return false;
-			// Magearna and doubles Dragonite, though these can work well as a general rule
+			// Physical Tera Blast
 			if (
-				move.id === 'terablast' && (species.id === 'porygon2' || species.id === 'thundurus' ||
+				move.id === 'terablast' && (species.id === 'porygon2' || ['Contrary', 'Defiant'].includes(ability) ||
 				moves.has('shiftgear') || species.baseStats.atk > species.baseStats.spa)
 			) return false;
 			return move.category !== 'Physical' || move.id === 'bodypress' || move.id === 'foulplay';
@@ -1651,7 +1651,7 @@ export class RandomTeams {
 			if (baseFormes[species.baseSpecies]) continue;
 
 			// Treat Ogerpon formes and Terapagos like the Tera Blast user role; reject if team has one already
-			if ((species.baseSpecies === 'Ogerpon' || species.baseSpecies === 'Terapagos') && teamDetails.teraBlast) continue;
+			if (['ogerpon', 'ogerponhearthflame', 'terapagos'].includes(species.id) && teamDetails.teraBlast) continue;
 
 			// Illusion shouldn't be on the last slot
 			if (species.baseSpecies === 'Zoroark' && pokemon.length >= (this.maxTeamSize - 1)) continue;
@@ -1804,7 +1804,7 @@ export class RandomTeams {
 			if (set.moves.includes('auroraveil') || (set.moves.includes('reflect') && set.moves.includes('lightscreen'))) {
 				teamDetails.screens = 1;
 			}
-			if (set.role === 'Tera Blast user' || species.baseSpecies === "Ogerpon" || species.baseSpecies === "Terapagos") {
+			if (set.role === 'Tera Blast user' || ['ogerpon', 'ogerponhearthflame', 'terapagos'].includes(species.id)) {
 				teamDetails.teraBlast = 1;
 			}
 		}

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -10,23 +10,6 @@
             }
         ]
     },
-    "applin": {
-        "level": 9,
-        "sets": [
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Pounce", "Recycle", "Sucker Punch", "Tera Blast"],
-                "abilities": ["Ripen"],
-                "teraTypes": ["Dragon", "Grass"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Defense Curl", "Pounce", "Recycle", "Rollout"],
-                "abilities": ["Ripen"],
-                "teraTypes": ["Rock"]
-            }
-        ]
-    },
     "arrokuda": {
         "level": 7,
         "sets": [
@@ -1044,14 +1027,14 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Nasty Plot", "Power Gem", "Shadow Ball", "Substitute"],
+                "role": "Bulky Support",
+                "movepool": ["Nasty Plot", "Power Gem", "Rest", "Shadow Ball", "Sleep Talk"],
                 "abilities": ["Rattled"],
                 "teraTypes": ["Fairy"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Nasty Plot", "Power Gem", "Shadow Ball", "Substitute", "Tera Blast"],
+                "movepool": ["Nasty Plot", "Power Gem", "Shadow Ball", "Tera Blast"],
                 "abilities": ["Rattled"],
                 "teraTypes": ["Fairy", "Fighting"]
             }
@@ -1191,6 +1174,12 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Drain Punch", "Grassy Glide", "Knock Off", "Swords Dance", "U-turn", "Wood Hammer"],
+                "abilities": ["Grassy Surge"],
+                "teraTypes": ["Grass"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Grassy Glide", "Knock Off", "U-turn", "Wood Hammer"],
                 "abilities": ["Grassy Surge"],
                 "teraTypes": ["Grass"]
             }
@@ -1908,7 +1897,7 @@
         "level": 6,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Bulky Attacker",
                 "movepool": ["First Impression", "Leech Life", "Sucker Punch", "U-turn"],
                 "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
@@ -1936,7 +1925,7 @@
                 "teraTypes": ["Dark", "Fighting", "Water"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Aqua Jet", "Knock Off", "Liquidation", "Sacred Sword", "Swords Dance"],
                 "abilities": ["Torrent"],
                 "teraTypes": ["Dark", "Fighting", "Water"]

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -477,8 +477,6 @@ export class RandomBabyTeams extends RandomTeams {
 			return this.sample(species.requiredItems);
 		}
 
-		if (species.id === 'nymble') return 'Silver Powder';
-
 		if (moves.has('focusenergy')) return 'Scope Lens';
 		if (moves.has('thief')) return '';
 		if (moves.has('trick') || moves.has('switcheroo')) return 'Choice Scarf';


### PR DESCRIPTION
**Gen 9 Random Battle**:
-add Piloswine, level 85 with Eviolite: Earthquake, Icicle Crash, and 2 of Ice Shard, Roar, and Stealth Rock. Tera Dragon/Poison.
-Typhlosion: +Blaze (roll with Flash Fire).
-Ariados: always Tera Ghost (to block Rapid Spin).
-CM Chimecho: -Psychic.
-CM Deoxys-D: -Psychic, -Dark Pulse, -Tera Dark.
-Bulky Attacker Gastrodon: +Spikes.
-Lycanroc: -Taunt.
-Mimikyu is set split so that it no longer gets Tera Ghost without Shadow Claw.
-Perrserker is always Tera Steel with Steely Spirit and Tera Fighting with Tough Claws.
-Duraludon: +Dragon Tail.
-Rabsca: +Recover, changed role so that it remains Revival Blessing + dual STABs + 4th move.
-Serperior will have max Atk EVs/IVs on its Tera Blast set, since Contrary means it will sometimes have higher Atk than SpA.
-Ogerpon-Cornerstone and Ogerpon-Wellspring no longer block the generation of Tera Blast users.

The following reversions are due to winrate analysis:
-Remove Tera Blast Ice Raikou.
-Remove SD Life Orb Sneasler.
-Remove HDB Tinted Lens Yanmega and bring back Tera Blast Ground with Speed Boost.
-Replace Healing Wish with Dazzling Gleam on Specs Shaymin-Sky.

**Gen 9 Random Doubles Battle**:
-Noivern runs Frisk now.
-Sinistcha: always Tera Fairy.
-Support Ogerpon: -Horn Leech, +Ivy Cudgel.

**Gen 9 Baby Random Battle**:
-Removed Applin.
-Gimmighoul's Bulky Setup set is now Bulky Support with Shadow Ball, Rest Talk, and a roll between Nasty Plot and Power Gem.
-Gimmighoul's Tera Blast set no longer runs Substitute.
-Grookey runs an Eviolite set with Grassy Glide, Wood Hammer, Knock Off, and U-turn.
-Nymble now runs Eviolite instead of Silver Powder.
-Swords Dance Oshawott now runs Eviolite instead of Life Orb

**Old Gens**:
-Gen 8 Latias: -Psychic, +Psyshock.
-Gen 8 Silvally-Poison: -Grass Pledge, +Surf.
-Gen 8 Buzzwole: -Iron Head, +Earthquake.

-Gen 7 Virzion no longer runs Calm Mind; the Z-Fighting set is now Swords Dance.
-Gen 7 Bulky Attacker Vikavolt: -Thunderbolt, +Discharge, +Toxic.
-Gen 7 Exeggutor-Alola no longer AV or Trick Room, and runs a Harvest set with Draco Meteor, Flamethrower, Giga Drain, and a random 4th move among several options.
-Gens 6-7 Houndoom and Houndoom-Mega: -HP Grass, +Sludge Bomb.
-Gens 6-7 Beheeyem: -Nasty Plot.
-Gens 5-7 Reuniclus no longer runs Trick Room and always runs Calm Mind with a roll between Focus Blast and Signal Beam.
-Gens 5-7 Beheeyem: +Recover.
-Gens 5-7 Wormadam now runs Choice Specs and Toxic + Protect sets.
-Gens 5-7: Pokemon with Rapid Spin as their only physical attack have minimum Atk EVs/IVs to minimize Foul Play damage.
-Gens 4-7: Magnezone now runs HP Ground on its choiced sets to hit Electric types, and a Toxic + Protect Staller set which is Analytic in Gens 5-7.

-Gens 4-5 Feraligatr has been reconfigured with three sets: DD with Ice Punch and Earthquake, SD with Return and Aqua Jet, and Choice Band with Ice Punch, Aqua Jet, and a roll between Earthquake and Superpower.
-Gen 3 Murkrow no longer runs a sub Liechi set, and can now run Pursuit.
-Gen 3 Skarmory no longer runs Rest, ensuring that it always has Leftovers.
-Gen 3 teams are soft limited to two Spikes users per team. This was not implemented previously because Skarmory could generate undesirable sets.

-Gen 1 Meowth and Persian no longer run Thunder.
-Gen 1 Growlithe always runs Agility.
-Gen 1 Poliwhirl no longer runs Counter.
-Gen 1 Poliwrath no longer runs Psychic and always runs Blizzard.
-Gen 1 Drowzee and Hypno no longer run Reflect.