### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -661,7 +661,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rockslide"],
+                "movepool": ["brickbreak", "bulkup", "earthquake", "hiddenpowerghost", "machpunch", "rockslide"],
                 "abilities": ["Limber"],
                 "preferredTypes": ["Ghost"]
             },
@@ -1532,8 +1532,8 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "crunch", "psychic", "rest", "substitute", "thunderbolt"],
+                "role": "Setup Sweeper",
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "psychic", "rest", "substitute", "thunderbolt"],
                 "abilities": ["Early Bird"]
             },
             {
@@ -1886,7 +1886,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rapidspin", "rockslide", "toxic"],
+                "movepool": ["brickbreak", "bulkup", "earthquake", "hiddenpowerghost", "machpunch", "rapidspin", "rockslide", "toxic"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Ghost"]
             }

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1357,8 +1357,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
-                "abilities": ["Guts", "Quick Feet"]
+                "movepool": ["closecombat", "crunch", "facade", "protect"],
+                "abilities": ["Guts"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["closecombat", "crunch", "facade", "swordsdance"],
+                "abilities": ["Quick Feet"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -838,6 +838,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["facade", "flamecharge", "protect", "superpower"],
                 "abilities": ["Guts"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["facade", "flamecharge", "firefang", "superpower"],
+                "abilities": ["Guts"]
             }
         ]
     },
@@ -1421,8 +1426,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
-                "abilities": ["Guts", "Quick Feet"]
+                "movepool": ["closecombat", "crunch", "facade", "protect"],
+                "abilities": ["Guts"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["closecombat", "crunch", "facade", "swordsdance"],
+                "abilities": ["Quick Feet"]
             }
         ]
     },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -822,7 +822,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "knockoff", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
-                "abilities": ["Mold Breaker", "Moxie"],
+                "abilities": ["Moxie"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1555,8 +1555,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
-                "abilities": ["Guts", "Quick Feet"]
+                "movepool": ["closecombat", "crunch", "facade", "protect"],
+                "abilities": ["Guts"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["closecombat", "crunch", "facade", "swordsdance"],
+                "abilities": ["Quick Feet"]
             }
         ]
     },
@@ -2143,8 +2148,8 @@
         "level": 85,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["boomburst", "fireblast", "focusblast", "icebeam", "surf"],
+                "role": "Fast Attacker",
+                "movepool": ["boomburst", "fireblast", "focusblast", "surf"],
                 "abilities": ["Scrappy"]
             }
         ]
