### PR TITLE
Gen 9 Battle Factory: Enhance team generation restrictions

### DIFF
--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2643,9 +2643,9 @@ export class RandomTeams {
 			for (const typeName of this.dex.types.names()) {
 				// Track resistances because we will require it for triple weaknesses
 				if (
-					this.dex.getEffectiveness(typeName, types) < 0 || // resists
-				    !this.dex.getImmunity(typeName, types) || // immunities
-					resistanceAbilities[ability.id]?.includes(typeName) // mitigating abilities (assume that it overcomes any weakness)
+					this.dex.getEffectiveness(typeName, types) < 0 ||
+					!this.dex.getImmunity(typeName, types) ||
+					resistanceAbilities[ability.id]?.includes(typeName)
 				) {
 					// Resistance is used as a boolean everywhere, but changing its type requires fixing all bf/bss code
 					// so instead just setting to 1

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2661,6 +2661,7 @@ export class RandomTeams {
 		// Quality control we cannot afford for monotype
 		if (!teamData.forceResult && !this.forceMonotype) {
 			for (const type in teamData.weaknesses) {
+				// We reject if our team is triple weak to any type without having a resist
 				if (teamData.resistances[type]) continue;
 				if (teamData.weaknesses[type] >= 3 * limitFactor) return this.randomFactoryTeam(side, ++depth);
 			}

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2581,7 +2581,6 @@ export class RandomTeams {
 				for (const typeName of this.dex.types.names()) {
 					// it's weak to the type
 					if (this.dex.getEffectiveness(typeName, species) > 0 && this.dex.getImmunity(typeName, types)) {
-						if (!teamData.weaknesses[typeName]) teamData.weaknesses[typeName] = 0;
 						if (teamData.weaknesses[typeName] >= 3 * limitFactor) {
 							skip = true;
 							break;
@@ -2642,9 +2641,12 @@ export class RandomTeams {
 
 			for (const typeName of this.dex.types.names()) {
 				let typeMod = this.dex.getEffectiveness(typeName, types);
-				if (!this.dex.getImmunity(typeName, types)) typeMod = -1;
 				// Track resistances because we will require it for triple weaknesses
-				if (typeMod < 0 || resistanceAbilities[ability.id]?.includes(typeName)) {
+				if (
+					typeMod < 0 ||
+					resistanceAbilities[ability.id]?.includes(typeName) ||
+					!this.dex.getImmunity(typeName, types)
+				) {
 					// We don't care about the number of resistances, so just set to 1
 					teamData.resistances[typeName] = 1;
 				// Track weaknesses

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2640,7 +2640,7 @@ export class RandomTeams {
 			}
 
 			for (const typeName of this.dex.types.names()) {
-				let typeMod = this.dex.getEffectiveness(typeName, types);
+				const typeMod = this.dex.getEffectiveness(typeName, types);
 				// Track resistances because we will require it for triple weaknesses
 				if (
 					typeMod < 0 ||

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2641,17 +2641,15 @@ export class RandomTeams {
 			}
 
 			for (const typeName of this.dex.types.names()) {
+				let typeMod = this.dex.getEffectiveness(typeName, types);
+				if (!this.dex.getImmunity(typeName, types)) typeMod = -1;
 				// Track resistances because we will require it for triple weaknesses
-				if (
-					this.dex.getEffectiveness(typeName, types) < 0 ||
-					!this.dex.getImmunity(typeName, types) ||
-					resistanceAbilities[ability.id]?.includes(typeName)
-				) {
+				if (typeMod < 0 || resistanceAbilities[ability.id]?.includes(typeName)) {
 					// Resistance is used as a boolean everywhere, but changing its type requires fixing all bf/bss code
 					// so instead just setting to 1
 					teamData.resistances[typeName] = 1;
 				// Track weaknesses
-				} else if (this.dex.getEffectiveness(typeName, types) > 0) {
+				} else if (typeMod > 0) {
 					teamData.weaknesses[typeName] = (teamData.weaknesses[typeName] || 0) + 1;
 				}
 			}

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2580,7 +2580,7 @@ export class RandomTeams {
 				// Limit 3 of any weakness
 				for (const typeName of this.dex.types.names()) {
 					// it's weak to the type
-					if (this.dex.getEffectiveness(typeName, species) > 0) {
+					if (this.dex.getEffectiveness(typeName, species) > 0 && this.dex.getImmunity(typeName, types)) {
 						if (!teamData.weaknesses[typeName]) teamData.weaknesses[typeName] = 0;
 						if (teamData.weaknesses[typeName] >= 3 * limitFactor) {
 							skip = true;

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2645,8 +2645,7 @@ export class RandomTeams {
 				if (!this.dex.getImmunity(typeName, types)) typeMod = -1;
 				// Track resistances because we will require it for triple weaknesses
 				if (typeMod < 0 || resistanceAbilities[ability.id]?.includes(typeName)) {
-					// Resistance is used as a boolean everywhere, but changing its type requires fixing all bf/bss code
-					// so instead just setting to 1
+					// We don't care about the number of resistances, so just set to 1
 					teamData.resistances[typeName] = 1;
 				// Track weaknesses
 				} else if (typeMod > 0) {


### PR DESCRIPTION
BF teamgen restrictions were too lax, allowing for arbitrary number of shared weaknesses if there was a resistance to that type on the team. Now the resistance check only occurs for triple weakness, and more than that simply gets rejected. 

This allows for during-generation rejection, which will remove most instances of failed teamgen, thus not reach maximum depth as often, and making it all faster.