### PR TITLE
Fix TypeError When Room Cache Is Undefined

### DIFF
--- a/server/chat-plugins/abuse-monitor.ts
+++ b/server/chat-plugins/abuse-monitor.ts
@@ -344,7 +344,9 @@ export async function runActions(user: User, room: GameRoom, message: string, re
 		});
 		if (result !== false) {
 			// returning false means not to close the 'ticket'
-			if (!cache[room.roomid]) continue;
+			if (!cache[room.roomid]) {
+				return;
+			}
 			const notified = cache[room.roomid].staffNotified;
 			if (notified) {
 				if (typeof notified === 'string') {

--- a/server/chat-plugins/abuse-monitor.ts
+++ b/server/chat-plugins/abuse-monitor.ts
@@ -344,6 +344,7 @@ export async function runActions(user: User, room: GameRoom, message: string, re
 		});
 		if (result !== false) {
 			// returning false means not to close the 'ticket'
+			if (!cache[room.roomid]) continue;
 			const notified = cache[room.roomid].staffNotified;
 			if (notified) {
 				if (typeof notified === 'string') {


### PR DESCRIPTION
This PR addresses a ``TypeError`` that occurs in the ``runActions`` function when attempting to access the ``staffNotified`` property of an undefined ``cache[room.roomid]``. By adding a conditional check, the function now safely skips the notification logic if the room cache does not exist, preventing runtime crashes.