### PR TITLE
Fix JSON Parsing Error for Ladder Top Retrieval

### DIFF
--- a/server/chat-plugins/seasons.ts
+++ b/server/chat-plugins/seasons.ts
@@ -143,14 +143,20 @@ export function generateFormatSchedule() {
 }
 
 export async function getLadderTop(format: string) {
-	try {
-		const results = await Net(`https://${Config.routes.root}/ladder/?format=${toID(format)}&json`).get();
-		const reply = JSON.parse(results);
-		return reply.toplist;
-	} catch (e) {
-		Monitor.crashlog(e, "A season ladder request");
-		return null;
-	}
+    try {
+        const results = await Net(`https://${Config.routes.root}/ladder/?format=${toID(format)}&json`).get();
+        let reply;
+        try {
+            reply = JSON.parse(results);
+        } catch (parseError) {
+            Monitor.crashlog(parseError, "Invalid JSON response from ladder request");
+            return null;
+        }
+        return reply.toplist;
+    } catch (e) {
+        Monitor.crashlog(e, "A season ladder request");
+        return null;
+    }
 }
 
 export async function updateBadgeholders() {


### PR DESCRIPTION
This pull request addresses a recurring JSON parsing error (“Unexpected token <”) when fetching ladder top data. The code now validates the response before parsing, gracefully handles non-JSON responses, and prevents crashes by returning null if the data is invalid. This ensures that unexpected server responses (such as HTML errors) no longer cause runtime exceptions.