### PR TITLE
Chat: Don't allow unmatched square brackets in hyperlinks

### DIFF
--- a/server/chat-formatter.ts
+++ b/server/chat-formatter.ts
@@ -39,7 +39,9 @@ REGEXFREE SOURCE FOR LINKREGEX
 				|
 					# parentheses in URLs should be matched, so they're not confused
 					# for parentheses around URLs
-					\( ( [^\\s()<>&] | &amp; )* \)
+					\( ( [^\s()<>&[\]] | &amp; )* \)
+	  			|
+					\[ ( [^\s()<>&[\]] | &amp; )* ]
 				)*
 				# URLs usually don't end with punctuation, so don't allow
 				# punctuation symbols that probably arent related to URL.
@@ -47,7 +49,7 @@ REGEXFREE SOURCE FOR LINKREGEX
 					[^\s()[\]{}\".,!?;:&<>*`^~\\]
 				|
 					# annoyingly, Wikipedia URLs often end in )
-					\( ( [^\s()<>&] | &amp; )* \)
+					\( ( [^\s()<>&[\]] | &amp; )* \)
 				)
 			)?
 		)?
@@ -58,7 +60,7 @@ REGEXFREE SOURCE FOR LINKREGEX
 	(?! [^ ]*&gt; )
 
 */
-export const linkRegex = /(?:(?:https?:\/\/[a-z0-9-]+(?:\.[a-z0-9-]+)*|www\.[a-z0-9-]+(?:\.[a-z0-9-]+)+|\b[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:(?:com?|org|net|edu|info|us|jp)\b|[a-z]{2,3}(?=:[0-9]|\/)))(?::[0-9]+)?(?:\/(?:(?:[^\s()&<>]|&amp;|&quot;|\((?:[^\\s()<>&]|&amp;)*\))*(?:[^\s()[\]{}".,!?;:&<>*`^~\\]|\((?:[^\s()<>&]|&amp;)*\)))?)?|[a-z0-9.]+@[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,})(?![^ ]*&gt;)/ig;
+export const linkRegex = /(?:(?:https?:\/\/[a-z0-9-]+(?:\.[a-z0-9-]+)*|www\.[a-z0-9-]+(?:\.[a-z0-9-]+)+|\b[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:(?:com?|org|net|edu|info|us|jp)\b|[a-z]{2,3}(?=:[0-9]|\/)))(?::[0-9]+)?(?:\/(?:(?:[^\s()&<>]|&amp;|&quot;|\((?:[^\s()<>&[\]]|&amp;)*\)|\[(?:[^\s()<>&[\]]|&amp;)*])*(?:[^\s()[\]{}".,!?;:&<>*`^~\\]|\((?:[^\s()<>&[\]]|&amp;)*\)))?)?|[a-z0-9.]+@[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,})(?![^ ]*&gt;)/ig;
 
 /**
  * A span is a part of the text that's formatted. In the text:


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/urls-within-square-brackets-freeze-client.3755215/

This still allows for cases where e.g. brackets are used in url params (`https://example.com/?test[]=1&amp;test[]=2`)

Also removed an extra backslash in one of the character classes -- it seemed to be an error because `[\\s]` matches the backslash or the lowercase letter "s", rather than whitespace like the other ones

Seeing the change requires full client rebuild.