### PR TITLE
Gen 9 Battle Factory set updates

### DIFF
--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -416,7 +416,7 @@
 				"evs": {"hp": 248, "atk": 8, "def": 252},
 				"nature": ["Impish"],
 				"teraType": ["Fairy", "Water"],
-				"moves": [["Stealth Rock"], ["Earthquake"], ["U-turn"], ["Taunt", "Stone Edge", "Rock Tomb"]]
+				"moves": [["Stealth Rock"], ["Earthquake"], ["U-turn"], ["Stone Edge", "Rock Tomb"]]
 			}, {
 				"species": "Landorus-Therian",
 				"weight": 20,

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -1565,7 +1565,7 @@
 				"ability": ["Vessel of Ruin"],
 				"evs": {"hp": 252, "def": 4, "spd": 252},
 				"nature": ["Careful"],
-				"teraType": ["Water", "Grass", "Fairy"],
+				"teraType": ["Poison", "Ghost"],
 				"moves": [["Spikes", "Stealth Rock"], ["Earthquake"], ["Whirlwind"], ["Ruination"]]
 			}]
 		},

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -1496,16 +1496,7 @@
 			"weight": 8,
 			"sets": [{
 				"species": "Samurott-Hisui",
-				"weight": 20,
-				"item": ["Focus Sash"],
-				"ability": ["Sharpness"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": ["Jolly"],
-				"teraType": ["Ghost"],
-				"moves": [["Ceaseless Edge"], ["Razor Shell", "Aqua Cutter"], ["Aqua Jet", "Sucker Punch"], ["Knock Off", "Taunt", "Encore"]]
-			}, {
-				"species": "Samurott-Hisui",
-				"weight": 30,
+				"weight": 40,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Sharpness"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
@@ -1514,7 +1505,7 @@
 				"moves": [["Ceaseless Edge"], ["Razor Shell", "Aqua Cutter"], ["Knock Off"], ["Flip Turn", "Encore"]]
 			}, {
 				"species": "Samurott-Hisui",
-				"weight": 25,
+				"weight": 30,
 				"item": ["Choice Scarf"],
 				"ability": ["Sharpness"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
@@ -1523,7 +1514,7 @@
 				"moves": [["Ceaseless Edge"], ["Razor Shell", "Aqua Cutter"], ["Knock Off"], ["Flip Turn", "Sacred Sword"]]
 			}, {
 				"species": "Samurott-Hisui",
-				"weight": 25,
+				"weight": 30,
 				"item": ["Assault Vest"],
 				"ability": ["Sharpness"],
 				"evs": {"hp": 172, "atk": 252, "spe": 84},
@@ -1800,19 +1791,6 @@
 				"nature": ["Timid"],
 				"teraType": ["Fairy", "Ground", "Steel"],
 				"moves": [["Moonblast"], ["Earth Power"], ["Calm Mind"], ["Substitute"]]
-			}]
-		},
-		"glimmora": {
-			"weight": 6,
-			"sets": [{
-				"species": "Glimmora",
-				"weight": 100,
-				"item": ["Focus Sash", "Red Card"],
-				"ability": ["Toxic Debris"],
-				"evs": {"def": 4, "spa": 252, "spe": 252},
-				"nature": ["Timid"],
-				"teraType": ["Ghost"],
-				"moves": [["Stealth Rock"], ["Mortal Spin"], ["Power Gem"], ["Earth Power"]]
 			}]
 		},
 		"hatterene": {
@@ -2441,6 +2419,19 @@
 				"moves": [["Leaf Storm"], ["Glare"], ["Tera Blast"], ["Substitute", "Dragon Pulse"]]
 			}]
 		},