@@ -3662,18 +3667,18 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bodyslam", "healbell", "knockoff", "protect", "wish"],
-                "abilities": ["Cloud Nine"]
+                "abilities": ["Cloud Nine", "Oblivious"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["bodyslam", "dragontail", "earthquake", "explosion", "knockoff", "powerwhip"],
-                "abilities": ["Cloud Nine"],
+                "abilities": ["Cloud Nine", "Own Tempo"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bodyslam", "earthquake", "explosion", "knockoff", "powerwhip", "return", "swordsdance"],
-                "abilities": ["Cloud Nine"],
+                "abilities": ["Cloud Nine", "Oblivious"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -5913,7 +5918,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
+                "movepool": ["drainpunch", "earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
                 "abilities": ["Natural Cure"]
             },
             {

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1006,7 +1006,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "knockoff", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
-                "abilities": ["Mold Breaker", "Moxie"],
+                "abilities": ["Moxie"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -1781,8 +1781,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
-                "abilities": ["Guts", "Quick Feet"]
+                "movepool": ["closecombat", "crunch", "facade", "protect"],
+                "abilities": ["Guts"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["closecombat", "crunch", "facade", "swordsdance"],
+                "abilities": ["Quick Feet"]
             }
         ]
     },
@@ -2372,8 +2377,8 @@
         "level": 86,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["boomburst", "fireblast", "focusblast", "icebeam", "surf"],
+                "role": "Fast Attacker",
+                "movepool": ["boomburst", "fireblast", "focusblast", "surf"],
                 "abilities": ["Scrappy"]
             }
         ]
@@ -3964,18 +3969,18 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bodyslam", "healbell", "knockoff", "protect", "wish"],
-                "abilities": ["Cloud Nine"]
+                "abilities": ["Cloud Nine", "Oblivious"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["bodyslam", "dragontail", "earthquake", "explosion", "knockoff", "powerwhip"],
-                "abilities": ["Cloud Nine"],
+                "abilities": ["Cloud Nine", "Own Tempo"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["bodyslam", "earthquake", "explosion", "knockoff", "powerwhip", "return", "swordsdance"],
-                "abilities": ["Cloud Nine"],
+                "abilities": ["Cloud Nine", "Oblivious"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -6371,7 +6376,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
+                "movepool": ["drainpunch", "earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
                 "abilities": ["Natural Cure"]
             },
             {

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -1483,7 +1483,7 @@
       "sets": [
           {
               "species": "Dragapult",
-              "weight": 30,
+              "weight": 35,
               "moves": [
                   ["Dragon Darts"],
                   ["U-turn"],
@@ -1516,22 +1516,6 @@
               "species": "Dragapult",
               "weight": 15,
               "moves": [
-                  ["Reflect"],
-                  ["Light Screen"],
-                  ["Curse"],
-                  ["Shadow Ball", "Will-O-Wisp"]
-              ],
-              "item": ["Light Clay"],
-              "nature": "Timid",
-              "evs": {"hp": 244, "def": 12, "spe": 252},
-              "ivs": {"atk": 0},
-              "teraType": ["Ghost", "Normal"],
-              "ability": ["Cursed Body"]
-          },
-          {
-              "species": "Dragapult",
-              "weight": 10,
-              "moves": [
                   ["Dragon Darts"],
                   ["Baton Pass", "Tera Blast"],
                   ["Substitute"],
@@ -1562,7 +1546,7 @@
           },
           {
               "species": "Dragapult",
-              "weight": 15,
+              "weight": 20,
               "moves": [
                   ["Shadow Ball"],
                   ["Draco Meteor"],
@@ -3732,7 +3716,7 @@
               "weight": 65,
               "moves": [
                   ["Bitter Blade"],
-                  ["Close Combat", "Shadow Claw"],
+                  ["Close Combat", "Poltergeist"],
                   ["Shadow Sneak"],
                   ["Destiny Bond", "Swords Dance"]
               ],

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -906,6 +906,12 @@
                 "movepool": ["Draco Meteor", "Fire Punch", "Low Kick", "Tailwind", "Tera Blast"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Flying"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Scale Shot", "Extreme Speed", "Hurricane", "Protect", "Stomping Tantrum", "Tailwind"],
+                "abilities": ["Inner Focus"],
+                "teraTypes": ["Fairy", "Steel"]
             }
         ]
     },
@@ -2536,7 +2542,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Close Combat", "Dire Claw", "Fake Out", "Gunk Shot", "Switcheroo", "U-turn"],
+                "movepool": ["Close Combat", "Dire Claw", "Fake Out", "Throat Chop", "U-turn"],
                 "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
@@ -3799,8 +3805,8 @@
                 "teraTypes": ["Dragon", "Poison"]
             },
             {
-                "role": "Doubles Fast Attacker",
-                "movepool": ["Dark Pulse", "Draco Meteor", "Heat Wave", "Protect"],
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Dark Pulse", "Draco Meteor", "Heat Wave", "Protect", "Snarl"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Fire"]
             }
@@ -4301,6 +4307,12 @@
                 "movepool": ["Draco Meteor", "Dragon Tail", "Fire Blast", "Heavy Slam", "Hydro Pump", "Thunderbolt"],
                 "abilities": ["Sap Sipper"],
                 "teraTypes": ["Electric", "Fire", "Water"]
+            },
+            {
+                "role": "Doubles Bulky Setup",
+                "movepool": ["Acid Armor", "Body Press", "Heavy Slam", "Life Dew", "Protect"],
+                "abilities": ["Sap Sipper"],
+                "teraTypes": ["Fighting"] 
             }
         ]
     },
@@ -4342,7 +4354,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Body Press", "Mountain Gale", "Protect", "Rock Slide"],
+                "movepool": ["Body Press", "Icicle Spear", "Protect", "Rock Blast"],
                 "abilities": ["Sturdy"],
                 "teraTypes": ["Fighting", "Flying", "Poison"]
             }
@@ -4902,6 +4914,12 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Clanging Scales", "Clangorous Soul", "Iron Head", "Protect"],
+                "abilities": ["Soundproof"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Protect",
+                "movepool": ["Body Press", "Iron Defense", "Protect", "Throat Chop"],
                 "abilities": ["Soundproof"],
                 "teraTypes": ["Steel"]
             }
@@ -5603,13 +5621,13 @@
                 "role": "Bulky Protect",
                 "movepool": ["Blood Moon", "Earth Power", "Hyper Voice", "Protect"],
                 "abilities": ["Mind's Eye"],
-                "teraTypes": ["Ghost", "Normal", "Poison", "Water"]
+                "teraTypes": ["Normal"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Blood Moon", "Earth Power", "Hyper Voice", "Vacuum Wave"],
                 "abilities": ["Mind's Eye"],
-                "teraTypes": ["Ghost", "Normal", "Poison", "Water"]
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -6644,7 +6662,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Matcha Gotcha", "Rage Powder", "Shadow Ball", "Trick Room"],
+                "movepool": ["Matcha Gotcha", "Life Dew", "Rage Powder", "Trick Room"],
                 "abilities": ["Hospitality"],
                 "teraTypes": ["Fairy"]
             },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -283,6 +283,12 @@
                 "movepool": ["Dark Pulse", "Nasty Plot", "Tera Blast", "Thunderbolt"],
                 "abilities": ["Fur Coat"],
                 "teraTypes": ["Fairy", "Poison"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Knock Off", "Parting Shot", "Taunt", "Thunder Wave"],
+                "abilities": ["Fur Coat"],
+                "teraTypes": ["Fairy", "Ghost", "Poison"]
             }
         ]
     },
