### PR TITLE
Gen 4: Fix Assist/Copycat/Metronome under Gravity/Heal Block

### DIFF
--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -228,7 +228,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	copycat: {
 		inherit: true,
 		onHit(pokemon) {
-			let move: Move | ActiveMove | null = this.lastMove;
+			const move: Move | ActiveMove | null = this.lastMove;
 			if (!move) return;
 
 			if (

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -57,7 +57,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 					const moveid = moveSlot.id;
 					const move = this.dex.moves.get(moveid);
 					if (
-						move.flags['noassist'] || move.isZ || move.isMax ||
+						move.flags['noassist'] ||
 						(this.field.pseudoWeather['gravity'] && move.flags['gravity']) ||
 						(target.volatiles['healblock'] && move.flags['heal'])
 					) {
@@ -231,9 +231,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			let move: Move | ActiveMove | null = this.lastMove;
 			if (!move) return;
 
-			if (move.isMax && move.baseMove) move = this.dex.moves.get(move.baseMove);
 			if (
-				move.flags['failcopycat'] || move.isZ || move.isMax ||
+				move.flags['failcopycat'] ||
 				(this.field.pseudoWeather['gravity'] && move.flags['gravity']) ||
 				(pokemon.volatiles['healblock'] && move.flags['heal'])
 			) {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -56,7 +56,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				for (const moveSlot of pokemon.moveSlots) {
 					const moveid = moveSlot.id;
 					const move = this.dex.moves.get(moveid);
-					if (move.flags['noassist'] || move.isZ || move.isMax ||
+					if (
+						move.flags['noassist'] || move.isZ || move.isMax ||
 						(this.field.pseudoWeather['gravity'] && move.flags['gravity']) ||
 						(target.volatiles['healblock'] && move.flags['heal'])
 					) {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -232,7 +232,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			if (!move) return;
 
 			if (move.isMax && move.baseMove) move = this.dex.moves.get(move.baseMove);
-			if (move.flags['failcopycat'] || move.isZ || move.isMax ||
+			if (
+				move.flags['failcopycat'] || move.isZ || move.isMax ||
 				(this.field.pseudoWeather['gravity'] && move.flags['gravity']) ||
 				(pokemon.volatiles['healblock'] && move.flags['heal'])
 			) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -12187,9 +12187,8 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		pp: 10,
 		priority: 0,
 		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
-		onHit(target, source, effect) {
+		onHit(pokemon) {
 			const moves = this.dex.moves.all().filter(move => (
-				(![2, 4].includes(this.gen) || !source.moves.includes(move.id)) &&
 				(!move.isNonstandard || move.isNonstandard === 'Unobtainable') &&
 				move.flags['metronome']
 			));
@@ -12199,8 +12198,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				randomMove = this.sample(moves).id;
 			}
 			if (!randomMove) return false;
-			source.side.lastSelectedMove = this.toID(randomMove);
-			this.actions.useMove(randomMove, target);
+			this.actions.useMove(randomMove, pokemon);
 		},
 		callsMove: true,
 		secondary: null,

--- a/test/TESTS.md
+++ b/test/TESTS.md
@@ -20,7 +20,7 @@ Check the test/ directory to see if a file already exists for the effect that yo
 		it(`test should start here`, function () {
 
 		});
-	}
+	});
 
 To create the battle, use common.createBattle and pass in two arrays of teams. You can add additional flags as well:
 - gameType: 'doubles', 'triples', 'multi', 'freeforall', etc (tests default to singles)

--- a/test/sim/moves/assist.js
+++ b/test/sim/moves/assist.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe(`[Gen 4] Assist`, function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should never call moves that would fail under Gravity`, function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'furret', moves: ['assist']},
+			{species: 'smeargle', moves: ['bounce', 'fly', 'highjumpkick', 'splash']},
+			{species: 'smeargle', moves: ['bounce', 'fly', 'highjumpkick', 'splash']},
+			{species: 'smeargle', moves: ['bounce', 'fly', 'highjumpkick', 'splash']},
+			{species: 'smeargle', moves: ['doubleteam', 'fly', 'highjumpkick', 'splash']},
+			{species: 'smeargle', moves: ['bounce', 'fly', 'highjumpkick', 'splash']},
+		], [
+			{species: 'deoxys', moves: ['gravity']},
+		]]);
+		for (let i = 0; i < 5; i++) battle.makeChoices();
+		assert.statStage(battle.p1.active[0], 'evasion', 5);
+	});
+
+	it(`should never call moves that would fail under Heal Block`, function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'furret', moves: ['assist']},
+			{species: 'smeargle', moves: ['recover', 'rest', 'roost', 'wish']},
+			{species: 'smeargle', moves: ['recover', 'rest', 'doubleteam', 'wish']},
+			{species: 'smeargle', moves: ['recover', 'rest', 'roost', 'wish']},
+			{species: 'smeargle', moves: ['recover', 'rest', 'roost', 'wish']},
+			{species: 'smeargle', moves: ['recover', 'rest', 'roost', 'wish']},
+		], [
+			{species: 'latios', moves: ['healblock']},
+		]]);
+		for (let i = 0; i < 5; i++) battle.makeChoices();
+		assert.statStage(battle.p1.active[0], 'evasion', 5);
+	});
+});


### PR DESCRIPTION
In Gen 4, Assist, Copycat, and Metronome should never attempt to call moves that would fail due to Gravity or Heal Block being active. More info here: https://www.smogon.com/forums/threads/gen-4-metronome-copycat-assist-pools-should-adjust-based-on-gravity-and-heal-block.3756047/

Since the Metronome code is now modded in gen 4, I cleaned up unnecessary lines from the modern gen code. Also there were characters missing from TESTS.md that bothered me so i added them here too.