+    "slitherwing": {
+			"weight": 1,
+			"sets": [{
+				"species": "Slither Wing",
+				"weight": 100,
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Protosynthesis"],
+				"evs": {"hp": 252, "atk": 28, "def": 220, "spe": 8},
+				"nature": ["Impish"],
+				"teraType": ["Steel", "Dragon"],
+				"moves": [["First Impression"], ["U-turn"], ["Will-O-Wisp"], ["Morning Sun"]]
+			}]
+		},
 		"skeledirge": {
 			"weight": 4,
 			"sets": [{
@@ -2766,19 +2757,6 @@
 				"nature": ["Adamant", "Jolly"],
 				"teraType": ["Ice"],
 				"moves": [["Earthquake"], ["Icicle Crash"], ["Ice Shard"], ["Knock Off", "Stealth Rock"]]
-			}]
-		},
-		"maushold": {
-			"weight": 1,
-			"sets": [{
-				"species": "Maushold",
-				"weight": 100,
-				"item": ["Wide Lens"],
-				"ability": ["Technician"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": ["Jolly"],
-				"teraType": ["Ghost", "Dark"],
-				"moves": [["Tidy Up"], ["Population Bomb"], ["Bite"], ["Encore"]]
 			}]
 		},
 		"sandyshocks": {

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -1929,7 +1929,7 @@
 				"weight": 100,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Pickpocket"],
-				"evs": {"hp": 252, "spd": 4, "spe": 252},
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": ["Jolly"],
 				"teraType": ["Ice"],
 				"moves": [["Triple Axel"], ["Knock Off"], ["Ice Shard"], ["Swords Dance", "Low Kick"]]

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -2800,7 +2800,7 @@
 				"species": "Sandy Shocks",
 				"wantsTera": true,
 				"weight": 100,
-				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"item": ["Heavy-Duty Boots"],
 				"ability": ["Protosynthesis"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -2564,7 +2564,7 @@
 			"weight": 3,
 			"sets": [{
 				"species": "Toxapex",
-				"weight": 25,
+				"weight": 50,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Regenerator"],
 				"evs": {"hp": 248, "def": 252, "spd": 8},
@@ -2574,7 +2574,7 @@
 				"moves": [["Surf"], ["Toxic"], ["Haze", "Toxic Spikes", "Baneful Bunker"], ["Recover"]]
 			}, {
 				"species": "Toxapex",
-				"weight": 25,
+				"weight": 50,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Regenerator"],
 				"evs": {"hp": 248, "def": 8, "spd": 252},
@@ -2582,16 +2582,6 @@
 				"nature": ["Calm"],
 				"teraType": ["Steel", "Grass"],
 				"moves": [["Surf"], ["Toxic"], ["Haze", "Toxic Spikes", "Baneful Bunker"], ["Recover"]]
-			}, {
-				"species": "Toxapex",
-				"weight": 50,
-				"item": ["Assault Vest"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 248, "spa": 252, "spd": 8},
-				"ivs": {"atk": 0},
-				"nature": ["Modest"],
-				"teraType": ["Steel", "Fairy"],
-				"moves": [["Surf"], ["Sludge Bomb"], ["Ice Beam"], ["Acid Spray"]]
 			}]
 		},
 		"amoonguss": {

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -2367,7 +2367,7 @@
 			}]
 		},
 		"meowscarada": {
-			"weight": 4,
+			"weight": 3,
 			"sets": [{
 				"species": "Meowscarada",
 				"weight": 100,
@@ -2441,19 +2441,6 @@
 				"moves": [["Leaf Storm"], ["Glare"], ["Tera Blast"], ["Substitute", "Dragon Pulse"]]
 			}]
 		},
