### PR TITLE
Implement turn counter overflow with Wish / Future moves

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -374,8 +374,17 @@ export const Conditions: import('../sim/dex-conditions').ConditionDataTable = {
 	futuremove: {
 		// this is a slot condition
 		name: 'futuremove',
-		duration: 3,
+		onStart() {
+			this.effectState.endingTurn = (this.turn - 1) + 2;
+			if (this.effectState.endingTurn >= 254) {
+				this.hint(`In Gen 8+, Future moves will never resolve when used on turn 254 or later.`);
+			}
+		},
 		onResidualOrder: 3,
+		onResidual(side: any) {
+			if (this.getOverflowedTurnCount() < this.effectState.endingTurn) return;
+			side.removeSlotCondition(this.getAtSlot(this.effectState.sourceSlot), 'futuremove');
+		},
 		onEnd(target) {
 			const data = this.effectState;
 			// time's up; time to hit! :D

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -377,7 +377,7 @@ export const Conditions: import('../sim/dex-conditions').ConditionDataTable = {
 		onStart() {
 			this.effectState.endingTurn = (this.turn - 1) + 2;
 			if (this.effectState.endingTurn >= 254) {
-				this.hint(`In Gen 8+, Future moves will never resolve when used on turn 254 or later.`);
+				this.hint(`In Gen 8+, Future attacks will never resolve when used on the 255th turn or later.`);
 			}
 		},
 		onResidualOrder: 3,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -6616,7 +6616,6 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		onTry(source, target) {
 			if (!target.side.addSlotCondition(target, 'futuremove')) return false;
 			Object.assign(target.side.slotConditions[target.position]['futuremove'], {
-				duration: 3,
 				move: 'futuresight',
 				source: source,
 				moveData: {
@@ -21724,11 +21723,18 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		flags: {snatch: 1, heal: 1, metronome: 1},
 		slotCondition: 'Wish',
 		condition: {
-			duration: 2,
 			onStart(pokemon, source) {
 				this.effectState.hp = source.maxhp / 2;
+				this.effectState.startingTurn = this.getOverflowedTurnCount();
+				if (this.effectState.startingTurn === 255) {
+					this.hint(`In Gen 8+, Wish will never resolve when used on a turn that is a multiple of 256n - 1.`);
+				}
 			},
 			onResidualOrder: 4,
+			onResidual(side: any) {
+				if (this.getOverflowedTurnCount() <= this.effectState.startingTurn) return;
+				side.removeSlotCondition(this.getAtSlot(this.effectState.sourceSlot), 'wish');
+			},
 			onEnd(target) {
 				if (target && !target.fainted) {
 					const damage = this.heal(this.effectState.hp, target, target);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -21727,7 +21727,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				this.effectState.hp = source.maxhp / 2;
 				this.effectState.startingTurn = this.getOverflowedTurnCount();
 				if (this.effectState.startingTurn === 255) {
-					this.hint(`In Gen 8+, Wish will never resolve when used on a turn that is a multiple of 256n - 1.`);
+					this.hint(`In Gen 8+, Wish will never resolve when used on the ${this.turn}th turn.`);
 				}
 			},
 			onResidualOrder: 4,

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3147,6 +3147,15 @@ export class Battle {
 		return this.sides[parseInt(sideid[1]) - 1];
 	}
 
+	/**
+	 * Currently, we treat Team Preview as turn 0, but the games start counting their turns at turn 0
+	 * There is also overflow that occurs in Gen 8+ that affects moves like Wish / Future Sight
+	 * https://www.smogon.com/forums/threads/10352797
+	 */
+	getOverflowedTurnCount(): number {
+		return this.gen >= 8 ? (this.turn - 1) % 256 : this.turn - 1;
+	}
+
 	destroy() {
 		// deallocate ourself
 

--- a/test/sim/moves/futuresight.js
+++ b/test/sim/moves/futuresight.js
@@ -355,4 +355,21 @@ describe('Future Sight', function () {
 		damage = hooh.maxhp - hooh.hp;
 		assert.bounded(damage, [57, 68], `Future Sight should deal damage with +0 Sp. Atk`);
 	});
+
+	it(`should never resolve when used on turn 254 or later`, function () {
+		battle = common.createBattle([[
+			{species: 'Wynaut', moves: ['sleeptalk', 'futuresight']},
+		], [
+			{species: 'Stakataka', moves: ['sleeptalk']},
+		]]);
+
+		battle.turn = 255; // Showdown turn is +1 from what the games are; this would ordinarily be 254
+		battle.makeChoices('move futuresight', 'auto');
+		for (let i = 0; i < 5; i++) battle.makeChoices();
+		battle.makeChoices('move futuresight', 'auto');
+		for (let i = 0; i < 5; i++) battle.makeChoices();
+
+		const stak = battle.p2.active[0];
+		assert.fullHP(stak, `Future Sight should have never resolved.`);
+	});
 });

--- a/test/sim/moves/wish.js
+++ b/test/sim/moves/wish.js
@@ -42,4 +42,22 @@ describe('Wish', function () {
 		battle.makeChoices('auto', 'move thousandarrows');
 		assert.fullHP(battle.p1.active[0]);
 	});
+
+	it(`should never resolve when used on a turn that is a multiple of 256n - 1`, function () {
+		battle = common.createBattle([[
+			{species: 'Wynaut', moves: ['sleeptalk', 'wish', 'doubleedge']},
+		], [
+			{species: 'Stakataka', moves: ['sleeptalk']},
+		]]);
+
+		battle.turn = 255; // Showdown turn is +1 from what the games are; this would ordinarily be 254
+		battle.makeChoices('move doubleedge', 'auto');
+		battle.makeChoices('move wish', 'auto');
+		for (let i = 0; i < 5; i++) battle.makeChoices();
+		battle.makeChoices('move wish', 'auto');
+		battle.makeChoices();
+
+		const wynaut = battle.p1.active[0];
+		assert.false.fullHP(wynaut, `Wish should have never resolved.`);
+	});
 });


### PR DESCRIPTION
Big credit to Anubis for assisting in research and Karthik for help in implementation.

One implementation quirk Showdown has is that we treat Team Preview and everything before the first move selection as "turn 0", instead of everything up to the second move selection as "turn 0" (i.e. the first turn). If that was implemented correctly, we probably wouldn't need the hardcodes we have for things like Burning Jealousy vs Download. However, there's a lot of stuff that looks like it depends on the current turn count implementation, so I didn't touch that and just tossed in some -1s where appropriate.

See discussion of this mechanic starting at this post: https://www.smogon.com/forums/threads/10350377