@@ -883,6 +889,12 @@
                 "movepool": ["Calm Mind", "Protect", "Scald", "Wish"],
                 "abilities": ["Water Absorb"],
                 "teraTypes": ["Ghost", "Ground", "Poison"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Haze", "Protect", "Roar", "Scald", "Wish"],
+                "abilities": ["Water Absorb"],
+                "teraTypes": ["Ghost", "Ground", "Poison"]
             }
         ]
     },
@@ -1183,7 +1195,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Dazzling Gleam", "Discharge", "Focus Blast", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Dazzling Gleam", "Dragon Tail", "Discharge", "Focus Blast", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Static"],
                 "teraTypes": ["Fairy"]
             }
@@ -2573,7 +2585,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Setup",
                 "movepool": ["Cosmic Power", "Night Shade", "Recover", "Stored Power"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Steel"]
@@ -2583,12 +2595,6 @@
                 "movepool": ["Knock Off", "Psychic Noise", "Recover", "Spikes", "Stealth Rock", "Teleport"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Dark", "Fairy", "Steel"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Focus Blast", "Psychic Noise", "Psyshock", "Recover"],
-                "abilities": ["Pressure"],
-                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },
@@ -2754,9 +2760,9 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Crunch", "Ice Spinner", "Wave Crash"],
+                "movepool": ["Bulk Up", "Ice Spinner", "Taunt", "Wave Crash"],
                 "abilities": ["Water Veil"],
