### PR TITLE
REPL: Handle ENOENT errors during socket cleanup

### DIFF
--- a/lib/repl.ts
+++ b/lib/repl.ts
@@ -86,7 +86,15 @@ export const Repl = new class {
 					socket.end();
 					socket.destroy();
 				}).on('error', () => {
-					fs.unlinkSync(pathname);
+					try {
+						fs.unlinkSync(pathname);
+					} catch (err: any) {
+						// If the file doesn't exist, there's nothing to remove.
+						// Only log the error if it's something other than 'ENOENT'.
+						if (err.code !== 'ENOENT') {
+							console.error(`Failed to remove stale socket at ${pathname}:`, err);
+						}
+					}
 				});
 			}
 		}


### PR DESCRIPTION
This PR updates the REPL socket cleanup logic to safely handle ENOENT (no such file or directory) errors when attempting to remove stale socket files. Previously, if a socket file did not exist at cleanup time, the process would crash. Now, ENOENT errors are caught and ignored, ensuring stable cleanup behavior. Any other unexpected filesystem errors will still be logged, allowing for better reliability and easier debugging of file-related issues.