### PR TITLE
Gen 2 Random Battle updates

### DIFF
--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -28,6 +28,7 @@
         ]
     },
     "butterfree": {
+        "level": 85,
         "sets": [
             {
                 "role": "Generalist",
@@ -76,6 +77,7 @@
         ]
     },
     "fearow": {
+        "level": 71,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -151,6 +153,7 @@
         ]
     },
     "nidoking": {
+        "level": 67,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -303,6 +306,7 @@
         ]
     },
     "poliwhirl": {
+        "level": 75,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -713,6 +717,7 @@
         ]
     },
     "magmar": {
+        "level": 71,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -821,6 +826,7 @@
         ]
     },
     "kabutops": {
+        "level": 71,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -849,6 +855,7 @@
         ]
     },
     "snorlax": {
+        "level": 63,
         "sets": [
             {
                 "role": "Generalist",
@@ -905,6 +912,7 @@
         ]
     },
     "mewtwo": {
+        "level": 59,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -961,6 +969,7 @@
         ]
     },
     "furret": {
+        "level": 73,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -989,6 +998,7 @@
         ]
     },
     "ledian": {
+        "level": 77,
         "sets": [
             {
                 "role": "Generalist",
@@ -998,10 +1008,6 @@
     },
     "ariados": {
         "sets": [
-            {
-                "role": "Generalist",
-                "movepool": ["agility", "batonpass", "sludgebomb", "spiderweb"]
-            },
             {
                 "role": "Bulky Setup",
                 "movepool": ["agility", "batonpass", "growth", "sludgebomb"]
@@ -1013,6 +1019,7 @@
         ]
     },
     "crobat": {
+        "level": 73,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1066,6 +1073,7 @@
         ]
     },
     "bellossom": {
+        "level": 73,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1079,6 +1087,7 @@
         ]
     },
     "azumarill": {
+        "level": 77,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1119,6 +1128,7 @@
         ]
     },
     "jumpluff": {
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1135,6 +1145,7 @@
         ]
     },
     "aipom": {
+        "level": 77,
         "sets": [
             {
                 "role": "Generalist",
@@ -1147,6 +1158,7 @@
         ]
     },
     "sunflora": {
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1199,14 +1211,6 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["batonpass", "growth", "hiddenpowerdark", "moonlight"]
-            },
-            {
-                "role": "Generalist",
-                "movepool": ["batonpass", "meanlook", "moonlight", "sandattack"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["batonpass", "growth", "meanlook", "moonlight"]
             }
         ]
     },
@@ -1232,6 +1236,7 @@
         ]
     },
     "misdreavus": {
+        "level": 67,
         "sets": [
             {
                 "role": "Generalist",
@@ -1267,6 +1272,7 @@
         ]
     },
     "girafarig": {
+        "level": 71,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1303,6 +1309,7 @@
         ]
     },
     "gligar": {
+        "level": 73,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1347,6 +1354,7 @@
         ]
     },
     "qwilfish": {
+        "level": 71,
         "sets": [
             {
                 "role": "Generalist",
@@ -1451,6 +1459,7 @@
         ]
     },
     "delibird": {
+        "level": 81,
         "sets": [
             {
                 "role": "Thief user",
@@ -1459,6 +1468,7 @@
         ]
     },
     "mantine": {
+        "level": 77,
         "sets": [
             {
                 "role": "Generalist",
@@ -1524,6 +1534,7 @@
         ]
     },
     "stantler": {
+        "level": 71,
         "sets": [
             {
                 "role": "Generalist",
@@ -1535,7 +1546,7 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["agility", "batonpass", "spiderweb", "spikes", "spore", "swordsdance"]
+                "movepool": ["agility", "batonpass", "spikes", "spore", "swordsdance"]
             }
         ]
     },


### PR DESCRIPTION
Ready to merge.

This update manually adjusts the levels of some Pokemon to improve the balance of Gen 2 Random Battle. The levels were determined by consultation with staff and set development contributors and may be further fine-tuned in the future. 

It also implements a council vote to remove Mean Look/Spider Web + Baton Pass from the format, affecting Ariados, Smeargle, and Umbreon.

Level nerfs:
-Poliwhirl: 79 -> 75 (-4)
-Mantine: 81 -> 77 (-4)
-Aipom: 81 -> 77 (-4)
-Mewtwo: 61 -> 59 (-2)
-Snorlax: 65 -> 63 (-2)
-Stantler: 73 -> 71 (-2)
-Furret: 75 -> 73 (-2)
-Magmar: 73 -> 71 (-2)
-Fearow: 73 -> 71 (-2)

Level buffs:
-Jumpluff: 69 -> 81 (+12)
-Crobat: 69 -> 73 (+4)
-Gligar: 69 -> 73 (+4)
-Ledian: 73 -> 77 (+4)
-Butterfree: 81 -> 85 (+4)
-Sunflora: 77 -> 81 (+4)
-Bellossom: 69 -> 73 (+4)
-Delibird: 77 -> 81 (+4)
-Azumarill: 73 -> 77 (+4)
-Girafarig: 69 -> 71 (+2)
-Qwilfish: 69 -> 71 (+2)
-Kabutops: 69 -> 71 (+2)
-Nidoking: 65 -> 67 (+2)
-Misdreavus: 65 -> 67 (+2)