-                "teraTypes": ["Dark", "Steel", "Water"]
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -2889,7 +2895,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earthquake", "Outrage", "Spikes", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Dragon Tail", "Earthquake", "Outrage", "Spikes", "Stealth Rock"],
                 "abilities": ["Rough Skin"],
                 "teraTypes": ["Ground", "Steel"]
             },
@@ -4084,6 +4090,12 @@
                 "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Nasty Plot", "Psychic", "Sludge Bomb", "Trick", "U-turn"],
                 "abilities": ["Illusion"],
                 "teraTypes": ["Poison"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dark Pulse", "Encore", "Focus Blast", "Nasty Plot", "Psychic", "Sludge Bomb"],
+                "abilities": ["Illusion"],
+                "teraTypes": ["Poison"]
             }
         ]
     },
@@ -4093,6 +4105,12 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bitter Malice", "Flamethrower", "Focus Blast", "Hyper Voice", "Nasty Plot", "Trick", "U-turn"],
+                "abilities": ["Illusion"],
+                "teraTypes": ["Fighting", "Normal"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Hyper Voice", "Poltergeist", "Will-O-Wisp"],
                 "abilities": ["Illusion"],
                 "teraTypes": ["Fighting", "Normal"]
             }
@@ -4123,6 +4141,12 @@
                 "movepool": ["Dark Pulse", "Focus Blast", "Psychic", "Trick"],
                 "abilities": ["Shadow Tag"],
                 "teraTypes": ["Dark", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dark Pulse", "Focus Blast", "Psychic Noise", "Thunder Wave"],
+                "abilities": ["Shadow Tag"],
+                "teraTypes": ["Dark", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Steel"]
             }
         ]
     },
@@ -4221,7 +4245,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Close Combat", "Discharge", "Flamethrower", "Giga Drain", "Knock Off", "U-turn"],
+                "movepool": ["Close Combat", "Dragon Tail", "Discharge", "Flamethrower", "Giga Drain", "Knock Off", "U-turn"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Poison", "Steel"]
             }
@@ -4461,6 +4485,12 @@
                 "movepool": ["Bleakwind Storm", "Focus Blast", "Grass Knot", "Heat Wave", "Nasty Plot", "U-turn"],
                 "abilities": ["Defiant", "Prankster"],
                 "teraTypes": ["Fighting", "Fire", "Flying"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Bleakwind Storm", "Knock Off", "Taunt", "U-turn"],
+                "abilities": ["Prankster"],
+                "teraTypes": ["Dark", "Ground", "Steel"]
             }
         ]
     },
@@ -4678,9 +4708,9 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock"],
+                "movepool": ["Encore", "Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock"],
                 "abilities": ["Blaze"],
-                "teraTypes": ["Fighting", "Fire", "Grass", "Psychic"]
+                "teraTypes": ["Fighting", "Fire", "Grass"]
             }
         ]
     },
@@ -4745,7 +4775,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Fire Blast", "Hyper Voice", "Will-O-Wisp", "Work Up"],
+                "movepool": ["Dark Pulse", "Fire Blast", "Hyper Voice", "Taunt", "Will-O-Wisp", "Work Up"],
                 "abilities": ["Unnerve"],
                 "teraTypes": ["Fire"]
             }
@@ -4895,7 +4925,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Knock Off", "Power Whip", "Scald", "Sludge Bomb"],
+                "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Knock Off", "Power Whip", "Scald", "Sludge Bomb"],
                 "abilities": ["Sap Sipper"],
                 "teraTypes": ["Fire", "Grass", "Ground", "Poison", "Water"]
             }
@@ -5237,7 +5267,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Accelerock", "Close Combat", "Crunch", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance"],
+                "movepool": ["Accelerock", "Close Combat", "Crunch", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance", "Taunt"],
                 "abilities": ["Sand Rush"],
                 "teraTypes": ["Fighting"]
             }
