### PR TITLE
Properly validate Hidden Power type for events

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2372,17 +2372,17 @@ export class TeamValidator {
 					problems.push(`${name} must be at least level ${minLevel} to be from Pokemon GO.`);
 				}
 				const ivs = set.ivs || TeamValidator.fillStats(null, 31);
-				const postTransferminIVs = minIVs * 2 + 1;
+				const postTransferMinIVs = minIVs * 2 + 1;
 				let IVsTooLow = false;
 				let hasEvenIVs = false;
 				for (const stat in ivs) {
 					if (stat === 'spe') continue;
-					if (ivs[stat as 'hp'] < postTransferminIVs) IVsTooLow = true;
+					if (ivs[stat as 'hp'] < postTransferMinIVs) IVsTooLow = true;
 					if (ivs[stat as 'hp'] % 2 === 0) hasEvenIVs = true;
 				}
 				if (IVsTooLow) {
-					problems.push(`${name} must have at least ${postTransferminIVs} ` +
-						(postTransferminIVs === 1 ? `IV` : `IVs`) + ` in non-Speed stats to be from Pokemon GO.`);
+					problems.push(`${name} must have at least ${postTransferMinIVs} ` +
+						(postTransferMinIVs === 1 ? `IV` : `IVs`) + ` in non-Speed stats to be from Pokemon GO.`);
 				}
 				if (hasEvenIVs) {
 					problems.push(`${name} must have odd non-Speed IVs to be from Pokemon GO.`);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2377,15 +2377,15 @@ export class TeamValidator {
 				let hasEvenIVs = false;
 				for (const stat in ivs) {
 					if (stat === 'spe') continue;
-					if (!IVsTooLow && ivs[stat as 'hp'] < postTransferminIVs) {
-						problems.push(`${name} must have at least ${postTransferminIVs} ` +
+					if (ivs[stat as 'hp'] < postTransferminIVs) IVsTooLow = true;
+					if (ivs[stat as 'hp'] % 2 === 0) hasEvenIVs = true;
+				}
+				if (IVsTooLow) {
+					problems.push(`${name} must have at least ${postTransferminIVs} ` +
 						(postTransferminIVs === 1 ? `IV` : `IVs`) + ` in non-Speed stats to be from Pokemon GO.`);
-						IVsTooLow = true;
-					}
-					if (!hasEvenIVs && ivs[stat as 'hp'] % 2 === 0) {
-						problems.push(`${name} must have odd non-Speed IVs to be from Pokemon GO.`);
-						hasEvenIVs = true;
-					}
+				}
+				if (hasEvenIVs) {
+					problems.push(`${name} must have odd non-Speed IVs to be from Pokemon GO.`);
 				}
 				const canBottleCap = dex.gen >= 7 && set.level >= (dex.gen < 9 ? 100 : 50);
 				if (ivs.atk !== ivs.spa && !(canBottleCap && (ivs.atk === 31 || ivs.spa === 31))) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2389,10 +2389,10 @@ export class TeamValidator {
 				}
 				const canBottleCap = dex.gen >= 7 && set.level >= (dex.gen < 9 ? 100 : 50);
 				if (ivs.atk !== ivs.spa && !(canBottleCap && (ivs.atk === 31 || ivs.spa === 31))) {
-					problems.push(`${name}'s Atk and Spa IVs must match to be from Pokemon GO.`);
+					problems.push(`${name}'s Atk and Sp. Atk IVs must match to be from Pokemon GO.`);
 				}
 				if (ivs.def !== ivs.spd && !(canBottleCap && (ivs.def === 31 || ivs.spd === 31))) {
-					problems.push(`${name}'s Def and Spd IVs must match to be from Pokemon GO.`);
+					problems.push(`${name}'s Def and Sp. Def IVs must match to be from Pokemon GO.`);
 				}
 			}
 		}

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -779,7 +779,7 @@ export class TeamValidator {
 			problems.push(`${name} has ${set.moves.length} moves, which is more than the limit of ${ruleTable.maxMoveCount}.`);
 			return problems;
 		}
-		
+
 		const pokemonGoProblems = this.validatePokemonGo(outOfBattleSpecies, set, setSources);
 		if (ruleTable.isBanned('nonexistent')) {
 			problems.push(...this.validateStats(set, species, setSources, pokemonGoProblems));
@@ -2383,7 +2383,7 @@ export class TeamValidator {
 						IVsTooLow = true;
 					}
 					if (!hasEvenIVs && ivs[stat as 'hp'] % 2 === 0) {
-						problems.push(`${name} must have odd non-Speed IVs to be from Pokemon GO.`)
+						problems.push(`${name} must have odd non-Speed IVs to be from Pokemon GO.`);
 						hasEvenIVs = true;
 					}
 				}

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -676,7 +676,7 @@ export class TeamValidator {
 		}
 		if (set.hpType) {
 			const type = dex.types.get(set.hpType);
-			if (!type.exists || ['normal', 'fairy'].includes(type.id)) {
+			if (!type.exists || ['normal', 'fairy', 'stellar'].includes(type.id)) {
 				problems.push(`${name}'s Hidden Power type (${set.hpType}) is invalid.`);
 			} else {
 				set.hpType = type.name;


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-report-validator.3754044/

In #9646, I added support for validating Pokemon from Pokemon GO, and with this I decided to move the validateStats check lower to allow for IVs to be altered if needed, but this inadvertently caused the event-related check for Hidden Power type to not work properly. This change fixes this problem by returning validateStats back to where it originally was and remove all non-move related checks of the isFromPokemonGo flag (the stat-related validations, which were moved to validatePokemonGo. The auto-adjusting of IVs for Pokemon with even IVs is removed as a result of this, but I doubt this will have much impact considering how niche this is.