### PR TITLE
Chuggalong nerf 2

### DIFF
--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -99487,7 +99487,6 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			encore: ["9M"],
 			endure: ["9M"],
 			facade: ["9M"],
-			flamethrower: ["9M"],
 			flashcannon: ["9M"],
 			gigaimpact: ["9M"],
 			gunkshot: ["9M", "9L58"],

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -580,7 +580,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Clanging Scales", "Clangorous Soul", "Flamethrower", "Sludge Wave", "Surf"],
+                "movepool": ["Clanging Scales", "Clangorous Soul",  "Sludge Wave", "Surf"],
                 "abilities": ["Armor Tail"],
                 "teraTypes": ["Fire", "Water"]
             }

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -582,7 +582,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Clanging Scales", "Clangorous Soul",  "Sludge Wave", "Surf"],
                 "abilities": ["Armor Tail"],
-                "teraTypes": ["Fire", "Water"]
+                "teraTypes": ["Water"]
             }
         ]
     }


### PR DESCRIPTION
Flamethrower is being removed from Chuggalong per [1]. I have edited learnsets.ts and the random battle set for Chuggalong. I believe these are the only places where Flamethrower is referenced currently, however I could be wrong. I have not changed the tera type for the random-battles set as I believe that goes beyond the scope of this pull request. 

https://www.smogon.com/forums/threads/np-sv-cap-stage-4-fuel-rage-fist-ban-chuggalong-nerf.3755238/#post-10359001