@@ -5281,9 +5311,9 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Earthquake", "Heavy Slam", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Earthquake", "Heavy Slam", "Roar", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Stamina"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -5354,7 +5384,7 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Calm Mind", "Draining Kiss", "Giga Drain", "Synthesis", "Tera Blast"],
+                "movepool": ["Calm Mind", "Draining Kiss", "Encore", "Giga Drain", "Synthesis", "Taunt", "Tera Blast"],
                 "abilities": ["Triage"],
                 "teraTypes": ["Ground"]
             }
@@ -6064,7 +6094,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Crunch", "Iron Defense", "Iron Head", "Rest", "Stone Edge"],
+                "movepool": ["Body Press", "Crunch", "Iron Defense", "Iron Head", "Rest", "Stone Edge", "Substitute"],
                 "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Fighting", "Steel"]
             }
@@ -6075,7 +6105,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Crunch", "Heavy Slam", "Iron Defense", "Stone Edge", "Substitute"],
+                "movepool": ["Body Press", "Crunch", "Heavy Slam", "Iron Defense", "Stone Edge"],
                 "abilities": ["Dauntless Shield"],
                 "teraTypes": ["Fighting", "Ghost"]
             }
@@ -6379,7 +6409,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aqua Step", "Close Combat", "Knock Off", "Roost", "Swords Dance", "Triple Axel"],
+                "movepool": ["Aqua Step", "Close Combat", "Encore", "Knock Off", "Roost", "Swords Dance", "Triple Axel"],
                 "abilities": ["Moxie"],
                 "teraTypes": ["Fighting", "Water"]
             }
@@ -6404,6 +6434,12 @@
                 "movepool": ["Body Slam", "Curse", "Double-Edge", "High Horsepower", "Lash Out"],
                 "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Slam", "Curse", "Rest", "Sleep Talk"],
+                "abilities": ["Thick Fat"],
+                "teraTypes": ["Fairy", "Poison"]
             }
         ]
     },
@@ -7081,10 +7117,16 @@
         "level": 74,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Moonblast", "Mystical Fire", "Psyshock", "Shadow Ball", "Thunderbolt"],
                 "abilities": ["Protosynthesis"],
-                "teraTypes": ["Electric", "Fairy", "Fire", "Ghost", "Psychic"]
+                "teraTypes": ["Electric", "Fairy", "Fire", "Ghost"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Moonblast", "Mystical Fire", "Psyshock", "Shadow Ball", "Thunderbolt"],
+                "abilities": ["Protosynthesis"],
+                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -7098,10 +7140,16 @@
                 "teraTypes": ["Electric", "Fighting"]
             },
             {
-                "role": "Fast Support",
-                "movepool": ["Close Combat", "Earthquake", "First Impression", "Flare Blitz", "Morning Sun", "U-turn", "Wild Charge"],
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Earthquake", "First Impression", "Flare Blitz", "U-turn", "Wild Charge"],
                 "abilities": ["Protosynthesis"],
                 "teraTypes": ["Bug", "Electric", "Fighting", "Fire"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Close Combat", "Morning Sun", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Protosynthesis"],
+                "teraTypes": ["Fire", "Steel"]
             }
         ]
     },
@@ -7188,10 +7236,16 @@
         "level": 78,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Dark Pulse", "Earth Power", "Fire Blast", "Hurricane", "Hydro Pump", "U-turn"],
                 "abilities": ["Quark Drive"],
                 "teraTypes": ["Dark", "Flying", "Ground"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dark Pulse", "Earth Power", "Meteor Beam", "Hurricane"],
+                "abilities": ["Quark Drive"],
+                "teraTypes": ["Dark", "Ground"]
             }
         ]
     },

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -922,6 +922,16 @@ export class RandomTeams {
 			}
 		}
 
