### PR TITLE
Gen 4-5: Fix target in Frisk message

### DIFF
--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -191,7 +191,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		onStart(pokemon) {
 			const target = pokemon.side.randomFoe();
 			if (target?.item && !target.itemState.knockedOff) {
-				this.add('-item', pokemon, target.getItem().name, '[from] ability: Frisk', '[of] ' + pokemon);
+				this.add('-item', '', target.getItem().name, '[from] ability: Frisk', '[of] ' + pokemon);
 			}
 		},
 	},

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -21,7 +21,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		onStart(pokemon) {
 			const target = pokemon.side.randomFoe();
 			if (target?.item) {
-				this.add('-item', pokemon, target.getItem().name, '[from] ability: Frisk', '[of] ' + pokemon);
+				this.add('-item', '', target.getItem().name, '[from] ability: Frisk', '[of] ' + pokemon);
 			}
 		},
 	},


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/gen-4-5-frisk-pokemon-is-wrongly-given-as-holder-of-identified-item.3755568/

Client support requires https://github.com/smogon/pokemon-showdown-client/pull/2302