-		"slitherwing": {
-			"weight": 2,
-			"sets": [{
-				"species": "Slither Wing",
-				"weight": 100,
-				"item": ["Heavy-Duty Boots"],
-				"ability": ["Protosynthesis"],
-				"evs": {"hp": 252, "atk": 28, "def": 220, "spe": 8},
-				"nature": ["Impish"],
-				"teraType": ["Steel", "Dragon"],
-				"moves": [["First Impression"], ["U-turn"], ["Will-O-Wisp"], ["Morning Sun"]]
-			}]
-		},
 		"skeledirge": {
 			"weight": 4,
 			"sets": [{
@@ -2492,7 +2479,7 @@
 			}]
 		},
 		"volcanion": {
-			"weight": 4,
+			"weight": 3,
 			"sets": [{
 				"species": "Volcanion",
 				"wantsTera": true,
@@ -2729,7 +2716,7 @@
 			}]
 		},
 		"reuniclus": {
-			"weight": 2,
+			"weight": 1,
 			"sets": [{
 				"species": "Reuniclus",
 				"weight": 100,

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -1156,17 +1156,17 @@
 			}, {
 				"species": "Dragonite",
 				"wantsTera": true,
-				"weight": 20,
+				"weight": 40,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Multiscale"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": ["Adamant"],
 				"teraType": ["Ground"],
-				"moves": [["Earthquake"], ["Dragon Dance"], ["Roost"], ["Ice Spinner"]]
+				"moves": [["Earthquake"], ["Dragon Dance"], ["Roost", "Extreme Speed"], ["Ice Spinner"]]
 			}, {
 				"species": "Dragonite",
 				"wantsTera": true,
-				"weight": 40,
+				"weight": 20,
 				"item": ["Choice Band"],
 				"ability": ["Multiscale"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -814,7 +814,7 @@
 			"weight": 10,
 			"sets": [{
 				"species": "Kingambit",
-				"weight": 25,
+				"weight": 20,
 				"item": ["Black Glasses"],
 				"ability": ["Supreme Overlord"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
@@ -823,7 +823,7 @@
 				"moves": [["Kowtow Cleave"], ["Swords Dance"], ["Iron Head", "Low Kick"], ["Sucker Punch"]]
 			}, {
 				"species": "Kingambit",
-				"weight": 25,
+				"weight": 20,
 				"item": ["Air Balloon", "Leftovers"],
 				"ability": ["Supreme Overlord"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
@@ -832,16 +832,16 @@
 				"moves": [["Low Kick"], ["Swords Dance"], ["Iron Head", "Kowtow Cleave"], ["Sucker Punch"]]
 			}, {
 				"species": "Kingambit",
-				"weight": 25,
+				"weight": 20,
 				"item": ["Air Balloon", "Leftovers"],
 				"ability": ["Supreme Overlord"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": ["Adamant", "Jolly"],
+				"nature": ["Adamant"],
 				"teraType": ["Ghost", "Fairy"],
 				"moves": [["Iron Head"], ["Swords Dance"], ["Kowtow Cleave"], ["Sucker Punch"]]
 			}, {
 				"species": "Kingambit",
-				"weight": 25,
+				"weight": 40,
 				"item": ["Leftovers"],
 				"ability": ["Supreme Overlord"],
 				"evs": {"hp": 252, "atk": 252, "spd": 4},


### PR DESCRIPTION
HOPEFULLY this will be the last in the surge of post-release battle factory hotfixes; anything after this should be able to be handled either at the time of implementing new tiers bans or at the time of the usual rands updates.

-Actually fixes weavile in OU to have Attack EVs
-Fixes Ting-Lu in OU to correctly have Poison/Ghost Tera instead of teras copypasted from Galarian Slowking.
-OU Kingambit's weighting has been adjusted to be bulky more often and also it's not running Kickless Jolly anymore
-OU Sandy Shocks no longer runs Leftovers
-OU Toxapex no longer runs AV
-OU Hisuian Samurott no longer gets its suicide lead set.
-remove taunt from ubers lando-t (ordered to do so by RSB)
-OU Maushold and Glimmora are deleted entirely
-OU Reuniclus, Meowscarada, Slither Wing, and Volcanion are now less common.
-OU Dragonite's weighting has been changed so that choice band is less common, and also Tera Ground sets can now run Espeed.