+		// Enforce pivoting moves on AV Pivot
+		if (role === 'AV Pivot') {
+			const pivotMoves = movePool.filter(moveid => ['uturn', 'voltswitch'].includes(moveid));
+			if (pivotMoves.length) {
+				const moveid = this.sample(pivotMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
+					movePool, teraType, role);
+			}
+		}
+
 		// Enforce setup
 		if (role.includes('Setup') || role === 'Tera Blast user') {
 			// First, try to add a non-Speed setup move

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -6,7 +6,7 @@
                 "role": "Wallbreaker",
                 "movepool": ["Brick Break", "Double-Edge", "Fake Out", "Fire Punch", "Gunk Shot", "Knock Off", "U-turn"],
                 "abilities": ["Pickup"],
-                "teraTypes": ["Dark", "Normal"]
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -98,7 +98,7 @@
                 "teraTypes": ["Dark", "Grass"]
             },
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Knock Off", "Power Whip", "Sleep Powder", "Sludge Bomb", "Strength Sap", "Sucker Punch"],
                 "abilities": ["Chlorophyll"],
                 "teraTypes": ["Dark", "Steel"]
@@ -221,7 +221,7 @@
         "level": 6,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Drain Punch", "Giga Drain", "Leaf Storm", "Poison Jab", "Spikes", "Sucker Punch", "Toxic Spikes"],
                 "abilities": ["Water Absorb"],
                 "teraTypes": ["Poison", "Steel"]
@@ -255,10 +255,10 @@
         "level": 7,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Knock Off", "Liquidation", "Play Rough", "Yawn"],
-                "abilities": ["Sheer Force"],
-                "teraTypes": ["Fairy", "Water"]
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Spear", "Knock Off", "Liquidation", "Yawn"],
+                "abilities": ["Thick Fat"],
+                "teraTypes": ["Ground", "Water"]
             },
             {
                 "role": "Bulky Setup",
@@ -377,6 +377,12 @@
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic", "Recover"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Fairy", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Cosmic Power", "Dazzling Gleam", "Recover", "Stored Power"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -398,7 +404,7 @@
         ]
     },
     "cleffa": {
-        "level": 9,
+        "level": 8,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -469,9 +475,9 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Drain Punch", "Earthquake", "Gunk Shot", "Knock Off", "Sucker Punch"],
+                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off"],
                 "abilities": ["Dry Skin"],
-                "teraTypes": ["Dark", "Fighting", "Ground"]
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -531,6 +537,12 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Bullet Seed", "Headbutt", "Synthesis", "Thunder Wave"],
+                "abilities": ["Serene Grace"],
+                "teraTypes": ["Ghost", "Normal"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Body Slam", "Bullet Seed", "Headbutt", "Synthesis"],
                 "abilities": ["Serene Grace"],
                 "teraTypes": ["Ghost", "Normal"]
             }
@@ -647,13 +659,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Drain Punch", "Encore", "Knock Off", "Psychic", "Thunder Wave"],
+                "movepool": ["Calm Mind", "Draining Kiss", "Knock Off", "Psychic"],
                 "abilities": ["Inner Focus", "Insomnia"],
-                "teraTypes": ["Dark", "Fighting"]
+                "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Draining Kiss", "Encore", "Knock Off", "Psychic", "Thunder Wave"],
+                "movepool": ["Calm Mind", "Draining Kiss", "Encore", "Focus Blast", "Psychic", "Thunder Wave"],
                 "abilities": ["Inner Focus", "Insomnia"],
                 "teraTypes": ["Fairy"]
             }
@@ -720,7 +732,7 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
@@ -1718,7 +1730,7 @@
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Iron Head", "Knock Off", "Play Rough", "Stealth Rock", "U-turn"],
                 "abilities": ["Tough Claws"],
                 "teraTypes": ["Fairy", "Water"]
@@ -1802,7 +1814,7 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Ice Beam", "Liquidation", "Rest", "Roar", "Sleep Talk", "Sludge Wave", "Yawn"],
                 "abilities": ["Torrent"],
                 "teraTypes": ["Poison", "Steel"]
