### PR TITLE
Implement [Gen 9] Battle Factory

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2524,6 +2524,16 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 
 	},
 	{
+		name: "[Gen 9] Battle Factory",
+		desc: `Randomized teams of Pok&eacute;mon for a generated Smogon tier with sets that are competitively viable.`,
+		mod: 'gen9',
+		team: 'randomFactory',
+		ruleset: ['Standard'],
+		onBegin() {
+			this.add(`raw|<div class="broadcast-blue"><b>Battle Factory Tier: ${this.teamGenerator.factoryTier}</b></div>`);
+		},
+	},
+	{
 		name: "[Gen 9] BSS Factory",
 		desc: `Randomized 3v3 Singles featuring Pok&eacute;mon and movesets popular in Battle Stadium Singles.`,
 		mod: 'gen9',

--- a/data/random-battles/gen8/factory-sets.json
+++ b/data/random-battles/gen8/factory-sets.json
@@ -2754,7 +2754,7 @@
 				"ability": ["Sturdy"],
 				"evs": {"hp": 252, "atk": 4, "spd": 252},
 				"nature": "Careful",
-				"moves": [["Earthquake"], ["Heavy Slam"], ["Stealth Rock", "Stealth Rock", "Protect"], ["Toxic"]]
+				"moves": [["Earthquake"], ["Heavy Slam"], ["Stealth Rock", "Protect"], ["Toxic"]]
 			}]
 		},
 		"suicune": {

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -1,0 +1,9328 @@
+{
+	"Uber": {
+		"koraidon": {
+			"weight": 10,
+			"sets": [{
+				"species": "Koraidon",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Orichalcum Pulse"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire", "Ghost"],
+				"moves": [["Low Kick", "Close Combat"], ["Flare Blitz"], ["Outrage", "Dragon Claw"], ["U-turn"]]
+			}, {
+				"species": "Koraidon",
+				"weight": 50,
+				"item": ["Loaded Dice"],
+				"ability": ["Orichalcum Pulse"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire", "Ghost"],
+				"moves": [["Low Kick", "Substitute"], ["Flare Blitz"], ["Scale Shot"], ["Swords Dance"]]
+			}]
+		},
+		"necrozmaduskmane": {
+			"weight": 10,
+			"sets": [{
+				"species": "Necrozma-Dusk-Mane",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 252, "def": 204, "spe": 52},
+				"nature": ["Impish"],
+				"teraType": ["Fire"],
+				"moves": [["Dragon Dance"], ["Morning Sun"], ["Sunsteel Strike"], ["Knock Off"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 252, "def": 204, "spe": 52},
+				"nature": ["Impish"],
+				"teraType": ["Fire"],
+				"moves": [["Dragon Dance"], ["Morning Sun"], ["Photon Geyser"], ["Earthquake"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"weight": 15,
+				"item": ["Lum Berry", "Occa Berry", "Life Orb"],
+				"ability": ["Prism Armor"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Fire"],
+				"moves": [["Dragon Dance"], ["Sunsteel Strike"], ["Earthquake"], ["Stone Edge"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"weight": 15,
+				"item": ["Lum Berry", "Occa Berry", "Life Orb"],
+				"ability": ["Prism Armor"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Fire", "Psychic"],
+				"moves": [["Dragon Dance"], ["Photon Geyser"], ["Earthquake"], ["Sunsteel Strike"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"weight": 10,
+				"item": ["Life Orb", "Lum Berry", "Mental Herb", "Weakness Policy"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 252, "atk": 252, "def": 4},
+				"ivs": {"spe": 0},
+				"nature": ["Brave"],
+				"teraType": ["Fire"],
+				"moves": [["Swords Dance"], ["Photon Geyser"], ["Earthquake"], ["Trick Room"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"weight": 10,
+				"item": ["Covert Cloak", "Heavy-Duty Boots"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 252, "atk": 4, "def": 252},
+				"nature": ["Impish"],
+				"teraType": ["Fire", "Ground"],
+				"moves": [["Sunsteel Strike"], ["Earthquake"], ["Morning Sun"], ["Swords Dance", "Stealth Rock", "Knock Off"]]
+			}]
+		},
+		"hooh": {
+			"weight": 9,
+			"sets": [{
+				"species": "Ho-Oh",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Ground"],
+				"moves": [["Sacred Fire"], ["Recover"], ["Earthquake"], ["Brave Bird"]]
+			}, {
+				"species": "Ho-Oh",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Fairy", "Grass"],
+				"moves": [["Sacred Fire"], ["Recover"], ["Whirlwind"], ["Brave Bird"]]
+			}, {
+				"species": "Ho-Oh",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 104, "atk": 252, "spe": 152},
+				"nature": ["Adamant"],
+				"teraType": ["Ground"],
+				"moves": [["Sacred Fire"], ["Recover"], ["Earthquake"], ["Brave Bird"]]
+			}, {
+				"species": "Ho-Oh",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 104, "atk": 252, "spe": 152},
+				"nature": ["Adamant"],
+				"teraType": ["Flying"],
+				"moves": [["Sacred Fire"], ["Recover"], ["Substitute"], ["Brave Bird"]]
+			}, {
+				"species": "Ho-Oh",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Flying"],
+				"moves": [["Sacred Fire"], ["Recover"], ["Substitute"], ["Brave Bird"]]
+			}]
+		},
+		"arceusground": {
+			"weight": 9,
+			"sets": [{
+				"species": "Arceus-Ground",
+				"weight": 50,
+				"item": ["Earth Plate"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 132, "atk": 252, "spe": 124},
+				"nature": ["Adamant"],
+				"teraType": ["Ground"],
+				"moves": [["Dragon Dance"], ["Recover", "Taunt", "Ice Beam"], ["Earthquake"], ["Stone Edge"]]
+			}, {
+				"species": "Arceus-Ground",
+				"weight": 15,
+				"item": ["Earth Plate"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 132, "atk": 252, "spe": 124},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost"],
+				"moves": [["Dragon Dance"], ["Recover", "Taunt", "Ice Beam"], ["Earthquake"], ["Stone Edge"]]
+			}, {
+				"species": "Arceus-Ground",
+				"weight": 15,
+				"item": ["Earth Plate"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 240, "spd": 252, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Steel", "Ghost"],
+				"moves": [["Calm Mind"], ["Judgment"], ["Recover"], ["Ice Beam", "Power Gem"]]
+			}, {
+				"species": "Arceus-Ground",
+				"weight": 20,
+				"item": ["Earth Plate"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 132, "spa": 252, "spe": 124},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Steel", "Ghost"],
+				"moves": [["Calm Mind"], ["Judgment"], ["Recover"], ["Ice Beam", "Power Gem"]]
+			}]
+		},
+		"arceusfairy": {
+			"weight": 9,
+			"sets": [{
+				"species": "Arceus-Fairy",
+				"weight": 100,
+				"item": ["Pixie Plate"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 240, "def": 252, "spd": 16},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Judgment"], ["Recover"], ["Thunder Wave", "Will-O-Wisp"], ["Stealth Rock", "Taunt", "Dragon Tail"]]
+			}]
+		},
+		"zaciancrowned": {
+			"weight": 9,
+			"sets": [{
+				"species": "Zacian-Crowned",
+				"weight": 100,
+				"item": ["Rusted Sword"],
+				"ability": ["Intrepid Sword"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting", "Fire", "Flying"],
+				"moves": [["Behemoth Blade", "Play Rough"], ["Swords Dance"], ["Wild Charge"], ["Close Combat"]]
+			}]
+		},
+		"kyogre": {
+			"weight": 9,
+			"sets": [{
+				"species": "Kyogre",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Drizzle"],
+				"evs": {"hp": 240, "def": 76, "spa": 176, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy", "Poison"],
+				"moves": [["Calm Mind"], ["Origin Pulse", "Surf"], ["Ice Beam"], ["Thunder", "Thunder Wave"]]
+			}, {
+				"species": "Kyogre",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Drizzle"],
+				"evs": {"hp": 248, "def": 164, "spa": 80, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Poison"],
+				"moves": [["Calm Mind"], ["Origin Pulse", "Surf"], ["Ice Beam"], ["Thunder", "Thunder Wave"]]
+			}, {
+				"species": "Kyogre",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Drizzle"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water"],
+				"moves": [["Water Spout"], ["Thunder"], ["Ice Beam"], ["Origin Pulse"]]
+			}, {
+				"species": "Kyogre",
+				"weight": 5,
+				"item": ["Choice Specs"],
+				"ability": ["Drizzle"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water"],
+				"moves": [["Water Spout"], ["Thunder"], ["Ice Beam"], ["Origin Pulse"]]
+			},  {
+				"species": "Kyogre",
+				"weight": 20,
+				"item": ["Choice Specs"],
+				"ability": ["Drizzle"],
+				"evs": {"hp": 240, "def": 76, "spa": 176, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Water Spout"], ["Thunder"], ["Ice Beam"], ["Origin Pulse"]]
+			}]
+		},
+		"arceus": {
+			"weight": 8,
+			"sets": [{
+				"species": "Arceus",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 200, "atk": 252, "spe": 56},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost", "Fire"],
+				"moves": [["Swords Dance"], ["Extreme Speed"], ["Shadow Claw"], ["Taunt", "Recover", "Earthquake"]]
+			}, {
+				"species": "Arceus",
+				"weight": 20,
+				"item": ["Silk Scarf", "Life Orb"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 200, "atk": 252, "spe": 56},
+				"nature": ["Adamant"],
+				"teraType": ["Fire", "Normal"],
+				"moves": [["Swords Dance"], ["Extreme Speed"], ["Shadow Claw"], ["Taunt", "Recover", "Earthquake", "Double-Edge"]]
+			}, {
+				"species": "Arceus",
+				"weight": 30,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 248, "atk": 204, "spe": 56},
+				"nature": ["Adamant"],
+				"teraType": ["Fire"],
+				"moves": [["Bulk Up"], ["Extreme Speed"], ["Shadow Claw"], ["Taunt", "Recover"]]
+			}]
+		},
+		"arceuswater": {
+			"weight": 8,
+			"sets": [{
+				"species": "Arceus-Water",
+				"weight": 80,
+				"item": ["Splash Plate"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 240, "def": 252, "spe": 16},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Thunder Wave", "Will-O-Wisp"], ["Judgment"], ["Recover"], ["Ice Beam", "Dragon Tail"]]
+			}, {
+				"species": "Arceus-Water",
+				"weight": 20,
+				"item": ["Splash Plate"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 240, "def": 252, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Poison"],
+				"moves": [["Calm Mind"], ["Judgment"], ["Recover"], ["Ice Beam"]]
+			}]
+		},
+		"eternatus": {
+			"weight": 8,
+			"sets": [{
+				"species": "Eternatus",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 200, "spd": 252, "spe": 56},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Grass"],
+				"moves": [["Dynamax Cannon"], ["Toxic"], ["Recover"], ["Toxic Spikes", "Flamethrower"]]
+			}, {
+				"species": "Eternatus",
+				"weight": 30,
+				"item": ["Power Herb"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 168, "spa": 252, "spe": 88},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fire", "Dragon"],
+				"moves": [["Meteor Beam"], ["Dynamax Cannon"], ["Fire Blast"], ["Agility", "Sludge Bomb"]]
+			}, {
+				"species": "Eternatus",
+				"weight": 30,
+				"item": ["Power Herb"],
+				"ability": ["Pressure"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"teraType": ["Fire", "Flying", "Fairy"],
+				"moves": [["Sludge Bomb"], ["Dynamax Cannon"], ["Fire Blast", "Flamethrower"], ["Toxic Spikes"]]
+			}]
+		},
+		"gliscor": {
+			"weight": 7,
+			"sets": [{
+				"species": "Gliscor",
+				"weight": 40,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 252, "spd": 12},
+				"nature": ["Impish"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Earthquake"], ["Toxic"], ["Protect"], ["Spikes", "Toxic Spikes"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 40,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 252, "spd": 12},
+				"nature": ["Impish"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Earthquake", "Toxic"], ["Knock Off"], ["Protect"], ["Spikes", "Toxic Spikes"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 12, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Earthquake"], ["Toxic"], ["Protect"], ["Spikes", "Toxic Spikes"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 12, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Earthquake", "Toxic"], ["Knock Off"], ["Protect"], ["Spikes", "Toxic Spikes"]]
+			}]
+		},
+		"calyrexice": {
+			"weight": 7,
+			"sets": [{
+				"species": "Calyrex-Ice",
+				"wantsTera": true,
+				"weight": 80,
+				"item": ["Heavy-Duty Boots", "Occa Berry", "Weakness Policy"],
+				"ability": ["As One (Glastrier)"],
+				"evs": {"hp": 248, "atk": 252, "spd": 8},
+				"ivs": {"spe": 0},
+				"nature": ["Brave"],
+				"teraType": ["Fire", "Ground"],
+				"moves": [["Trick Room"], ["Swords Dance"], ["Glacial Lance"], ["High Horsepower"]]
+			}, {
+				"species": "Calyrex-Ice",
+				"wantsTera": true,
+				"weight": 20,
+				"item": ["Heavy-Duty Boots", "Occa Berry", "Weakness Policy"],
+				"ability": ["As One (Glastrier)"],
+				"evs": {"hp": 248, "atk": 252, "spd": 8},
+				"ivs": {"spe": 22},
+				"nature": ["Adamant"],
+				"teraType": ["Fire", "Ground"],
+				"moves": [["Trick Room"], ["Swords Dance"], ["Glacial Lance"], ["High Horsepower"]]
+			}]
+		},
+		"landorustherian": {
+			"weight": 7,
+			"sets": [{
+				"species": "Landorus-Therian",
+				"weight": 80,
+				"item": ["Rocky Helmet", "Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 248, "atk": 8, "def": 252},
+				"nature": ["Impish"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["U-turn"], ["Taunt", "Stone Edge", "Rock Tomb"]]
+			}, {
+				"species": "Landorus-Therian",
+				"weight": 20,
+				"item": ["Choice Scarf"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground"],
+				"moves": [["Earthquake"], ["Stone Edge"], ["U-turn"], ["Stealth Rock"]]
+			}]
+		},
+		"tinglu": {
+			"weight": 6,
+			"sets": [{
+				"species": "Ting-Lu",
+				"weight": 80,
+				"item": ["Leftovers"],
+				"ability": ["Vessel of Ruin"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Fairy", "Poison", "Water"],
+				"moves": [["Earthquake"], ["Ruination"], ["Spikes", "Stealth Rock"], ["Whirlwind", "Protect"]]
+			}, {
+				"species": "Ting-Lu",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Vessel of Ruin"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Fairy", "Poison", "Water"],
+				"moves": [["Earthquake"], ["Ruination"], ["Spikes"], ["Stealth Rock"]]
+			}]
+		},
+		"chienpao": {
+			"weight": 6,
+			"sets": [{
+				"species": "Chien-Pao",
+				"weight": 30,
+				"item": ["Life Orb", "Heavy-Duty Boots", "Black Glasses"],
+				"ability": ["Sword of Ruin"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Swords Dance"], ["Icicle Crash"], ["Crunch"], ["Sucker Punch", "Ice Shard"]]
+			}, {
+				"species": "Chien-Pao",
+				"weight": 30,
+				"item": ["Life Orb", "Heavy-Duty Boots", "Black Glasses"],
+				"ability": ["Sword of Ruin"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Dark"],
+				"moves": [["Swords Dance"], ["Icicle Crash"], ["Sucker Punch"], ["Ice Shard"]]
+			}, {
+				"species": "Chien-Pao",
+				"weight": 40,
+				"item": ["Choice Band"],
+				"ability": ["Sword of Ruin"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Ice"],
+				"moves": [["Icicle Crash", "Ice Spinner"], ["Crunch"], ["Sucker Punch"], ["Ice Shard"]]
+			}]
+		},
+		"deoxysattack": {
+			"weight": 6,
+			"sets": [{
+				"species": "Deoxys-Attack",
+				"weight": 50,
+				"item": ["Life Orb"],
+				"ability": ["Pressure"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": ["Naive"],
+				"teraType": ["Ghost"],
+				"moves": [["Psycho Boost"], ["Shadow Ball"], ["Low Kick"], ["Rock Slide"]]
+			}, {
+				"species": "Deoxys-Attack",
+				"weight": 50,
+				"item": ["Focus Sash"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Steel"],
+				"moves": [["Psycho Boost"], ["Shadow Ball"], ["Icy Wind"], ["Stealth Rock", "Spikes"]]
+			}]
+		},
+		"giratinaorigin": {
+			"weight": 8,
+			"sets": [{
+				"species": "Giratina-Origin",
+				"weight": 50,
+				"item": ["Griseous Core"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 248, "atk": 104, "def": 112, "spe": 44},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost", "Steel", "Poison"],
+				"moves": [["Poltergeist"], ["Dragon Tail"], ["Will-O-Wisp", "Thunder Wave"], ["Defog", "Shadow Sneak"]]
+			}, {
+				"species": "Giratina-Origin",
+				"weight": 50,
+				"item": ["Griseous Core"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 248, "def": 112, "spa": 104, "spe": 44},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Steel", "Poison"],
+				"moves": [["Hex"], ["Draco Meteor"], ["Will-O-Wisp", "Thunder Wave"], ["Defog"]]
+			}]
+		},
+		"glimmora": {
+			"weight": 7,
+			"sets": [{
+				"species": "Glimmora",
+				"weight": 100,
+				"item": ["Focus Sash"],
+				"ability": ["Toxic Debris"],
+				"evs": {"def": 172, "spa": 84, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Stealth Rock", "Spikes"], ["Mortal Spin"], ["Mud Shot"], ["Dazzling Gleam"]]
+			}]
+		},
+		"ironbundle": {
+			"weight": 6,
+			"sets": [{
+				"species": "Iron Bundle",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Quark Drive"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Ice"],
+				"moves": [["Freeze-Dry"], ["Hydro Pump"], ["Ice Beam"], ["Encore", "Taunt"]]
+			}]
+		},
+		"groudon": {
+			"weight": 6,
+			"sets": [{
+				"species": "Groudon",
+				"weight": 60,
+				"item": ["Leftovers"],
+				"ability": ["Drought"],
+				"evs": {"hp": 240, "def": 252, "spe": 16},
+				"nature": ["Impish"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Precipice Blades", "Earthquake"], ["Stealth Rock", "Protect"], ["Will-O-Wisp", "Roar"], ["Spikes"]]
+			}, {
+				"species": "Groudon",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Drought"],
+				"evs": {"hp": 240, "def": 252, "spe": 16},
+				"nature": ["Impish"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Precipice Blades", "Earthquake"], ["Stealth Rock", "Spikes"], ["Roar"], ["Thunder Wave"]]
+			}]
+		},
+		"kingambit": {
+			"weight": 5,
+			"sets": [{
+				"species": "Kingambit",
+				"weight": 70,
+				"item": ["Black Glasses", "Lum Berry"],
+				"ability": ["Supreme Overlord"],
+				"evs": {"hp": 252, "atk": 252, "spd": 4},
+				"nature": ["Adamant"],
+				"teraType": ["Dark", "Flying"],
+				"moves": [["Kowtow Cleave"], ["Swords Dance"], ["Iron Head"], ["Sucker Punch"]]
+			}, {
+				"species": "Kingambit",
+				"weight": 30,
+				"item": ["Air Balloon"],
+				"ability": ["Supreme Overlord"],
+				"evs": {"hp": 252, "atk": 252, "spd": 4},
+				"nature": ["Adamant"],
+				"teraType": ["Fire"],
+				"moves": [["Kowtow Cleave"], ["Swords Dance"], ["Iron Head"], ["Sucker Punch"]]
+			}]
+		},
+		"kyuremblack": {
+			"weight": 5,
+			"sets": [{
+				"species": "Kyurem-Black",
+				"weight": 100,
+				"item": ["Loaded Dice"],
+				"ability": ["Teravolt"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Fusion Bolt"], ["Icicle Spear"], ["Dragon Dance"], ["Substitute", "Scale Shot"]]
+			}]
+		},
+		"fluttermane": {
+			"weight": 5,
+			"sets": [{
+				"species": "Flutter Mane",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Protosynthesis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Stellar"],
+				"moves": [["Moonblast"], ["Shadow Ball"], ["Psyshock", "Mystical Fire"], ["Power Gem"]]
+			}, {
+				"species": "Flutter Mane",
+				"weight": 50,
+				"item": ["Life Orb"],
+				"ability": ["Protosynthesis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Stellar"],
+				"moves": [["Moonblast"], ["Shadow Ball"], ["Psyshock", "Mystical Fire", "Calm Mind"], ["Power Gem"]]
+			}]
+		},
+		"rayquaza": {
+			"weight": 4,
+			"sets": [{
+				"species": "Rayquaza",
+				"weight": 50,
+				"item": ["Life Orb"],
+				"ability": ["Air Lock"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Flying", "Normal", "Ground", "Steel"],
+				"moves": [["Dragon Ascent"], ["Earthquake"], ["Extreme Speed"], ["Dragon Dance"]]
+			}, {
+				"species": "Rayquaza",
+				"weight": 50,
+				"item": ["Life Orb"],
+				"ability": ["Air Lock"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Dragon Ascent"], ["Earthquake"], ["Extreme Speed"], ["Swords Dance"]]
+			}]
+		},
+		"arceusghost": {
+			"weight": 3,
+			"sets": [{
+				"species": "Arceus-Ghost",
+				"weight": 50,
+				"item": ["Spooky Plate"],
+				"ability": ["Multitype"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Stellar"],
+				"moves": [["Calm Mind"], ["Judgment"], ["Focus Blast"], ["Power Gem"]]
+			}, {
+				"species": "Arceus-Ghost",
+				"weight": 50,
+				"item": ["Spooky Plate"],
+				"ability": ["Multitype"],
+				"evs": {"hp": 248, "def": 204, "spe": 56},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Fairy", "Poison"],
+				"moves": [["Calm Mind"], ["Judgment"], ["Recover"], ["Dragon Tail"]]
+			}]
+		},
+		"lunala": {
+			"weight": 3,
+			"sets": [{
+				"species": "Lunala",
+				"weight": 50,
+				"item": ["Power Herb"],
+				"ability": ["Shadow Shield"],
+				"evs": {"hp": 56, "spa": 252, "spe": 200},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Agility"], ["Meteor Beam"], ["Moonblast"], ["Moongeist Beam"]]
+			}, {
+				"species": "Lunala",
+				"weight": 50,
+				"item": ["Power Herb"],
+				"ability": ["Shadow Shield"],
+				"evs": {"hp": 56, "spa": 252, "spe": 200},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Ghost"],
+				"moves": [["Agility"], ["Meteor Beam"], ["Focus Blast"], ["Moongeist Beam"]]
+			}]
+		},
+		"mewtwo": {
+			"weight": 1,
+			"sets": [{
+				"species": "Mewtwo",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Leftovers", "Life Orb"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Nasty Plot"], ["Psystrike"], ["Flamethrower"], ["Taunt", "Earth Power", "Grass Knot"]]
+			}, {
+				"species": "Mewtwo",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fire"],
+				"moves": [["Ice Beam"], ["Psystrike"], ["Flamethrower"], ["Grass Knot"]]
+			}]
+		},
+		"skeledirge": {
+			"weight": 6,
+			"sets": [{
+				"species": "Skeledirge",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Torch Song"], ["Hex"], ["Will-O-Wisp"], ["Slack Off"]]
+			}]
+		},
+		"toxapex": {
+			"weight": 4,
+			"sets": [{
+				"species": "Toxapex",
+				"weight": 67,
+				"item": ["Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Toxic"], ["Recover"], ["Haze"], ["Toxic Spikes", "Ice Beam"]]
+			}, {
+				"species": "Toxapex",
+				"weight": 33,
+				"item": ["Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Fairy"],
+				"moves": [["Toxic"], ["Recover"], ["Haze"], ["Poison Jab"]]
+			}]
+		},
+		"ditto": {
+			"weight": 1,
+			"sets": [{
+				"species": "Ditto",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Imposter"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Transform"]]
+			}]
+		},
+		"necrozmadawnwings": {
+			"weight": 1,
+			"sets": [{
+				"species": "Necrozma-Dawn-Wings",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 252, "def": 4, "spa": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy", "Steel"],
+				"moves": [["Calm Mind"], ["Iron Defense"], ["Moonlight"], ["Stored Power"]]
+			}]
+		},
+		"arceuselectric": {
+			"weight": 1,
+			"sets": [{
+				"species": "Arceus-Electric",
+				"weight": 100,
+				"item": ["Zap Plate"],
+				"ability": ["Multitype"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Fairy"],
+				"moves": [["Calm Mind"], ["Judgment"], ["Ice Beam"], ["Recover"]]
+			}]
+		}
+	},
+	"OU": {
+		"kingambit": {
+			"weight": 10,
+			"sets": [{
+				"species": "Kingambit",
+				"weight": 25,
+				"item": ["Black Glasses"],
+				"ability": ["Supreme Overlord"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Kowtow Cleave"], ["Swords Dance"], ["Iron Head", "Low Kick"], ["Sucker Punch"]]
+			}, {
+				"species": "Kingambit",
+				"weight": 25,
+				"item": ["Air Balloon", "Leftovers"],
+				"ability": ["Supreme Overlord"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Low Kick"], ["Swords Dance"], ["Iron Head", "Kowtow Cleave"], ["Sucker Punch"]]
+			}, {
+				"species": "Kingambit",
+				"weight": 25,
+				"item": ["Air Balloon", "Leftovers"],
+				"ability": ["Supreme Overlord"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Iron Head"], ["Swords Dance"], ["Kowtow Cleave"], ["Sucker Punch"]]
+			}, {
+				"species": "Kingambit",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Supreme Overlord"],
+				"evs": {"hp": 252, "atk": 252, "spd": 4},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Kowtow Cleave"], ["Swords Dance"], ["Iron Head"], ["Sucker Punch"]]
+			}]
+		},
+		"zamazenta": {
+			"weight": 10,
+			"sets": [{
+				"species": "Zamazenta",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Dauntless Shield"],
+				"evs": {"hp": 252, "def": 88, "spe": 168},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Fire", "Dark"],
+				"moves": [["Iron Defense"], ["Body Press"], ["Crunch"], ["Roar", "Stone Edge"]]
+			}, {
+				"species": "Zamazenta",
+				"weight": 15,
+				"item": ["Chesto Berry"],
+				"ability": ["Dauntless Shield"],
+				"evs": {"hp": 252, "def": 88, "spe": 168},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Fire", "Dark"],
+				"moves": [["Iron Defense"], ["Body Press"], ["Crunch"], ["Rest"]]
+			}, {
+				"species": "Zamazenta",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dauntless Shield"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Dark"],
+				"moves": [["Close Combat"], ["Stone Edge"], ["Crunch"], ["Heavy Slam"]]
+			}, {
+				"species": "Zamazenta",
+				"weight": 15,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dauntless Shield"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Close Combat"], ["Stone Edge"], ["Crunch"], ["Ice Fang"]]
+			}]
+		},
+		"dragapult": {
+			"weight": 9,
+			"sets": [{
+				"species": "Dragapult",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Infiltrator"],
+				"evs": {"atk": 60, "spa": 196, "spe": 252},
+				"nature": ["Naive"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Dragon Darts"], ["Hex"], ["Will-O-Wisp", "Thunder Wave"], ["U-turn"]]
+			}, {
+				"species": "Dragapult",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Infiltrator"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Draco Meteor"], ["Hex"], ["Will-O-Wisp", "Thunder Wave"], ["U-turn"]]
+			}, {
+				"species": "Dragapult",
+				"weight": 30,
+				"item": ["Choice Specs"],
+				"ability": ["Infiltrator"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid", "Modest"],
+				"teraType": ["Dragon", "Ghost"],
+				"moves": [["Draco Meteor"], ["Shadow Ball"], ["Flamethrower"], ["U-turn"]]
+			}, {
+				"species": "Dragapult",
+				"wantsTera": true,
+				"weight": 30,
+				"item": ["Choice Band"],
+				"ability": ["Clear Body"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost"],
+				"moves": [["Dragon Darts"], ["Tera Blast"], ["U-turn"], ["Phantom Force", "Sucker Punch"]]
+			}]
+		},
+		"gholdengo": {
+			"weight": 9,
+			"sets": [{
+				"species": "Gholdengo",
+				"weight": 14,
+				"item": ["Heavy-Duty Boots", "Air Balloon"],
+				"ability": ["Good as Gold"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Steel"],
+				"moves": [["Nasty Plot"], ["Shadow Ball"], ["Make It Rain"], ["Recover", "Psyshock"]]
+			}, {
+				"species": "Gholdengo",
+				"weight": 14,
+				"item": ["Heavy-Duty Boots", "Air Balloon"],
+				"ability": ["Good as Gold"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting"],
+				"moves": [["Nasty Plot"], ["Shadow Ball"], ["Make It Rain"], ["Focus Blast"]]
+			}, {
+				"species": "Gholdengo",
+				"weight": 12,
+				"item": ["Heavy-Duty Boots", "Air Balloon", "Rocky Helmet"],
+				"ability": ["Good as Gold"],
+				"evs": {"hp": 252, "def": 196, "spe": 60},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Nasty Plot"], ["Shadow Ball"], ["Make It Rain", "Dazzling Gleam"], ["Recover"]]
+			}, {
+				"species": "Gholdengo",
+				"weight": 12,
+				"item": ["Heavy-Duty Boots", "Air Balloon", "Rocky Helmet"],
+				"ability": ["Good as Gold"],
+				"evs": {"hp": 252, "def": 196, "spe": 60},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Nasty Plot"], ["Shadow Ball"], ["Make It Rain"], ["Recover"]]
+			}, {
+				"species": "Gholdengo",
+				"weight": 12,
+				"item": ["Leftovers", "Air Balloon", "Rocky Helmet"],
+				"ability": ["Good as Gold"],
+				"evs": {"hp": 252, "def": 196, "spe": 60},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Hex"], ["Thunder Wave"], ["Make It Rain", "Dazzling Gleam"], ["Recover"]]
+			}, {
+				"species": "Gholdengo",
+				"weight": 12,
+				"item": ["Leftovers", "Air Balloon", "Rocky Helmet"],
+				"ability": ["Good as Gold"],
+				"evs": {"hp": 252, "def": 196, "spe": 60},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Hex"], ["Thunder Wave"], ["Make It Rain", "Focus Blast"], ["Recover"]]
+			}, {
+				"species": "Gholdengo",
+				"weight": 12,
+				"item": ["Choice Scarf"],
+				"ability": ["Good as Gold"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting"],
+				"moves": [["Trick"], ["Shadow Ball"], ["Make It Rain"], ["Focus Blast"]]
+			}, {
+				"species": "Gholdengo",
+				"weight": 12,
+				"item": ["Choice Scarf"],
+				"ability": ["Good as Gold"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Flying"],
+				"moves": [["Trick"], ["Shadow Ball"], ["Make It Rain"], ["Nasty Plot", "Recover"]]
+			}]
+		},
+		"greattusk": {
+			"weight": 9,
+			"sets": [{
+				"species": "Great Tusk",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots", "Rocky Helmet", "Booster Energy"],
+				"ability": ["Protosynthesis"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground", "Steel", "Fire"],
+				"moves": [["Headlong Rush"], ["Ice Spinner"], ["Rapid Spin"], ["Knock Off", "Close Combat"]]
+			}, {
+				"species": "Great Tusk",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots", "Rocky Helmet", "Leftovers"],
+				"ability": ["Protosynthesis"],
+				"evs": {"hp": 252, "atk": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Water"],
+				"moves": [["Headlong Rush"], ["Ice Spinner"], ["Rapid Spin"], ["Knock Off", "Stealth Rock"]]
+			}, {
+				"species": "Great Tusk",
+				"weight": 30,
+				"item": ["Booster Energy"],
+				"ability": ["Protosynthesis"],
+				"evs": {"hp": 252, "atk": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Water"],
+				"moves": [["Headlong Rush"], ["Ice Spinner"], ["Rapid Spin", "Close Combat", "Knock Off"], ["Bulk Up"]]
+			}]
+		},
+		"landorustherian": {
+			"weight": 9,
+			"sets": [{
+				"species": "Landorus-Therian",
+				"weight": 20,
+				"item": ["Rocky Helmet"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "atk": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Dragon"],
+				"moves": [["Earthquake"], ["U-turn"], ["Stealth Rock"], ["Taunt"]]
+			}, {
+				"species": "Landorus-Therian",
+				"weight": 20,
+				"item": ["Rocky Helmet"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Dragon"],
+				"moves": [["Earth Power"], ["U-turn"], ["Stealth Rock"], ["Taunt"]]
+			}, {
+				"species": "Landorus-Therian",
+				"weight": 30,
+				"item": ["Soft Sand"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 8, "atk": 240, "spd": 8, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Ground"],
+				"moves": [["Earthquake"], ["U-turn", "Taunt"], ["Stealth Rock"], ["Stone Edge"]]
+			}, {
+				"species": "Landorus-Therian",
+				"wantsTera": true,
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 8, "atk": 240, "spd": 8, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Flying", "Ice"],
+				"moves": [["Earthquake"], ["U-turn"], ["Tera Blast"], ["Stone Edge"]]
+			}]
+		},
+		"darkrai": {
+			"weight": 8,
+			"sets": [{
+				"species": "Darkrai",
+				"weight": 5,
+				"item": ["Heavy-Duty Boots", "Leftovers", "Expert Belt"],
+				"ability": ["Bad Dreams"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Dark Pulse"], ["Focus Blast"], ["Ice Beam"], ["Nasty Plot"]]
+			}, {
+				"species": "Darkrai",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots", "Leftovers", "Expert Belt"],
+				"ability": ["Bad Dreams"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison", "Ghost"],
+				"moves": [["Dark Pulse"], ["Sludge Bomb"], ["Ice Beam", "Focus Blast"], ["Nasty Plot"]]
+			}, {
+				"species": "Darkrai",
+				"weight": 15,
+				"item": ["Choice Scarf"],
+				"ability": ["Bad Dreams"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison", "Dark"],
+				"moves": [["Dark Pulse"], ["Sludge Bomb"], ["Ice Beam", "Focus Blast"], ["Trick"]]
+			}, {
+				"species": "Darkrai",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Bad Dreams"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison", "Dark"],
+				"moves": [["Dark Pulse"], ["Sludge Bomb"], ["Ice Beam"], ["Will-O-Wisp"]]
+			}, {
+				"species": "Darkrai",
+				"weight": 35,
+				"item": ["Life Orb", "Expert Belt", "Choice Scarf"],
+				"ability": ["Bad Dreams"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison", "Dark"],
+				"moves": [["Dark Pulse"], ["Sludge Bomb"], ["Ice Beam"], ["Focus Blast"]]
+			}]
+		},
+		"dragonite": {
+			"weight": 8,
+			"sets": [{
+				"species": "Dragonite",
+				"wantsTera": true,
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Multiscale"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Normal"],
+				"moves": [["Earthquake"], ["Dragon Dance"], ["Extreme Speed"], ["Ice Spinner", "Roost"]]
+			}, {
+				"species": "Dragonite",
+				"wantsTera": true,
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Multiscale"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Ground"],
+				"moves": [["Earthquake"], ["Dragon Dance"], ["Roost"], ["Ice Spinner"]]
+			}, {
+				"species": "Dragonite",
+				"wantsTera": true,
+				"weight": 40,
+				"item": ["Choice Band"],
+				"ability": ["Multiscale"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Normal"],
+				"moves": [["Earthquake", "Fire Punch"], ["Extreme Speed"], ["Outrage"], ["Ice Spinner"]]
+			}]
+		},
+		"gliscor": {
+			"weight": 8,
+			"sets": [{
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 248, "spd": 16},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Earthquake"], ["Toxic"], ["Protect"], ["Spikes"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 248, "spd": 16},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Earthquake", "Toxic"], ["Knock Off"], ["Protect"], ["Spikes"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 36, "spd": 228},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Earthquake"], ["Toxic"], ["Protect"], ["Spikes"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 36, "spd": 228},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Earthquake", "Toxic"], ["Knock Off"], ["Protect"], ["Spikes"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 248, "spd": 16},
+				"nature": ["Impish"],
+				"teraType": ["Normal"],
+				"moves": [["Earthquake", "Knock Off"], ["Swords Dance"], ["Facade"], ["Protect"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 248, "spd": 16},
+				"nature": ["Impish"],
+				"teraType": ["Water"],
+				"moves": [["Earthquake"], ["Swords Dance"], ["Knock Off"], ["Protect"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 36, "spd": 228},
+				"nature": ["Careful"],
+				"teraType": ["Normal"],
+				"moves": [["Earthquake", "Knock Off"], ["Swords Dance"], ["Facade"], ["Protect"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "def": 36, "spd": 228},
+				"nature": ["Careful"],
+				"teraType": ["Water"],
+				"moves": [["Earthquake"], ["Swords Dance"], ["Knock Off"], ["Protect"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "atk": 12, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Earthquake", "Knock Off"], ["Swords Dance"], ["Facade"], ["Protect"]]
+			}, {
+				"species": "Gliscor",
+				"weight": 10,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 244, "atk": 12, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Earthquake"], ["Swords Dance"], ["Knock Off"], ["Protect"]]
+			}]
+		},
+		"ironmoth": {
+			"weight": 8,
+			"sets": [{
+				"species": "Iron Moth",
+				"weight": 25,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"def": 124, "spa": 132, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Fiery Dance"], ["Sludge Wave"], ["Dazzling Gleam"], ["Substitute"]]
+			}, {
+				"species": "Iron Moth",
+				"weight": 25,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"def": 124, "spa": 132, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Fiery Dance"], ["Sludge Wave"], ["Psychic"], ["Substitute", "Dazzling Gleam"]]
+			}, {
+				"species": "Iron Moth",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"def": 124, "spa": 132, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Fiery Dance"], ["Sludge Wave"], ["Tera Blast"], ["Substitute", "Dazzling Gleam"]]
+			}, {
+				"species": "Iron Moth",
+				"weight": 25,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"def": 124, "spa": 132, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Grass"],
+				"moves": [["Fiery Dance"], ["Sludge Wave"], ["Energy Ball"], ["Substitute", "Dazzling Gleam"]]
+			}]
+		},
+		"ironvaliant": {
+			"weight": 8,
+			"sets": [{
+				"species": "Iron Valiant",
+				"weight": 15,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Shadow Ball"], ["Encore", "Thunderbolt"]]
+			}, {
+				"species": "Iron Valiant",
+				"weight": 15,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Psyshock"], ["Encore"]]
+			}, {
+				"species": "Iron Valiant",
+				"weight": 15,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Electric"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Shadow Ball", "Psyshock"], ["Thunderbolt"]]
+			}, {
+				"species": "Iron Valiant",
+				"weight": 25,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Dark"],
+				"moves": [["Swords Dance"], ["Close Combat"], ["Spirit Break", "Encore"], ["Knock Off"]]
+			}, {
+				"species": "Iron Valiant",
+				"weight": 15,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": ["Naive"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Moonblast"], ["Knock Off"], ["Close Combat"], ["Encore", "Destiny Bond"]]
+			}, {
+				"species": "Iron Valiant",
+				"weight": 15,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": ["Naive"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Moonblast"], ["Knock Off", "Close Combat"], ["Destiny Bond"], ["Encore"]]
+			}]
+		},
+		"kyurem": {
+			"weight": 8,
+			"sets": [{
+				"species": "Kyurem",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Loaded Dice"],
+				"ability": ["Pressure"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground", "Fire"],
+				"moves": [["Icicle Spear"], ["Scale Shot"], ["Dragon Dance"], ["Tera Blast"]]
+			}, {
+				"species": "Kyurem",
+				"weight": 20,
+				"item": ["Never-Melt Ice", "Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"atk": 168, "spa": 88, "spe": 252},
+				"nature": ["Hasty"],
+				"teraType": ["Ground", "Ice"],
+				"moves": [["Icicle Spear"], ["Freeze-Dry"], ["Earth Power"], ["Dragon Dance"]]
+			}, {
+				"species": "Kyurem",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 52, "spa": 204, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Substitute"], ["Freeze-Dry"], ["Earth Power"], ["Protect"]]
+			}, {
+				"species": "Kyurem",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground", "Ice"],
+				"moves": [["Draco Meteor"], ["Freeze-Dry"], ["Earth Power"], ["Ice Beam"]]
+			}, {
+				"species": "Kyurem",
+				"weight": 15,
+				"item": ["Choice Specs"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"teraType": ["Ground", "Ice", "Fairy"],
+				"moves": [["Draco Meteor"], ["Freeze-Dry"], ["Earth Power"], ["Ice Beam"]]
+			}]
+		},
+		"ogerponwellspring": {
+			"weight": 8,
+			"sets": [{
+				"species": "Ogerpon-Wellspring",
+				"weight": 40,
+				"item": ["Wellspring Mask"],
+				"ability": ["Water Absorb"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Ivy Cudgel"], ["Power Whip", "Horn Leech"], ["Swords Dance"], ["Play Rough", "Encore", "Knock Off"]]
+			}, {
+				"species": "Ogerpon-Wellspring",
+				"weight": 30,
+				"item": ["Wellspring Mask"],
+				"ability": ["Water Absorb"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Ivy Cudgel"], ["Horn Leech"], ["U-turn"], ["Knock Off", "Encore", "Spikes"]]
+			}, {
+				"species": "Ogerpon-Wellspring",
+				"weight": 20,
+				"item": ["Wellspring Mask"],
+				"ability": ["Water Absorb"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Water"],
+				"moves": [["Ivy Cudgel"], ["Power Whip"], ["Knock Off", "Play Rough"], ["Trailblaze"]]
+			}, {
+				"species": "Ogerpon-Wellspring",
+				"weight": 10,
+				"item": ["Wellspring Mask"],
+				"ability": ["Water Absorb"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Water"],
+				"moves": [["Ivy Cudgel"], ["Power Whip"], ["Knock Off"], ["Play Rough"]]
+			}]
+		},
+		"ragingbolt": {
+			"weight": 8,
+			"sets": [{
+				"species": "Raging Bolt",
+				"weight": 50,
+				"item": ["Leftovers", "Booster Energy"],
+				"ability": ["Protosynthesis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 20},
+				"nature": ["Modest"],
+				"teraType": ["Fairy", "Flying", "Bug"],
+				"moves": [["Thunderclap"], ["Calm Mind"], ["Dragon Pulse", "Draco Meteor"], ["Thunderbolt"]]
+			}, {
+				"species": "Raging Bolt",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Protosynthesis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 20},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Thunderclap"], ["Volt Switch"], ["Dragon Pulse"], ["Taunt"]]
+			}]
+		},
+		"samurotthisui": {
+			"weight": 8,
+			"sets": [{
+				"species": "Samurott-Hisui",
+				"weight": 20,
+				"item": ["Focus Sash"],
+				"ability": ["Sharpness"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost"],
+				"moves": [["Ceaseless Edge"], ["Razor Shell", "Aqua Cutter"], ["Aqua Jet", "Sucker Punch"], ["Knock Off", "Taunt", "Encore"]]
+			}, {
+				"species": "Samurott-Hisui",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sharpness"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Poison", "Fire"],
+				"moves": [["Ceaseless Edge"], ["Razor Shell", "Aqua Cutter"], ["Knock Off"], ["Flip Turn", "Encore"]]
+			}, {
+				"species": "Samurott-Hisui",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Sharpness"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Dark"],
+				"moves": [["Ceaseless Edge"], ["Razor Shell", "Aqua Cutter"], ["Knock Off"], ["Flip Turn", "Sacred Sword"]]
+			}, {
+				"species": "Samurott-Hisui",
+				"weight": 25,
+				"item": ["Assault Vest"],
+				"ability": ["Sharpness"],
+				"evs": {"hp": 172, "atk": 252, "spe": 84},
+				"nature": ["Adamant"],
+				"teraType": ["Poison"],
+				"moves": [["Ceaseless Edge"], ["Razor Shell", "Aqua Cutter"], ["Knock Off", "Flip Turn"], ["Aqua Jet", "Sucker Punch"]]
+			}]
+		},
+		"slowkinggalar": {
+			"weight": 8,
+			"sets": [{
+				"species": "Slowking-Galar",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 16, "spd": 240},
+				"ivs": {"atk": 0, "spe": 0},
+				"nature": ["Sassy"],
+				"teraType": ["Water", "Grass", "Fairy"],
+				"moves": [["Future Sight", "Psychic Noise"], ["Chilly Reception"], ["Sludge Bomb"], ["Thunder Wave", "Toxic"]]
+			}, {
+				"species": "Slowking-Galar",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 16, "spa": 144, "spd": 96},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Water", "Grass"],
+				"moves": [["Psyshock", "Psychic Noise"], ["Flamethrower"], ["Sludge Bomb"], ["Ice Beam"]]
+			}]
+		},
+		"tinglu": {
+			"weight": 8,
+			"sets": [{
+				"species": "Ting-Lu",
+				"weight": 80,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Vessel of Ruin"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Grass", "Fairy"],
+				"moves": [["Spikes", "Stealth Rock"], ["Earthquake"], ["Whirlwind"], ["Ruination"]]
+			}, {
+				"species": "Ting-Lu",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Vessel of Ruin"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Poison"],
+				"moves": [["Payback"], ["Earthquake"], ["Rest"], ["Sleep Talk"]]
+			}]
+		},
+		"alomomola": {
+			"weight": 7,
+			"sets": [{
+				"species": "Alomomola",
+				"weight": 33,
+				"item": ["Heavy-Duty Boots", "Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"spe": 0},
+				"nature": ["Relaxed"],
+				"teraType": ["Ghost", "Flying"],
+				"moves": [["Flip Turn"], ["Scald"], ["Wish"], ["Protect"]]
+			}, {
+				"species": "Alomomola",
+				"weight": 33,
+				"item": ["Heavy-Duty Boots", "Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 4, "def": 252, "spd": 252},
+				"ivs": {"spe": 0},
+				"nature": ["Relaxed"],
+				"teraType": ["Ghost", "Flying"],
+				"moves": [["Flip Turn"], ["Scald"], ["Wish"], ["Protect"]]
+			}, {
+				"species": "Alomomola",
+				"weight": 34,
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 20, "def": 236, "spd": 252},
+				"ivs": {"spe": 0},
+				"nature": ["Sassy"],
+				"teraType": ["Ghost", "Flying"],
+				"moves": [["Flip Turn"], ["Scald"], ["Play Rough"], ["Mirror Coat"]]
+			}]
+		},
+		"cinderace": {
+			"weight": 7,
+			"sets": [{
+				"species": "Cinderace",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Blaze"],
+				"evs": {"hp": 224, "atk": 32, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Flying"],
+				"moves": [["Pyro Ball"], ["U-turn"], ["Court Change"], ["Will-O-Wisp"]]
+			}, {
+				"species": "Cinderace",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Libero"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire"],
+				"moves": [["Pyro Ball"], ["U-turn"], ["Court Change"], ["Sucker Punch", "Gunk Shot"]]
+			}]
+		},
+		"deoxysspeed": {
+			"weight": 7,
+			"sets": [{
+				"species": "Deoxys-Speed",
+				"weight": 20,
+				"item": ["Life Orb", "Expert Belt"],
+				"ability": ["Pressure"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": ["Naive"],
+				"teraType": ["Fighting"],
+				"moves": [["Psycho Boost"], ["Superpower"], ["Knock Off"], ["Ice Beam", "Taunt"]]
+			}, {
+				"species": "Deoxys-Speed",
+				"weight": 20,
+				"item": ["Life Orb", "Expert Belt"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Psychic", "Ghost"],
+				"moves": [["Psycho Boost"], ["Focus Blast"], ["Shadow Ball"], ["Ice Beam", "Nasty Plot", "Taunt"]]
+			}, {
+				"species": "Deoxys-Speed",
+				"weight": 20,
+				"item": ["Life Orb", "Expert Belt"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Electric", "Psychic"],
+				"moves": [["Psycho Boost"], ["Thunderbolt"], ["Ice Beam"], ["Nasty Plot"]]
+			}, {
+				"species": "Deoxys-Speed",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"atk": 200, "spa": 252, "spe": 56},
+				"nature": ["Naive"],
+				"teraType": ["Fighting"],
+				"moves": [["Psycho Boost"], ["Knock Off"], ["Ice Beam"], ["Superpower"]]
+			}]
+		},
+		"garganacl": {
+			"weight": 7,
+			"sets": [{
+				"species": "Garganacl",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Purifying Salt"],
+				"evs": {"hp": 252, "def": 52, "spd": 204},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Fairy"],
+				"moves": [["Salt Cure"], ["Recover"], ["Curse"], ["Earthquake"]]
+			}, {
+				"species": "Garganacl",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Purifying Salt"],
+				"evs": {"hp": 252, "def": 52, "spd": 204},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Fairy"],
+				"moves": [["Salt Cure"], ["Recover"], ["Stealth Rock"], ["Protect"]]
+			}]
+		},
+		"ironcrown": {
+			"weight": 7,
+			"sets": [{
+				"species": "Iron Crown",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Quark Drive"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 20},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Fairy"],
+				"moves": [["Tachyon Cutter"], ["Future Sight", "Psychic Noise"], ["Focus Blast"], ["Volt Switch"]]
+			}, {
+				"species": "Iron Crown",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Quark Drive"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 20},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Steel"],
+				"moves": [["Tachyon Cutter"], ["Psyshock", "Psychic Noise"], ["Focus Blast"], ["Volt Switch"]]
+			}]
+		},
+		"moltres": {
+			"weight": 7,
+			"sets": [{
+				"species": "Moltres",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 248, "def": 248, "spe": 12},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Grass", "Fairy"],
+				"moves": [["Flamethrower"], ["Will-O-Wisp", "Hurricane"], ["Roar"], ["Roost"]]
+			}, {
+				"species": "Moltres",
+				"weight": 60,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 248, "def": 248, "spe": 12},
+				"nature": ["Bold"],
+				"teraType": ["Grass", "Fairy"],
+				"moves": [["Flamethrower"], ["Will-O-Wisp", "Hurricane", "Roar"], ["U-turn"], ["Roost"]]
+			}]
+		},
+		"roaringmoon": {
+			"weight": 7,
+			"sets": [{
+				"species": "Roaring Moon",
+				"weight": 50,
+				"item": ["Booster Energy"],
+				"ability": ["Protosynthesis"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Flying"],
+				"moves": [["Dragon Dance"], ["Knock Off"], ["Acrobatics"], ["Earthquake", "Taunt"]]
+			}, {
+				"species": "Roaring Moon",
+				"weight": 50,
+				"item": ["Booster Energy"],
+				"ability": ["Protosynthesis"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Ground"],
+				"moves": [["Dragon Dance"], ["Knock Off"], ["Earthquake"], ["Acrobatics", "Taunt"]]
+			}]
+		},
+		"enamorus": {
+			"weight": 6,
+			"sets": [{
+				"species": "Enamorus",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Contrary"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Stellar"],
+				"moves": [["Moonblast"], ["Earth Power"], ["Tera Blast"], ["Healing Wish"]]
+			}, {
+				"species": "Enamorus",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Contrary"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Ground"],
+				"moves": [["Moonblast"], ["Earth Power"], ["Mystical Fire"], ["Healing Wish"]]
+			}, {
+				"species": "Enamorus",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Cute Charm"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Ground", "Steel"],
+				"moves": [["Moonblast"], ["Earth Power"], ["Calm Mind"], ["Taunt"]]
+			}, {
+				"species": "Enamorus",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Cute Charm"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Ground", "Steel"],
+				"moves": [["Moonblast"], ["Earth Power"], ["Calm Mind"], ["Substitute"]]
+			}]
+		},
+		"glimmora": {
+			"weight": 6,
+			"sets": [{
+				"species": "Glimmora",
+				"weight": 100,
+				"item": ["Focus Sash", "Red Card"],
+				"ability": ["Toxic Debris"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Stealth Rock"], ["Mortal Spin"], ["Power Gem"], ["Earth Power"]]
+			}]
+		},
+		"hatterene": {
+			"weight": 6,
+			"sets": [{
+				"species": "Hatterene",
+				"weight": 60,
+				"item": ["Leftovers"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "def": 204, "spe": 52},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Fire"],
+				"moves": [["Calm Mind"], ["Draining Kiss"], ["Psyshock", "Stored Power"], ["Mystical Fire"]]
+			}, {
+				"species": "Hatterene",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "def": 204, "spe": 52},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Calm Mind"], ["Draining Kiss"], ["Psyshock", "Stored Power"], ["Nuzzle"]]
+			}]
+		},
+		"ogerpon": {
+			"weight": 6,
+			"sets": [{
+				"species": "Ogerpon",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Grass"],
+				"moves": [["Ivy Cudgel"], ["Knock Off"], ["U-turn"], ["Encore"]]
+			}]
+		},
+		"primarina": {
+			"weight": 6,
+			"sets": [{
+				"species": "Primarina",
+				"weight": 40,
+				"item": ["Assault Vest"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 80, "spa": 252, "spe": 176},
+				"nature": ["Modest"],
+				"teraType": ["Grass", "Steel"],
+				"moves": [["Surf"], ["Moonblast"], ["Psychic Noise"], ["Flip Turn"]]
+			}, {
+				"species": "Primarina",
+				"weight": 30,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 80, "spa": 252, "spe": 176},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ghost", "Steel"],
+				"moves": [["Surf", "Hydro Pump"], ["Moonblast"], ["Psychic Noise", "Substitute"], ["Calm Mind"]]
+			}, {
+				"species": "Primarina",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Liquid Voice"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel"],
+				"moves": [["Psychic Noise"], ["Draining Kiss"], ["Substitute"], ["Calm Mind"]]
+			}, {
+				"species": "Primarina",
+				"weight": 10,
+				"item": ["Leftovers"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel"],
+				"moves": [["Surf"], ["Draining Kiss"], ["Substitute"], ["Calm Mind"]]
+			}]
+		},
+		"sinistcha": {
+			"weight": 6,
+			"sets": [{
+				"species": "Sinistcha",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Heatproof"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Poison"],
+				"moves": [["Calm Mind"], ["Matcha Gotcha"], ["Shadow Ball"], ["Strength Sap"]]
+			}]
+		},
+		"tinkaton": {
+			"weight": 6,
+			"sets": [{
+				"species": "Tinkaton",
+				"weight": 100,
+				"item": ["Air Balloon"],
+				"ability": ["Pickpocket", "Mold Breaker"],
+				"evs": {"hp": 252, "spd": 24, "spe": 232},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Stealth Rock"], ["Gigaton Hammer"], ["Encore"], ["Thunder Wave", "Knock Off"]]
+			}]
+		},
+		"weavile": {
+			"weight": 6,
+			"sets": [{
+				"species": "Weavile",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pickpocket"],
+				"evs": {"hp": 252, "spd": 24, "spe": 232},
+				"nature": ["Jolly"],
+				"teraType": ["Ice"],
+				"moves": [["Triple Axel"], ["Knock Off"], ["Ice Shard"], ["Swords Dance", "Low Kick"]]
+			}]
+		},
+		"zapdos": {
+			"weight": 6,
+			"sets": [{
+				"species": "Zapdos",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Static"],
+				"evs": {"hp": 248, "def": 244, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Fairy", "Water"],
+				"moves": [["Hurricane"], ["Volt Switch"], ["Thunder Wave"], ["Roost"]]
+			}, {
+				"species": "Zapdos",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Static"],
+				"evs": {"hp": 248, "def": 244, "spe": 16},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Fairy", "Water"],
+				"moves": [["Hurricane"], ["U-turn"], ["Discharge"], ["Roost"]]
+			}]
+		},
+		"clefable": {
+			"weight": 5,
+			"sets": [{
+				"species": "Clefable",
+				"weight": 50,
+				"item": ["Leftovers", "Sticky Barb"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Water"],
+				"moves": [["Stealth Rock"], ["Moonlight"], ["Moonblast"], ["Knock Off"]]
+			}, {
+				"species": "Clefable",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fire"],
+				"moves": [["Calm Mind"], ["Moonlight"], ["Moonblast"], ["Flamethrower"]]
+			}, {
+				"species": "Clefable",
+				"weight": 25,
+				"item": ["Sticky Barb"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Water"],
+				"moves": [["Calm Mind"], ["Moonlight"], ["Moonblast"], ["Knock Off"]]
+			}]
+		},
+		"clodsire": {
+			"weight": 5,
+			"sets": [{
+				"species": "Clodsire",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Dark", "Steel"],
+				"moves": [["Earthquake"], ["Recover"], ["Toxic"], ["Spikes", "Stealth Rock"]]
+			}]
+		},
+		"corviknight": {
+			"weight": 5,
+			"sets": [{
+				"species": "Corviknight",
+				"weight": 50,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"nature": ["Impish"],
+				"teraType": ["Water", "Dragon"],
+				"moves": [["Brave Bird"], ["Roost"], ["U-turn"], ["Defog"]]
+			}, {
+				"species": "Corviknight",
+				"weight": 15,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"nature": ["Impish"],
+				"teraType": ["Water", "Dragon"],
+				"moves": [["Body Press"], ["Roost"], ["U-turn"], ["Defog"]]
+			}, {
+				"species": "Corviknight",
+				"weight": 20,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Dragon", "Fighting"],
+				"moves": [["Body Press"], ["Roost"], ["Iron Defense"], ["Defog"]]
+			}, {
+				"species": "Corviknight",
+				"weight": 15,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"nature": ["Impish"],
+				"teraType": ["Water", "Dragon", "Fighting"],
+				"moves": [["Body Press"], ["Roost"], ["U-turn"], ["Iron Defense"]]
+			}]
+		},
+		"dondozo": {
+			"weight": 5,
+			"sets": [{
+				"species": "Dondozo",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Dark", "Grass"],
+				"moves": [["Rest"], ["Sleep Talk"], ["Waterfall"], ["Curse", "Avalanche"]]
+			}, {
+				"species": "Dondozo",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Fighting", "Dark", "Grass"],
+				"moves": [["Rest"], ["Sleep Talk"], ["Body Press"], ["Avalanche"]]
+			}, {
+				"species": "Dondozo",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fighting", "Dark", "Grass"],
+				"moves": [["Rest"], ["Sleep Talk"], ["Body Press"], ["Curse"]]
+			}]
+		},
+		"hydrapple": {
+			"weight": 5,
+			"sets": [{
+				"species": "Hydrapple",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 244, "spa": 252, "spe": 12},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Steel", "Fairy", "Poison"],
+				"moves": [["Fickle Beam"], ["Nasty Plot"], ["Giga Drain"], ["Earth Power"]]
+			}]
+		},
+		"ogerponcornerstone": {
+			"weight": 5,
+			"sets": [{
+				"species": "Ogerpon-Cornerstone",
+				"weight": 50,
+				"item": ["Cornerstone Mask"],
+				"ability": ["Sturdy"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Rock"],
+				"moves": [["Ivy Cudgel"], ["Swords Dance"], ["Power Whip", "Horn Leech"], ["Low Kick"]]
+			}, {
+				"species": "Ogerpon-Cornerstone",
+				"weight": 50,
+				"item": ["Cornerstone Mask"],
+				"ability": ["Sturdy"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Rock"],
+				"moves": [["Ivy Cudgel"], ["Knock Off"], ["Horn Leech"], ["Spikes"]]
+			}]
+		},
+		"rillaboom": {
+			"weight": 5,
+			"sets": [{
+				"species": "Rillaboom",
+				"weight": 50,
+				"item": ["Choice Band"],
+				"ability": ["Grassy Surge"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Grass"],
+				"moves": [["Grassy Glide"], ["Wood Hammer"], ["U-turn"], ["Knock Off"]]
+			}, {
+				"species": "Rillaboom",
+				"weight": 25,
+				"item": ["Assault Vest"],
+				"ability": ["Grassy Surge"],
+				"evs": {"hp": 204, "atk": 252, "spe": 52},
+				"nature": ["Adamant"],
+				"teraType": ["Grass", "Fighting"],
+				"moves": [["Grassy Glide"], ["Low Kick"], ["U-turn"], ["Knock Off"]]
+			}, {
+				"species": "Rillaboom",
+				"weight": 25,
+				"item": ["Assault Vest"],
+				"ability": ["Grassy Surge"],
+				"evs": {"hp": 204, "atk": 252, "spe": 52},
+				"nature": ["Adamant"],
+				"teraType": ["Grass", "Fighting"],
+				"moves": [["Grassy Glide"], ["Wood Hammer"], ["U-turn"], ["Knock Off"]]
+			}]
+		},
+		"scizor": {
+			"weight": 5,
+			"sets": [{
+				"species": "Scizor",
+				"weight": 50,
+				"item": ["Life Orb"],
+				"ability": ["Technician"],
+				"evs": {"hp": 120, "atk": 252, "spe": 136},
+				"nature": ["Adamant"],
+				"teraType": ["Steel", "Fire"],
+				"moves": [["Swords Dance"], ["Bullet Punch"], ["Close Combat"], ["Knock Off"]]
+			}, {
+				"species": "Scizor",
+				"weight": 50,
+				"item": ["Choice Band"],
+				"ability": ["Technician"],
+				"evs": {"hp": 120, "atk": 252, "spe": 136},
+				"nature": ["Adamant"],
+				"teraType": ["Steel"],
+				"moves": [["U-turn"], ["Bullet Punch"], ["Close Combat"], ["Knock Off"]]
+			}]
+		},
+		"skarmory": {
+			"weight": 5,
+			"sets": [{
+				"species": "Skarmory",
+				"weight": 50,
+				"item": ["Rocky Helmet"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Dragon", "Fighting"],
+				"moves": [["Body Press"], ["Roost"], ["Spikes", "Stealth Rock"], ["Iron Defense"]]
+			}, {
+				"species": "Skarmory",
+				"weight": 50,
+				"item": ["Rocky Helmet"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Dragon"],
+				"moves": [["Whirlwind"], ["Roost"], ["Spikes", "Stealth Rock"], ["Brave Bird"]]
+			}]
+		},
+		"ursaluna": {
+			"weight": 5,
+			"sets": [{
+				"species": "Ursaluna",
+				"weight": 100,
+				"item": ["Flame Orb"],
+				"ability": ["Guts"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Normal", "Ghost"],
+				"moves": [["Swords Dance"], ["Facade"], ["Headlong Rush"], ["Fire Punch", "Ice Punch"]]
+			}]
+		},
+		"weezinggalar": {
+			"weight": 5,
+			"sets": [{
+				"species": "Weezing-Galar",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Neutralizing Gas"],
+				"evs": {"hp": 252, "def": 240, "spa": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Flying", "Grass"],
+				"moves": [["Strange Steam"], ["Pain Split"], ["Will-O-Wisp", "Toxic"], ["Defog"]]
+			}]
+		},
+		"greninjabond": {
+			"weight": 4,
+			"sets": [{
+				"species": "Greninja-Bond",
+				"weight": 100,
+				"item": ["Life Orb"],
+				"ability": ["Battle Bond"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Ghost"],
+				"moves": [["Surf", "Hydro Pump"], ["Dark Pulse"], ["Ice Beam"], ["Water Shuriken"]]
+			}]
+		},
+		"heatran": {
+			"weight": 4,
+			"sets": [{
+				"species": "Heatran",
+				"weight": 50,
+				"item": ["Air Balloon", "Leftovers"],
+				"ability": ["Flash Fire"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"teraType": ["Grass", "Ghost"],
+				"moves": [["Magma Storm"], ["Earth Power"], ["Taunt"], ["Stealth Rock", "Will-O-Wisp"]]
+			}, {
+				"species": "Heatran",
+				"weight": 15,
+				"item": ["Air Balloon", "Leftovers"],
+				"ability": ["Flash Fire"],
+				"evs": {"hp": 252, "def": 4, "spd": 212, "spe": 40},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Grass"],
+				"moves": [["Magma Storm"], ["Earth Power"], ["Taunt", "Stealth Rock"], ["Will-O-Wisp"]]
+			}, {
+				"species": "Heatran",
+				"weight": 15,
+				"item": ["Air Balloon", "Leftovers"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 212, "spe": 40},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Ghost"],
+				"moves": [["Magma Storm"], ["Earth Power"], ["Taunt", "Stealth Rock"], ["Will-O-Wisp"]]
+			}, {
+				"species": "Heatran",
+				"weight": 10,
+				"item": ["Air Balloon", "Leftovers"],
+				"ability": ["Flash Fire"],
+				"evs": {"hp": 252, "def": 4, "spd": 212, "spe": 40},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Grass"],
+				"moves": [["Magma Storm"], ["Earth Power"], ["Taunt"], ["Stealth Rock"]]
+			}, {
+				"species": "Heatran",
+				"weight": 10,
+				"item": ["Air Balloon", "Leftovers"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 212, "spe": 40},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Ghost"],
+				"moves": [["Magma Storm"], ["Earth Power"], ["Taunt"], ["Stealth Rock"]]
+			}]
+		},
+		"hoopaunbound": {
+			"weight": 4,
+			"sets": [{
+				"species": "Hoopa-Unbound",
+				"weight": 100,
+				"item": ["Assault Vest"],
+				"ability": ["Magician"],
+				"evs": {"hp": 252, "def": 156, "spa": 100},
+				"nature": ["Quiet"],
+				"teraType": ["Poison", "Fairy"],
+				"moves": [["Knock Off"], ["Psychic Noise"], ["Drain Punch"], ["Thunderbolt"]]
+			}]
+		},
+		"latios": {
+			"weight": 4,
+			"sets": [{
+				"species": "Latios",
+				"weight": 35,
+				"item": ["Choice Specs", "Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Dragon"],
+				"moves": [["Draco Meteor"], ["Aura Sphere"], ["Luster Purge"], ["Psyshock", "Trick"]]
+			}, {
+				"species": "Latios",
+				"weight": 15,
+				"item": ["Choice Specs", "Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Dragon"],
+				"moves": [["Draco Meteor"], ["Aura Sphere"], ["Luster Purge"], ["Flip Turn"]]
+			}, {
+				"species": "Latios",
+				"weight": 50,
+				"item": ["Soul Dew"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Draco Meteor"], ["Aura Sphere", "Calm Mind"], ["Luster Purge", "Psychic Noise"], ["Recover"]]
+			}]
+		},
+		"lokix": {
+			"weight": 4,
+			"sets": [{
+				"species": "Lokix",
+				"weight": 100,
+				"item": ["Choice Band"],
+				"ability": ["Tinted Lens"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Bug"],
+				"moves": [["First Impression"], ["Knock Off"], ["U-turn"], ["Leech Life"]]
+			}]
+		},
+		"manaphy": {
+			"weight": 4,
+			"sets": [{
+				"species": "Manaphy",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Hydration"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Grass"],
+				"moves": [["Tail Glow"], ["Surf", "Scald"], ["Energy Ball"], ["Alluring Voice", "Ice Beam"]]
+			}, {
+				"species": "Manaphy",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Hydration"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Tail Glow"], ["Surf", "Scald"], ["Alluring Voice"], ["Energy Ball", "Ice Beam"]]
+			}]
+		},
+		"meowscarada": {
+			"weight": 4,
+			"sets": [{
+				"species": "Meowscarada",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Choice Scarf", "Choice Band"],
+				"ability": ["Protean"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Grass", "Dark"],
+				"moves": [["Flower Trick"], ["Knock Off"], ["Triple Axel"], ["U-turn"]]
+			}]
+		},
+		"pecharunt": {
+			"weight": 4,
+			"sets": [{
+				"species": "Pecharunt",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Air Balloon"],
+				"ability": ["Poison Puppeteer"],
+				"evs": {"hp": 252, "def": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Dark"],
+				"moves": [["Malignant Chain"], ["Recover"], ["Hex"], ["Parting Shot"]]
+			}, {
+				"species": "Pecharunt",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Air Balloon"],
+				"ability": ["Poison Puppeteer"],
+				"evs": {"hp": 252, "def": 228, "spe": 28},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ghost", "Dark"],
+				"moves": [["Malignant Chain"], ["Recover"], ["Hex"], ["Parting Shot"]]
+			}]
+		},
+		"rotomwash": {
+			"weight": 4,
+			"sets": [{
+				"species": "Rotom-Wash",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 212, "spe": 44},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel"],
+				"moves": [["Hydro Pump"], ["Volt Switch"], ["Will-O-Wisp", "Thunder Wave"], ["Pain Split"]]
+			}, {
+				"species": "Rotom-Wash",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "spd": 212, "spe": 44},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Steel"],
+				"moves": [["Hydro Pump"], ["Volt Switch"], ["Will-O-Wisp", "Thunder Wave"], ["Pain Split"]]
+			}]
+		},
+		"serperior": {
+			"weight": 4,
+			"sets": [{
+				"species": "Serperior",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Contrary"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fire", "Ground"],
+				"moves": [["Leaf Storm"], ["Glare"], ["Tera Blast"], ["Substitute", "Dragon Pulse"]]
+			}]
+		},
+		"slitherwing": {
+			"weight": 2,
+			"sets": [{
+				"species": "Slither Wing",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Protosynthesis"],
+				"evs": {"hp": 252, "atk": 28, "def": 220, "spe": 8},
+				"nature": ["Impish"],
+				"teraType": ["Steel", "Dragon"],
+				"moves": [["First Impression"], ["U-turn"], ["Will-O-Wisp"], ["Morning Sun"]]
+			}]
+		},
+		"skeledirge": {
+			"weight": 4,
+			"sets": [{
+				"species": "Skeledirge",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Torch Song"], ["Will-O-Wisp"], ["Hex"], ["Slack Off"]]
+			}, {
+				"species": "Skeledirge",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Torch Song"], ["Will-O-Wisp"], ["Hex"], ["Slack Off"]]
+			}]
+		},
+		"tornadustherian": {
+			"weight": 4,
+			"sets": [{
+				"species": "Tornadus-Therian",
+				"weight": 100,
+				"item": ["Assault Vest", "Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "spa": 16, "spd": 72, "spe": 168},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Bleakwind Storm", "Hurricane"], ["Heat Wave"], ["Knock Off"], ["U-turn"]]
+			}]
+		},
+		"volcanion": {
+			"weight": 4,
+			"sets": [{
+				"species": "Volcanion",
+				"wantsTera": true,
+				"weight": 75,
+				"item": ["Choice Specs", "Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Steam Eruption"], ["Flamethrower"], ["Tera Blast"], ["Earth Power"]]
+			}, {
+				"species": "Volcanion",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Steam Eruption"], ["Flamethrower"], ["Sludge Bomb"], ["Earth Power"]]
+			}]
+		},
+		"ironboulder": {
+			"weight": 3,
+			"sets": [{
+				"species": "Iron Boulder",
+				"weight": 60,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Mighty Cleave"], ["Close Combat"], ["Zen Headbutt", "Earthquake"], ["Swords Dance"]]
+			}, {
+				"species": "Iron Boulder",
+				"weight": 40,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground"],
+				"moves": [["Mighty Cleave"], ["Earthquake"], ["Zen Headbutt", "Close Combat"], ["Swords Dance"]]
+			}]
+		},
+		"okidogi": {
+			"weight": 3,
+			"sets": [{
+				"species": "Okidogi",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Guard Dog", "Toxic Chain"],
+				"evs": {"hp": 240, "atk": 252, "spe": 16},
+				"nature": ["Adamant"],
+				"teraType": ["Water", "Dark"],
+				"moves": [["Drain Punch"], ["Gunk Shot"], ["Knock Off"], ["Ice Punch"]]
+			}, {
+				"species": "Okidogi",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Guard Dog"],
+				"evs": {"hp": 252, "spd": 160, "spe": 96},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Ghost"],
+				"moves": [["Drain Punch"], ["Bulk Up"], ["Knock Off"], ["Ice Punch"]]
+			}]
+		},
+		"toxapex": {
+			"weight": 3,
+			"sets": [{
+				"species": "Toxapex",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Grass"],
+				"moves": [["Surf"], ["Toxic"], ["Haze", "Toxic Spikes", "Baneful Bunker"], ["Recover"]]
+			}, {
+				"species": "Toxapex",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Steel", "Grass"],
+				"moves": [["Surf"], ["Toxic"], ["Haze", "Toxic Spikes", "Baneful Bunker"], ["Recover"]]
+			}, {
+				"species": "Toxapex",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "spa": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Surf"], ["Sludge Bomb"], ["Ice Beam"], ["Acid Spray"]]
+			}]
+		},
+		"amoonguss": {
+			"weight": 2,
+			"sets": [{
+				"species": "Amoonguss",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 244, "spd": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Dark", "Water", "Steel"],
+				"moves": [["Foul Play"], ["Toxic"], ["Synthesis"], ["Clear Smog", "Sludge Bomb", "Giga Drain"]]
+			}]
+		},
+		"enamorustherian": {
+			"weight": 2,
+			"sets": [{
+				"species": "Enamorus-Therian",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat"],
+				"evs": {"hp": 248, "spa": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground", "Poison"],
+				"moves": [["Moonblast", "Draining Kiss"], ["Earth Power"], ["Mystical Fire", "Taunt"], ["Calm Mind"]]
+			}]
+		},
+		"fezandipiti": {
+			"weight": 2,
+			"sets": [{
+				"species": "Fezandipiti",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Toxic Chain"],
+				"evs": {"hp": 248, "atk": 152, "spd": 44, "spe": 64},
+				"nature": ["Careful"],
+				"teraType": ["Dark", "Water"],
+				"moves": [["Play Rough"], ["Roost"], ["U-turn"], ["Beat Up"]]
+			}]
+		},
+		"garchomp": {
+			"weight": 2,
+			"sets": [{
+				"species": "Garchomp",
+				"weight": 50,
+				"item": ["Rocky Helmet"],
+				"ability": ["Rough Skin"],
+				"evs": {"hp": 252, "def": 216, "spe": 40},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Steel"],
+				"moves": [["Earthquake"], ["Dragon Tail"], ["Stealth Rock"], ["Spikes"]]
+			}, {
+				"species": "Garchomp",
+				"weight": 50,
+				"item": ["Loaded Dice"],
+				"ability": ["Rough Skin"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire"],
+				"moves": [["Earthquake"], ["Scale Shot"], ["Swords Dance"], ["Fire Fang", "Stealth Rock"]]
+			}]
+		},
+		"goodrahisui": {
+			"weight": 2,
+			"sets": [{
+				"species": "Goodra-Hisui",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Gooey", "Sap Sipper"],
+				"evs": {"hp": 248, "spa": 252, "spd": 8},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Draco Meteor"], ["Flash Cannon"], ["Knock Off"], ["Flamethrower", "Ice Beam"]]
+			}, {
+				"species": "Goodra-Hisui",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Gooey", "Sap Sipper"],
+				"evs": {"hp": 248, "spa": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Draco Meteor"], ["Flash Cannon"], ["Ice Beam"], ["Flamethrower"]]
+			}]
+		},
+		"ironhands": {
+			"weight": 2,
+			"sets": [{
+				"species": "Iron Hands",
+				"weight": 50,
+				"item": ["Booster Energy"],
+				"ability": ["Quark Drive"],
+				"evs": {"atk": 252, "spd": 172, "spe": 84},
+				"nature": ["Adamant"],
+				"teraType": ["Flying"],
+				"moves": [["Swords Dance"], ["Drain Punch"], ["Supercell Slam", "Thunder Punch"], ["Ice Punch"]]
+			}, {
+				"species": "Iron Hands",
+				"weight": 50,
+				"item": ["Shuca Berry"],
+				"ability": ["Quark Drive"],
+				"evs": {"atk": 252, "spd": 172, "spe": 84},
+				"nature": ["Adamant"],
+				"teraType": ["Fighting"],
+				"moves": [["Swords Dance"], ["Drain Punch"], ["Supercell Slam", "Thunder Punch"], ["Ice Punch"]]
+			}]
+		},
+		"keldeo": {
+			"weight": 2,
+			"sets": [{
+				"species": "Keldeo",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Justified"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Water"],
+				"moves": [["Aura Sphere"], ["Surf"], ["Flip Turn"], ["Vacuum Wave"]]
+			}]
+		},
+		"mandibuzz": {
+			"weight": 2,
+			"sets": [{
+				"species": "Mandibuzz",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat", "Big Pecks"],
+				"evs": {"hp": 248, "def": 244, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Poison"],
+				"moves": [["Foul Play"], ["Roost"], ["Defog"], ["Toxic"]]
+			}, {
+				"species": "Mandibuzz",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat", "Big Pecks"],
+				"evs": {"hp": 248, "def": 244, "spe": 16},
+				"nature": ["Impish"],
+				"teraType": ["Water", "Poison"],
+				"moves": [["Foul Play"], ["Roost"], ["Defog"], ["U-turn"]]
+			}]
+		},
+		"reuniclus": {
+			"weight": 2,
+			"sets": [{
+				"species": "Reuniclus",
+				"weight": 100,
+				"item": ["Life Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "spa": 212, "spe": 44},
+				"nature": ["Modest"],
+				"teraType": ["Water"],
+				"moves": [["Psychic Noise"], ["Recover"], ["Knock Off"], ["Focus Blast"]]
+			}]
+		},
+		"azumarill": {
+			"weight": 1,
+			"sets": [{
+				"species": "Azumarill",
+				"weight": 100,
+				"item": ["Assault Vest"],
+				"ability": ["Huge Power"],
+				"evs": {"hp": 252, "atk": 252, "spd": 4},
+				"nature": ["Adamant"],
+				"teraType": ["Water", "Grass"],
+				"moves": [["Liquidation"], ["Aqua Jet"], ["Play Rough"], ["Knock Off", "Ice Spinner"]]
+			}]
+		},
+		"chansey": {
+			"weight": 1,
+			"sets": [{
+				"species": "Chansey",
+				"weight": 100,
+				"item": ["Eviolite"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel"],
+				"moves": [["Seismic Toss"], ["Soft-Boiled"], ["Thunder Wave"], ["Stealth Rock"]]
+			}]
+		},
+		"mamoswine": {
+			"weight": 1,
+			"sets": [{
+				"species": "Mamoswine",
+				"weight": 100,
+				"item": ["Never-Melt Ice", "Life Orb"],
+				"ability": ["Thick Fat", "Oblivious"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Ice"],
+				"moves": [["Earthquake"], ["Icicle Crash"], ["Ice Shard"], ["Knock Off", "Stealth Rock"]]
+			}]
+		},
+		"maushold": {
+			"weight": 1,
+			"sets": [{
+				"species": "Maushold",
+				"weight": 100,
+				"item": ["Wide Lens"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Dark"],
+				"moves": [["Tidy Up"], ["Population Bomb"], ["Bite"], ["Encore"]]
+			}]
+		},
+		"sandyshocks": {
+			"weight": 1,
+			"sets": [{
+				"species": "Sandy Shocks",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Protosynthesis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ice"],
+				"moves": [["Earth Power"], ["Volt Switch"], ["Tera Blast"], ["Spikes", "Stealth Rock", "Thunderbolt"]]
+			}]
+		},
+		"thundurustherian": {
+			"weight": 1,
+			"sets": [{
+				"species": "Thundurus-Therian",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ice", "Fairy", "Flying"],
+				"moves": [["Thunderbolt"], ["Nasty Plot"], ["Tera Blast"], ["Agility", "Grass Knot", "Psychic"]]
+			}]
+		}
+	}, 
+	"UU": {
+		"tornadustherian": {
+			"weight": 10,
+			"sets": [{
+				"species": "Tornadus-Therian",
+				"weight": 60,
+				"item": ["Assault Vest", "Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "spd": 64, "spe": 192},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Water"],
+				"moves": [["Bleakwind Storm"], ["Focus Blast"], ["Knock Off"], ["U-turn"]]
+			}, {
+				"species": "Tornadus-Therian",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Bleakwind Storm", "Hurricane"], ["Focus Blast", "Heat Wave"], ["Taunt"], ["Nasty Plot"]]
+			}]
+		},
+		"excadrill": {
+			"weight": 10,
+			"sets": [{
+				"species": "Excadrill",
+				"weight": 50,
+				"item": ["Leftovers", "Air Balloon"],
+				"ability": ["Mold Breaker"],
+				"evs": {"hp": 156, "spd": 252, "spe": 100},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Dragon", "Fairy"],
+				"moves": [["Earthquake"], ["Rapid Spin"], ["Iron Head"], ["Stealth Rock"]]
+			}, {
+				"species": "Excadrill",
+				"weight": 50,
+				"item": ["Leftovers", "Air Balloon"],
+				"ability": ["Mold Breaker"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Dragon", "Fairy"],
+				"moves": [["Earthquake"], ["Rapid Spin"], ["Iron Head"], ["Swords Dance"]]
+			}]
+		},
+		"cobalion": {
+			"weight": 8,
+			"sets": [{
+				"species": "Cobalion",
+				"weight": 50,
+				"item": ["Leftovers", "Rocky Helmet", "Shuca Berry"],
+				"ability": ["Justified"],
+				"evs": {"def": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Dragon", "Flying"],
+				"moves": [["Body Press"], ["Volt Switch"], ["Thunder Wave", "Taunt"], ["Stealth Rock"]]
+			}, {
+				"species": "Cobalion",
+				"weight": 50,
+				"item": ["Leftovers", "Rocky Helmet", "Shuca Berry"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Dragon", "Flying"],
+				"moves": [["Close Combat"], ["Volt Switch"], ["Thunder Wave", "Taunt"], ["Stealth Rock"]]
+			}]
+		},
+		"hoopaunbound": {
+			"weight": 8,
+			"sets": [{
+				"species": "Hoopa-Unbound",
+				"weight": 70,
+				"item": ["Choice Scarf"],
+				"ability": ["Magician"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Dark", "Fairy"],
+				"moves": [["Hyperspace Fury"], ["Psychic"], ["Drain Punch"], ["Knock Off", "Thunderbolt", "Gunk Shot"]]
+			}, {
+				"species": "Hoopa-Unbound",
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Magician"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Dark", "Fairy"],
+				"moves": [["Hyperspace Fury"], ["Psychic"], ["Gunk Shot"], ["Knock Off", "Thunderbolt"]]
+			}]
+		},
+		"lokix": {
+			"weight": 8,
+			"sets": [{
+				"species": "Lokix",
+				"weight": 70,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Tinted Lens"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Bug"],
+				"moves": [["First Impression"], ["Knock Off"], ["U-turn"], ["Sucker Punch"]]
+			}, {
+				"species": "Lokix",
+				"weight": 30,
+				"item": ["Black Glasses"],
+				"ability": ["Tinted Lens"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["First Impression", "Protect"], ["Knock Off"], ["Swords Dance"], ["Sucker Punch"]]
+			}]
+		},
+		"weavile": {
+			"weight": 8,
+			"sets": [{
+				"species": "Weavile",
+				"weight": 80,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pickpocket"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Dark"],
+				"moves": [["Swords Dance"], ["Triple Axel", "Icicle Crash"], ["Knock Off"], ["Ice Shard", "Low Kick"]]
+			}, {
+				"species": "Weavile",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pickpocket"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ice"],
+				"moves": [["Swords Dance"], ["Triple Axel"], ["Knock Off"], ["Ice Shard"]]
+			}]
+		},
+		"greninja": {
+			"weight": 5,
+			"sets": [{
+				"species": "Greninja",
+				"gender": "M",
+				"weight": 67,
+				"item": ["Choice Specs"],
+				"ability": ["Protean"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water"],
+				"moves": [["Dark Pulse"], ["Surf", "Hydro Pump"], ["Ice Beam"], ["Sludge Wave", "Spikes"]]
+			}, {
+				"species": "Greninja",
+				"gender": "M",
+				"weight": 33,
+				"item": ["Choice Specs"],
+				"ability": ["Protean"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Water"],
+				"moves": [["Dark Pulse"], ["Surf", "Hydro Pump"], ["Ice Beam"], ["U-turn"]]
+			}]
+		},
+		"greninjabond": {	
+			"weight": 2,
+			"sets": [{
+				"species": "Greninja-Bond",
+				"weight": 100,
+				"item": ["Life Orb"],
+				"ability": ["Battle Bond"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Stellar"],
+				"moves": [["Surf"], ["Dark Pulse"], ["Ice Beam", "Sludge Wave"], ["Protect", "Water Shuriken"]]
+			}]
+		},
+		"heatran": {
+			"weight": 7,
+			"sets": [{
+				"species": "Heatran",
+				"weight": 50,
+				"item": ["Air Balloon"],
+				"ability": ["Flame Body"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Magma Storm"], ["Earth Power"], ["Taunt"], ["Stealth Rock"]]
+			}, {
+				"species": "Heatran",
+				"weight": 50,
+				"item": ["Air Balloon"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 252, "def": 96, "spe": 160},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Ghost", "Water"],
+				"moves": [["Magma Storm", "Lava Plume"], ["Earth Power"], ["Taunt", "Protect"], ["Stealth Rock"]]
+			}]
+		},
+		"hydrapple": {
+			"weight": 7,
+			"sets": [{
+				"species": "Hydrapple",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 108, "spa": 136, "spe": 12},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Steel", "Fairy", "Poison"],
+				"moves": [["Fickle Beam", "Draco Meteor"], ["Nasty Plot"], ["Giga Drain"], ["Earth Power"]]
+			}, {
+				"species": "Hydrapple",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Regenerator"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Fickle Beam", "Giga Drain"], ["Leaf Storm"], ["Draco Meteor"], ["Earth Power"]]
+			}]
+		},
+		"rotomwash": {
+			"weight": 7,
+			"sets": [{
+				"species": "Rotom-Wash",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 168, "spe": 88},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel"],
+				"moves": [["Hydro Pump"], ["Volt Switch"], ["Will-O-Wisp", "Thunder Wave"], ["Pain Split"]]
+			}, {
+				"species": "Rotom-Wash",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "spd": 168, "spe": 88},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Steel"],
+				"moves": [["Hydro Pump"], ["Volt Switch"], ["Will-O-Wisp", "Thunder Wave"], ["Pain Split"]]
+			}]
+		},
+		"scizor": {
+			"weight": 7,
+			"sets": [{
+				"species": "Scizor",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"hp": 120, "atk": 252, "spe": 136},
+				"nature": ["Adamant"],
+				"teraType": ["Steel", "Fire"],
+				"moves": [["Swords Dance"], ["Bullet Punch"], ["U-turn"], ["Knock Off"]]
+			}, {
+				"species": "Scizor",
+				"weight": 30,
+				"item": ["Life Orb"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Steel", "Fire"],
+				"moves": [["Swords Dance"], ["Bullet Punch"], ["Close Combat"], ["Knock Off"]]
+			}, {
+				"species": "Scizor",
+				"weight": 30,
+				"item": ["Choice Band"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Steel"],
+				"moves": [["U-turn"], ["Bullet Punch"], ["Close Combat"], ["Knock Off"]]
+			}]
+		},
+		"latios": {
+			"weight": 6,
+			"sets": [{
+				"species": "Latios",
+				"weight": 20,
+				"item": ["Choice Specs"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Dragon"],
+				"moves": [["Draco Meteor"], ["Luster Purge"], ["Flip Turn"], ["Surf", "Trick"]]
+			}, {
+				"species": "Latios",
+				"weight": 10,
+				"item": ["Choice Specs"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Dragon"],
+				"moves": [["Draco Meteor"], ["Luster Purge"], ["Surf"], ["Trick"]]
+			}, {
+				"species": "Latios",
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Dragon"],
+				"moves": [["Draco Meteor"], ["Luster Purge"], ["Flip Turn"], ["Trick"]]
+			}, {
+				"species": "Latios",
+				"weight": 30,
+				"item": ["Soul Dew"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Draco Meteor"], ["Luster Purge"], ["Flip Turn"], ["Recover"]]
+			}, {
+				"species": "Latios",
+				"weight": 5,
+				"item": ["Soul Dew"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Draco Meteor"], ["Luster Purge"], ["Calm Mind"], ["Recover"]]
+			}, {
+				"species": "Latios",
+				"weight": 5,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Water"],
+				"moves": [["Draco Meteor"], ["Surf"], ["Calm Mind"], ["Recover"]]
+			}]
+		},
+		"ogerponcornerstone": {
+			"weight": 6,
+			"sets": [{
+				"species": "Ogerpon-Cornerstone",
+				"weight": 50,
+				"item": ["Cornerstone Mask"],
+				"ability": ["Sturdy"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Rock"],
+				"moves": [["Ivy Cudgel"], ["Swords Dance"], ["Power Whip", "Horn Leech"], ["Stomping Tantrum", "Spiky Shield"]]
+			}, {
+				"species": "Ogerpon-Cornerstone",
+				"weight": 50,
+				"item": ["Cornerstone Mask"],
+				"ability": ["Sturdy"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Rock"],
+				"moves": [["Ivy Cudgel"], ["Stomping Tantrum"], ["Power Whip"], ["U-turn", "Spiky Shield"]]
+			}]
+		},
+		"quaquaval": {
+			"weight": 6,
+			"sets": [{
+				"species": "Quaquaval",
+				"weight": 100,
+				"item": ["Life Orb", "Lum Berry"],
+				"ability": ["Moxie"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Electric", "Steel"],
+				"moves": [["Aqua Step"], ["Close Combat"], ["Swords Dance"], ["Knock Off"]]
+			}]
+		},
+		"skeledirge": {
+			"weight": 6,
+			"sets": [{
+				"species": "Skeledirge",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 96, "spd": 160},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Torch Song"], ["Will-O-Wisp"], ["Hex"], ["Slack Off"]]
+			}]
+		},
+		"slowking": {
+			"weight": 6,
+			"sets": [{
+				"species": "Slowking",
+				"weight": 70,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0, "spe": 0},
+				"nature": ["Relaxed"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Scald"], ["Chilly Reception"], ["Thunder Wave", "Future Sight"], ["Slack Off"]]
+			}, {
+				"species": "Slowking",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 172, "spd": 84},
+				"ivs": {"atk": 0, "spe": 0},
+				"nature": ["Sassy"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Scald"], ["Chilly Reception"], ["Thunder Wave", "Future Sight"], ["Slack Off"]]
+			}]
+		},
+		"thundurustherian": {
+			"weight": 6,
+			"sets": [{
+				"species": "Thundurus-Therian",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Water"],
+				"moves": [["Volt Switch", "Nasty Plot"], ["Thunderbolt"], ["Sludge Bomb"], ["Focus Blast"]]
+			}]
+		},
+		"tyranitar": {
+			"weight": 6,
+			"sets": [{
+				"species": "Tyranitar",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "spd": 212, "spe": 44},
+				"nature": ["Careful"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Stone Edge"], ["Knock Off"], ["Thunder Wave"], ["Stealth Rock"]]
+			}, {
+				"species": "Tyranitar",
+				"weight": 50,
+				"item": ["Choice Band"],
+				"ability": ["Sand Stream"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Dark", "Rock"],
+				"moves": [["Stone Edge"], ["Knock Off"], ["Earthquake"], ["Ice Punch"]]
+			}]
+		},
+		"zarude": {
+			"weight": 6,
+			"sets": [{
+				"species": "Zarude",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Leaf Guard"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Poison"],
+				"moves": [["Power Whip"], ["Knock Off"], ["Swords Dance"], ["Jungle Healing"]]
+			}, {
+				"species": "Zarude",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Leaf Guard"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Power Whip"], ["Knock Off"], ["U-turn"], ["Close Combat", "Jungle Healing"]]
+			}, {
+				"species": "Zarude",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Leaf Guard"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Power Whip"], ["Knock Off"], ["U-turn"], ["Close Combat"]]
+			}]
+		},
+		"clodsire": {
+			"weight": 5,
+			"sets": [{
+				"species": "Clodsire",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 248, "def": 176, "spd": 84},
+				"nature": ["Careful"],
+				"teraType": ["Dark", "Ghost"],
+				"moves": [["Earthquake"], ["Recover"], ["Toxic"], ["Spikes", "Stealth Rock"]]
+			}]
+		},
+		"gastrodon": {
+			"weight": 5,
+			"sets": [{
+				"species": "Gastrodon",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Storm Drain"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Poison"],
+				"moves": [["Earth Power"], ["Recover"], ["Ice Beam", "Sludge Bomb"], ["Spikes", "Stealth Rock"]]
+			}]
+		},
+		"ogerpon": {
+			"weight": 5,
+			"sets": [{
+				"species": "Ogerpon",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Grass"],
+				"moves": [["Ivy Cudgel"], ["Knock Off"], ["U-turn"], ["Spikes", "Encore", "Stomping Tantrum"]]
+			}]
+		},
+		"pecharunt": {
+			"weight": 5,
+			"sets": [{
+				"species": "Pecharunt",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Poison Puppeteer"],
+				"evs": {"hp": 252, "def": 200, "spa": 4, "spd": 12, "spe": 40},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Malignant Chain", "Sludge Bomb"], ["Recover"], ["Hex"], ["Parting Shot"]]
+			}, {
+				"species": "Pecharunt",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Poison Puppeteer"],
+				"evs": {"hp": 252, "def": 200, "spa": 4, "spd": 12, "spe": 40},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy"],
+				"moves": [["Malignant Chain", "Sludge Bomb"], ["Recover"], ["Hex"], ["Parting Shot"]]
+			}, {
+				"species": "Pecharunt",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Poison Puppeteer"],
+				"evs": {"hp": 252, "spa": 88, "spd": 96, "spe": 72},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Malignant Chain"], ["Recover"], ["Hex"], ["Nasty Plot"]]
+			}, {
+				"species": "Pecharunt",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Poison Puppeteer"],
+				"evs": {"hp": 252, "spa": 88, "spd": 96, "spe": 72},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Sludge Bomb"], ["Recover"], ["Shadow Ball"], ["Nasty Plot"]]
+			}]
+		},
+		"skarmory": {
+			"weight": 5,
+			"sets": [{
+				"species": "Skarmory",
+				"weight": 50,
+				"item": ["Rocky Helmet"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "def": 208, "spe": 48},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Dragon", "Water"],
+				"moves": [["Body Press"], ["Roost"], ["Spikes"], ["Whirlwind", "Iron Defense"]]
+			}, {
+				"species": "Skarmory",
+				"weight": 50,
+				"item": ["Rocky Helmet"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"nature": ["Impish"],
+				"teraType": ["Dragon", "Water"],
+				"moves": [["Body Press"], ["Roost"], ["Spikes"], ["Brave Bird"]]
+			}]
+		},
+		"tinkaton": {
+			"weight": 5,
+			"sets": [{
+				"species": "Tinkaton",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Mold Breaker"],
+				"evs": {"hp": 252, "def": 232, "spe": 24},
+				"nature": ["Impish"],
+				"teraType": ["Flying", "Ghost", "Dark", "Dragon"],
+				"moves": [["Gigaton Hammer"], ["Encore"], ["Knock Off"], ["Stealth Rock", "Thunder Wave"]]
+			}, {
+				"species": "Tinkaton",
+				"weight": 50,
+				"item": ["Air Balloon"],
+				"ability": ["Pickpocket"],
+				"evs": {"hp": 252, "def": 232, "spe": 24},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Dark", "Dragon"],
+				"moves": [["Gigaton Hammer"], ["Encore"], ["Knock Off"], ["Stealth Rock", "Thunder Wave"]]
+			}]
+		},
+		"bellibolt": {
+			"weight": 4,
+			"sets": [{
+				"species": "Bellibolt",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Static"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Dragon"],
+				"moves": [["Volt Switch"], ["Muddy Water"], ["Slack Off"], ["Toxic"]]
+			}]
+		},
+		"enamorustherian": {
+			"weight": 4,
+			"sets": [{
+				"species": "Enamorus-Therian",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat"],
+				"evs": {"hp": 84, "spa": 252, "spe": 172},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Moonblast"], ["Earth Power"], ["Draining Kiss"], ["Mystical Fire", "Calm Mind"]]
+			}, {
+				"species": "Enamorus-Therian",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat"],
+				"evs": {"hp": 84, "spa": 252, "spe": 172},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Moonblast"], ["Earth Power"], ["Mystical Fire"], ["Calm Mind"]]
+			}]
+		},
+		"gardevoir": {
+			"weight": 4,
+			"sets": [{
+				"species": "Gardevoir",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Trace"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Moonblast"], ["Psychic"], ["Focus Blast", "Trick"], ["Healing Wish"]]
+			}]
+		},
+		"arcaninehisui": {
+			"weight": 4,
+			"sets": [{
+				"species": "Arcanine-Hisui",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Rock Head"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Head Smash"], ["Flare Blitz"], ["Extreme Speed"], ["Stealth Rock", "Morning Sun"]]
+			}]
+		},
+		"keldeo": {
+			"weight": 4,
+			"sets": [{
+				"species": "Keldeo",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Justified"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Secret Sword"], ["Surf"], ["Calm Mind"], ["Substitute", "Taunt"]]
+			}, {
+				"species": "Keldeo",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Justified"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Fighting"],
+				"moves": [["Secret Sword"], ["Surf", "Hydro Pump"], ["Flip Turn"], ["Vacuum Wave"]]
+			}]
+		},
+		"manaphy": {
+			"weight": 4,
+			"sets": [{
+				"species": "Manaphy",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Hydration"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Tail Glow"], ["Scald"], ["Ice Beam"], ["Alluring Voice"]]
+			}]
+		},
+		"polteageist": {
+			"weight": 4,
+			"sets": [{
+				"species": "Polteageist",
+				"weight": 100,
+				"item": ["White Herb"],
+				"ability": ["Cursed Body"],
+				"evs": {"hp": 248, "def": 184, "spe": 76},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel"],
+				"moves": [["Shell Smash"], ["Shadow Ball"], ["Stored Power"], ["Strength Sap"]]
+			}]
+		},
+		"revavroom": {
+			"weight": 4,
+			"sets": [{
+				"species": "Revavroom",
+				"weight": 100,
+				"item": ["Air Balloon"],
+				"ability": ["Filter"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Ground", "Fire"],
+				"moves": [["Shift Gear"], ["Temper Flare"], ["Gunk Shot"], ["High Horsepower"]]
+			}]
+		},
+		"sandyshocks": {
+			"weight": 4,
+			"sets": [{
+				"species": "Sandy Shocks",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Protosynthesis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ice"],
+				"moves": [["Earth Power"], ["Volt Switch"], ["Tera Blast"], ["Spikes", "Stealth Rock"]]
+			}]
+		},
+		"serperior": {
+			"weight": 4,
+			"sets": [{
+				"species": "Serperior",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Contrary"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Electric"],
+				"moves": [["Leaf Storm"], ["Glare"], ["Tera Blast"], ["Synthesis", "Dragon Pulse"]]
+			}]
+		},
+		"toxapex": {
+			"weight": 4,
+			"sets": [{
+				"species": "Toxapex",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots", "Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 152, "spd": 108},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Surf"], ["Toxic"], ["Haze"], ["Recover"]]
+			}, {
+				"species": "Toxapex",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots", "Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 152, "spd": 108},
+				"nature": ["Impish"],
+				"teraType": ["Fairy"],
+				"moves": [["Liquidation"], ["Toxic"], ["Haze"], ["Recover"]]
+			}]
+		},
+		"azumarill": {
+			"weight": 2,
+			"sets": [{
+				"species": "Azumarill",
+				"weight": 50,
+				"item": ["Leftovers", "Choice Band"],
+				"ability": ["Huge Power"],
+				"evs": {"hp": 124, "atk": 252, "spe": 132},
+				"nature": ["Adamant"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Aqua Jet"], ["Play Rough"], ["Liquidation"], ["Knock Off"]]
+			}, {
+				"species": "Azumarill",
+				"weight": 50,
+				"item": ["Leftovers", "Choice Band"],
+				"ability": ["Huge Power"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Aqua Jet"], ["Play Rough"], ["Liquidation"], ["Knock Off"]]
+			}]
+		},
+		"chesnaught": {
+			"weight": 2,
+			"sets": [{
+				"species": "Chesnaught",
+				"weight": 100,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Bulletproof"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Poison", "Ghost"],
+				"moves": [["Spikes"], ["Body Press"], ["Synthesis"], ["Knock Off", "Wood Hammer", "Stone Edge"]]
+			}]
+		},
+		"comfey": {
+			"weight": 3,
+			"sets": [{
+				"species": "Comfey",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Life Orb"],
+				"ability": ["Triage"],
+				"evs": {"hp": 240, "spa": 252, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Calm Mind"], ["Taunt"], ["Draining Kiss"], ["Tera Blast"]]
+			}]
+		},
+		"fezandipiti": {
+			"weight": 2,
+			"sets": [{
+				"species": "Fezandipiti",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Toxic Chain"],
+				"evs": {"hp": 248, "def": 128, "spd": 16, "spe": 116},
+				"nature": ["Calm"],
+				"teraType": ["Water"],
+				"moves": [["Moonblast"], ["U-turn"], ["Beat Up"], ["Roost"]]
+			}]
+		},
+		"hippowdon": {
+			"weight": 2,
+			"sets": [{
+				"species": "Hippowdon",
+				"weight": 100,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "def": 208, "spd": 48},
+				"nature": ["Impish"],
+				"teraType": ["Dragon"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Slack Off"], ["Stone Edge"]]
+			}]
+		},
+		"hydreigon": {
+			"weight": 2,
+			"sets": [{
+				"species": "Hydreigon",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison"],
+				"moves": [["Nasty Plot"], ["Dark Pulse"], ["Draco Meteor"], ["Substitute"]]
+			}, {
+				"species": "Hydreigon",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Modest", "Timid"],
+				"teraType": ["Dark"],
+				"moves": [["Fire Blast"], ["Dark Pulse"], ["Draco Meteor"], ["U-turn"]]
+			}]
+		},
+		"mamoswine": {
+			"weight": 3,
+			"sets": [{
+				"species": "Mamoswine",
+				"weight": 50,
+				"item": ["Never-Melt Ice"],
+				"ability": ["Thick Fat"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Grass"],
+				"moves": [["Earthquake"], ["Icicle Crash"], ["Ice Shard"], ["Trailblaze"]]
+			}, {
+				"species": "Mamoswine",
+				"weight": 50,
+				"item": ["Never-Melt Ice"],
+				"ability": ["Thick Fat"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Ice"],
+				"moves": [["Earthquake"], ["Icicle Crash"], ["Ice Shard"], ["Knock Off"]]
+			}]
+		},
+		"mandibuzz": {
+			"weight": 4,
+			"sets": [{
+				"species": "Mandibuzz",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat"],
+				"evs": {"hp": 248, "def": 136, "spd": 108, "spe": 16},
+				"nature": ["Impish"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Foul Play"], ["Roost"], ["U-turn"], ["Defog", "Toxic"]]
+			}, {
+				"species": "Mandibuzz",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat"],
+				"evs": {"hp": 248, "def": 136, "spd": 108, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Foul Play"], ["Roost"], ["Toxic"], ["Defog"]]
+			}]
+		},
+		"metagross": {
+			"weight": 3,
+			"sets": [{
+				"species": "Metagross",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "atk": 160, "spe": 96},
+				"nature": ["Adamant"],
+				"teraType": ["Dark"],
+				"moves": [["Heavy Slam"], ["Psychic Fangs"], ["Knock Off"], ["Stealth Rock", "Bullet Punch"]]
+			}, {
+				"species": "Metagross",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "atk": 160, "spe": 96},
+				"nature": ["Adamant"],
+				"teraType": ["Water"],
+				"moves": [["Heavy Slam"], ["Psychic Fangs"], ["Earthquake"], ["Stealth Rock", "Bullet Punch"]]
+			}]
+		},
+		"rhyperior": {
+			"weight": 3,
+			"sets": [{
+				"species": "Rhyperior",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Solid Rock"],
+				"evs": {"hp": 252, "atk": 16, "spd": 240},
+				"nature": ["Adamant"],
+				"teraType": ["Dragon"],
+				"moves": [["Earthquake"], ["Stone Edge"], ["Stealth Rock"], ["Megahorn"]]
+			}]
+		},
+		"salamence": {
+			"weight": 2,
+			"sets": [{
+				"species": "Salamence",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Moxie"],
+				"evs": {"hp": 96, "atk": 252, "spe": 160},
+				"nature": ["Jolly"],
+				"teraType": ["Fire"],
+				"moves": [["Roost", "Temper Flare"], ["Outrage"], ["Earthquake"], ["Dragon Dance"]]
+			}, {
+				"species": "Salamence",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 160, "spa": 252, "spe": 96},
+				"nature": ["Modest"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Roost"], ["Draco Meteor"], ["Hurricane"], ["Earthquake"]]
+			}, {
+				"species": "Salamence",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 160, "spa": 252, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Roost"], ["Draco Meteor"], ["Hurricane"], ["Flamethrower"]]
+			}]
+		},
+		"sinistcha": {
+			"weight": 3,
+			"sets": [{
+				"species": "Sinistcha",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Heatproof"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Poison"],
+				"moves": [["Calm Mind"], ["Matcha Gotcha"], ["Shadow Ball"], ["Strength Sap"]]
+			}]
+		},
+		"volcanion": {
+			"weight": 2,
+			"sets": [{
+				"species": "Volcanion",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Steam Eruption"], ["Flamethrower"], ["Sludge Bomb"], ["Taunt"]]
+			}, {
+				"species": "Volcanion",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Steam Eruption"], ["Flamethrower"], ["Sludge Bomb"], ["Earth Power"]]
+			}]
+		},
+		"araquanid": {
+			"weight": 1,
+			"sets": [{
+				"species": "Araquanid",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Bubble"],
+				"evs": {"hp": 252, "atk": 76, "def": 156, "spe": 24},
+				"nature": ["Impish"],
+				"teraType": ["Ghost"],
+				"moves": [["Liquidation"], ["Leech Life"], ["Sticky Web"], ["Mirror Coat", "Trailblaze"]]
+			}]
+		},
+		"donphan": {
+			"weight": 2,
+			"sets": [{
+				"species": "Donphan",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Assault Vest"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "atk": 104, "def": 132, "spe": 20},
+				"nature": ["Adamant"],
+				"teraType": ["Dragon", "Grass", "Fairy"],
+				"moves": [["Earthquake"], ["Rapid Spin"], ["Ice Spinner", "Ice Shard"], ["Knock Off"]]
+			}, {
+				"species": "Donphan",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "atk": 104, "def": 132, "spe": 20},
+				"nature": ["Adamant"],
+				"teraType": ["Dragon", "Grass", "Fairy", "Ghost"],
+				"moves": [["Earthquake"], ["Rapid Spin"], ["Stealth Rock"], ["Knock Off"]]
+			}]
+		},
+		"conkeldurr": {
+			"weight": 1,
+			"sets": [{
+				"species": "Conkeldurr",
+				"weight": 100,
+				"item": ["Flame Orb"],
+				"ability": ["Guts"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Normal"],
+				"moves": [["Close Combat"], ["Mach Punch"], ["Facade"], ["Knock Off"]]
+			}]
+		},
+		"empoleon": {
+			"weight": 1,
+			"sets": [{
+				"species": "Empoleon",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Competitive"],
+				"evs": {"hp": 252, "def": 40, "spd": 216},
+				"nature": ["Sassy"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Surf"], ["Haze"], ["Flip Turn", "Knock Off"], ["Roost"]]
+			}]
+		},
+		"zapdosgalar": {
+			"weight": 1,
+			"sets": [{
+				"species": "Zapdos-Galar",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Flying"],
+				"moves": [["Close Combat"], ["Brave Bird"], ["Thunderous Kick", "Knock Off"], ["U-turn"]]
+			}]
+		},
+		"haxorus": {
+			"weight": 1,
+			"sets": [{
+				"species": "Haxorus",
+				"weight": 100,
+				"item": ["Choice Band"],
+				"ability": ["Mold Breaker"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Dragon"],
+				"moves": [["Close Combat", "Earthquake"], ["Outrage"], ["First Impression"], ["Poison Jab"]]
+			}]
+		},
+		"jirachi": {
+			"weight": 1,
+			"sets": [{
+				"species": "Jirachi",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 252, "atk": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Iron Head"], ["Wish"], ["Protect"], ["U-turn"]]
+			}]
+		},
+		"slowbro": {
+			"weight": 1,
+			"sets": [{
+				"species": "Slowbro",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Colbur Berry"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison"],
+				"moves": [["Scald"], ["Psychic Noise"], ["Slack Off"], ["Calm Mind"]]
+			}, {
+				"species": "Slowbro",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Colbur Berry"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fighting"],
+				"moves": [["Thunder Wave"], ["Scald"], ["Slack Off"], ["Body Press"]]
+			}]
+		},
+		"krookodile": {
+			"weight": 1,
+			"sets": [{
+				"species": "Krookodile",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Poison"],
+				"moves": [["Stealth Rock"], ["Knock Off"], ["Earthquake"], ["Gunk Shot"]]
+			}]
+		}
+	},
+	"RU": {
+		"slowbro": {
+			"weight": 10,
+			"sets": [{
+				"species": "Slowbro",
+				"weight": 50,
+				"item": ["Rocky Helmet", "Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison", "Fairy"],
+				"moves": [["Scald"], ["Slack Off"], ["Psychic Noise"], ["Calm Mind"]]
+			}, {
+				"species": "Slowbro",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison", "Fairy"],
+				"moves": [["Scald"], ["Slack Off"], ["Future Sight"], ["Thunder Wave"]]
+			}]
+		},
+		"armarouge": {
+			"weight": 9,
+			"sets": [{
+				"species": "Armarouge",
+				"weight": 85,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Weak Armor"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Grass", "Fairy"],
+				"moves": [["Armor Cannon"], ["Psyshock"], ["Energy Ball"], ["Calm Mind"]]
+			}, {
+				"species": "Armarouge",
+				"weight": 15,
+				"item": ["Weakness Policy"],
+				"ability": ["Weak Armor"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Normal", "Ground"],
+				"moves": [["Armor Cannon"], ["Stored Power"], ["Energy Ball", "Calm Mind"], ["Endure"]]
+			}]
+		},
+		"bisharp": {
+			"weight": 9,
+			"sets": [{
+				"species": "Bisharp",
+				"weight": 100,
+				"item": ["Eviolite"],
+				"ability": ["Defiant"],
+				"evs": {"hp": 200, "atk": 252, "spe": 56},
+				"nature": ["Adamant"],
+				"teraType": ["Flying", "Dark"],
+				"moves": [["Swords Dance"], ["Sucker Punch"], ["Iron Head"], ["Throat Chop"]]
+			}]
+		},
+		"cyclizar": {
+			"weight": 9,
+			"sets": [{
+				"species": "Cyclizar",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 104, "spd": 152, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fairy", "Steel", "Ghost"],
+				"moves": [["Rapid Spin"], ["Knock Off"], ["U-turn"], ["Dragon Tail", "Facade"]]
+			}, {
+				"species": "Cyclizar",
+				"weight": 30,
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 104, "spd": 152, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Steel", "Ghost"],
+				"moves": [["Rapid Spin"], ["Knock Off"], ["U-turn"], ["Draco Meteor"]]
+			}, {
+				"species": "Cyclizar",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "atk": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost"],
+				"moves": [["Rapid Spin"], ["Knock Off"], ["U-turn"], ["Taunt", "Double-Edge"]]
+			}]
+		},
+		"goodrahisui": {
+			"weight": 9,
+			"sets": [{
+				"species": "Goodra-Hisui",
+				"weight": 100,
+				"item": ["Choice Specs"],
+				"ability": ["Gooey"],
+				"evs": {"hp": 120, "spa": 252, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ghost", "Dragon"],
+				"moves": [["Flash Cannon"], ["Draco Meteor"], ["Thunderbolt"], ["Flamethrower"]]
+			}]
+		},
+		"jirachi": {
+			"weight": 9,
+			"sets": [{
+				"species": "Jirachi",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 252, "spd": 32, "spe": 224},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Steel", "Fairy"],
+				"moves": [["Iron Head"], ["Stealth Rock"], ["Body Slam"], ["U-turn", "Encore", "Wish"]]
+			}, {
+				"species": "Jirachi",
+				"weight": 25,
+				"item": ["Leftovers", "Expert Belt"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 32, "spa": 252, "spe": 224},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Fairy"],
+				"moves": [["Calm Mind"], ["Psychic Noise"], ["Grass Knot"], ["Aura Sphere", "Thunder", "Shadow Ball"]]
+			}, {
+				"species": "Jirachi",
+				"weight": 5,
+				"item": ["Expert Belt"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 32, "spa": 252, "spe": 224},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting"],
+				"moves": [["Calm Mind"], ["Psychic Noise"], ["Grass Knot"], ["Aura Sphere"]]
+			}, {
+				"species": "Jirachi",
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Serene Grace"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Iron Head"], ["U-turn"], ["Trick"], ["Healing Wish"]]
+			}]
+		},
+		"krookodile": {
+			"weight": 9,
+			"sets": [{
+				"species": "Krookodile",
+				"weight": 40,
+				"item": ["Choice Band"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Poison"],
+				"moves": [["Earthquake"], ["Knock Off"], ["Gunk Shot"], ["Close Combat", "Crunch"]]
+			}, {
+				"species": "Krookodile",
+				"weight": 15,
+				"item": ["Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Poison", "Ghost"],
+				"moves": [["Earthquake"], ["Knock Off"], ["Gunk Shot"], ["Close Combat", "Crunch"]]
+			}, {
+				"species": "Krookodile",
+				"weight": 15,
+				"item": ["Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost"],
+				"moves": [["Earthquake"], ["Knock Off"], ["Taunt"], ["Close Combat", "Crunch"]]
+			}, {
+				"species": "Krookodile",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Poison"],
+				"moves": [["Earthquake"], ["Knock Off"], ["Gunk Shot"], ["Stone Edge", "Close Combat", "Stealth Rock"]]
+			}, {
+				"species": "Krookodile",
+				"weight": 5,
+				"item": ["Choice Scarf"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Poison"],
+				"moves": [["Earthquake"], ["Knock Off"], ["Stone Edge"], ["Close Combat", "Stealth Rock"]]
+			}]
+		},
+		"slitherwing": {
+			"weight": 9,
+			"sets": [{
+				"species": "Slither Wing",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Protosynthesis"],
+				"evs": {"hp": 252, "atk": 16, "def": 72, "spe": 168},
+				"nature": ["Adamant"],
+				"teraType": ["Steel"],
+				"moves": [["U-turn"], ["Close Combat"], ["First Impression", "Will-O-Wisp"], ["Morning Sun"]]
+			}, {
+				"species": "Slither Wing",
+				"weight": 50,
+				"item": ["Choice Band"],
+				"ability": ["Protosynthesis"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Steel", "Bug"],
+				"moves": [["U-turn"], ["Close Combat"], ["First Impression"], ["Earthquake", "Heavy Slam"]]
+			}]
+		},
+		"empoleon": {
+			"weight": 8,
+			"sets": [{
+				"species": "Empoleon",
+				"weight": 30,
+				"item": ["Leftovers"],
+				"ability": ["Competitive"],
+				"evs": {"hp": 144, "spa": 228, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Surf"], ["Roost"], ["Ice Beam"], ["Grass Knot"]]
+			}, {
+				"species": "Empoleon",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Competitive"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Surf"], ["Roost"], ["Flip Turn"], ["Knock Off", "Ice Beam"]]
+			}, {
+				"species": "Empoleon",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Competitive"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Surf"], ["Roost"], ["Stealth Rock"], ["Roar", "Ice Beam"]]
+			}, {
+				"species": "Empoleon",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Competitive"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Surf"], ["Roost"], ["Stealth Rock"], ["Knock Off"]]
+			}]
+		},
+		"fezandipiti": {
+			"weight": 8,
+			"sets": [{
+				"species": "Fezandipiti",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Covert Cloak"],
+				"ability": ["Toxic Chain"],
+				"evs": {"hp": 252, "def": 56, "spe": 200},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Moonblast"], ["Roost"], ["Calm Mind"], ["U-turn"]]
+			}, {
+				"species": "Fezandipiti",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Covert Cloak"],
+				"ability": ["Toxic Chain"],
+				"evs": {"hp": 252, "def": 56, "spe": 200},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Moonblast"], ["Roost"], ["Calm Mind"], ["Taunt"]]
+			}]
+		},
+		"hippowdon": {
+			"weight": 8,
+			"sets": [{
+				"species": "Hippowdon",
+				"weight": 80,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Dragon", "Ghost", "Poison"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Slack Off"], ["Stone Edge", "Whirlwind"]]
+			}, {
+				"species": "Hippowdon",
+				"weight": 20,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Dragon", "Ghost", "Poison"],
+				"moves": [["Stone Edge"], ["Earthquake"], ["Slack Off"], ["Whirlwind"]]
+			}]
+		},
+		"suicune": {
+			"weight": 8,
+			"sets": [{
+				"species": "Suicune",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Dark", "Fairy"],
+				"moves": [["Substitute"], ["Calm Mind"], ["Scald"], ["Protect", "Ice Beam", "Shadow Ball"]]
+			}]
+		},
+		"volcanion": {
+			"weight": 8,
+			"sets": [{
+				"species": "Volcanion",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 120, "spa": 252, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy", "Ghost", "Dark"],
+				"moves": [["Steam Eruption"], ["Flamethrower"], ["Body Press"], ["Earth Power"]]
+			}, {
+				"species": "Volcanion",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 120, "spa": 252, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy", "Ghost", "Dark"],
+				"moves": [["Steam Eruption"], ["Flamethrower"], ["Taunt"], ["Body Press", "Earth Power"]]
+			}]
+		},
+		"zapdosgalar": {
+			"weight": 8,
+			"sets": [{
+				"species": "Zapdos-Galar",
+				"weight": 100,
+				"item": ["Choice Scarf", "Choice Band"],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Flying", "Steel", "Dark"],
+				"moves": [["Close Combat"], ["Brave Bird"], ["Knock Off"], ["U-turn"]]
+			}]
+		},
+		"basculegionf": {
+			"weight": 7,
+			"sets": [{
+				"species": "Basculegion-F",
+				"weight": 45,
+				"item": ["Choice Scarf"],
+				"ability": ["Adaptability"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Surf"], ["Shadow Ball"], ["Ice Beam"], ["Flip Turn"]]
+			}, {
+				"species": "Basculegion-F",
+				"weight": 30,
+				"item": ["Choice Specs"],
+				"ability": ["Adaptability"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Surf"], ["Shadow Ball"], ["Ice Beam"], ["Flip Turn"]]
+			}, {
+				"species": "Basculegion-F",
+				"weight": 25,
+				"item": ["Weakness Policy", "Life Orb"],
+				"ability": ["Adaptability"],
+				"evs": {"hp": 108, "def": 52, "spa": 252, "spd": 24, "spe": 72},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Surf"], ["Shadow Ball"], ["Ice Beam"], ["Agility"]]
+			}]
+		},
+		"flygon": {
+			"weight": 6,
+			"sets": [{
+				"species": "Flygon",
+				"weight": 55,
+				"item": ["Loaded Dice"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Fairy", "Steel"],
+				"moves": [["Stealth Rock"], ["Scale Shot"], ["Earthquake"], ["U-turn", "Stone Edge"]]
+			}, {
+				"species": "Flygon",
+				"weight": 20,
+				"item": ["Loaded Dice"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Dragon Dance"], ["Scale Shot"], ["Earthquake"], ["Stone Edge"]]
+			}, {
+				"species": "Flygon",
+				"weight": 5,
+				"item": ["Loaded Dice"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire"],
+				"moves": [["Dragon Dance"], ["Scale Shot"], ["Earthquake"], ["Fire Punch"]]
+			}, {
+				"species": "Flygon",
+				"weight": 15,
+				"item": ["Choice Band"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Bug"],
+				"moves": [["Outrage", "Dragon Claw", "Stone Edge"], ["Earthquake"], ["First Impression"], ["U-turn"]]
+			}, {
+				"species": "Flygon",
+				"weight": 5,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Dragon"],
+				"moves": [["Outrage"], ["U-turn"], ["Earthquake"], ["Stone Edge"]]
+			}]
+		},
+		"gardevoir": {
+			"weight": 7,
+			"sets": [{
+				"species": "Gardevoir",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Trace"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Moonblast"], ["Psychic"], ["Trick"], ["Healing Wish"]]
+			}]
+		},
+		"gengar": {
+			"weight": 7,
+			"sets": [{
+				"species": "Gengar",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Cursed Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Dark"],
+				"moves": [["Shadow Ball"], ["Sludge Wave"], ["Trick"], ["Toxic Spikes", "Focus Blast", "Thunder Wave", "Destiny Bond"]]
+			}, {
+				"species": "Gengar",
+				"weight": 25,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Cursed Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Dark"],
+				"moves": [["Hex"], ["Sludge Bomb"], ["Will-O-Wisp"], ["Toxic Spikes", "Focus Blast"]]
+			}, {
+				"species": "Gengar",
+				"weight": 15,
+				"item": ["Air Balloon"],
+				"ability": ["Cursed Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting"],
+				"moves": [["Shadow Ball"], ["Sludge Wave"], ["Nasty Plot"], ["Focus Blast"]]
+			}, {
+				"species": "Gengar",
+				"weight": 10,
+				"item": ["Air Balloon"],
+				"ability": ["Cursed Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Shadow Ball"], ["Sludge Wave"], ["Nasty Plot"], ["Encore"]]
+			}]
+		},
+		"magnezone": {
+			"weight": 7,
+			"sets": [{
+				"species": "Magnezone",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Choice Specs"],
+				"ability": ["Analytic"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Grass", "Water"],
+				"moves": [["Thunderbolt"], ["Flash Cannon"], ["Volt Switch"], ["Tera Blast"]]
+			}, {
+				"species": "Magnezone",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Choice Specs"],
+				"ability": ["Magnet Pull"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Thunderbolt"], ["Flash Cannon"], ["Volt Switch"], ["Tera Blast"]]
+			}, {
+				"species": "Magnezone",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Assault Vest"],
+				"ability": ["Analytic"],
+				"evs": {"hp": 88, "spa": 208, "spd": 76, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Discharge"], ["Flash Cannon"], ["Volt Switch"], ["Tera Blast"]]
+			}, {
+				"species": "Magnezone",
+				"weight": 25,
+				"item": ["Assault Vest"],
+				"ability": ["Analytic"],
+				"evs": {"hp": 88, "spa": 208, "spd": 76, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Flying", "Water"],
+				"moves": [["Discharge"], ["Flash Cannon"], ["Volt Switch"], ["Body Press", "Mirror Coat"]]
+			}]
+		},
+		"maushold": {
+			"weight": 4,
+			"sets": [{
+				"species": "Maushold",
+				"weight": 100,
+				"item": ["Wide Lens"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Normal"],
+				"moves": [["Tidy Up"], ["Population Bomb"], ["Bite", "Bullet Seed"], ["Encore"]]
+			}]
+		},
+		"mew": {
+			"weight": 7,
+			"sets": [{
+				"species": "Mew",
+				"weight": 100,
+				"item": ["Life Orb"],
+				"ability": ["Synchronize"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Nasty Plot"], ["Psyshock"], ["Earth Power"], ["Draining Kiss"]]
+			}]
+		},
+		"mimikyu": {
+			"weight": 4,
+			"sets": [{
+				"species": "Mimikyu",
+				"weight": 100,
+				"item": ["Life Orb", "Red Card"],
+				"ability": ["Disguise"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost"],
+				"moves": [["Swords Dance"], ["Shadow Sneak"], ["Play Rough"], ["Shadow Claw"]]
+			}]
+		},
+		"noivern": {
+			"weight": 7,
+			"sets": [{
+				"species": "Noivern",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Infiltrator"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fire"],
+				"moves": [["Roost"], ["U-turn"], ["Draco Meteor"], ["Flamethrower"]]
+			}, {
+				"species": "Noivern",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Infiltrator"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fire"],
+				"moves": [["Roost"], ["Defog"], ["Draco Meteor"], ["Flamethrower"]]
+			}, {
+				"species": "Noivern",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Infiltrator"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Roost"], ["Defog"], ["Draco Meteor", "Psychic Noise"], ["Super Fang"]]
+			}]
+		},
+		"registeel": {
+			"weight": 6,
+			"sets": [{
+				"species": "Registeel",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 180, "spd": 76},
+				"nature": ["Impish"],
+				"teraType": ["Ghost"],
+				"moves": [["Stealth Rock"], ["Heavy Slam"], ["Body Press"], ["Iron Defense"]]
+			}]
+		},
+		"reuniclus": {
+			"weight": 7,
+			"sets": [{
+				"species": "Reuniclus",
+				"weight": 50,
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Fairy"],
+				"moves": [["Psychic Noise"], ["Calm Mind"], ["Focus Blast", "Shadow Ball"], ["Recover"]]
+			}, {
+				"species": "Reuniclus",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Fairy"],
+				"moves": [["Psychic Noise"], ["Thunder Wave"], ["Focus Blast"], ["Recover"]]
+			}, {
+				"species": "Reuniclus",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Fairy"],
+				"moves": [["Psychic Noise"], ["Thunder Wave"], ["Knock Off"], ["Recover"]]
+			}]
+		},
+		"revavroom": {
+			"weight": 4,
+			"sets": [{
+				"species": "Revavroom",
+				"weight": 100,
+				"item": ["Air Balloon"],
+				"ability": ["Filter"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Ground"],
+				"moves": [["Shift Gear"], ["Iron Head"], ["Gunk Shot"], ["High Horsepower"]]
+			}]
+		},
+		"salamence": {
+			"weight": 7,
+			"sets": [{
+				"species": "Salamence",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Water"],
+				"moves": [["Draco Meteor"], ["Hurricane"], ["Flamethrower"], ["Roost"]]
+			}, {
+				"species": "Salamence",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots", "Life Orb"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Ground"],
+				"moves": [["Dragon Claw"], ["Dual Wingbeat", "Roost"], ["Earthquake"], ["Dragon Dance"]]
+			}, {
+				"species": "Salamence",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots", "Lum Berry"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Ground"],
+				"moves": [["Outrage"], ["Dual Wingbeat", "Roost"], ["Earthquake"], ["Dragon Dance"]]
+			}]
+		},
+		"terrakion": {
+			"weight": 7,
+			"sets": [{
+				"species": "Terrakion",
+				"weight": 25,
+				"item": ["Choice Band"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Rock"],
+				"moves": [["Close Combat"], ["Stone Edge"], ["Earthquake"], ["Quick Attack"]]
+			}, {
+				"species": "Terrakion",
+				"weight": 25,
+				"item": ["Choice Band"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost"],
+				"moves": [["Close Combat"], ["Stone Edge"], ["Earthquake"], ["Tera Blast"]]
+			}, {
+				"species": "Terrakion",
+				"weight": 20,
+				"item": ["Air Balloon"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Flying"],
+				"moves": [["Close Combat"], ["Stone Edge"], ["Earthquake", "Taunt"], ["Swords Dance"]]
+			}, {
+				"species": "Terrakion",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Flying"],
+				"moves": [["Close Combat"], ["Stone Edge"], ["Earthquake", "Substitute"], ["Swords Dance"]]
+			}, {
+				"species": "Terrakion",
+				"weight": 10,
+				"item": ["Leftovers"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Rock", "Ground"],
+				"moves": [["Close Combat"], ["Stone Edge"], ["Earthquake"], ["Rock Slide", "Stealth Rock"]]
+			}]
+		},
+		"umbreon": {
+			"weight": 7,
+			"sets": [{
+				"species": "Umbreon",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Synchronize", "Inner Focus"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Poison", "Ghost"],
+				"moves": [["Foul Play"], ["Toxic"], ["Wish"], ["Protect"]]
+			}, {
+				"species": "Umbreon",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Synchronize", "Inner Focus"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Poison", "Ghost"],
+				"moves": [["Foul Play"], ["Toxic"], ["Wish"], ["Moonlight"]]
+			}]
+		},
+		"weezinggalar": {
+			"weight": 7,
+			"sets": [{
+				"species": "Weezing-Galar",
+				"weight": 90,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Ghost", "Water"],
+				"moves": [["Strange Steam"], ["Pain Split"], ["Will-O-Wisp"], ["Defog", "Flamethrower", "Taunt"]]
+			}, {
+				"species": "Weezing-Galar",
+				"weight": 10,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Neutralizing Gas"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Strange Steam"], ["Pain Split"], ["Will-O-Wisp"], ["Defog", "Flamethrower", "Taunt"]]
+			}]
+		},
+		"yanmega": {
+			"weight": 4,
+			"sets": [{
+				"species": "Yanmega",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Throat Spray"],
+				"ability": ["Speed Boost"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Bug Buzz"], ["Air Slash"], ["Tera Blast"], ["Protect"]]
+			}]
+		},
+		"zoroarkhisui": {
+			"weight": 7,
+			"sets": [{
+				"species": "Zoroark-Hisui",
+				"weight": 20,
+				"item": ["Choice Specs"],
+				"ability": ["Illusion"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Shadow Ball"], ["Tera Blast"], ["Flamethrower"], ["Trick", "Grass Knot"]]
+			}, {
+				"species": "Zoroark-Hisui",
+				"weight": 10,
+				"item": ["Choice Specs"],
+				"ability": ["Illusion"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Shadow Ball"], ["Tera Blast"], ["Flamethrower"], ["U-turn"]]
+			}, {
+				"species": "Zoroark-Hisui",
+				"weight": 20,
+				"item": ["Choice Specs"],
+				"ability": ["Illusion"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Shadow Ball"], ["Hyper Voice"], ["Flamethrower"], ["Trick", "Grass Knot"]]
+			}, {
+				"species": "Zoroark-Hisui",
+				"weight": 10,
+				"item": ["Choice Specs"],
+				"ability": ["Illusion"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Shadow Ball"], ["Hyper Voice"], ["Flamethrower"], ["U-turn"]]
+			}, {
+				"species": "Zoroark-Hisui",
+				"weight": 20,
+				"item": ["Choice Scarf"],
+				"ability": ["Illusion"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Shadow Ball"], ["Hyper Voice"], ["Flamethrower"], ["Trick"]]
+			}, {
+				"species": "Zoroark-Hisui",
+				"weight": 20,
+				"item": ["Choice Scarf"],
+				"ability": ["Illusion"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Shadow Ball"], ["Hyper Voice"], ["U-turn"], ["Trick"]]
+			}]
+		},
+		"amoonguss": {
+			"weight": 5,
+			"sets": [{
+				"species": "Amoonguss",
+				"weight": 100,
+				"item": ["Rocky Helmet", "Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Water", "Steel"],
+				"moves": [["Stun Spore"], ["Giga Drain"], ["Sludge Bomb"], ["Foul Play", "Toxic"]]
+			}]
+		},
+		"conkeldurr": {
+			"weight": 5,
+			"sets": [{
+				"species": "Conkeldurr",
+				"weight": 90,
+				"item": ["Flame Orb"],
+				"ability": ["Guts"],
+				"evs": {"hp": 92, "atk": 252, "spe": 164},
+				"nature": ["Adamant"],
+				"teraType": ["Steel", "Normal"],
+				"moves": [["Facade"], ["Close Combat", "Drain Punch"], ["Knock Off"], ["Mach Punch"]]
+			}, {
+				"species": "Conkeldurr",
+				"weight": 10,
+				"item": ["Flame Orb"],
+				"ability": ["Guts"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Steel", "Normal"],
+				"moves": [["Facade"], ["Close Combat", "Drain Punch"], ["Knock Off"], ["Mach Punch"]]
+			}]
+		},
+		"feraligatr": {
+			"weight": 4,
+			"sets": [{
+				"species": "Feraligatr",
+				"weight": 70,
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Dragon Dance"], ["Ice Punch"], ["Liquidation"], ["Crunch"]]
+			}, {
+				"species": "Feraligatr",
+				"weight": 30,
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Swords Dance"], ["Aqua Jet"], ["Liquidation", "Ice Punch"], ["Crunch"]]
+			}]
+		},
+		"gligar": {
+			"weight": 4,
+			"sets": [{
+				"species": "Gligar",
+				"weight": 100,
+				"item": ["Eviolite"],
+				"ability": ["Immunity"],
+				"evs": {"hp": 252, "def": 204, "spd": 36, "spe": 16},
+				"nature": ["Impish"],
+				"teraType": ["Water"],
+				"moves": [["Spikes", "Stealth Rock"], ["Earthquake"], ["Toxic"], ["U-turn", "Knock Off"]]
+			}]
+		},
+		"gyarados": {
+			"weight": 4,
+			"sets": [{
+				"species": "Gyarados",
+				"wantsTera": true,
+				"weight": 70,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Flying"],
+				"moves": [["Dragon Dance"], ["Waterfall"], ["Earthquake"], ["Tera Blast"]]
+			}, {
+				"species": "Gyarados",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground"],
+				"moves": [["Dragon Dance"], ["Waterfall"], ["Earthquake"], ["Ice Fang"]]
+			}, {
+				"species": "Gyarados",
+				"weight": 20,
+				"item": ["Covert Cloak"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground"],
+				"moves": [["Dragon Dance"], ["Waterfall"], ["Earthquake"], ["Taunt"]]
+			}]
+		},
+		"mienshao": {
+			"weight": 4,
+			"sets": [{
+				"species": "Mienshao",
+				"weight": 50,
+				"item": ["Life Orb"],
+				"ability": ["Regenerator"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Steel"],
+				"moves": [["Close Combat"], ["Knock Off"], ["U-turn"], ["Triple Axel", "Ice Spinner"]]
+			}, {
+				"species": "Mienshao",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Regenerator"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Fighting"],
+				"moves": [["Close Combat"], ["Knock Off"], ["U-turn"], ["Ice Spinner", "Stone Edge"]]
+			}]
+		},
+		"necrozma": {
+			"weight": 4,
+			"sets": [{
+				"species": "Necrozma",
+				"weight": 25,
+				"item": ["Lum Berry"],
+				"ability": ["Prism Armor"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fairy", "Electric"],
+				"moves": [["Photon Geyser"], ["Earthquake"], ["Dragon Dance"], ["Knock Off", "X-Scissor"]]
+			}, {
+				"species": "Necrozma",
+				"weight": 25,
+				"item": ["Weakness Policy"],
+				"ability": ["Prism Armor"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire"],
+				"moves": [["Photon Geyser"], ["Earthquake"], ["Dragon Dance"], ["Knock Off", "X-Scissor"]]
+			}, {
+				"species": "Necrozma",
+				"weight": 50,
+				"item": ["Power Herb"],
+				"ability": ["Prism Armor"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ghost"],
+				"moves": [["Photon Geyser"], ["Earth Power"], ["Meteor Beam"], ["Stealth Rock"]]
+			}]
+		},
+		"ninetalesalola": {
+			"weight": 4,
+			"sets": [{
+				"species": "Ninetales-Alola",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Snow Warning"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Nasty Plot"], ["Freeze-Dry", "Blizzard"], ["Moonblast"], ["Tera Blast"]]
+			}]
+		},
+		"slowbrogalar": {
+			"weight": 3,
+			"sets": [{
+				"species": "Slowbro-Galar",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Psyshock"], ["Flamethrower"], ["Slack Off"], ["Toxic"]]
+			}, {
+				"species": "Slowbro-Galar",
+				"weight": 30,
+				"item": ["Colbur Berry"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ghost"],
+				"moves": [["Psyshock"], ["Flamethrower"], ["Slack Off"], ["Toxic"]]
+			}, {
+				"species": "Slowbro-Galar",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots", "Covert Cloak"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Sludge Bomb"], ["Flamethrower"], ["Slack Off"], ["Calm Mind"]]
+			}]
+		},
+		"talonflame": {
+			"weight": 1,
+			"sets": [{
+				"species": "Talonflame",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 248, "def": 28, "spe": 232},
+				"nature": ["Jolly"],
+				"teraType": ["Dragon", "Ghost"],
+				"moves": [["Brave Bird"], ["Defog", "U-turn"], ["Will-O-Wisp"], ["Roost"]]
+			}]
+		},
+		"vaporeon": {
+			"weight": 4,
+			"sets": [{
+				"species": "Vaporeon",
+				"weight": 75,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison", "Fairy"],
+				"moves": [["Scald"], ["Protect"], ["Wish"], ["Haze", "Calm Mind", "Ice Beam"]]
+			}, {
+				"species": "Vaporeon",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Bold"],
+				"teraType": ["Poison", "Fairy"],
+				"moves": [["Scald"], ["Protect"], ["Wish"], ["Flip Turn"]]
+			}]
+		},
+		"wochien": {
+			"weight": 4,
+			"sets": [{
+				"species": "Wo-Chien",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Tablets of Ruin"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"nature": ["Impish"],
+				"teraType": ["Poison", "Ghost"],
+				"moves": [["Knock Off"], ["Protect"], ["Leech Seed"], ["Foul Play", "Ruination"]]
+			}, {
+				"species": "Wo-Chien",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Tablets of Ruin"],
+				"evs": {"hp": 252, "spd": 200, "spe": 56},
+				"nature": ["Careful"],
+				"teraType": ["Poison", "Ghost"],
+				"moves": [["Knock Off"], ["Protect"], ["Leech Seed"], ["Foul Play", "Ruination"]]
+			}]
+		},
+		"azelf": {
+			"weight": 4,
+			"sets": [{
+				"species": "Azelf",
+				"weight": 60,
+				"item": ["Expert Belt"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": ["Naive"],
+				"teraType": ["Steel"],
+				"moves": [["Psychic"], ["Flamethrower"], ["U-turn"], ["Energy Ball"]]
+			}, {
+				"species": "Azelf",
+				"weight": 10,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Fire"],
+				"moves": [["Psyshock"], ["Flamethrower"], ["Dazzling Gleam"], ["Trick"]]
+			}, {
+				"species": "Azelf",
+				"weight": 10,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Fire"],
+				"moves": [["Psyshock"], ["Flamethrower"], ["Dazzling Gleam"], ["U-turn"]]
+			}, {
+				"species": "Azelf",
+				"weight": 10,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Psyshock"], ["Shadow Ball"], ["Dazzling Gleam"], ["Trick"]]
+			}, {
+				"species": "Azelf",
+				"weight": 10,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Psyshock"], ["Shadow Ball"], ["Dazzling Gleam"], ["U-turn"]]
+			}]
+		},
+		"crawdaunt": {
+			"weight": 4,
+			"sets": [{
+				"species": "Crawdaunt",
+				"weight": 50,
+				"item": ["Life Orb"],
+				"ability": ["Adaptability"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Water"],
+				"moves": [["Crabhammer"], ["Knock Off"], ["Aqua Jet"], ["Swords Dance"]]
+			}, {
+				"species": "Crawdaunt",
+				"weight": 50,
+				"item": ["Choice Band"],
+				"ability": ["Adaptability"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Fighting"],
+				"moves": [["Crabhammer"], ["Knock Off"], ["Aqua Jet"], ["Close Combat"]]
+			}]
+		},
+		"chesnaught": {
+			"weight": 4,
+			"sets": [{
+				"species": "Chesnaught",
+				"weight": 100,
+				"item": ["Rocky Helmet"],
+				"ability": ["Bulletproof"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Steel"],
+				"moves": [["Spikes"], ["Knock Off"], ["Synthesis"], ["Body Press"]]
+			}]
+		},
+		"cresselia": {
+			"weight": 3,
+			"sets": [{
+				"species": "Cresselia",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 236, "spe": 20},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison"],
+				"moves": [["Calm Mind"], ["Moonblast"], ["Stored Power"], ["Moonlight"]]
+			}]
+		},
+		"entei": {
+			"weight": 4,
+			"sets": [{
+				"species": "Entei",
+				"weight": 100,
+				"item": ["Choice Band"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal", "Dark"],
+				"moves": [["Extreme Speed"], ["Sacred Fire"], ["Crunch"], ["Stone Edge", "Stomping Tantrum"]]
+			}]
+		},
+		"gastrodon": {
+			"weight": 3,
+			"sets": [{
+				"species": "Gastrodon",
+				"weight": 100,
+				"item": ["Rocky Helmet", "Heavy-Duty Boots"],
+				"ability": ["Sticky Hold"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Relaxed"],
+				"teraType": ["Ghost", "Poison"],
+				"moves": [["Spikes"], ["Earthquake"], ["Ice Beam"], ["Recover"]]
+			}]
+		},
+		"kleavor": {
+			"weight": 3,
+			"sets": [{
+				"species": "Kleavor",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Sharpness"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Stone Axe"], ["U-turn"], ["Close Combat"], ["X-Scissor"]]
+			}]
+		},
+		"klefki": {
+			"weight": 3,
+			"sets": [{
+				"species": "Klefki",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Thunder Wave"], ["Foul Play", "Magnet Rise"], ["Spikes"], ["Play Rough"]]
+			}, {
+				"species": "Klefki",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Thunder Wave"], ["Foul Play", "Magnet Rise"], ["Spikes"], ["Dazzling Gleam"]]
+			}]
+		},
+		"lilliganthisui": {
+			"weight": 3,
+			"sets": [{
+				"species": "Lilligant-Hisui",
+				"wantsTera": true,
+				"weight": 50,
+				"item": ["Wide Lens"],
+				"ability": ["Hustle"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Psychic"],
+				"moves": [["Close Combat"], ["Leaf Blade"], ["Victory Dance"], ["Tera Blast"]]
+			}, {
+				"species": "Lilligant-Hisui",
+				"weight": 50,
+				"item": ["Wide Lens"],
+				"ability": ["Hustle"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ice", "Fighting"],
+				"moves": [["Close Combat"], ["Leaf Blade"], ["Victory Dance"], ["Ice Spinner"]]
+			}]
+		},
+		"lycanrocdusk": {
+			"weight": 3,
+			"sets": [{
+				"species": "Lycanroc-Dusk",
+				"weight": 50,
+				"item": ["Choice Band", "Life Orb"],
+				"ability": ["Tough Claws"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting", "Dark"],
+				"moves": [["Close Combat"], ["Accelerock"], ["Crunch"], ["Psychic Fangs", "Stone Edge"]]
+			}, {
+				"species": "Lycanroc-Dusk",
+				"weight": 25,
+				"item": ["Life Orb"],
+				"ability": ["Tough Claws"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Close Combat"], ["Swords Dance"], ["Stone Edge"], ["Accelerock"]]
+			}, {
+				"species": "Lycanroc-Dusk",
+				"weight": 25,
+				"item": ["Life Orb"],
+				"ability": ["Tough Claws"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Close Combat"], ["Swords Dance"], ["Stone Edge"], ["Sucker Punch"]]
+			}]
+		},
+		"mukalola": {
+			"weight": 3,
+			"sets": [{
+				"species": "Muk-Alola",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Poison Touch"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Fairy", "Steel", "Flying"],
+				"moves": [["Poison Jab"], ["Knock Off"], ["Rest"], ["Sleep Talk"]]
+			}]
+		},
+		"rotomheat": {
+			"weight": 3,
+			"sets": [{
+				"species": "Rotom-Heat",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Fairy", "Steel"],
+				"moves": [["Overheat"], ["Volt Switch", "Thunderbolt"], ["Nasty Plot"], ["Will-O-Wisp"]]
+			}, {
+				"species": "Rotom-Heat",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Fairy", "Steel"],
+				"moves": [["Overheat"], ["Volt Switch"], ["Trick"], ["Will-O-Wisp", "Thunderbolt"]]
+			}]
+		},
+		"bellibolt": {
+			"weight": 3,
+			"sets": [{
+				"species": "Bellibolt",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Static"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Volt Switch"], ["Slack Off"], ["Muddy Water"], ["Toxic"]]
+			}]
+		},
+		"breloom": {
+			"weight": 3,
+			"sets": [{
+				"species": "Breloom",
+				"weight": 50,
+				"item": ["Choice Band"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Mach Punch"], ["Bullet Seed"], ["Close Combat"], ["Rock Tomb", "Bulldoze"]]
+			}, {
+				"species": "Breloom",
+				"weight": 50,
+				"item": ["Loaded Dice", "Life Orb"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Fighting", "Fire"],
+				"moves": [["Mach Punch"], ["Bullet Seed"], ["Swords Dance"], ["Rock Tomb", "Bulldoze"]]
+			}]
+		},
+		"chansey": {
+			"weight": 2,
+			"sets": [{
+				"species": "Chansey",
+				"weight": 100,
+				"item": ["Eviolite"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 4, "def": 252, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ghost"],
+				"moves": [["Seismic Toss"], ["Soft-Boiled"], ["Heal Bell"], ["Stealth Rock"]]
+			}]
+		},
+		"gallade": {
+			"weight": 3,
+			"sets": [{
+				"species": "Gallade",
+				"weight": 100,
+				"item": ["Lum Berry"],
+				"ability": ["Sharpness"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Dark"],
+				"moves": [["Night Slash"], ["Agility"], ["Sacred Sword"], ["Psycho Cut"]]
+			}]
+		},
+		"infernape": {
+			"weight": 3,
+			"sets": [{
+				"species": "Infernape",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Blaze"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["U-turn"], ["Switcheroo"], ["Close Combat"], ["Flare Blitz"]]
+			}, {
+				"species": "Infernape",
+				"weight": 50,
+				"item": ["Air Balloon", "Expert Belt"],
+				"ability": ["Blaze"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Grass"],
+				"moves": [["Nasty Plot"], ["Vacuum Wave"], ["Fire Blast"], ["Grass Knot"]]
+			}]
+		},
+		"kilowattrel": {
+			"weight": 3,
+			"sets": [{
+				"species": "Kilowattrel",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Electric", "Steel"],
+				"moves": [["U-turn"], ["Thunderbolt"], ["Hurricane"], ["Roost"]]
+			}, {
+				"species": "Kilowattrel",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Electric", "Steel"],
+				"moves": [["Volt Switch"], ["Thunderbolt"], ["Hurricane"], ["Roost"]]
+			}]
+		},
+		"oricoriopompom": {
+			"weight": 3,
+			"sets": [{
+				"species": "Oricorio-Pom-Pom",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dancer"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground", "Water"],
+				"moves": [["Quiver Dance"], ["Revelation Dance"], ["Hurricane", "Taunt"], ["Roost"]]
+			}]
+		},
+		"palossand": {
+			"weight": 3,
+			"sets": [{
+				"species": "Palossand",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Water Compaction"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Water", "Poison"],
+				"moves": [["Stealth Rock"], ["Scorching Sands"], ["Shadow Ball"], ["Shore Up"]]
+			}]
+		},
+		"porygonz": {
+			"weight": 3,
+			"sets": [{
+				"species": "Porygon-Z",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Agility"], ["Tera Blast"], ["Ice Beam"], ["Thunderbolt"]]
+			}]
+		},
+		"quagsire": {
+			"weight": 3,
+			"sets": [{
+				"species": "Quagsire",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers", "Rocky Helmet"],
+				"ability": ["Unaware", "Water Absorb"],
+				"evs": {"hp": 252, "atk": 4, "def": 252},
+				"nature": ["Impish"],
+				"teraType": ["Poison"],
+				"moves": [["Toxic"], ["Earthquake"], ["Recover"], ["Spikes", "Stealth Rock"]]
+			}]
+		},
+		"raikou": {
+			"weight": 3,
+			"sets": [{
+				"species": "Raikou",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Flying"],
+				"moves": [["Calm Mind"], ["Thunderbolt"], ["Scald"], ["Aura Sphere", "Volt Switch"]]
+			}, {
+				"species": "Raikou",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Flying"],
+				"moves": [["Calm Mind"], ["Thunderbolt"], ["Scald"], ["Substitute"]]
+			}, {
+				"species": "Raikou",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Fairy", "Fighting"],
+				"moves": [["Volt Switch"], ["Thunderbolt"], ["Scald"], ["Aura Sphere"]]
+			}]
+		},
+		"regidrago": {
+			"weight": 3,
+			"sets": [{
+				"species": "Regidrago",
+				"wantsTera": true,
+				"weight": 40,
+				"item": ["Choice Specs"],
+				"ability": ["Dragon's Maw"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"teraType": ["Steel"],
+				"moves": [["Dragon Energy"], ["Draco Meteor"], ["Earth Power"], ["Tera Blast"]]
+			}, {
+				"species": "Regidrago",
+				"wantsTera": true,
+				"weight": 30,
+				"item": ["Loaded Dice"],
+				"ability": ["Dragon's Maw"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Scale Shot"], ["Dragon Dance"], ["Earthquake"], ["Tera Blast"]]
+			}, {
+				"species": "Regidrago",
+				"wantsTera": true,
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Dragon's Maw"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Dragon Energy"], ["Draco Meteor"], ["Earth Power"], ["Tera Blast"]]
+			}]
+		},
+		"rotommow": {
+			"weight": 3,
+			"sets": [{
+				"species": "Rotom-Mow",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Nasty Plot"], ["Leaf Storm"], ["Discharge"], ["Pain Split"]]
+			}]
+		},
+		"swampert": {
+			"weight": 3,
+			"sets": [{
+				"species": "Swampert",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 252, "atk": 4, "def": 252},
+				"nature": ["Impish"],
+				"teraType": ["Poison"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Knock Off", "Roar"], ["Flip Turn"]]
+			}, {
+				"species": "Swampert",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Relaxed"],
+				"teraType": ["Poison"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Knock Off", "Roar"], ["Surf"]]
+			}]
+		},
+		"toxtricity": {
+			"weight": 3,
+			"sets": [{
+				"species": "Toxtricity",
+				"weight": 100,
+				"item": ["Choice Specs"],
+				"ability": ["Punk Rock"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Normal"],
+				"moves": [["Overdrive"], ["Boomburst"], ["Volt Switch"], ["Sludge Bomb", "Snarl"]]
+			}]
+		},
+		"araquanid": {
+			"weight": 2,
+			"sets": [{
+				"species": "Araquanid",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Bubble"],
+				"evs": {"hp": 68, "atk": 252, "spe": 188},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Liquidation"], ["Sticky Web"], ["Mirror Coat"], ["Leech Life"]]
+			}]
+		},
+		"golurk": {
+			"weight": 2,
+			"sets": [{
+				"species": "Golurk",
+				"weight": 100,
+				"item": ["Colbur Berry"],
+				"ability": ["No Guard"],
+				"evs": {"hp": 172, "atk": 252, "spe": 84},
+				"nature": ["Adamant"],
+				"teraType": ["Steel"],
+				"moves": [["Earthquake"], ["Poltergeist"], ["Stone Edge"], ["Stealth Rock"]]
+			}]
+		},
+		"ditto": {
+			"weight": 1,
+			"sets": [{
+				"species": "Ditto",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Imposter"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel"],
+				"moves": [["Transform"]]
+			}]
+		},
+		"munkidori": {
+			"weight": 1,
+			"sets": [{
+				"species": "Munkidori",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Grass"],
+				"moves": [["Sludge Wave"], ["Psychic", "Psyshock"], ["U-turn"], ["Grass Knot"]]
+			}, {
+				"species": "Munkidori",
+				"weight": 5,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Dark"],
+				"moves": [["Sludge Wave"], ["Psychic", "Psyshock"], ["U-turn"], ["Fake Out"]]
+			}, {
+				"species": "Munkidori",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Choice Scarf"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fighting"],
+				"moves": [["Sludge Wave"], ["Psychic", "Psyshock"], ["U-turn"], ["Focus Blast"]]
+			}, {
+				"species": "Munkidori",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Poison"],
+				"moves": [["Sludge Wave"], ["Psychic", "Psyshock"], ["U-turn"], ["Trick"]]
+			}]
+		},
+		"torterra": {
+			"weight": 2,
+			"sets": [{
+				"species": "Torterra",
+				"weight": 100,
+				"item": ["Loaded Dice"],
+				"ability": ["Overgrow"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Fire", "Poison"],
+				"moves": [["Bullet Seed"], ["Headlong Rush"], ["Rock Blast"], ["Shell Smash"]]
+			}]
+		},
+		"barraskewda": {
+			"weight": 1,
+			"sets": [{
+				"species": "Barraskewda",
+				"weight": 70,
+				"item": ["Choice Band", "Heavy-Duty Boots"],
+				"ability": ["Swift Swim"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Fighting"],
+				"moves": [["Liquidation"], ["Flip Turn"], ["Close Combat"], ["Crunch"]]
+			}, {
+				"species": "Barraskewda",
+				"weight": 30,
+				"item": ["Choice Band", "Heavy-Duty Boots"],
+				"ability": ["Swift Swim"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Fighting"],
+				"moves": [["Liquidation"], ["Flip Turn"], ["Close Combat"], ["Aqua Jet"]]
+			}]
+		},
+		"ribombee": {
+			"weight": 1,
+			"sets": [{
+				"species": "Ribombee",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Shield Dust"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Moonblast"], ["Bug Buzz"], ["Tera Blast"], ["Quiver Dance"]]
+			}]
+		},
+		"diancie": {
+			"weight": 1,
+			"sets": [{
+				"species": "Diancie",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Ghost"],
+				"moves": [["Stealth Rock"], ["Encore"], ["Diamond Storm"], ["Body Press"]]
+			}]
+		},
+		"lucario": {
+			"weight": 1,
+			"sets": [{
+				"species": "Lucario",
+				"weight": 40,
+				"item": ["Life Orb"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Swords Dance"], ["Close Combat"], ["Meteor Mash"], ["Extreme Speed"]]
+			}, {
+				"species": "Lucario",
+				"weight": 30,
+				"item": ["Choice Band"],
+				"ability": ["Inner Focus", "Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Crunch"], ["Close Combat"], ["Meteor Mash"], ["Extreme Speed"]]
+			}, {
+				"species": "Lucario",
+				"weight": 30,
+				"item": ["Life Orb"],
+				"ability": ["Inner Focus"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Nasty Plot"], ["Flash Cannon"], ["Aura Sphere", "Vacuum Wave"], ["Shadow Ball"]]
+			}]
+		},
+		"salazzle": {
+			"weight": 1,
+			"sets": [{
+				"species": "Salazzle",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Corrosion"],
+				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Dark"],
+				"moves": [["Substitute"], ["Toxic"], ["Flamethrower"], ["Protect"]]
+			}, {
+				"species": "Salazzle",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Corrosion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Dark"],
+				"moves": [["Fire Blast", "Flamethrower"], ["Sludge Bomb"], ["Knock Off"], ["Toxic"]]
+			}, {
+				"species": "Salazzle",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Corrosion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Dark"],
+				"moves": [["Fire Blast", "Flamethrower"], ["Sludge Bomb"], ["Encore"], ["Toxic"]]
+			}]
+		},
+		"indeedee": {
+			"weight": 1,
+			"sets": [{
+				"species": "Indeedee",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Psychic Surge"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Expanding Force"], ["Dazzling Gleam"], ["Trick"], ["Healing Wish"]]
+			}]
+		},
+		"toxicroak": {
+			"weight": 1,
+			"sets": [{
+				"species": "Toxicroak",
+				"weight": 100,
+				"item": ["Life Orb", "Air Balloon"],
+				"ability": ["Dry Skin"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Swords Dance"], ["Gunk Shot"], ["Close Combat", "Drain Punch"], ["Knock Off", "Sucker Punch"]]
+			}]
+		}
+	},
+	"NU": {
+		"flygon": {
+			"weight": 10,
+			"sets": [{
+				"species": "Flygon",
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Earthquake"], ["U-turn"], ["Outrage", "Dragon Claw"], ["Stone Edge", "Superpower"]]
+			}, {
+				"species": "Flygon",
+				"weight": 20,
+				"item": ["Loaded Dice"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Earthquake"], ["Scale Shot"], ["Dragon Dance"], ["Substitute", "Throat Chop"]]
+			}, {
+				"species": "Flygon",
+				"weight": 20,
+				"item": ["Loaded Dice"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire"],
+				"moves": [["Earthquake"], ["Scale Shot"], ["Dragon Dance"], ["Fire Punch"]]
+			}, {
+				"species": "Flygon",
+				"weight": 20,
+				"item": ["Insect Plate"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Bug"],
+				"moves": [["Earthquake"], ["U-turn"], ["First Impression"], ["Stealth Rock"]]
+			}, {
+				"species": "Flygon",
+				"weight": 5,
+				"item": ["Choice Band"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Bug"],
+				"moves": [["Earthquake"], ["U-turn"], ["Scale Shot", "Outrage"], ["First Impression"]]
+			}, {
+				"species": "Flygon",
+				"weight": 5,
+				"item": ["Choice Band"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Earthquake"], ["U-turn"], ["Scale Shot", "Outrage"], ["Throat Chop", "Stone Edge"]]
+			}]
+		},
+		"mienshao": {
+			"weight": 10,
+			"sets": [{
+				"species": "Mienshao",
+				"weight": 40,
+				"item": ["Choice Scarf"],
+				"ability": ["Regenerator"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting", "Dark"],
+				"moves": [["Close Combat"], ["U-turn"], ["Knock Off"], ["Ice Spinner", "Poison Jab", "Triple Axel"]]
+			}, {
+				"species": "Mienshao",
+				"weight": 15,
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 132, "spd": 160, "spe": 216},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Close Combat"], ["U-turn"], ["Knock Off"], ["Triple Axel", "Ice Spinner"]]
+			}, {
+				"species": "Mienshao",
+				"weight": 15,
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"atk": 132, "spd": 160, "spe": 216},
+				"nature": ["Jolly"],
+				"teraType": ["Poison"],
+				"moves": [["Close Combat"], ["U-turn"], ["Knock Off"], ["Poison Jab"]]
+			}, {
+				"species": "Mienshao",
+				"weight": 30,
+				"item": ["Life Orb"],
+				"ability": ["Regenerator"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting", "Dark"],
+				"moves": [["Close Combat"], ["Fake Out"], ["Knock Off"], ["U-turn"]]
+			}]
+		},
+		"bronzong": {
+			"weight": 9,
+			"sets": [{
+				"species": "Bronzong",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Stealth Rock"], ["Psychic Noise"], ["Iron Defense"], ["Body Press"]]
+			}, {
+				"species": "Bronzong",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 164, "spd": 92},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Stealth Rock"], ["Psychic Noise"], ["Iron Defense"], ["Body Press"]]
+			}, {
+				"species": "Bronzong",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Sassy"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Stealth Rock"], ["Psychic Noise"], ["Earthquake"], ["Heavy Slam"]]
+			}, {
+				"species": "Bronzong",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "spd": 204, "spe": 52},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Water", "Poison"],
+				"moves": [["Calm Mind"], ["Iron Defense"], ["Body Press"], ["Stored Power"]]
+			}]
+		},
+		"incineroar": {
+			"weight": 9,
+			"sets": [{
+				"species": "Incineroar",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Ghost", "Flying", "Poison", "Water", "Dragon", "Fairy"],
+				"moves": [["Knock Off"], ["Flare Blitz"], ["Swords Dance"], ["Earthquake", "U-turn", "Drain Punch"]]
+			}, {
+				"species": "Incineroar",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Ghost", "Flying", "Poison", "Grass"],
+				"moves": [["Knock Off"], ["Flare Blitz"], ["Swords Dance"], ["Trailblaze"]]
+			}, {
+				"species": "Incineroar",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "spd": 212, "spe": 44},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Flying", "Poison", "Water", "Dragon", "Fairy"],
+				"moves": [["Knock Off"], ["Flare Blitz"], ["Swords Dance"], ["U-turn", "Earthquake"]]
+			}, {
+				"species": "Incineroar",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "spd": 212, "spe": 44},
+				"nature": ["Careful"],
+				"teraType": ["Fairy", "Water", "Poison", "Ghost", "Dragon", "Flying"],
+				"moves": [["Knock Off"], ["Flare Blitz"], ["Will-O-Wisp"], ["U-turn", "Parting Shot"]]
+			}]
+		},
+		"kilowattrel": {
+			"weight": 9,
+			"sets": [{
+				"species": "Kilowattrel",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["U-turn"], ["Thunderbolt"], ["Hurricane"], ["Roost"]]
+			}, {
+				"species": "Kilowattrel",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Volt Switch"], ["Thunderbolt"], ["Hurricane"], ["Roost"]]
+			}]
+		},
+		"overqwil": {
+			"weight": 9,
+			"sets": [{
+				"species": "Overqwil",
+				"weight": 45,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "atk": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Fairy", "Flying"],
+				"moves": [["Barb Barrage"], ["Throat Chop"], ["Spikes"], ["Taunt", "Haze", "Pain Split"]]
+			}, {
+				"species": "Overqwil",
+				"weight": 45,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel", "Fairy", "Flying"],
+				"moves": [["Gunk Shot"], ["Throat Chop"], ["Spikes"], ["Taunt", "Haze", "Pain Split"]]
+			}, {
+				"species": "Overqwil",
+				"weight": 10,
+				"item": ["Loaded Dice"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dragon"],
+				"moves": [["Gunk Shot"], ["Throat Chop"], ["Swords Dance"], ["Scale Shot"]]
+			}]
+		},
+		"taurospaldeaaqua": {
+			"weight": 9,
+			"sets": [{
+				"species": "Tauros-Paldea-Aqua",
+				"weight": 25,
+				"item": ["Choice Band"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Flying"],
+				"moves": [["Wave Crash"], ["Close Combat"], ["Aqua Jet"], ["Earthquake", "Zen Headbutt"]]
+			}, {
+				"species": "Tauros-Paldea-Aqua",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Flying"],
+				"moves": [["Wave Crash"], ["Close Combat"], ["Raging Bull"], ["Earthquake", "Zen Headbutt"]]
+			}, {
+				"species": "Tauros-Paldea-Aqua",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Wave Crash"], ["Close Combat"], ["Bulk Up"], ["Substitute", "Aqua Jet", "Earthquake"]]
+			}, {
+				"species": "Tauros-Paldea-Aqua",
+				"weight": 25,
+				"item": ["Lum Berry"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Wave Crash"], ["Close Combat"], ["Bulk Up"], ["Zen Headbutt", "Aqua Jet", "Earthquake"]]
+			}]
+		},
+		"toxicroak": {
+			"weight": 9,
+			"sets": [{
+				"species": "Toxicroak",
+				"weight": 60,
+				"item": ["Life Orb"],
+				"ability": ["Dry Skin"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Close Combat", "Drain Punch"], ["Gunk Shot"], ["Swords Dance"], ["Knock Off", "Sucker Punch"]]
+			}, {
+				"species": "Toxicroak",
+				"weight": 10,
+				"item": ["Life Orb"],
+				"ability": ["Dry Skin"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Dark"],
+				"moves": [["Close Combat"], ["Knock Off"], ["Swords Dance"], ["Sucker Punch"]]
+			}, {
+				"species": "Toxicroak",
+				"weight": 30,
+				"item": ["Life Orb"],
+				"ability": ["Dry Skin"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground"],
+				"moves": [["Close Combat", "Drain Punch"], ["Gunk Shot"], ["Swords Dance"], ["Earthquake"]]
+			}]
+		},
+		"basculegion": {
+			"weight": 7,
+			"sets": [{
+				"species": "Basculegion",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Adaptability"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Wave Crash"], ["Flip Turn"], ["Psychic Fangs", "Phantom Force"], ["Aqua Jet"]]
+			}, {
+				"species": "Basculegion",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Adaptability"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Wave Crash"], ["Flip Turn"], ["Psychic Fangs", "Phantom Force"], ["Liquidation"]]
+			}]
+		},
+		"breloom": {
+			"weight": 8,
+			"sets": [{
+				"species": "Breloom",
+				"weight": 25,
+				"item": ["Life Orb", "Loaded Dice"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Steel", "Fighting"],
+				"moves": [["Swords Dance"], ["Mach Punch"], ["Bullet Seed"], ["Aerial Ace", "Bulldoze"]]
+			}, {
+				"species": "Breloom",
+				"weight": 15,
+				"item": ["Life Orb", "Loaded Dice"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Rock"],
+				"moves": [["Swords Dance"], ["Mach Punch"], ["Bullet Seed"], ["Rock Tomb"]]
+			}, {
+				"species": "Breloom",
+				"weight": 15,
+				"item": ["Choice Band"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Rock"],
+				"moves": [["Close Combat"], ["Mach Punch"], ["Bullet Seed"], ["Rock Tomb"]]
+			}, {
+				"species": "Breloom",
+				"weight": 15,
+				"item": ["Choice Band"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Fighting", "Fire"],
+				"moves": [["Close Combat"], ["Mach Punch"], ["Bullet Seed"], ["Aerial Ace", "Bulldoze"]]
+			}, {
+				"species": "Breloom",
+				"weight": 30,
+				"item": ["Toxic Orb"],
+				"ability": ["Poison Heal"],
+				"evs": {"hp": 240, "atk": 80, "spe": 188},
+				"nature": ["Adamant"],
+				"teraType": ["Normal"],
+				"moves": [["Swords Dance", "Bulk Up"], ["Facade"], ["Seed Bomb"], ["Protect", "Substitute", "Toxic"]]
+			}]
+		},
+		"mukalola": {
+			"weight": 8,
+			"sets": [{
+				"species": "Muk-Alola",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Poison Touch"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Dragon"],
+				"moves": [["Poison Jab", "Poison Fang"], ["Knock Off"], ["Rest"], ["Sleep Talk"]]
+			}, {
+				"species": "Muk-Alola",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Poison Touch"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Dragon"],
+				"moves": [["Poison Jab", "Poison Fang"], ["Knock Off"], ["Drain Punch"], ["Protect"]]
+			}]
+		},
+		"munkidori": {
+			"weight": 8,
+			"sets": [{
+				"species": "Munkidori",
+				"wantsTera": true,
+				"weight": 20,
+				"item": ["Heavy-Duty Boots", "Choice Scarf"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Sludge Wave", "Sludge Bomb"], ["Psychic", "Psyshock"], ["U-turn"], ["Tera Blast"]]
+			}, {
+				"species": "Munkidori",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots", "Choice Scarf"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Flying"],
+				"moves": [["Sludge Wave", "Sludge Bomb"], ["Psychic", "Psyshock"], ["U-turn"], ["Focus Blast"]]
+			}, {
+				"species": "Munkidori",
+				"weight": 20,
+				"item": ["Choice Scarf"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Flying"],
+				"moves": [["Sludge Wave", "Sludge Bomb"], ["Psychic", "Psyshock"], ["U-turn"], ["Trick"]]
+			}, {
+				"species": "Munkidori",
+				"wantsTera": true,
+				"weight": 10,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Sludge Wave", "Sludge Bomb"], ["Psychic", "Psyshock"], ["Nasty Plot"], ["Tera Blast"]]
+			}, {
+				"species": "Munkidori",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Toxic Chain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Flying", "Fighting"],
+				"moves": [["Sludge Wave", "Sludge Bomb"], ["Psychic", "Psyshock"], ["Nasty Plot"], ["Focus Blast"]]
+			}]
+		},
+		"vaporeon": {
+			"weight": 8,
+			"sets": [{
+				"species": "Vaporeon",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison", "Dark"],
+				"moves": [["Scald"], ["Protect"], ["Wish"], ["Haze"]]
+			}, {
+				"species": "Vaporeon",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Bold"],
+				"teraType": ["Poison", "Dark"],
+				"moves": [["Scald"], ["Protect"], ["Wish"], ["Flip Turn"]]
+			}]
+		},
+		"vileplume": {
+			"weight": 8,
+			"sets": [{
+				"species": "Vileplume",
+				"weight": 100,
+				"item": ["Rocky Helmet", "Leftovers"],
+				"ability": ["Effect Spore"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Fairy"],
+				"moves": [["Sludge Bomb"], ["Giga Drain", "Stun Spore"], ["Leech Seed"], ["Strength Sap"]]
+			}]
+		},
+		"brambleghast": {
+			"weight": 7,
+			"sets": [{
+				"species": "Brambleghast",
+				"weight": 70,
+				"item": ["Heavy-Duty Boots", "Colbur Berry"],
+				"ability": ["Wind Rider"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Poltergeist"], ["Power Whip"], ["Rapid Spin"], ["Strength Sap", "Spikes", "Shadow Sneak"]]
+			}, {
+				"species": "Brambleghast",
+				"weight": 30,
+				"item": ["Rocky Helmet"],
+				"ability": ["Wind Rider"],
+				"evs": {"hp": 252, "def": 240, "spe": 16},
+				"nature": ["Impish"],
+				"teraType": ["Fairy"],
+				"moves": [["Poltergeist", "Power Whip", "Night Shade"], ["Infestation", "Spikes", "Leech Seed"], ["Rapid Spin"], ["Strength Sap"]]
+			}]
+		},
+		"chandelure": {
+			"weight": 7,
+			"sets": [{
+				"species": "Chandelure",
+				"weight": 40,
+				"item": ["Choice Specs"],
+				"ability": ["Flash Fire"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Grass", "Fire"],
+				"moves": [["Fire Blast", "Flamethrower"], ["Shadow Ball"], ["Energy Ball"], ["Trick", "Overheat"]]
+			}, {
+				"species": "Chandelure",
+				"weight": 40,
+				"item": ["Choice Scarf"],
+				"ability": ["Flash Fire"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Grass", "Fire"],
+				"moves": [["Fire Blast", "Flamethrower"], ["Shadow Ball"], ["Energy Ball"], ["Trick"]]
+			}, {
+				"species": "Chandelure",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots", "Air Balloon"],
+				"ability": ["Flash Fire"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Grass"],
+				"moves": [["Fire Blast", "Flamethrower"], ["Shadow Ball"], ["Energy Ball"], ["Calm Mind"]]
+			}, {
+				"species": "Chandelure",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots", "Air Balloon"],
+				"ability": ["Flame Body"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Fire Blast", "Flamethrower"], ["Shadow Ball"], ["Energy Ball"], ["Calm Mind"]]
+			}]
+		},
+		"cinccino": {
+			"weight": 7,
+			"sets": [{
+				"species": "Cinccino",
+				"weight": 100,
+				"item": ["Loaded Dice"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Fire"],
+				"moves": [["Tidy Up"], ["Tail Slap"], ["Bullet Seed", "Knock Off"], ["Encore", "Rock Blast", "Triple Axel"]]
+			}]
+		},
+		"diancie": {
+			"weight": 7,
+			"sets": [{
+				"species": "Diancie",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Sassy"],
+				"teraType": ["Water", "Steel", "Dragon"],
+				"moves": [["Stealth Rock"], ["Diamond Storm"], ["Moonblast"], ["Body Press"]]
+			}, {
+				"species": "Diancie",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Steel", "Dragon"],
+				"moves": [["Stealth Rock"], ["Diamond Storm"], ["Encore"], ["Body Press"]]
+			}, {
+				"species": "Diancie",
+				"weight": 50,
+				"item": ["Power Herb"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 4, "spa": 252},
+				"ivs": {"atk": 0, "spe": 0},
+				"nature": ["Quiet"],
+				"teraType": ["Grass", "Ground"],
+				"moves": [["Trick Room"], ["Moonblast"], ["Meteor Beam"], ["Earth Power"]]
+			}]
+		},
+		"gligar": {
+			"weight": 7,
+			"sets": [{
+				"species": "Gligar",
+				"weight": 50,
+				"item": ["Eviolite"],
+				"ability": ["Immunity"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"nature": ["Impish"],
+				"teraType": ["Water"],
+				"moves": [["Spikes"], ["Earthquake"], ["U-turn"], ["Toxic", "Stealth Rock"]]
+			}, {
+				"species": "Gligar",
+				"weight": 50,
+				"item": ["Eviolite"],
+				"ability": ["Immunity"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"nature": ["Impish"],
+				"teraType": ["Water"],
+				"moves": [["Spikes", "Stealth Rock"], ["Earthquake"], ["U-turn", "Toxic"], ["Knock Off"]]
+			}]
+		},
+		"inteleon": {
+			"weight": 7,
+			"sets": [{
+				"species": "Inteleon",
+				"weight": 100,
+				"item": ["Choice Specs"],
+				"ability": ["Torrent"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Ghost"],
+				"moves": [["Hydro Pump", "Surf"], ["Ice Beam"], ["U-turn"], ["Dark Pulse"]]
+			}]
+		},
+		"milotic": {
+			"weight": 7,
+			"sets": [{
+				"species": "Milotic",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots", "Rocky Helmet"],
+				"ability": ["Marvel Scale", "Competitive"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Dragon", "Steel"],
+				"moves": [["Scald"], ["Ice Beam", "Haze", "Dragon Tail"], ["Recover"], ["Flip Turn"]]
+			}, {
+				"species": "Milotic",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots", "Rocky Helmet"],
+				"ability": ["Marvel Scale", "Competitive"],
+				"evs": {"hp": 252, "def": 128, "spd": 128},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Dragon", "Steel"],
+				"moves": [["Scald"], ["Ice Beam", "Haze", "Dragon Tail"], ["Recover"], ["Flip Turn"]]
+			}]
+		},
+		"porygonz": {
+			"weight": 7,
+			"sets": [{
+				"species": "Porygon-Z",
+				"weight": 25,
+				"item": ["Choice Specs"],
+				"ability": ["Adaptability", "Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Tri Attack"], ["Shadow Ball"], ["Trick"], ["Nasty Plot", "Agility", "Recover"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 25,
+				"item": ["Choice Specs"],
+				"ability": ["Adaptability", "Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Tera Blast"], ["Shadow Ball"], ["Trick"], ["Nasty Plot", "Agility", "Recover"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 5,
+				"item": ["Life Orb", "Heavy-Duty Boots"],
+				"ability": ["Adaptability", "Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Tri Attack"], ["Shadow Ball"], ["Recover"], ["Nasty Plot"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 5,
+				"item": ["Life Orb", "Heavy-Duty Boots"],
+				"ability": ["Adaptability", "Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Tera Blast"], ["Shadow Ball"], ["Recover"], ["Nasty Plot"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 5,
+				"item": ["Life Orb", "Heavy-Duty Boots"],
+				"ability": ["Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Electric"],
+				"moves": [["Tri Attack"], ["Thunderbolt"], ["Recover"], ["Nasty Plot"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 5,
+				"item": ["Life Orb"],
+				"ability": ["Adaptability", "Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"teraType": ["Ghost"],
+				"moves": [["Tri Attack"], ["Shadow Ball"], ["Agility"], ["Nasty Plot"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 5,
+				"item": ["Life Orb"],
+				"ability": ["Adaptability", "Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Tera Blast"], ["Shadow Ball"], ["Agility"], ["Nasty Plot"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 5,
+				"item": ["Life Orb"],
+				"ability": ["Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"teraType": ["Electric"],
+				"moves": [["Tri Attack"], ["Thunderbolt"], ["Recover"], ["Nasty Plot"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 5,
+				"item": ["Life Orb"],
+				"ability": ["Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Electric", "Ghost"],
+				"moves": [["Tri Attack", "Ice Beam"], ["Thunderbolt"], ["Shadow Ball"], ["Agility"]]
+			}, {
+				"species": "Porygon-Z",
+				"weight": 10,
+				"item": ["Life Orb"],
+				"ability": ["Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Tera Blast"], ["Thunderbolt"], ["Shadow Ball"], ["Agility"]]
+			}, {
+				"species": "Porygon-Z",
+				"wantsTera": true,
+				"weight": 5,
+				"item": ["Life Orb"],
+				"ability": ["Download"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fighting"],
+				"moves": [["Tera Blast"], ["Tri Attack"], ["Shadow Ball"], ["Agility"]]
+			}]
+		},
+		"registeel": {
+			"weight": 7,
+			"sets": [{
+				"species": "Registeel",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Fairy", "Dragon", "Water"],
+				"moves": [["Heavy Slam"], ["Stealth Rock"], ["Earthquake"], ["Thunder Wave"]]
+			}, {
+				"species": "Registeel",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Fairy", "Dragon", "Water"],
+				"moves": [["Heavy Slam"], ["Stealth Rock"], ["Body Press"], ["Iron Defense", "Thunder Wave"]]
+			}]
+		},
+		"scyther": {
+			"weight": 6,
+			"sets": [{
+				"species": "Scyther",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric", "Fighting"],
+				"moves": [["Swords Dance"], ["Dual Wingbeat"], ["Close Combat"], ["Trailblaze"]]
+			}, {
+				"species": "Scyther",
+				"weight": 35,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric", "Fighting"],
+				"moves": [["Swords Dance"], ["Dual Wingbeat"], ["U-turn"], ["Close Combat", "Defog"]]
+			}, {
+				"species": "Scyther",
+				"weight": 15,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Close Combat"], ["Dual Wingbeat"], ["U-turn"], ["Defog"]]
+			}]
+		},
+		"slowbrogalar": {
+			"weight": 7,
+			"sets": [{
+				"species": "Slowbro-Galar",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Rocky Helmet", "Leftovers"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy"],
+				"moves": [["Slack Off"], ["Calm Mind", "Thunder Wave"], ["Flamethrower"], ["Sludge Bomb"]]
+			}, {
+				"species": "Slowbro-Galar",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Rocky Helmet", "Leftovers"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Slack Off"], ["Calm Mind", "Thunder Wave", "Toxic"], ["Surf"], ["Psyshock"]]
+			}]
+		},
+		"swampert": {
+			"weight": 7,
+			"sets": [{
+				"species": "Swampert",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 252, "atk": 4, "def": 252},
+				"nature": ["Impish"],
+				"teraType": ["Fairy"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Knock Off", "Roar"], ["Flip Turn"]]
+			}, {
+				"species": "Swampert",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Fairy"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Knock Off", "Roar"], ["Flip Turn"]]
+			}]
+		},
+		"sylveon": {
+			"weight": 7,
+			"sets": [{
+				"species": "Sylveon",
+				"weight": 25,
+				"item": ["Choice Specs"],
+				"ability": ["Pixilate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Hyper Voice"], ["Psyshock"], ["Shadow Ball"], ["Draining Kiss"]]
+			}, {
+				"species": "Sylveon",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Choice Specs"],
+				"ability": ["Pixilate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Hyper Voice"], ["Psyshock"], ["Shadow Ball"], ["Tera Blast"]]
+			}, {
+				"species": "Sylveon",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Pixilate"],
+				"evs": {"hp": 252, "def": 212, "spe": 44},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Poison", "Water"],
+				"moves": [["Hyper Voice"], ["Wish"], ["Protect"], ["Roar", "Calm Mind"]]
+			}]
+		},
+		"toxtricity": {
+			"weight": 6,
+			"sets": [{
+				"species": "Toxtricity",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Punk Rock"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"teraType": ["Normal"],
+				"moves": [["Overdrive"], ["Boomburst"], ["Volt Switch"], ["Sludge Bomb", "Snarl"]]
+			}, {
+				"species": "Toxtricity",
+				"wantsTera": true,
+				"weight": 50,
+				"item": ["Throat Spray"],
+				"ability": ["Punk Rock"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Normal"],
+				"moves": [["Overdrive"], ["Boomburst"], ["Shift Gear"], ["Encore", "Snarl"]]
+			}]
+		},
+		"typhlosionhisui": {
+			"weight": 7,
+			"sets": [{
+				"species": "Typhlosion-Hisui",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Frisk"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting"],
+				"moves": [["Eruption"], ["Flamethrower"], ["Shadow Ball"], ["Focus Blast"]]
+			}, {
+				"species": "Typhlosion-Hisui",
+				"weight": 50,
+				"item": ["Choice Scarf", "Choice Specs"],
+				"ability": ["Frisk"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Fire"],
+				"moves": [["Eruption"], ["Flamethrower", "Fire Blast"], ["Shadow Ball"], ["Focus Blast"]]
+			}]
+		},
+		"articunogalar": {
+			"weight": 5,
+			"sets": [{
+				"species": "Articuno-Galar",
+				"weight": 70,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Competitive"],
+				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Calm Mind"], ["Recover"], ["Hurricane"], ["Psychic Noise"]]
+			}, {
+				"species": "Articuno-Galar",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Competitive"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Fairy", "Ground"],
+				"moves": [["Future Sight"], ["Recover"], ["Hurricane"], ["U-turn"]]
+			}]
+		},
+		"copperajah": {
+			"weight": 4,
+			"sets": [{
+				"species": "Copperajah",
+				"weight": 80,
+				"item": ["Leftovers"],
+				"ability": ["Heavy Metal"],
+				"evs": {"hp": 252, "spd": 228, "spe": 28},
+				"nature": ["Careful"],
+				"teraType": ["Dragon", "Fairy"],
+				"moves": [["Heavy Slam"], ["Stealth Rock"], ["Knock Off"], ["Whirlwind", "Protect", "Earthquake"]]
+			}, {
+				"species": "Copperajah",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Sheer Force"],
+				"evs": {"hp": 252, "spd": 228, "spe": 28},
+				"nature": ["Careful"],
+				"teraType": ["Dragon", "Fairy"],
+				"moves": [["Iron Head"], ["Stealth Rock"], ["Knock Off"], ["Whirlwind", "Protect", "Earthquake"]]
+			}]
+		},
+		"decidueye": {
+			"weight": 4,
+			"sets": [{
+				"species": "Decidueye",
+				"weight": 100,
+				"item": ["Spell Tag"],
+				"ability": ["Long Reach"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost"],
+				"moves": [["Swords Dance"], ["Spirit Shackle", "Poltergeist"], ["Shadow Sneak"], ["Leaf Blade"]]
+			}]
+		},
+		"gastrodon": {
+			"weight": 4,
+			"sets": [{
+				"species": "Gastrodon",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Sticky Hold", "Storm Drain"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Poison", "Dragon"],
+				"moves": [["Spikes", "Stealth Rock"], ["Earth Power"], ["Ice Beam", "Sludge Bomb", "Surf"], ["Recover"]]
+			}, {
+				"species": "Gastrodon",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Sticky Hold", "Storm Drain"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Poison", "Dragon"],
+				"moves": [["Spikes", "Stealth Rock"], ["Earth Power"], ["Ice Beam", "Sludge Bomb", "Surf"], ["Recover"]]
+			}]
+		},
+		"klefki": {
+			"weight": 5,
+			"sets": [{
+				"species": "Klefki",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "def": 96, "spd": 160},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Water"],
+				"moves": [["Spikes"], ["Foul Play"], ["Thunder Wave"], ["Dazzling Gleam"]]
+			}, {
+				"species": "Klefki",
+				"weight": 25,
+				"item": ["Air Balloon"],
+				"ability": ["Magician"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Water"],
+				"moves": [["Spikes"], ["Foul Play"], ["Thunder Wave"], ["Dazzling Gleam"]]
+			}, {
+				"species": "Klefki",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Water"],
+				"moves": [["Spikes"], ["Magnet Rise"], ["Thunder Wave"], ["Dazzling Gleam"]]
+			}, {
+				"species": "Klefki",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "def": 96, "spd": 160},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Water"],
+				"moves": [["Calm Mind"], ["Iron Defense"], ["Draining Kiss"], ["Stored Power"]]
+			}]
+		},
+		"taurospaldeablaze": {
+			"weight": 4,
+			"sets": [{
+				"species": "Tauros-Paldea-Blaze",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Lum Berry"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Grass", "Electric", "Steel"],
+				"moves": [["Bulk Up"], ["Close Combat"], ["Raging Bull"], ["Trailblaze"]]
+			}, {
+				"species": "Tauros-Paldea-Blaze",
+				"weight": 50,
+				"item": ["Choice Scarf", "Choice Band"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Flare Blitz"], ["Close Combat"], ["Earthquake"], ["Stone Edge", "Iron Head"]]
+			}]
+		},
+		"tentacruel": {
+			"weight": 4,
+			"sets": [{
+				"species": "Tentacruel",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Liquid Ooze"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Flying"],
+				"moves": [["Flip Turn"], ["Knock Off"], ["Rapid Spin"], ["Sludge Bomb", "Ice Beam", "Haze", "Toxic"]]
+			}]
+		},
+		"tornadus": {
+			"weight": 5,
+			"sets": [{
+				"species": "Tornadus",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Defiant"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Ground"],
+				"moves": [["Knock Off"], ["U-turn"], ["Hurricane", "Bleakwind Storm"], ["Heat Wave", "Grass Knot", "Taunt"]]
+			}, {
+				"species": "Tornadus",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Prankster"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Steel", "Ground", "Dark"],
+				"moves": [["Nasty Plot"], ["Heat Wave", "Focus Blast"], ["Hurricane", "Bleakwind Storm"], ["Dark Pulse"]]
+			}, {
+				"species": "Tornadus",
+				"wantsTera": true,
+				"weight": 20,
+				"item": ["Sitrus Berry", ""],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground"],
+				"moves": [["Knock Off"], ["Bulk Up"], ["Acrobatics"], ["Tera Blast"]]
+			}, {
+				"species": "Tornadus",
+				"weight": 10,
+				"item": ["Sitrus Berry", ""],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground", "Steel"],
+				"moves": [["Knock Off"], ["Bulk Up"], ["Acrobatics"], ["Brick Break", "Hammer Arm"]]
+			}]
+		},
+		"torterra": {
+			"weight": 5,
+			"sets": [{
+				"species": "Torterra",
+				"weight": 50,
+				"item": ["Loaded Dice"],
+				"ability": ["Overgrow"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Bullet Seed"], ["Headlong Rush", "Earthquake"], ["Rock Blast"], ["Shell Smash"]]
+			}, {
+				"species": "Torterra",
+				"wantsTera": true,
+				"weight": 50,
+				"item": ["Loaded Dice"],
+				"ability": ["Overgrow"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ghost", "Fire"],
+				"moves": [["Bullet Seed"], ["Headlong Rush", "Earthquake"], ["Tera Blast"], ["Shell Smash"]]
+			}]
+		},
+		"uxie": {
+			"weight": 4,
+			"sets": [{
+				"species": "Uxie",
+				"wantsTera": true,
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 40, "spe": 216},
+				"nature": ["Timid"],
+				"teraType": ["Dark", "Steel"],
+				"moves": [["U-turn"], ["Psychic Noise"], ["Stealth Rock"], ["Encore", "Knock Off", "Thunder Wave"]]
+			}, {
+				"species": "Uxie",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Leftovers", "Kee Berry"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Calm Mind"], ["Psychic Noise"], ["Draining Kiss"], ["Encore"]]
+			}, {
+				"species": "Uxie",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Calm Mind"], ["Psychic Noise"], ["Draining Kiss"], ["Substitute"]]
+			}]
+		},
+		"araquanid": {
+			"weight": 3,
+			"sets": [{
+				"species": "Araquanid",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Bubble"],
+				"evs": {"hp": 68, "atk": 252, "spe": 188},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost"],
+				"moves": [["Liquidation"], ["Leech Life"], ["Sticky Web"], ["Mirror Coat", "Trailblaze"]]
+			}]
+		},
+		"avalugg": {
+			"weight": 3,
+			"sets": [{
+				"species": "Avalugg",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "atk": 4, "def": 252},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Poison", "Water"],
+				"moves": [["Avalanche", "Ice Spinner"], ["Body Press", "Earthquake"], ["Recover"], ["Rapid Spin"]]
+			}]
+		},
+		"dragalge": {
+			"weight": 3,
+			"sets": [{
+				"species": "Dragalge",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Adaptability"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Sludge Bomb"], ["Draco Meteor"], ["Toxic Spikes", "Dragon Tail"], ["Flip Turn"]]
+			}, {
+				"species": "Dragalge",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Adaptability"],
+				"evs": {"hp": 80, "spa": 252, "spe": 176},
+				"nature": ["Modest"],
+				"teraType": ["Poison"],
+				"moves": [["Sludge Bomb", "Sludge Wave"], ["Draco Meteor"], ["Focus Blast"], ["Flip Turn"]]
+			}]
+		},
+		"florges": {
+			"weight": 3,
+			"sets": [{
+				"species": "Florges",
+				"wantsTera": true,
+				"weight": 30,
+				"item": ["Choice Specs"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Moonblast"], ["Psychic"], ["Tera Blast"], ["Trick"]]
+			}, {
+				"species": "Florges",
+				"wantsTera": true,
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ground"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Tera Blast"], ["Synthesis"]]
+			}, {
+				"species": "Florges",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Psychic Noise", "Wish"], ["Synthesis"]]
+			}, {
+				"species": "Florges",
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Moonblast"], ["Trick"], ["Calm Mind", "Psychic"], ["Synthesis"]]
+			}]
+		},
+		"goodra": {
+			"weight": 3,
+			"sets": [{
+				"species": "Goodra",
+				"weight": 40,
+				"item": ["Choice Specs"],
+				"ability": ["Sap Sipper"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison"],
+				"moves": [["Draco Meteor"], ["Fire Blast", "Flamethrower"], ["Sludge Bomb", "Sludge Wave"], ["Hydro Pump", "Dragon Pulse"]]
+			}, {
+				"species": "Goodra",
+				"weight": 30,
+				"item": ["Leftovers"],
+				"ability": ["Sap Sipper"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison"],
+				"moves": [["Draco Meteor"], ["Fire Blast", "Flamethrower"], ["Acid Spray"], ["Substitute"]]
+			}, {
+				"species": "Goodra",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sap Sipper"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Poison", "Steel"],
+				"moves": [["Draco Meteor"], ["Fire Blast", "Flamethrower"], ["Knock Off"], ["Toxic", "Scald", "Dragon Tail"]]
+			}, {
+				"species": "Goodra",
+				"weight": 5,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sap Sipper"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison"],
+				"moves": [["Draco Meteor"], ["Fire Blast", "Flamethrower"], ["Sludge Wave"], ["Toxic", "Scald"]]
+			}, {
+				"species": "Goodra",
+				"weight": 5,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sap Sipper"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Poison"],
+				"moves": [["Draco Meteor"], ["Fire Blast", "Flamethrower"], ["Sludge Wave"], ["Dragon Tail"]]
+			}]
+		},
+		"heracross": {
+			"weight": 3,
+			"sets": [{
+				"species": "Heracross",
+				"weight": 70,
+				"item": ["Flame Orb"],
+				"ability": ["Guts"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Facade"], ["Close Combat"], ["Trailblaze"], ["Knock Off"]]
+			}, {
+				"species": "Heracross",
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Fighting"],
+				"moves": [["Megahorn"], ["Close Combat"], ["Earthquake", "Stone Edge"], ["Knock Off"]]
+			}]
+		},
+		"meloetta": {
+			"weight": 3,
+			"sets": [{
+				"species": "Meloetta",
+				"weight": 45,
+				"item": ["Choice Specs", "Choice Scarf"],
+				"ability": ["Serene Grace"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Hyper Voice"], ["Psychic", "Psyshock"], ["Shadow Ball"], ["Trick", "Focus Blast"]]
+			}, {
+				"species": "Meloetta",
+				"weight": 25,
+				"item": ["Choice Specs", "Choice Scarf"],
+				"ability": ["Serene Grace"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Hyper Voice"], ["Psychic", "Psyshock"], ["Shadow Ball"], ["U-turn"]]
+			}, {
+				"species": "Meloetta",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Hyper Voice"], ["Shadow Ball"], ["Substitute"], ["Calm Mind"]]
+			}, {
+				"species": "Meloetta",
+				"weight": 10,
+				"item": ["Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting"],
+				"moves": [["Tera Blast"], ["Shadow Ball"], ["Substitute"], ["Calm Mind"]]
+			}]
+		},
+		"orthworm": {
+			"weight": 3,
+			"sets": [{
+				"species": "Orthworm",
+				"weight": 70,
+				"item": ["Leftovers"],
+				"ability": ["Earth Eater"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Stealth Rock", "Spikes"], ["Heavy Slam"], ["Body Press"], ["Iron Defense", "Protect"]]
+			}, {
+				"species": "Orthworm",
+				"weight": 30,
+				"item": ["Leftovers"],
+				"ability": ["Earth Eater"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Stealth Rock"], ["Heavy Slam"], ["Body Press"], ["Spikes"]]
+			}]
+		},
+		"raikou": {
+			"weight": 3,
+			"sets": [{
+				"species": "Raikou",
+				"weight": 15,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water"],
+				"moves": [["Calm Mind"], ["Thunderbolt"], ["Scald"], ["Volt Switch"]]
+			}, {
+				"species": "Raikou",
+				"wantsTera": true,
+				"weight": 15,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Calm Mind"], ["Thunderbolt"], ["Tera Blast"], ["Volt Switch"]]
+			}, {
+				"species": "Raikou",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Calm Mind"], ["Thunderbolt"], ["Shadow Ball"], ["Volt Switch"]]
+			}, {
+				"species": "Raikou",
+				"weight": 15,
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water"],
+				"moves": [["Calm Mind"], ["Thunderbolt"], ["Scald"], ["Substitute"]]
+			}, {
+				"species": "Raikou",
+				"wantsTera": true,
+				"weight": 15,
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Calm Mind"], ["Thunderbolt"], ["Tera Blast"], ["Substitute"]]
+			}, {
+				"species": "Raikou",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Calm Mind"], ["Thunderbolt"], ["Shadow Ball"], ["Substitute"]]
+			}]
+		},
+		"rotomheat": {
+			"weight": 3,
+			"sets": [{
+				"species": "Rotom-Heat",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Steel", "Fairy"],
+				"moves": [["Volt Switch"], ["Pain Split"], ["Overheat"], ["Will-O-Wisp", "Nasty Plot"]]
+			}]
+		},
+		"scrafty": {
+			"weight": 3,
+			"sets": [{
+				"species": "Scrafty",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin"],
+				"evs": {"hp": 252, "spd": 196, "spe": 60},
+				"nature": ["Careful"],
+				"teraType": ["Poison", "Steel"],
+				"moves": [["Bulk Up"], ["Drain Punch"], ["Knock Off"], ["Rest"]]
+			}, {
+				"species": "Scrafty",
+				"weight": 10,
+				"item": ["Leftovers", "Lum Berry"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Poison"],
+				"moves": [["Dragon Dance"], ["Drain Punch", "Close Combat"], ["Knock Off"], ["Encore", "Poison Jab"]]
+			}, {
+				"species": "Scrafty",
+				"weight": 15,
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin", "Intimidate", "Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Poison"],
+				"moves": [["Dragon Dance"], ["Drain Punch", "Close Combat"], ["Knock Off"], ["Encore", "Poison Jab"]]
+			}, {
+				"species": "Scrafty",
+				"weight": 15,
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin", "Intimidate", "Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Dragon Dance"], ["Drain Punch", "Close Combat"], ["Knock Off"], ["Encore", "Iron Head"]]
+			}, {
+				"species": "Scrafty",
+				"weight": 10,
+				"item": ["Leftovers", "Lum Berry"],
+				"ability": ["Intimidate", "Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Dragon Dance"], ["Drain Punch", "Close Combat"], ["Knock Off"], ["Encore", "Iron Head"]]
+			}]
+		},
+		"screamtail": {
+			"weight": 3,
+			"sets": [{
+				"species": "Scream Tail",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Protosynthesis"],
+				"evs": {"hp": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Steel", "Dragon"],
+				"moves": [["Wish"], ["Protect"], ["Encore", "Thunder Wave"], ["Psychic Noise"]]
+			}, {
+				"species": "Scream Tail",
+				"wantsTera": true,
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Protosynthesis"],
+				"evs": {"hp": 40, "spa": 252, "spe": 216},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Normal"],
+				"moves": [["Fire Blast", "Flamethrower"], ["Calm Mind"], ["Boomburst"], ["Psychic Noise", "Dazzling Gleam"]]
+			}]
+		},
+		"bellibolt": {
+			"weight": 1,
+			"sets": [{
+				"species": "Bellibolt",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Rocky Helmet"],
+				"ability": ["Static", "Electromorphosis"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Volt Switch"], ["Slack Off"], ["Muddy Water"], ["Toxic"]]
+			}]
+		},
+		"ditto": {
+			"weight": 1,
+			"sets": [{
+				"species": "Ditto",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Imposter"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Steel", "Ghost"],
+				"moves": [["Transform"]]
+			}]
+		},
+		"drednaw": {
+			"weight": 1,
+			"sets": [{
+				"species": "Drednaw",
+				"weight": 100,
+				"item": ["White Herb"],
+				"ability": ["Strong Jaw"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Shell Smash"], ["Liquidation"], ["Stone Edge"], ["Crunch"]]
+			}]
+		},
+		"dudunsparce": {
+			"weight": 1,
+			"sets": [{
+				"species": "Dudunsparce",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Poison", "Fairy"],
+				"moves": [["Body Slam"], ["Coil", "Stealth Rock"], ["Roost"], ["Dragon Tail"]]
+			}, {
+				"species": "Dudunsparce",
+				"weight": 50,
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Rattled"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ghost"],
+				"moves": [["Boomburst"], ["Calm Mind"], ["Roost"], ["Shadow Ball"]]
+			}]
+		},
+		"palossand": {
+			"weight": 1,
+			"sets": [{
+				"species": "Palossand",
+				"weight": 100,
+				"item": ["Leftovers", "Rocky Helmet", "Colbur Berry"],
+				"ability": ["Water Compaction"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Dragon", "Fairy", "Water"],
+				"moves": [["Stealth Rock"], ["Scorching Sands", "Earth Power"], ["Shore Up"], ["Shadow Ball", "Sludge Bomb"]]
+			}]
+		},
+		"tsareena": {
+			"weight": 1,
+			"sets": [{
+				"species": "Tsareena",
+				"weight": 50,
+				"item": ["Lum Berry", "Heavy-Duty Boots"],
+				"ability": ["Queenly Majesty"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Dragon", "Steel"],
+				"moves": [["Power Whip"], ["Rapid Spin"], ["Knock Off"], ["Triple Axel", "U-turn"]]
+			}, {
+				"species": "Tsareena",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Queenly Majesty"],
+				"evs": {"atk": 252, "def": 228, "spe": 28},
+				"nature": ["Impish"],
+				"teraType": ["Dragon", "Steel", "Poison"],
+				"moves": [["Power Whip"], ["Rapid Spin"], ["Knock Off"], ["Synthesis"]]
+			}]
+		},
+		"whimsicott": {
+			"weight": 1,
+			"sets": [{
+				"species": "Whimsicott",
+				"weight": 50,
+				"item": ["Rocky Helmet", "Heavy-Duty Boots"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "def": 12, "spa": 76, "spe": 168},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Moonblast"], ["U-turn"], ["Encore"], ["Stun Spore", "Giga Drain", "Leech Seed"]]
+			}, {
+				"species": "Whimsicott",
+				"weight": 50,
+				"item": ["Rocky Helmet", "Heavy-Duty Boots"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 180, "spa": 76, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Moonblast"], ["U-turn"], ["Encore"], ["Stun Spore", "Giga Drain", "Leech Seed"]]
+			}]
+		},
+		"wochien": {
+			"weight": 1,
+			"sets": [{
+				"species": "Wo-Chien",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Tablets of Ruin"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Poison", "Fairy", "Dragon", "Water"],
+				"moves": [["Knock Off"], ["Protect"], ["Leech Seed"], ["Stun Spore", "Ruination"]]
+			}]
+		},
+		"duraludon": {
+			"weight": 1,
+			"sets": [{
+				"species": "Duraludon",
+				"weight": 100,
+				"item": ["Eviolite"],
+				"ability": ["Heavy Metal"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Fairy", "Water"],
+				"moves": [["Draco Meteor"], ["Flash Cannon"], ["Stealth Rock"], ["Dark Pulse", "Body Press"]]
+			}]
+		},
+		"minior": {
+			"weight": 1,
+			"sets": [{
+				"species": "Minior",
+				"weight": 50,
+				"item": ["White Herb"],
+				"ability": ["Shields Down"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Flying", "Ground"],
+				"moves": [["Shell Smash"], ["Acrobatics"], ["Earthquake"], ["Stone Edge", "Substitute"]]
+			}, {
+				"species": "Minior",
+				"wantsTera": true,
+				"weight": 50,
+				"item": ["White Herb"],
+				"ability": ["Shields Down"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Ghost"],
+				"moves": [["Shell Smash"], ["Acrobatics"], ["Earthquake"], ["Tera Blast"]]
+			}]
+		},
+		"pawmot": {
+			"weight": 1,
+			"sets": [{
+				"species": "Pawmot",
+				"weight": 40,
+				"item": ["Life Orb"],
+				"ability": ["Natural Cure"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Double Shock"], ["Close Combat"], ["Knock Off", "Ice Punch"], ["Rest"]]
+			}, {
+				"species": "Pawmot",
+				"weight": 30,
+				"item": ["Life Orb"],
+				"ability": ["Volt Absorb"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Double Shock"], ["Close Combat"], ["Knock Off", "Ice Punch"], ["Volt Switch"]]
+			}, {
+				"species": "Pawmot",
+				"weight": 30,
+				"item": ["Life Orb"],
+				"ability": ["Iron Fist"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Double Shock"], ["Close Combat"], ["Ice Punch"], ["Mach Punch"]]
+			}]
+		}
+	},
+	"PU": {
+		"arcanine": {
+			"weight": 10,
+			"sets": [{
+				"species": "Arcanine",
+				"weight": 70,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 160, "atk": 252, "spe": 96},
+				"nature": ["Adamant"],
+				"teraType": ["Normal"],
+				"moves": [["Curse"], ["Extreme Speed"], ["Flare Blitz"], ["Morning Sun"]]
+			}, {
+				"species": "Arcanine",
+				"weight": 30,
+				"item": ["Choice Band"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Raging Fury"], ["Extreme Speed"], ["Flare Blitz"], ["Close Combat"]]
+			}]
+		},
+		"meloetta": {
+			"weight": 10,
+			"sets": [{
+				"species": "Meloetta",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Serene Grace"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Normal"],
+				"moves": [["Hyper Voice"], ["Psychic"], ["Shadow Ball"], ["Focus Blast"]]
+			}, {
+				"species": "Meloetta",
+				"weight": 15,
+				"item": ["Choice Scarf"],
+				"ability": ["Serene Grace"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Hyper Voice"], ["Psychic"], ["Shadow Ball"], ["U-turn"]]
+			}, {
+				"species": "Meloetta",
+				"weight": 10,
+				"item": ["Choice Scarf"],
+				"ability": ["Serene Grace"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Hyper Voice"], ["Psychic"], ["Shadow Ball"], ["Trick"]]
+			}, {
+				"species": "Meloetta",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Serene Grace"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fire"],
+				"moves": [["Tera Blast"], ["Psyshock"], ["Substitute"], ["Calm Mind"]]
+			}]
+		},
+		"scyther": {
+			"weight": 10,
+			"sets": [{
+				"species": "Scyther",
+				"weight": 13,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Swords Dance"], ["Dual Wingbeat"], ["Close Combat"], ["U-turn"]]
+			}, {
+				"species": "Scyther",
+				"wantsTera": true,
+				"weight": 13,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ground"],
+				"moves": [["Swords Dance"], ["Dual Wingbeat"], ["Close Combat"], ["Tera Blast"]]
+			}, {
+				"species": "Scyther",
+				"weight": 12,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Swords Dance"], ["Dual Wingbeat"], ["Close Combat"], ["Quick Attack"]]
+			}, {
+				"species": "Scyther",
+				"weight": 12,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting", "Grass"],
+				"moves": [["Swords Dance"], ["Dual Wingbeat"], ["Close Combat"], ["Trailblaze"]]
+			}, {
+				"species": "Scyther",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting", "Flying", "Ground"],
+				"moves": [["Defog"], ["Dual Wingbeat"], ["Close Combat"], ["U-turn"]]
+			}]
+		},
+		"bombirdier": {
+			"weight": 9,
+			"sets": [{
+				"species": "Bombirdier",
+				"weight": 70,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Big Pecks"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Dark"],
+				"moves": [["Knock Off"], ["Brave Bird"], ["Sucker Punch"], ["Taunt", "Stealth Rock", "Roost"]]
+			}, {
+				"species": "Bombirdier",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Big Pecks"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Dark"],
+				"moves": [["Knock Off"], ["Parting Shot"], ["Stealth Rock"], ["Roost"]]
+			}]
+		},
+		"florges": {
+			"weight": 9,
+			"sets": [{
+				"species": "Florges",
+				"weight": 20,
+				"item": ["Choice Scarf"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison", "Fairy"],
+				"moves": [["Moonblast"], ["Psychic Noise", "Calm Mind", "Wish"], ["Synthesis"], ["Trick"]]
+			}, {
+				"species": "Florges",
+				"weight": 20,
+				"item": ["Choice Specs"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Fairy"],
+				"moves": [["Moonblast"], ["Trick"], ["Psychic Noise"], ["Synthesis"]]
+			}, {
+				"species": "Florges",
+				"wantsTera": true,
+				"weight": 15,
+				"item": ["Choice Scarf"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Moonblast"], ["Tera Blast"], ["Synthesis"], ["Trick"]]
+			}, {
+				"species": "Florges",
+				"wantsTera": true,
+				"weight": 15,
+				"item": ["Choice Specs"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Moonblast"], ["Trick"], ["Tera Blast"], ["Synthesis", "Psychic Noise"]]
+			}, {
+				"species": "Florges",
+				"wantsTera": true,
+				"weight": 10,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Tera Blast"], ["Synthesis"]]
+			}, {
+				"species": "Florges",
+				"weight": 10,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Wish", "Psychic Noise"], ["Synthesis"]]
+			}, {
+				"species": "Florges",
+				"weight": 5,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Wish"], ["Synthesis"]]
+			}, {
+				"species": "Florges",
+				"weight": 5,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Flower Veil", "Symbiosis"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Poison"],
+				"moves": [["Moonblast"], ["Calm Mind"], ["Wish"], ["Protect"]]
+			}]
+		},
+		"gastrodon": {
+			"weight": 9,
+			"sets": [{
+				"species": "Gastrodon",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Storm Drain", "Sticky Hold"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Fairy", "Poison"],
+				"moves": [["Earth Power"], ["Recover"], ["Ice Beam", "Surf", "Clear Smog"], ["Spikes", "Stealth Rock"]]
+			}, {
+				"species": "Gastrodon",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Leftovers", "Rocky Helmet"],
+				"ability": ["Storm Drain", "Sticky Hold"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Earth Power"], ["Recover"], ["Ice Beam", "Surf", "Clear Smog"], ["Spikes", "Stealth Rock"]]
+			}]
+		},
+		"taurospaldeablaze": {
+			"weight": 9,
+			"sets": [{
+				"species": "Tauros-Paldea-Blaze",
+				"weight": 25,
+				"item": ["Leftovers", "Lum Berry"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Grass"],
+				"moves": [["Bulk Up"], ["Close Combat"], ["Raging Bull", "Flare Blitz"], ["Trailblaze"]]
+			}, {
+				"species": "Tauros-Paldea-Blaze",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Steel"],
+				"moves": [["Bulk Up"], ["Close Combat"], ["Raging Bull", "Flare Blitz"], ["Stone Edge", "Substitute"]]
+			}, {
+				"species": "Tauros-Paldea-Blaze",
+				"weight": 50,
+				"item": ["Choice Scarf", "Choice Band"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting"],
+				"moves": [["Flare Blitz"], ["Close Combat"], ["Earthquake"], ["Stone Edge", "Raging Bull"]]
+			}]
+		},
+		"zoroark": {
+			"weight": 9,
+			"sets": [{
+				"species": "Zoroark",
+				"weight": 30,
+				"item": ["Life Orb"],
+				"ability": ["Illusion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Dark", "Ghost", "Poison"],
+				"moves": [["Dark Pulse"], ["Sludge Bomb"], ["Nasty Plot"], ["Focus Blast", "Flamethrower"]]
+			}, {
+				"species": "Zoroark",
+				"weight": 20,
+				"item": ["Choice Specs"],
+				"ability": ["Illusion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Dark", "Poison"],
+				"moves": [["Dark Pulse"], ["Sludge Bomb"], ["Trick"], ["U-turn"]]
+			}, {
+				"species": "Zoroark",
+				"weight": 5,
+				"item": ["Choice Specs"],
+				"ability": ["Illusion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Dark", "Poison", "Fighting"],
+				"moves": [["Dark Pulse"], ["Sludge Bomb"], ["Trick"], ["Focus Blast"]]
+			}, {
+				"species": "Zoroark",
+				"weight": 25,
+				"item": ["Choice Scarf"],
+				"ability": ["Illusion"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Fighting"],
+				"moves": [["Knock Off"], ["U-turn"], ["Trick"], ["Low Kick"]]
+			}, {
+				"species": "Zoroark",
+				"weight": 20,
+				"item": ["Life Orb", "Heavy-Duty Boots"],
+				"ability": ["Illusion"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Knock Off"], ["Sucker Punch"], ["Swords Dance"], ["Low Kick", "Aerial Ace"]]
+			}]
+		},
+		"bellibolt": {
+			"weight": 8,
+			"sets": [{
+				"species": "Bellibolt",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Static"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Volt Switch"], ["Muddy Water"], ["Slack Off"], ["Toxic"]]
+			}]
+		},
+		"decidueye": {
+			"weight": 8,
+			"sets": [{
+				"species": "Decidueye",
+				"weight": 35,
+				"item": ["Spell Tag"],
+				"ability": ["Long Reach"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["Swords Dance"], ["Spirit Shackle", "Poltergeist"], ["Shadow Sneak"], ["Leaf Blade", "Low Kick"]]
+			}, {
+				"species": "Decidueye",
+				"weight": 35,
+				"item": ["Spell Tag", "Choice Band", "Heavy-Duty Boots"],
+				"ability": ["Long Reach"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Ghost", "Fairy"],
+				"moves": [["U-turn"], ["Spirit Shackle", "Poltergeist"], ["Shadow Sneak"], ["Leaf Blade", "Low Kick"]]
+			}, {
+				"species": "Decidueye",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Long Reach"],
+				"evs": {"hp": 252, "spd": 120, "spe": 136},
+				"nature": ["Calm"],
+				"teraType": ["Fairy"],
+				"moves": [["U-turn"], ["Roost"], ["Defog"], ["Leaf Storm"]]
+			}]
+		},
+		"golurk": {
+			"weight": 8,
+			"sets": [{
+				"species": "Golurk",
+				"weight": 50,
+				"item": ["Colbur Berry"],
+				"ability": ["No Guard"],
+				"evs": {"hp": 172, "atk": 252, "spe": 84},
+				"nature": ["Adamant"],
+				"teraType": ["Steel"],
+				"moves": [["Earthquake"], ["Poltergeist"], ["Stone Edge"], ["Stealth Rock"]]
+			}, {
+				"species": "Golurk",
+				"weight": 50,
+				"item": ["Choice Band"],
+				"ability": ["No Guard"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Dark"],
+				"moves": [["Earthquake"], ["Poltergeist"], ["Stone Edge"], ["Dynamic Punch", "Close Combat"]]
+			}]
+		},
+		"pawmot": {
+			"weight": 8,
+			"sets": [{
+				"species": "Pawmot",
+				"weight": 40,
+				"item": ["Life Orb", "Heavy-Duty Boots"],
+				"ability": ["Iron Fist"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Close Combat"], ["Double Shock"], ["Knock Off"], ["Mach Punch"]]
+			}, {
+				"species": "Pawmot",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb", "Natural Cure"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Close Combat"], ["Double Shock"], ["Knock Off"], ["Volt Switch"]]
+			}, {
+				"species": "Pawmot",
+				"weight": 20,
+				"item": ["Life Orb"],
+				"ability": ["Natural Cure"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Electric"],
+				"moves": [["Close Combat"], ["Double Shock"], ["Knock Off"], ["Rest"]]
+			}]
+		},
+		"rhydon": {
+			"weight": 8,
+			"sets": [{
+				"species": "Rhydon",
+				"weight": 100,
+				"item": ["Eviolite"],
+				"ability": ["Lightning Rod"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Poison", "Water"],
+				"moves": [["Earthquake"], ["Stone Edge"], ["Rock Polish", "Heat Crash"], ["Swords Dance"]]
+			}]
+		},
+		"rotomheat": {
+			"weight": 8,
+			"sets": [{
+				"species": "Rotom-Heat",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison", "Steel"],
+				"moves": [["Overheat"], ["Volt Switch"], ["Nasty Plot", "Thunder Wave"], ["Pain Split"]]
+			}]
+		},
+		"salazzle": {
+			"weight": 8,
+			"sets": [{
+				"species": "Salazzle",
+				"wantsTera": true,
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Corrosion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Fire Blast"], ["Sludge Bomb"], ["Nasty Plot"], ["Tera Blast"]]
+			}, {
+				"species": "Salazzle",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Corrosion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Dark", "Ghost"],
+				"moves": [["Encore", "Toxic"], ["Sludge Bomb"], ["Nasty Plot"], ["Fire Blast"]]
+			}, {
+				"species": "Salazzle",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Corrosion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Grass", "Steel"],
+				"moves": [["Encore"], ["Sludge Bomb"], ["Toxic"], ["Fire Blast", "Flamethrower"]]
+			}, {
+				"species": "Salazzle",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Corrosion"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Grass", "Steel"],
+				"moves": [["Knock Off"], ["Sludge Bomb"], ["Toxic"], ["Fire Blast", "Flamethrower"]]
+			}]
+		},
+		"skuntank": {
+			"weight": 8,
+			"sets": [{
+				"species": "Skuntank",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Rocky Helmet", "Black Glasses"],
+				"ability": ["Aftermath"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"teraType": ["Dark", "Ghost"],
+				"moves": [["Gunk Shot"], ["Knock Off"], ["Sucker Punch"], ["Taunt", "Toxic", "Toxic Spikes"]]
+			}]
+		},
+		"tornadus": {
+			"weight": 8,
+			"sets": [{
+				"species": "Tornadus",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Defiant"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": ["Naive"],
+				"teraType": ["Flying", "Ground"],
+				"moves": [["Bleakwind Storm"], ["Focus Blast"], ["U-turn"], ["Knock Off"]]
+			}, {
+				"species": "Tornadus",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Prankster"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Flying", "Ground"],
+				"moves": [["Bleakwind Storm"], ["Focus Blast"], ["U-turn"], ["Taunt"]]
+			}, {
+				"species": "Tornadus",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Prankster"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Flying", "Ground"],
+				"moves": [["Bleakwind Storm"], ["Focus Blast"], ["Nasty Plot"], ["Heat Wave"]]
+			}, {
+				"species": "Tornadus",
+				"weight": 20,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Defiant"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Bleakwind Storm"], ["Focus Blast", "Heat Wave"], ["Nasty Plot"], ["Tera Blast"]]
+			}, {
+				"species": "Tornadus",
+				"wantsTera": true,
+				"weight": 10,
+				"item": ["Choice Specs"],
+				"ability": ["Defiant"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Bleakwind Storm"], ["Grass Knot"], ["Heat Wave"], ["Tera Blast"]]
+			}, {
+				"species": "Tornadus",
+				"weight": 10,
+				"item": ["Choice Specs"],
+				"ability": ["Prankster"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Flying"],
+				"moves": [["Bleakwind Storm"], ["Grass Knot"], ["Heat Wave"], ["Focus Blast"]]
+			}]
+		},
+		"toxtricity": {
+			"weight": 8,
+			"sets": [{
+				"species": "Toxtricity",
+				"weight": 35,
+				"item": ["Throat Spray"],
+				"ability": ["Punk Rock"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Normal"],
+				"moves": [["Overdrive"], ["Boomburst"], ["Shift Gear"], ["Sludge Bomb", "Snarl"]]
+			}, {
+				"species": "Toxtricity",
+				"weight": 35,
+				"item": ["Choice Specs"],
+				"ability": ["Punk Rock"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Normal"],
+				"moves": [["Overdrive"], ["Boomburst"], ["Volt Switch"], ["Snarl"]]
+			}, {
+				"species": "Toxtricity",
+				"weight": 30,
+				"item": ["Choice Scarf"],
+				"ability": ["Punk Rock"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Normal"],
+				"moves": [["Overdrive"], ["Boomburst"], ["Volt Switch"], ["Snarl", "Sludge Bomb"]]
+			}]
+		},
+		"bruxish": {
+			"weight": 6,
+			"sets": [{
+				"species": "Bruxish",
+				"weight": 35,
+				"item": ["Choice Scarf"],
+				"ability": ["Strong Jaw"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Psychic", "Water"],
+				"moves": [["Psychic Fangs"], ["Wave Crash"], ["Flip Turn"], ["Crunch", "Ice Fang", "Aqua Jet"]]
+			}, {
+				"species": "Bruxish",
+				"weight": 35,
+				"item": ["Choice Band"],
+				"ability": ["Strong Jaw"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Psychic", "Water"],
+				"moves": [["Psychic Fangs"], ["Wave Crash"], ["Flip Turn"], ["Aqua Jet"]]
+			}, {
+				"species": "Bruxish",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots", "Mystic Water"],
+				"ability": ["Dazzling"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Psychic Fangs"], ["Swords Dance"], ["Wave Crash"], ["Aqua Jet"]]
+			}]
+		},
+		"copperajah": {
+			"weight": 7,
+			"sets": [{
+				"species": "Copperajah",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Heavy Metal"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Heavy Slam"], ["Whirlwind"], ["Knock Off"], ["Stealth Rock", "Protect"]]
+			}, {
+				"species": "Copperajah",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Heavy Metal"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Ground", "Ghost", "Water"],
+				"moves": [["Heavy Slam"], ["Whirlwind", "Stealth Rock", "Protect"], ["Knock Off"], ["Earthquake"]]
+			}, {
+				"species": "Copperajah",
+				"weight": 50,
+				"item": ["Assault Vest"],
+				"ability": ["Sheer Force"],
+				"evs": {"atk": 192, "spd": 192, "spe": 124},
+				"nature": ["Adamant"],
+				"teraType": ["Fairy", "Ground"],
+				"moves": [["Iron Head"], ["Knock Off"], ["Earthquake"], ["Play Rough"]]
+			}]
+		},
+		"goodra": {
+			"weight": 7,
+			"sets": [{
+				"species": "Goodra",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sap Sipper"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Poison"],
+				"moves": [["Draco Meteor"], ["Flamethrower"], ["Sludge Bomb"], ["Toxic", "Acid Spray"]]
+			}, {
+				"species": "Goodra",
+				"weight": 25,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sap Sipper"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Dragon", "Fairy", "Poison"],
+				"moves": [["Draco Meteor"], ["Flamethrower"], ["Sludge Bomb"], ["Knock Off", "Dragon Tail"]]
+			}, {
+				"species": "Goodra",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Sap Sipper"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Dragon", "Fairy", "Poison"],
+				"moves": [["Draco Meteor"], ["Flamethrower", "Fire Blast"], ["Sludge Bomb"], ["Scald", "Dragon Pulse"]]
+			}]
+		},
+		"grimmsnarl": {
+			"weight": 7,
+			"sets": [{
+				"species": "Grimmsnarl",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Poison", "Steel"],
+				"moves": [["Parting Shot"], ["Spirit Break"], ["Sucker Punch"], ["Thunder Wave"]]
+			}, {
+				"species": "Grimmsnarl",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Poison", "Steel"],
+				"moves": [["Bulk Up"], ["Spirit Break"], ["Sucker Punch"], ["Substitute"]]
+			}]
+		},
+		"mudsdale": {
+			"weight": 7,
+			"sets": [{
+				"species": "Mudsdale",
+				"weight": 100,
+				"item": ["Rocky Helmet", "Leftovers"],
+				"ability": ["Stamina"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Steel"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Body Press", "Heavy Slam", "Stone Edge"], ["Roar"]]
+			}]
+		},
+		"scrafty": {
+			"weight": 7,
+			"sets": [{
+				"species": "Scrafty",
+				"weight": 20,
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin"],
+				"evs": {"hp": 248, "atk": 8, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Poison"],
+				"moves": [["Bulk Up"], ["Drain Punch"], ["Knock Off"], ["Rest"]]
+			}, {
+				"species": "Scrafty",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Poison"],
+				"moves": [["Dragon Dance"], ["Drain Punch"], ["Knock Off"], ["Poison Jab", "Ice Punch"]]
+			}, {
+				"species": "Scrafty",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin"],
+				"evs": {"hp": 176, "atk": 100, "spe": 232},
+				"nature": ["Adamant"],
+				"teraType": ["Poison"],
+				"moves": [["Dragon Dance"], ["Drain Punch"], ["Knock Off"], ["Poison Jab", "Ice Punch"]]
+			}]
+		},
+		"tatsugiri": {
+			"weight": 6,
+			"sets": [{
+				"species": "Tatsugiri",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Storm Drain"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid", "Modest"],
+				"teraType": ["Fairy", "Ghost"],
+				"moves": [["Nasty Plot"], ["Draco Meteor"], ["Rapid Spin"], ["Surf"]]
+			}]
+		},
+		"venusaur": {
+			"weight": 7,
+			"sets": [{
+				"species": "Venusaur",
+				"weight": 70,
+				"item": ["Heavy-Duty Boots", "Life Orb"],
+				"ability": ["Overgrow"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Leaf Storm"], ["Sludge Bomb"], ["Earth Power"], ["Synthesis"]]
+			}, {
+				"species": "Venusaur",
+				"weight": 15,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Overgrow"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Leech Seed"], ["Sludge Bomb"], ["Giga Drain"], ["Synthesis"]]
+			}, {
+				"species": "Venusaur",
+				"weight": 15,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Overgrow"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"nature": ["Bold"],
+				"teraType": ["Water"],
+				"moves": [["Knock Off"], ["Sludge Bomb"], ["Giga Drain"], ["Synthesis"]]
+			}]
+		},
+		"articunogalar": {
+			"weight": 5,
+			"sets": [{
+				"species": "Articuno-Galar",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Competitive"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Steel"],
+				"moves": [["Future Sight"], ["Recover"], ["Hurricane"], ["U-turn"]]
+			}]
+		},
+		"coalossal": {
+			"weight": 5,
+			"sets": [{
+				"species": "Coalossal",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Calm"],
+				"teraType": ["Ghost"],
+				"moves": [["Rapid Spin"], ["Flamethrower"], ["Earth Power"], ["Stealth Rock", "Spikes"]]
+			}, {
+				"species": "Coalossal",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ghost"],
+				"moves": [["Rapid Spin"], ["Flamethrower"], ["Earth Power"], ["Stealth Rock", "Spikes"]]
+			}]
+		},
+		"cramorant": {
+			"weight": 5,
+			"sets": [{
+				"species": "Cramorant",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Gulp Missile"],
+				"evs": {"hp": 248, "def": 188, "spd": 56, "spe": 16},
+				"nature": ["Bold"],
+				"teraType": ["Steel"],
+				"moves": [["Roost"], ["Defog"], ["Surf"], ["Brave Bird"]]
+			}]
+		},
+		"decidueyehisui": {
+			"weight": 5,
+			"sets": [{
+				"species": "Decidueye-Hisui",
+				"weight": 25,
+				"item": ["Lum Berry"],
+				"ability": ["Scrappy"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Swords Dance"], ["Trailblaze", "Leaf Blade", "Sucker Punch"], ["Triple Arrows", "Close Combat"], ["Knock Off"]]
+			}, {
+				"species": "Decidueye-Hisui",
+				"weight": 25,
+				"item": ["Lum Berry"],
+				"ability": ["Scrappy"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Swords Dance"], ["Knock Off", "Leaf Blade"], ["Triple Arrows", "Close Combat"], ["Sucker Punch"]]
+			}, {
+				"species": "Decidueye-Hisui",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Scrappy"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["U-turn"], ["Knock Off"], ["Triple Arrows", "Close Combat"], ["Leaf Blade"]]
+			}]
+		},
+		"delphox": {
+			"weight": 5,
+			"sets": [{
+				"species": "Delphox",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Blaze"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Nasty Plot"], ["Fire Blast", "Flamethrower"], ["Psyshock"], ["Encore"]]
+			}, {
+				"species": "Delphox",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Blaze"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Grass"],
+				"moves": [["Nasty Plot"], ["Fire Blast", "Flamethrower"], ["Psyshock"], ["Grass Knot"]]
+			}]
+		},
+		"dudunsparce": {
+			"weight": 5,
+			"sets": [{
+				"species": "Dudunsparce",
+				"weight": 40,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Rattled"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ghost", "Poison"],
+				"moves": [["Calm Mind"], ["Boomburst"], ["Shadow Ball"], ["Roost"]]
+			}, {
+				"species": "Dudunsparce",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Poison"],
+				"moves": [["Dragon Tail"], ["Body Slam"], ["Coil"], ["Roost"]]
+			}, {
+				"species": "Dudunsparce",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Poison"],
+				"moves": [["Dragon Tail", "Toxic"], ["Body Slam"], ["Stealth Rock"], ["Roost"]]
+			}]
+		},
+		"electrodehisui": {
+			"weight": 5,
+			"sets": [{
+				"species": "Electrode-Hisui",
+				"wantsTera": true,
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Soundproof", "Aftermath"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fire"],
+				"moves": [["Volt Switch"], ["Giga Drain", "Leaf Storm"], ["Thunderbolt"], ["Tera Blast"]]
+			}, {
+				"species": "Electrode-Hisui",
+				"weight": 60,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Soundproof", "Aftermath"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Volt Switch"], ["Giga Drain", "Leaf Storm"], ["Thunderbolt"], ["Taunt", "Foul Play"]]
+			}]
+		},
+		"frosmoth": {
+			"weight": 5,
+			"sets": [{
+				"species": "Frosmoth",
+				"wantsTera": true,
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Ice Scales"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ground"],
+				"moves": [["Quiver Dance"], ["Ice Beam"], ["Tera Blast"], ["Giga Drain", "Bug Buzz"]]
+			}, {
+				"species": "Frosmoth",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Ice Scales"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Defog"], ["Ice Beam"], ["U-turn"], ["Giga Drain", "Stun Spore"]]
+			}]
+		},
+		"hariyama": {
+			"weight": 5,
+			"sets": [{
+				"species": "Hariyama",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Guts", "Thick Fat"],
+				"evs": {"hp": 12, "atk": 200, "spd": 252, "spe": 44},
+				"nature": ["Adamant"],
+				"teraType": ["Steel"],
+				"moves": [["Bulk Up"], ["Drain Punch"], ["Knock Off"], ["Bullet Punch"]]
+			}]
+		},
+		"hoopa": {
+			"weight": 5,
+			"sets": [{
+				"species": "Hoopa",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Magician"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fighting", "Ghost"],
+				"moves": [["Trick"], ["Shadow Ball"], ["Psyshock", "Psychic"], ["Focus Blast"]]
+			}, {
+				"species": "Hoopa",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Magician"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost", "Psychic", "Dark", "Fighting"],
+				"moves": [["Psyshock"], ["Shadow Ball"], ["Future Sight", "Psychic"], ["Focus Blast"]]
+			}]
+		},
+		"sandslashalola": {
+			"weight": 5,
+			"sets": [{
+				"species": "Sandslash-Alola",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Slush Rush"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water", "Ghost"],
+				"moves": [["Rapid Spin"], ["Ice Spinner", "Triple Axel"], ["Knock Off"], ["Spikes", "Stealth Rock"]]
+			}]
+		},
+		"uxie": {
+			"weight": 5,
+			"sets": [{
+				"species": "Uxie",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Steel"],
+				"moves": [["Draining Kiss"], ["Nasty Plot"], ["Psyshock", "Psychic Noise"], ["Encore"]]
+			}, {
+				"species": "Uxie",
+				"weight": 40,
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Electric"],
+				"moves": [["Thunderbolt"], ["Nasty Plot"], ["Psyshock", "Psychic Noise"], ["Encore"]]
+			}, {
+				"species": "Uxie",
+				"weight": 20,
+				"item": ["Leftovers", "Colbur Berry"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Bold"],
+				"teraType": ["Steel", "Fairy"],
+				"moves": [["Stealth Rock", "Encore"], ["Knock Off"], ["Psychic Noise"], ["U-turn"]]
+			}]
+		},
+		"virizion": {
+			"weight": 5,
+			"sets": [{
+				"species": "Virizion",
+				"weight": 100,
+				"item": ["Lum Berry"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Rock"],
+				"moves": [["Swords Dance"], ["Close Combat"], ["Stone Edge"], ["Leaf Blade", "Synthesis"]]
+			}]
+		},
+		"wochien": {
+			"weight": 5,
+			"sets": [{
+				"species": "Wo-Chien",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Tablets of Ruin"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Poison"],
+				"moves": [["Knock Off"], ["Protect"], ["Leech Seed"], ["Foul Play", "Ruination"]]
+			}]
+		},
+		"altaria": {
+			"weight": 4,
+			"sets": [{
+				"species": "Altaria",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 252, "def": 200, "spd": 56},
+				"nature": ["Impish"],
+				"teraType": ["Steel"],
+				"moves": [["Brave Bird"], ["Roost"], ["Defog"], ["Will-O-Wisp", "Haze", "Roar"]]
+			}]
+		},
+		"ambipom": {
+			"weight": 4,
+			"sets": [{
+				"species": "Ambipom",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Normal"],
+				"moves": [["Fake Out"], ["U-turn"], ["Knock Off"], ["Triple Axel"]]
+			}]
+		},
+		"articuno": {
+			"weight": 4,
+			"sets": [{
+				"species": "Articuno",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"nature": ["Bold"],
+				"teraType": ["Fairy", "Water", "Steel"],
+				"moves": [["Roost"], ["U-turn"], ["Freeze-Dry"], ["Roar", "Haze", "Hurricane"]]
+			}]
+		},
+		"floatzel": {
+			"weight": 4,
+			"sets": [{
+				"species": "Floatzel",
+				"weight": 100,
+				"item": ["Choice Band"],
+				"ability": ["Water Veil"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Wave Crash"], ["Flip Turn"], ["Ice Spinner"], ["Aqua Jet"]]
+			}]
+		},
+		"glastrier": {
+			"weight": 4,
+			"sets": [{
+				"species": "Glastrier",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Chilling Neigh"],
+				"evs": {"hp": 132, "atk": 252, "spe": 124},
+				"nature": ["Adamant"],
+				"teraType": ["Water", "Poison"],
+				"moves": [["Icicle Crash"], ["Close Combat"], ["High Horsepower"], ["Swords Dance"]]
+			}]
+		},
+		"mesprit": {
+			"weight": 4,
+			"sets": [{
+				"species": "Mesprit",
+				"weight": 100,
+				"item": ["Colbur Berry", "Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Bold"],
+				"teraType": ["Ghost", "Fairy", "Steel"],
+				"moves": [["Stealth Rock"], ["Psychic Noise"], ["U-turn"], ["Knock Off", "Thunder Wave", "Healing Wish"]]
+			}]
+		},
+		"oricorio": {
+			"weight": 4,
+			"sets": [{
+				"species": "Oricorio",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dancer"],
+				"evs": {"hp": 252, "spa": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground"],
+				"moves": [["Quiver Dance"], ["Revelation Dance"], ["Hurricane", "Taunt"], ["Roost"]]
+			}, {
+				"species": "Oricorio",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dancer"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ground"],
+				"moves": [["Quiver Dance"], ["Revelation Dance"], ["Hurricane", "Taunt"], ["Roost"]]
+			}]
+		},
+		"palossand": {
+			"weight": 4,
+			"sets": [{
+				"species": "Palossand",
+				"weight": 100,
+				"item": ["", "Rocky Helmet", "Colbur Berry"],
+				"ability": ["Water Compaction"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Dark", "Water"],
+				"moves": [["Stealth Rock"], ["Scorching Sands", "Earth Power"], ["Shore Up"], ["Shadow Ball", "Sludge Bomb"]]
+			}]
+		},
+		"qwilfish": {
+			"weight": 4,
+			"sets": [{
+				"species": "Qwilfish",
+				"weight": 50,
+				"item": ["Rocky Helmet"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "def": 240, "spe": 16},
+				"nature": ["Impish"],
+				"teraType": ["Ground", "Ghost"],
+				"moves": [["Spikes"], ["Barb Barrage"], ["Flip Turn"], ["Pain Split", "Taunt", "Thunder Wave", "Toxic"]]
+			}, {
+				"species": "Qwilfish",
+				"weight": 50,
+				"item": ["Leftovers", "Life Orb"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Swords Dance"], ["Gunk Shot"], ["Liquidation"], ["Aqua Jet"]]
+			}]
+		},
+		"qwilfishhisui": {
+			"weight": 4,
+			"sets": [{
+				"species": "Qwilfish-Hisui",
+				"weight": 50,
+				"item": ["Eviolite"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "spd": 240, "spe": 16},
+				"nature": ["Careful"],
+				"teraType": ["Dragon"],
+				"moves": [["Spikes"], ["Barb Barrage"], ["Crunch"], ["Taunt", "Haze", "Toxic"]]
+			}, {
+				"species": "Qwilfish-Hisui",
+				"weight": 50,
+				"item": ["Eviolite"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Water"],
+				"moves": [["Swords Dance"], ["Gunk Shot"], ["Crunch"], ["Aqua Jet"]]
+			}]
+		},
+		"rotommow": {
+			"weight": 4,
+			"sets": [{
+				"species": "Rotom-Mow",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Electric"],
+				"moves": [["Volt Switch"], ["Thunderbolt", "Discharge"], ["Leaf Storm"], ["Trick"]]
+			}]
+		},
+		"sandaconda": {
+			"weight": 4,
+			"sets": [{
+				"species": "Sandaconda",
+				"weight": 100,
+				"item": ["Rocky Helmet", "Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Shed Skin"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Dragon"],
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Glare", "Stone Edge"], ["Rest"]]
+			}]
+		},
+		"sneasel": {
+			"weight": 4,
+			"sets": [{
+				"species": "Sneasel",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Ice", "Dark", "Ghost"],
+				"moves": [["Swords Dance"], ["Triple Axel", "Icicle Crash"], ["Knock Off"], ["Ice Shard"]]
+			}]
+		},
+		"sneaselhisui": {
+			"weight": 4,
+			"sets": [{
+				"species": "Sneasel-Hisui",
+				"weight": 100,
+				"item": ["Eviolite"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Swords Dance"], ["Gunk Shot"], ["Close Combat"], ["Throat Chop"]]
+			}]
+		},
+		"whimsicott": {
+			"weight": 4,
+			"sets": [{
+				"species": "Whimsicott",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Prankster", "Infiltrator"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Energy Ball"], ["Moonblast"], ["Psychic"], ["Switcheroo"]]
+			}, {
+				"species": "Whimsicott",
+				"weight": 50,
+				"item": ["Choice Specs"],
+				"ability": ["Infiltrator"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Energy Ball"], ["Moonblast"], ["Psychic"], ["U-turn"]]
+			}]
+		},
+		"braviaryhisui": {
+			"weight": 3,
+			"sets": [{
+				"species": "Braviary-Hisui",
+				"weight": 100,
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Fire"],
+				"moves": [["Psychic"], ["Hurricane"], ["Heat Wave"], ["Agility", "Roost"]]
+			}]
+		},
+		"farigiraf": {
+			"weight": 3,
+			"sets": [{
+				"species": "Farigiraf",
+				"wantsTera": true,
+				"weight": 100,
+				"item": ["Life Orb"],
+				"ability": ["Armor Tail"],
+				"evs": {"hp": 252, "def": 4, "spa": 252},
+				"ivs": {"atk": 0, "spe": 0},
+				"nature": ["Quiet"],
+				"teraType": ["Fairy", "Fire"],
+				"moves": [["Psyshock"], ["Tera Blast"], ["Trick Room"], ["Nasty Plot"]]
+			}]
+		},
+		"hattrem": {
+			"weight": 2,
+			"sets": [{
+				"species": "Hattrem",
+				"weight": 100,
+				"item": ["Eviolite"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy", "Fire"],
+				"moves": [["Psychic"], ["Nuzzle"], ["Mystical Fire"], ["Giga Drain", "Healing Wish"]]
+			}]
+		},
+		"naclstack": {
+			"weight": 2,
+			"sets": [{
+				"species": "Naclstack",
+				"weight": 50,
+				"item": ["Eviolite"],
+				"ability": ["Purifying Salt"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Water"],
+				"moves": [["Salt Cure"], ["Protect"], ["Recover"], ["Curse"]]
+			}, {
+				"species": "Naclstack",
+				"weight": 50,
+				"item": ["Eviolite"],
+				"ability": ["Purifying Salt"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Ghost"],
+				"moves": [["Salt Cure"], ["Protect"], ["Recover"], ["Stealth Rock"]]
+			}]
+		},
+		"orthworm": {
+			"weight": 1,
+			"sets": [{
+				"species": "Orthworm",
+				"weight": 50,
+				"item": ["Leftovers"],
+				"ability": ["Earth Eater"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Electric"],
+				"moves": [["Coil"], ["Iron Tail"], ["Body Press"], ["Stealth Rock"]]
+			}, {
+				"species": "Orthworm",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Earth Eater"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Electric"],
+				"moves": [["Iron Defense"], ["Heavy Slam"], ["Body Press"], ["Stealth Rock", "Spikes"]]
+			}, {
+				"species": "Orthworm",
+				"weight": 25,
+				"item": ["Leftovers"],
+				"ability": ["Earth Eater"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"nature": ["Careful"],
+				"teraType": ["Ghost", "Electric"],
+				"moves": [["Spikes"], ["Heavy Slam"], ["Body Press"], ["Stealth Rock"]]
+			}]
+		},
+		"passimian": {
+			"weight": 3,
+			"sets": [{
+				"species": "Passimian",
+				"weight": 100,
+				"item": ["Choice Scarf"],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fighting", "Dark"],
+				"moves": [["Close Combat"], ["U-turn"], ["Knock Off"], ["Gunk Shot", "Earthquake"]]
+			}]
+		},
+		"brutebonnet": {
+			"weight": 2,
+			"sets": [{
+				"species": "Brute Bonnet",
+				"weight": 100,
+				"item": ["Choice Band"],
+				"ability": ["Protosynthesis"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"teraType": ["Fighting", "Dark"],
+				"moves": [["Close Combat"], ["Seed Bomb"], ["Crunch"], ["Sucker Punch"]]
+			}]
+		},
+		"jolteon": {
+			"weight": 2,
+			"sets": [{
+				"species": "Jolteon",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Fairy"],
+				"moves": [["Thunderbolt"], ["Calm Mind"], ["Volt Switch"], ["Alluring Voice"]]
+			}, {
+				"species": "Jolteon",
+				"weight": 30,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ghost"],
+				"moves": [["Thunderbolt"], ["Calm Mind"], ["Volt Switch"], ["Shadow Ball"]]
+			}, {
+				"species": "Jolteon",
+				"wantsTera": true,
+				"weight": 40,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"teraType": ["Ice"],
+				"moves": [["Thunderbolt"], ["Calm Mind"], ["Volt Switch"], ["Tera Blast"]]
+			}]
+		},
+		"sandslash": {
+			"weight": 2,
+			"sets": [{
+				"species": "Sandslash",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots", "Leftovers", "Rocky Helmet"],
+				"ability": ["Sand Rush"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Water"],
+				"moves": [["Earthquake"], ["Rapid Spin"], ["Spikes", "Stealth Rock"], ["Knock Off"]]
+			}]
+		},
+		"emboar": {
+			"weight": 1,
+			"sets": [{
+				"species": "Emboar",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots", "Choice Band"],
+				"ability": ["Reckless"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"teraType": ["Dark"],
+				"moves": [["Flare Blitz"], ["Close Combat"], ["Sucker Punch"], ["Knock Off", "Earthquake"]]
+			}, {
+				"species": "Emboar",
+				"weight": 50,
+				"item": ["Choice Scarf"],
+				"ability": ["Reckless"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Dark", "Fighting", "Fire"],
+				"moves": [["Flare Blitz"], ["Close Combat"], ["Knock Off"], ["Head Smash", "Earthquake"]]
+			}]
+		},
+		"oricoriosensu": {
+			"weight": 1,
+			"sets": [{
+				"species": "Oricorio-Sensu",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dancer"],
+				"evs": {"hp": 252, "spa": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Ground", "Fairy"],
+				"moves": [["Quiver Dance"], ["Revelation Dance"], ["Hurricane", "Taunt"], ["Roost"]]
+			}, {
+				"species": "Oricorio-Sensu",
+				"weight": 50,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dancer"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"teraType": ["Ground", "Fairy"],
+				"moves": [["Quiver Dance"], ["Revelation Dance"], ["Hurricane", "Taunt"], ["Roost"]]
+			}]
+		},
+		"regirock": {
+			"weight": 1,
+			"sets": [{
+				"species": "Regirock",
+				"weight": 100,
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": ["Impish"],
+				"teraType": ["Ghost", "Poison"],
+				"moves": [["Stealth Rock"], ["Stone Edge"], ["Body Press"], ["Thunder Wave", "Iron Defense"]]
+			}]
+		}
+	}
+}

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -4826,21 +4826,6 @@
 				"moves": [["Strange Steam"], ["Pain Split"], ["Will-O-Wisp"], ["Defog", "Flamethrower", "Taunt"]]
 			}]
 		},
-		"yanmega": {
-			"weight": 4,
-			"sets": [{
-				"species": "Yanmega",
-				"wantsTera": true,
-				"weight": 100,
-				"item": ["Throat Spray"],
-				"ability": ["Speed Boost"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Modest"],
-				"teraType": ["Ground"],
-				"moves": [["Bug Buzz"], ["Air Slash"], ["Tera Blast"], ["Protect"]]
-			}]
-		},
 		"zoroarkhisui": {
 			"weight": 7,
 			"sets": [{

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -20,15 +20,19 @@ export interface TeamData {
 	gigantamax?: boolean;
 }
 export interface BattleFactorySpecies {
-	flags: {limEevee?: 1};
 	sets: BattleFactorySet[];
+	weight: number;
 }
 interface BattleFactorySet {
 	species: string;
-	item: string;
-	ability: string;
-	nature: string;
-	moves: string[];
+	weight: number;
+	item: string[];
+	ability: string[];
+	nature: string[];
+	moves: string[][];
+	teraType: string[];
+	gender?: string;
+	wantsTera?: boolean;
 	evs?: Partial<StatsTable>;
 	ivs?: Partial<StatsTable>;
 }
@@ -2354,6 +2358,303 @@ export class RandomTeams {
 		}
 
 		return team;
+	}
+
+	randomFactorySets: {[format: string]: {[species: string]: BattleFactorySpecies}} = require('./factory-sets.json');
+
+	randomFactorySet(
+		species: Species, teamData: RandomTeamsTypes.FactoryTeamDetails, tier: string
+	): RandomTeamsTypes.RandomFactorySet | null {
+		const id = toID(species.name);
+		const setList = this.randomFactorySets[tier][id].sets;
+
+		const itemsLimited = ['choicespecs', 'choiceband', 'choicescarf'];
+		const movesLimited: {[k: string]: string} = {
+			stealthrock: 'stealthRock',
+			stoneaxe: 'stealthRock',
+			spikes: 'spikes',
+			ceaselessedge: 'spikes',
+			toxicspikes: 'toxicSpikes',
+			rapidspin: 'hazardClear',
+			defog: 'hazardClear',
+		};
+		const abilitiesLimited: {[k: string]: string} = {
+			toxicdebris: 'toxicSpikes',
+		};
+
+		// Build a pool of eligible sets, given the team partners
+		// Also keep track of moves and items limited to one per team
+		const effectivePool: {
+			set: BattleFactorySet, moves?: string[], item?: string,
+		}[] = [];
+
+		for (const curSet of setList) {
+			let reject = false;
+
+			// limit to 1 dedicated tera user per team
+			if (curSet.wantsTera && teamData.wantsTeraCount) {
+				continue;
+			}
+
+			// reject disallowed items, specifically a second of any given choice item
+			const allowedItems: string[] = [];
+			for (const itemString of curSet.item) {
+				const item = this.dex.items.get(itemString);
+				if (itemsLimited.includes(item.id) && teamData.has[item.id]) continue;
+				allowedItems.push(itemString);
+			}
+			if (allowedItems.length === 0) continue;
+			const curSetItem = this.sample(allowedItems);
+
+			const curSetAbility = this.sample(curSet.ability);
+			const ability = this.dex.abilities.get(curSetAbility);
+
+			if (abilitiesLimited[ability.id] && teamData.has[abilitiesLimited[ability.id]]) continue;
+
+			const curSetMoves: string[] = [];
+			for (const move of curSet.moves) {
+				const allowedMoves: string[] = [];
+				for (const m of move) {
+					const moveId = toID(m);
+					if (movesLimited[moveId] && teamData.has[movesLimited[moveId]]) continue;
+					allowedMoves.push(m);
+				}
+				if (allowedMoves.length === 0) {
+					reject = true;
+					break;
+				}
+				curSetMoves.push(this.sample(allowedMoves));
+			}
+			if (reject) continue;
+			const set = {set: curSet, moves: curSetMoves, item: curSetItem};
+			effectivePool.push(set);
+		}
+
+		if (!effectivePool.length) {
+			if (!teamData.forceResult) return null;
+			for (const curSet of setList) {
+				effectivePool.push({set: curSet});
+			}
+		}
+
+		// Sets have individual weight, choose one with weighted random selection
+
+		let setData = this.sample(effectivePool); // Init with unweighted random set as fallback
+
+		const total = effectivePool.reduce((a, b) => a + b.set.weight, 0);
+		const setRand = this.random(total);
+
+		let cur = 0;
+		for (const set of effectivePool) {
+			cur += set.set.weight;
+			if (cur > setRand) {
+				setData = set; // Bingo!
+				break;
+			}
+		}
+
+		const moves = [];
+		for (const [i, moveSlot] of setData.set.moves.entries()) {
+			moves.push(setData.moves ? setData.moves[i] : this.sample(moveSlot));
+		}
+
+		const item = setData.item || this.sample(setData.set.item);
+
+		return {
+			name: species.baseSpecies,
+			species: (typeof species.battleOnly === 'string') ? species.battleOnly : species.name,
+			teraType: this.sample(setData.set.teraType),
+			gender:	setData.set.gender || species.gender,
+			item,
+			ability: this.sample(setData.set.ability),
+			shiny: this.randomChance(1, 1024),
+			level: this.adjustLevel || (tier === "LC" ? 5 : 100),
+			happiness: 255,
+			evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0, ...setData.set.evs},
+			ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31, ...setData.set.ivs},
+			nature: this.sample(setData.set.nature) || "Serious",
+			moves,
+			wantsTera: setData.set.wantsTera,
+		};
+	}
+
+
+	randomFactoryTeam(side: PlayerOptions, depth = 0): RandomTeamsTypes.RandomFactorySet[] {
+		this.enforceNoDirectCustomBanlistChanges();
+
+		const forceResult = depth >= 12;
+
+		if (!this.factoryTier) {
+			// this.factoryTier = this.sample(['Uber', 'OU', 'UU', 'RU', 'NU', 'PU', 'LC']);
+			this.factoryTier = this.sample(['Uber', 'OU', 'UU', 'RU', 'NU', 'PU']);
+		}
+
+		const tierValues: {[k: string]: number} = {
+			Uber: 5,
+			OU: 4, UUBL: 4,
+			UU: 3, RUBL: 3,
+			RU: 2, NUBL: 2,
+			NU: 1, PUBL: 1,
+			PU: 0,
+		};
+
+		const pokemon = [];
+		const pokemonPool = Object.keys(this.randomFactorySets[this.factoryTier]);
+
+		const teamData: TeamData = {
+			typeCount: {},
+			typeComboCount: {},
+			baseFormes: {},
+			has: {},
+			wantsTeraCount: 0,
+			forceResult: forceResult,
+			weaknesses: {},
+			resistances: {},
+		};
+		const resistanceAbilities: {[k: string]: string[]} = {
+			dryskin: ['Water'], waterabsorb: ['Water'], stormdrain: ['Water'],
+			flashfire: ['Fire'], heatproof: ['Fire'], waterbubble: ['Fire'], wellbakedbody: ['Fire'],
+			lightningrod: ['Electric'], motordrive: ['Electric'], voltabsorb: ['Electric'],
+			sapsipper: ['Grass'],
+			thickfat: ['Ice', 'Fire'],
+			eartheater: ['Ground'], levitate: ['Ground'],
+		};
+		const movesLimited: {[k: string]: string} = {
+			stealthrock: 'stealthRock',
+			stoneaxe: 'stealthRock',
+			spikes: 'spikes',
+			ceaselessedge: 'spikes',
+			toxicspikes: 'toxicSpikes',
+			rapidspin: 'hazardClear',
+			defog: 'hazardClear',
+		};
+		const abilitiesLimited: {[k: string]: string} = {
+			toxicdebris: 'toxicSpikes',
+		};
+		const limitFactor = Math.ceil(this.maxTeamSize / 6);
+		/**
+		 * Weighted random shuffle
+		 * Uses the fact that for two uniform variables x1 and x2, x1^(1/w1) is larger than x2^(1/w2)
+		 * with probability equal to w1/(w1+w2), which is what we want. See e.g. here https://arxiv.org/pdf/1012.0256.pdf,
+		 * original paper is behind a paywall.
+		 */
+		const shuffledSpecies = [];
+		for (const speciesName of pokemonPool) {
+			const sortObject = {
+				speciesName,
+				score: Math.pow(this.prng.next(), 1 / this.randomFactorySets[this.factoryTier][speciesName].weight),
+			};
+			shuffledSpecies.push(sortObject);
+		}
+		shuffledSpecies.sort((a, b) => a.score - b.score);
+
+		while (shuffledSpecies.length && pokemon.length < this.maxTeamSize) {
+			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
+			const species = this.dex.species.get(shuffledSpecies.pop()!.speciesName);
+			if (!species.exists) continue;
+
+			// Lessen the need of deleting sets of Pokemon after tier shifts
+			if (
+				this.factoryTier in tierValues && species.tier in tierValues &&
+				tierValues[species.tier] > tierValues[this.factoryTier]
+			) continue;
+
+			if (this.forceMonotype && !species.types.includes(this.forceMonotype)) continue;
+
+			// Limit to one of each species (Species Clause)
+			if (teamData.baseFormes[species.baseSpecies]) continue;
+
+			// Limit 2 of any type (most of the time)
+			const types = species.types;
+			let skip = false;
+			if (!this.forceMonotype) {
+				for (const type of types) {
+					if (teamData.typeCount[type] >= 2 * limitFactor && this.randomChance(4, 5)) {
+						skip = true;
+						break;
+					}
+				}
+			}
+			if (skip) continue;
+
+			const set = this.randomFactorySet(species, teamData, this.factoryTier);
+			if (!set) continue;
+
+			// Limit 1 of any type combination
+			let typeCombo = types.slice().sort().join();
+			if (set.ability === "Drought" || set.ability === "Drizzle") {
+				// Drought and Drizzle don't count towards the type combo limit
+				typeCombo = set.ability;
+			}
+			if (!this.forceMonotype && teamData.typeComboCount[typeCombo] >= limitFactor) continue;
+
+			const itemData = this.dex.items.get(set.item);
+
+			// Okay, the set passes, add it to our team
+			pokemon.push(set);
+
+			// Now that our Pokemon has passed all checks, we can update team data:
+			for (const type of types) {
+				if (type in teamData.typeCount) {
+					teamData.typeCount[type]++;
+				} else {
+					teamData.typeCount[type] = 1;
+				}
+			}
+			if (typeCombo in teamData.typeComboCount) {
+				teamData.typeComboCount[typeCombo]++;
+			} else {
+				teamData.typeComboCount[typeCombo] = 1;
+			}
+
+			teamData.baseFormes[species.baseSpecies] = 1;
+
+			teamData.has[itemData.id] = 1;
+
+			if (set.wantsTera) {
+				if (!teamData.wantsTeraCount) teamData.wantsTeraCount = 0;
+				teamData.wantsTeraCount++;
+			}
+
+			for (const move of set.moves) {
+				const moveId = toID(move);
+				if (movesLimited[moveId]) {
+					teamData.has[movesLimited[moveId]] = 1;
+				}
+			}
+
+			const ability = this.dex.abilities.get(set.ability);
+			if (abilitiesLimited[ability.id]) {
+				teamData.has[abilitiesLimited[ability.id]] = 1;
+			}
+
+			for (const typeName of this.dex.types.names()) {
+				// Cover any major weakness (3+) with at least one resistance
+				if (teamData.resistances[typeName] >= 1) continue;
+				if (resistanceAbilities[ability.id]?.includes(typeName) ||	!this.dex.getImmunity(typeName, types)) {
+					// Heuristic: assume that Pokémon with these abilities don't have (too) negative typing.
+					teamData.resistances[typeName] = (teamData.resistances[typeName] || 0) + 1;
+					if (teamData.resistances[typeName] >= 1) teamData.weaknesses[typeName] = 0;
+					continue;
+				}
+				const typeMod = this.dex.getEffectiveness(typeName, types);
+				if (typeMod < 0) {
+					teamData.resistances[typeName] = (teamData.resistances[typeName] || 0) + 1;
+					if (teamData.resistances[typeName] >= 1) teamData.weaknesses[typeName] = 0;
+				} else if (typeMod > 0) {
+					teamData.weaknesses[typeName] = (teamData.weaknesses[typeName] || 0) + 1;
+				}
+			}
+		}
+		if (!teamData.forceResult && pokemon.length < this.maxTeamSize) return this.randomFactoryTeam(side, ++depth);
+
+		// Quality control we cannot afford for monotype
+		if (!teamData.forceResult && !this.forceMonotype) {
+			for (const type in teamData.weaknesses) {
+				if (teamData.weaknesses[type] >= 3 * limitFactor) return this.randomFactoryTeam(side, ++depth);
+			}
+		}
+		return pokemon;
 	}
 
 	randomBSSFactorySets: AnyObject = require("./bss-factory-sets.json");

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2419,7 +2419,7 @@ export class RandomTeams {
 					if (movesLimited[moveId] && teamData.has[movesLimited[moveId]]) continue;
 					allowedMoves.push(m);
 				}
-				if (allowedMoves.length === 0) {
+				if (!allowedMoves.length) {
 					reject = true;
 					break;
 				}

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2464,7 +2464,7 @@ export class RandomTeams {
 			name: species.baseSpecies,
 			species: (typeof species.battleOnly === 'string') ? species.battleOnly : species.name,
 			teraType: this.sample(setData.set.teraType),
-			gender:	setData.set.gender || species.gender,
+			gender:	setData.set.gender || species.gender || (tier === 'OU' ? 'F' : ''), // F for Cute Charm Enamorus
 			item,
 			ability: this.sample(setData.set.ability),
 			shiny: this.randomChance(1, 1024),

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -35,6 +35,7 @@ interface BattleFactorySet {
 	wantsTera?: boolean;
 	evs?: Partial<StatsTable>;
 	ivs?: Partial<StatsTable>;
+	shiny?: boolean;
 }
 interface BSSFactorySet {
 	species: string;
@@ -2399,17 +2400,17 @@ export class RandomTeams {
 			// reject disallowed items, specifically a second of any given choice item
 			const allowedItems: string[] = [];
 			for (const itemString of set.item) {
-				const item = this.dex.items.get(itemString);
-				if (itemsLimited.includes(item.id) && teamData.has[item.id]) continue;
+				const itemId = toID(itemString);
+				if (itemsLimited.includes(itemId) && teamData.has[itemId]) continue;
 				allowedItems.push(itemString);
 			}
 			if (!allowedItems.length) continue;
 			const item = this.sample(allowedItems);
 
-			const curSetAbility = this.sample(set.ability);
-			const ability = this.dex.abilities.get(curSetAbility);
+			const ability = this.sample(set.ability);
+			const abilityId = toID(ability);
 
-			if (abilitiesLimited[ability.id] && teamData.has[abilitiesLimited[ability.id]]) continue;
+			if (abilitiesLimited[abilityId] && teamData.has[abilitiesLimited[abilityId]]) continue;
 
 			const moves: string[] = [];
 			for (const move of set.moves) {
@@ -2466,7 +2467,7 @@ export class RandomTeams {
 			gender:	setData.set.gender || species.gender || (tier === 'OU' ? 'F' : ''), // F for Cute Charm Enamorus
 			item,
 			ability: this.sample(setData.set.ability),
-			shiny: this.randomChance(1, 1024),
+			shiny: setData.set.shiny || this.randomChance(1, 1024),
 			level: this.adjustLevel || (tier === "LC" ? 5 : 100),
 			happiness: 255,
 			evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0, ...setData.set.evs},
@@ -2587,8 +2588,6 @@ export class RandomTeams {
 			}
 			if (!this.forceMonotype && teamData.typeComboCount[typeCombo] >= limitFactor) continue;
 
-			const itemData = this.dex.items.get(set.item);
-
 			// Okay, the set passes, add it to our team
 			pokemon.push(set);
 
@@ -2608,7 +2607,7 @@ export class RandomTeams {
 
 			teamData.baseFormes[species.baseSpecies] = 1;
 
-			teamData.has[itemData.id] = 1;
+			teamData.has[toID(set.item)] = 1;
 
 			if (set.wantsTera) {
 				if (!teamData.wantsTeraCount) teamData.wantsTeraCount = 0;

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2388,31 +2388,31 @@ export class RandomTeams {
 			set: BattleFactorySet, moves?: string[], item?: string,
 		}[] = [];
 
-		for (const curSet of setList) {
+		for (const set of setList) {
 			let reject = false;
 
 			// limit to 1 dedicated tera user per team
-			if (curSet.wantsTera && teamData.wantsTeraCount) {
+			if (set.wantsTera && teamData.wantsTeraCount) {
 				continue;
 			}
 
 			// reject disallowed items, specifically a second of any given choice item
 			const allowedItems: string[] = [];
-			for (const itemString of curSet.item) {
+			for (const itemString of set.item) {
 				const item = this.dex.items.get(itemString);
 				if (itemsLimited.includes(item.id) && teamData.has[item.id]) continue;
 				allowedItems.push(itemString);
 			}
-			if (allowedItems.length === 0) continue;
-			const curSetItem = this.sample(allowedItems);
+			if (!allowedItems.length) continue;
+			const item = this.sample(allowedItems);
 
-			const curSetAbility = this.sample(curSet.ability);
+			const curSetAbility = this.sample(set.ability);
 			const ability = this.dex.abilities.get(curSetAbility);
 
 			if (abilitiesLimited[ability.id] && teamData.has[abilitiesLimited[ability.id]]) continue;
 
-			const curSetMoves: string[] = [];
-			for (const move of curSet.moves) {
+			const moves: string[] = [];
+			for (const move of set.moves) {
 				const allowedMoves: string[] = [];
 				for (const m of move) {
 					const moveId = toID(m);
@@ -2423,17 +2423,16 @@ export class RandomTeams {
 					reject = true;
 					break;
 				}
-				curSetMoves.push(this.sample(allowedMoves));
+				moves.push(this.sample(allowedMoves));
 			}
 			if (reject) continue;
-			const set = {set: curSet, moves: curSetMoves, item: curSetItem};
-			effectivePool.push(set);
+			effectivePool.push({set, moves, item});
 		}
 
 		if (!effectivePool.length) {
 			if (!teamData.forceResult) return null;
-			for (const curSet of setList) {
-				effectivePool.push({set: curSet});
+			for (const set of setList) {
+				effectivePool.push({set});
 			}
 		}
 

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2407,8 +2407,7 @@ export class RandomTeams {
 			if (!allowedItems.length) continue;
 			const item = this.sample(allowedItems);
 
-			const ability = this.sample(set.ability);
-			const abilityId = toID(ability);
+			const abilityId = toID(this.sample(set.ability));
 
 			if (abilitiesLimited[abilityId] && teamData.has[abilitiesLimited[abilityId]]) continue;
 

--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -258,7 +258,7 @@ function getLetsGoMoves(species: string | Species) {
 	return data.moves.map(formatMove).sort().join(`, `);
 }
 
-function battleFactorySets(species: string | Species, tier: string | null, gen = 'gen8', isBSS = false) {
+function battleFactorySets(species: string | Species, tier: string | null, gen = 'gen9', isBSS = false) {
 	species = Dex.species.get(species);
 	if (typeof species.battleOnly === 'string') {
 		species = Dex.species.get(species.battleOnly);
@@ -284,9 +284,16 @@ function battleFactorySets(species: string | Species, tier: string | null, gen =
 			return {e: `${species.name} doesn't have any sets in ${TIERS[toID(tier)]} for ${formatName}.`};
 		}
 		const setObj = t[species.id];
+		if (genNum >= 9) {
+			buf += `Species rarity: ${setObj.weight} (higher is more common, max 10)<br />`;
+		}
 		buf += `<span style="color:#999999;">Sets for ${species.name} in${genNum === 8 ? `` : ` ${GEN_NAMES[gen]}`} ${TIERS[toID(tier)]}:</span><br />`;
 		for (const [i, set] of setObj.sets.entries()) {
-			buf += `<details><summary>Set ${i + 1}</summary>`;
+			if (genNum >= 9) {
+				buf += `<details><summary>Set ${i + 1} (${set.weight}%)</summary>`;
+			} else {
+				buf += `<details><summary>Set ${i + 1}</summary>`;
+			}
 			buf += `<ul style="list-style-type:none;">`;
 			buf += `<li>${set.species}${set.gender ? ` (${set.gender})` : ``} @ ${Array.isArray(set.item) ? set.item.map(formatItem).join(" / ") : formatItem(set.item)}</li>`;
 			buf += `<li>Ability: ${Array.isArray(set.ability) ? set.ability.map(formatAbility).join(" / ") : formatAbility(set.ability)}</li>`;
@@ -294,6 +301,9 @@ function battleFactorySets(species: string | Species, tier: string | null, gen =
 			if (set.level && set.level < 100) buf += `<li>Level: ${set.level}</li>`;
 			if (set.shiny) buf += `<li>Shiny: Yes</li>`;
 			if (set.happiness) buf += `<li>Happiness: ${set.happiness}</li>`;
+			if (genNum === 9 && set.teraType) {
+				buf += `<li>Tera Type: ${set.teraType.map(formatType).join(' / ')}</li>`;
+			}
 			if (set.evs) {
 				buf += `<li>EVs: `;
 				const evs: string[] = [];
@@ -620,7 +630,7 @@ export const commands: Chat.ChatCommands = {
 			} else {
 				tier = 'ou';
 			}
-			const mod = args[2] || 'gen8';
+			const mod = args[2] || 'gen9';
 			let bfSets;
 			if (species.name === 'Necrozma-Ultra') {
 				bfSets = battleFactorySets(Dex.species.get('necrozma-dawnwings'), tier, mod);

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -295,12 +295,13 @@ describe('randomly generated teams should be valid (slow)', () => {
 });
 
 describe('Battle Factory and BSS Factory data should be valid (slow)', () => {
-	for (const filename of ['gen8/bss-factory-sets', 'gen7/bss-factory-sets', 'gen7/factory-sets', 'gen6/factory-sets']) {
+	for (const filename of ['gen9/factory-sets', 'gen8/factory-sets', 'gen8/bss-factory-sets', 'gen7/bss-factory-sets', 'gen7/factory-sets', 'gen6/factory-sets']) {
 		it(`${filename}.json should contain valid sets`, function () {
 			this.timeout(0);
 			const setsJSON = require(`../../dist/data/random-battles/${filename}.json`);
 			const mod = filename.split('/')[0] || 'gen' + Dex.gen;
 			const genNum = isNaN(mod[3]) ? Dex.gen : parseInt(mod[3]);
+			const dex = Dex.mod(mod);
 
 			for (const type in setsJSON) {
 				const typeTable = filename.includes('bss-factory-sets') ? setsJSON : setsJSON[type];
@@ -317,54 +318,75 @@ describe('Battle Factory and BSS Factory data should be valid (slow)', () => {
 				for (const species in typeTable) {
 					const speciesData = typeTable[species];
 					for (const set of speciesData.sets) {
-						const species = Dex.species.get(set.species);
+						const species = dex.species.get(set.species);
 						assert(species.exists, `invalid species "${set.species}" of ${species}`);
 						assert.equal(species.name, set.species, `miscapitalized species "${set.species}" of ${species}`);
 
-						// currently failing due to a Piloswine labeled as a Mamoswine set
 						assert(species.id.startsWith(toID(species.baseSpecies)), `non-matching species "${set.species}" of ${species}`);
 
-						assert(!species.battleOnly, `invalid battle-only forme "${set.species}" of ${species}`);
-
 						for (const itemName of [].concat(set.item)) {
-							if (!itemName && [].concat(...set.moves).includes("Acrobatics")) continue;
-							const item = Dex.forGen(genNum).items.get(itemName);
+							if (!itemName) continue;
+							const item = dex.items.get(itemName);
 							assert(item.exists, `invalid item "${itemName}" of ${species}`);
 							assert.equal(item.name, itemName, `miscapitalized item "${itemName}" of ${species}`);
 						}
 
 						for (const abilityName of [].concat(set.ability)) {
-							const ability = Dex.forGen(genNum).abilities.get(abilityName);
+							const ability = dex.abilities.get(abilityName);
 							assert(ability.exists, `invalid ability "${abilityName}" of ${species}`);
 							assert.equal(ability.name, abilityName, `miscapitalized ability "${abilityName}" of ${species}`);
+							const allowedAbilities = new Set(Object.values((species.battleOnly && !species.requiredAbility) ? dex.species.get(species.battleOnly).abilities : species.abilities));
+							if (species.unreleasedHidden) allowedAbilities.delete(species.abilities.H);
+							assert(allowedAbilities.has(abilityName), `${species.name} can't have ${abilityName}`);
 						}
 
 						for (const natureName of [].concat(set.nature)) {
-							const nature = Dex.forGen(genNum).natures.get(natureName);
+							const nature = dex.natures.get(natureName);
 							assert(nature.exists, `invalid nature "${natureName}" of ${species}`);
 							assert.equal(nature.name, natureName, `miscapitalized nature "${natureName}" of ${species}`);
 						}
 
 						for (const moveSpec of set.moves) {
 							for (const moveName of [].concat(moveSpec)) {
-								const move = Dex.forGen(genNum).moves.get(moveName);
+								const move = dex.moves.get(moveName);
 								assert(move.exists, `invalid move "${moveName}" of ${species}`);
 								assert.equal(move.name, moveName, `miscapitalized move "${moveName}" ≠ "${move.name}" of ${species}`);
 								assert(validateLearnset(move, set, vType, mod), `illegal move "${moveName}" of ${species}`);
 							}
 						}
 
+
+						// Check that no moves appear more than once in a set
+						assert.equal(set.moves.flat(1).length, new Set(set.moves.flat(1)).size, `${species} has repeat moves`);
+
 						assert(!!set.evs, `Set of ${species} has no EVs specified`);
 						const keys = Object.keys(set.evs);
 						let totalEVs = 0;
 						for (const ev of keys) {
-							assert(Dex.stats.ids().includes(ev), `Invalid EV key (${ev}) on set of ${species}`);
+							assert(dex.stats.ids().includes(ev), `Invalid EV key (${ev}) on set of ${species}`);
 							totalEVs += set.evs[ev];
 							assert.equal(set.evs[ev] % 4, 0, `EVs of ${ev} not divisible by 4 on ${species}`);
 						}
-						const sortedKeys = Utils.sortBy([...keys], ev => Dex.stats.ids().indexOf(ev));
+						const sortedKeys = Utils.sortBy([...keys], ev => dex.stats.ids().indexOf(ev));
 						assert.deepEqual(keys, sortedKeys, `EVs out of order on set of ${species}, possibly because one of them is for the wrong stat`);
 						assert(totalEVs <= 510, `more than 510 EVs on set of ${species}`);
+
+						if (genNum === 9) {
+							assert(set.teraType, `missing Tera Types on set of ${species}`);
+							for (const type of set.teraType) {
+								const dexType = dex.types.get(type);
+								assert(dexType.exists, `${species} has invalid Tera Type: ${type}`);
+								assert.equal(type, dexType.name, `${species.name} has misformatted Tera Type: ${type}`);
+							}
+						}
+					}
+					if (filename === 'gen9/factory-sets') {
+						// Set weights should add up to 100
+						let totalWeight = 0;
+						for (const set of speciesData.sets) {
+							totalWeight += set.weight;
+						}
+						assert.equal(totalWeight, 100, `Total set weight for ${species} is ${totalWeight < 100 ? 'less' : 'greater'} than 100%`);
 					}
 				}
 			}


### PR DESCRIPTION
This implements [Gen 9] Battle Factory. The /battlefactory chat command has been update for Gen 9. We are releasing it without LC, but it will be added as soon as practicable. 

The PR also updates the tests to include the [Gen 9] and [Gen 8] Battle Factory data files.

Credits:
Project Leader: Cake
Code and proof-checking sets: livid washed
Consultants:
Ubers: Lasen, OreoSpeedruns, SBPC
OU: Marnie
UU: Lily, haxlolo
RU: Rarelyme
NU: Stories, Lucario
PU: Bella, gulch
Typo checks: Atlas