### PR TITLE
GSC Doubles: Ban Bright Powder, Quick Claw, and King's Rock

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -388,12 +388,12 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen2doubles',
 		gameType: 'doubles',
 		ruleset: ['Standard Doubles', 'Swagger Clause'],
-		banlist: ['Uber'],
+		banlist: ['Uber', 'Bright Powder', 'King\'s Rock', 'Quick Claw'],
 		onBegin() {
 			this.add('-message', `Welcome to GSC Doubles!`);
 			this.add('-message', `This is a Generation 2 Pet Mod that brings the Doubles game mode introduced in Generation 3 back in time to GSC.`);
 			this.add('-message', `You can find our metagame resources here:`);
-			this.add('-message', `https://www.smogon.com/forums/threads/3660004/post-9132049`);
+			this.add('-message', `https://www.smogon.com/forums/threads/3755811/`);
 		},
 	},
 


### PR DESCRIPTION
Bans haven't been publicly announced yet, but I was told to implement this by GSC Doubles' council directly.