@@ -1894,7 +1906,7 @@
         ]
     },
     "nymble": {
-        "level": 6,
+        "level": 7,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1922,7 +1934,7 @@
                 "role": "Fast Support",
                 "movepool": ["Aqua Jet", "Encore", "Flip Turn", "Ice Beam", "Knock Off", "Sacred Sword", "Surf", "X-Scissor"],
                 "abilities": ["Torrent"],
-                "teraTypes": ["Dark", "Fighting", "Water"]
+                "teraTypes": ["Dragon", "Fighting", "Steel"]
             },
             {
                 "role": "Bulky Setup",
@@ -1937,7 +1949,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Discharge", "Encore", "Nuzzle", "Play Rough", "Super Fang", "Volt Switch"],
+                "movepool": ["Discharge", "Encore", "Nuzzle", "Play Rough", "Super Fang", "Thief", "Volt Switch"],
                 "abilities": ["Natural Cure", "Static"],
                 "teraTypes": ["Electric", "Fairy", "Grass"]
             }
@@ -1978,7 +1990,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Gunk Shot", "Ice Shard", "Knock Off", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Pickup"],
-                "teraTypes": ["Dark", "Poison"]
+                "teraTypes": ["Dragon", "Poison"]
             }
         ]
     },
@@ -2123,7 +2135,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Encore", "Flip Turn", "Ice Beam", "Knock Off", "Surf", "Yawn"],
                 "abilities": ["Cloud Nine", "Swift Swim"],
-                "teraTypes": ["Dark", "Fairy", "Steel"]
+                "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Bulky Setup",
@@ -2322,13 +2334,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Earthquake", "Ice Shard", "Rapid Spin", "Swords Dance", "Triple Axel"],
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Spear", "Rapid Spin", "Swords Dance"],
                 "abilities": ["Slush Rush"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Triple Axel"],
+                "movepool": ["Earthquake", "Icicle Spear", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock"],
                 "abilities": ["Slush Rush"],
                 "teraTypes": ["Flying", "Water"]
             }
@@ -2517,7 +2529,7 @@
         "level": 8,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Drain Punch", "Giga Drain", "Sludge Bomb", "Spore", "Stun Spore"],
                 "abilities": ["Effect Spore"],
                 "teraTypes": ["Poison", "Steel", "Water"]
@@ -2528,7 +2540,7 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Gunk Shot", "Pain Split", "Poltergeist", "Shadow Sneak", "Thunder Wave", "Trick", "Will-O-Wisp"],
                 "abilities": ["Cursed Body", "Insomnia"],
                 "teraTypes": ["Fairy"]
@@ -2607,9 +2619,15 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Body Slam", "Gunk Shot", "Hammer Arm", "Ice Punch", "Play Rough", "Slack Off", "Throat Chop"],
+                "movepool": ["Body Slam", "Gunk Shot", "Hammer Arm", "Play Rough", "Throat Chop"],
                 "abilities": ["Truant"],
                 "teraTypes": ["Fairy", "Fighting", "Normal"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Body Slam", "Hammer Arm", "Slack Off", "Throat Chop"],
+                "abilities": ["Truant"],
+                "teraTypes": ["Poison", "Ghost"]
             }
         ]
     },
@@ -2907,13 +2925,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Freeze-Dry", "Ice Shard", "Icicle Spear", "Stealth Rock"],
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Spear", "Stealth Rock", "Trailblaze"],
                 "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Water"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Earthquake", "Freeze-Dry", "Ice Shard", "Icicle Spear", "Stealth Rock"],
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Spear", "Stealth Rock", "Trailblaze"],
                 "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Ice"]
             }
@@ -2992,7 +3010,7 @@
         ]
     },
     "timburr": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -220,6 +220,12 @@ export class RandomBabyTeams extends RandomTeams {
 				movePool, teraType, role);
 		}
 
+		// Enforce Knock Off on most roles
+		if (movePool.includes('knockoff') && role !== 'Bulky Support') {
+			counter = this.addMove('knockoff', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+				movePool, teraType, role);
+		}
+
 		// Enforce hazard removal on Bulky Support if the team doesn't already have it
 		if (role === 'Bulky Support' && !teamDetails.defog && !teamDetails.rapidSpin) {
 			if (movePool.includes('rapidspin')) {


### PR DESCRIPTION
Gen 9 Random Battle:

-We have instituted a new long-term goal where we want to increase the rate of "anti-setup" moves and strategies, to better combat the amount of setup spam Gen 9 is. We'll even keep some of these moves and strategies around even if their winrate is slightly lower than it would be without. As such:
--Zoroark's sets have been split between Choice item and Nasty Plot. The Nasty Plot set has Encore as a possibility.
--Swords Dance Quaquaval: +Encore
--Delphox: -Tera Psychic, +Encore
--Added a third set for Alolan Persian of Heavy-Duty Boots with Knock Off/Taunt/Thunder Wave/Parting Shot, Tera Ghost/Fairy/Poison
--Added a second set for Tornadus (Incarnate) of Prankster Knock Off/Taunt/Bleakwind Storm/U-turn, Tera Dark/Ground/Steel
--Lycanroc: +Taunt (again)
--Pyroar: +Taunt
--Bulk Up Floatzel: -Crunch, -Tera Dark, +Taunt
--Tera Blast Comfey: +Taunt, +Encore
--Goodra: +Dragon Tail
--AV Eelektross: +Dragon Tail
--AV Ampharos: +Dragon Tail
--Hazards Garchomp: -Stone Edge, +Dragon Tail
--Mudsdale: -Tera Fighting, -Body Press (it's not as strong as you think), +Tera Steel, +Roar, Choice Band is gone.
--Added a third set for Vaporeon of WishTect with Roar or Haze as the last move, otherwise identical to the other sets.
--Added back the Life Orb Poltergeist/Focus Blast/Hyper Voice/Will-O-Wisp Hisuian Zoroark set for its ability to burn things that aren't expecting it.
--Added a third set to Slither Wing of Heavy-Duty Boots with Morning Sun, Close Combat, U-turn, and Will-O-Wisp. Tera Steel/Fire. Morning Sun was removed from the set that used to have it.
--Added a third set to Gothitelle of Leftovers with Psychic Noise, Focus Blast, Dark Pulse, and Thunder Wave, with all the funny immunity Teras and no Tera Psychic.

-Also, we've changed the "AV Pivot" role to actually enforce Volt Switch or U-turn if they're on the set (it didn't do that before)! As such:
--AV Ampharos still always has Volt Switch with Dragon Tail as an option now.
--AV Luxray now always has Volt Switch.
--AV Iron Hands now always has Volt Switch
--AV Eelektross now always has U-turn
--AV Clawitzer now always has U-turn
--AV Incineroar now always has U-turn (Fake Out is now much less common as a result)
--AV Fezandipiti now always has U-turn (Heat Wave is now much less common as a result)

And we also have a few miscellaneous changes.
-Iron Jugulis now no longer gets Choice Scarf has a second set of Setup Sweeper with Power Herb Meteor Beam, Earth Power, Hurricane, and Dark Pulse, with Tera Ground/Dark.
-Oinkologne-F specifically now runs The Snorlax Set™ as a second set, with Curse, Body Slam, Rest, and Sleep Talk with Leftovers and Tera Fairy/Poison. F was chosen over M for this due to its increased HP and Special Defense comparatively.
-Calm Mind Deoxys-Defense no longer exists.
-Calm Mind and Choice Specs Flutter Mane are now different sets to optimize their Tera Types. Choice Specs is now only Tera Fairy while Calm Mind has Tera Fairy/Ghost/Fire/Electric.
-Last update we accidentally added Substitute to Zamazenta-Crowned instead of regular Zamazenta. Substitute is on the right one now.
-Donphan's Tera Types are now Dragon/Steel/Water.