### PR TITLE
Randomized format set & ladder updates

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2501,7 +2501,6 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		desc: `Random Battles in a random generation! [Gen 1] Random Battle - [Gen 9] Random Battle.`,
 		mod: 'randomroulette',
 		team: 'random',
-		searchShow: false,
 	},
 	{
 		name: "[Gen 9] Super Staff Bros Ultimate",
@@ -2555,6 +2554,12 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen9',
 		team: 'random',
 		ruleset: ['Obtainable', 'Same Type Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Illusion Level Mod'],
+	},
+	{
+		name: "[Gen 9] Pick-Your-Team Random Battle",
+		mod: 'gen9',
+		team: 'random',
+		ruleset: ['Team Preview', 'Max Team Size = 12', 'Picked Team Size = 6', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Illusion Level Mod'],
 	},
 	{
 		name: "[Gen 9] Random Battle Mayhem",
@@ -2678,7 +2683,6 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		desc: `[Gen 9] Hackmons Cup but with only the most powerful Pok&eacute;mon, moves, abilities, and items.`,
 
 		team: 'randomHC',
-		searchShow: false,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['All Pokemon', 'All Abilities', 'All Items', 'All Moves'],
 		unbanlist: [
@@ -2860,6 +2864,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen8',
 		gameType: 'doubles',
 		team: 'random',
+		searchShow: false,
 		ruleset: ['PotD', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Illusion Level Mod'],
 	},
 	{
@@ -2867,7 +2872,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen8',
 		team: 'random',
 		gameType: 'freeforall',
-		// searchShow: false,
+		searchShow: false,
 		tournamentShow: false,
 		rated: false,
 		ruleset: ['Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Illusion Level Mod'],
@@ -2890,6 +2895,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		desc: `Randomized teams of Pok&eacute;mon for a generated Smogon tier with sets that are competitively viable.`,
 		mod: 'gen8',
 		team: 'randomFactory',
+		searchShow: false,
 		ruleset: ['Standard', 'Dynamax Clause'],
 		onBegin() {
 			this.add(`raw|<div class="broadcast-blue"><b>Battle Factory Tier: ${this.teamGenerator.factoryTier}</b></div>`);
@@ -2908,54 +2914,9 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		desc: `Randomized teams of level-balanced Pok&eacute;mon with absolutely any ability, moves, and item.`,
 		mod: 'gen8',
 		team: 'randomHC',
+		searchShow: false,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Nonexistent'],
-	},
-	{
-		name: "[Gen 8] Metronome Battle",
-		mod: 'gen8',
-		gameType: 'doubles',
-		searchShow: false,
-		ruleset: ['Max Team Size = 2', 'HP Percentage Mod', 'Cancel Mod'],
-		banlist: [
-			'Pokestar Spirit', 'Shedinja + Sturdy', 'Battle Bond', 'Cheek Pouch', 'Cursed Body', 'Dry Skin', 'Fur Coat', 'Gorilla Tactics', 'Grassy Surge',
-			'Huge Power', 'Ice Body', 'Iron Barbs', 'Libero', 'Moody', 'Neutralizing Gas', 'Parental Bond', 'Perish Body', 'Poison Heal', 'Power Construct',
-			'Pressure', 'Protean', 'Pure Power', 'Rain Dish', 'Rough Skin', 'Sand Spit', 'Sand Stream', 'Snow Warning', 'Stamina', 'Volt Absorb', 'Water Absorb',
-			'Wonder Guard', 'Abomasite', 'Aguav Berry', 'Assault Vest', 'Berry', 'Berry Juice', 'Berserk Gene', 'Black Sludge', 'Enigma Berry', 'Figy Berry',
-			'Gold Berry', 'Iapapa Berry', 'Kangaskhanite', 'Leftovers', 'Mago Berry', 'Medichamite', 'Steel Memory', 'Oran Berry', 'Rocky Helmet', 'Shell Bell',
-			'Sitrus Berry', 'Wiki Berry', 'Harvest + Jaboca Berry', 'Harvest + Rowap Berry',
-		],
-		onValidateSet(set) {
-			const species = this.dex.species.get(set.species);
-			if (species.gen > 8) {
-				return [`${species.name} is from gen 9, which is banned from [Gen 8] Metronome Battle.`];
-			}
-			if (species.types.includes('Steel')) {
-				return [`${species.name} is a Steel-type, which is banned from Metronome Battle.`];
-			}
-			if (species.bst > 625) {
-				return [`${species.name} is banned.`, `(Pok\u00e9mon with a BST higher than 625 are banned)`];
-			}
-			const item = this.dex.items.get(set.item);
-			if (item.gen > 8) {
-				return [`${species.name} is from gen 9, which is banned from [Gen 8] Metronome Battle.`];
-			}
-			if (set.item && item.megaStone) {
-				const megaSpecies = this.dex.species.get(item.megaStone);
-				if (species.baseSpecies === item.megaEvolves && megaSpecies.bst > 625) {
-					return [
-						`${set.name || set.species}'s item ${item.name} is banned.`, `(Pok\u00e9mon with a BST higher than 625 are banned)`,
-					];
-				}
-			}
-			const ability = this.dex.abilities.get(set.ability);
-			if (ability.gen > 8) {
-				return [`${species.name} is from gen 9, which is banned from [Gen 8] Metronome Battle.`];
-			}
-			if (set.moves.length !== 1 || this.dex.moves.get(set.moves[0]).id !== 'metronome') {
-				return [`${set.name || set.species} has illegal moves.`, `(Pok\u00e9mon can only have one Metronome in their moveset)`];
-			}
-		},
 	},
 	{
 		name: "[Gen 8] CAP 1v1",
@@ -2989,6 +2950,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		desc: `Randomized teams of Pok&eacute;mon for a generated Smogon tier with sets that are competitively viable.`,
 		mod: 'gen7',
 		team: 'randomFactory',
+		searchShow: false,
 		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Team Preview', 'HP Percentage Mod', 'Cancel Mod', 'Mega Rayquaza Clause'],
 		onBegin() {
 			this.add(`raw|<div class="broadcast-blue"><b>Battle Factory Tier: ${this.teamGenerator.factoryTier}</b></div>`);
@@ -3008,6 +2970,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen7',
 		team: 'randomHC',
 		searchShow: false,
+		challengeShow: false,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Nonexistent'],
 	},

--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -281,13 +281,11 @@
     },
     "poliwag": {
         "level": 86,
-        "moves": ["amnesia", "blizzard", "surf"],
-        "exclusiveMoves": ["hypnosis", "hypnosis", "hypnosis", "psychic"]
+        "moves": ["amnesia", "blizzard", "hypnosis", "surf"]
     },
     "poliwhirl": {
         "level": 79,
-        "moves": ["amnesia", "blizzard", "surf"],
-        "exclusiveMoves": ["hypnosis", "hypnosis", "hypnosis", "psychic"]
+        "moves": ["amnesia", "blizzard", "hypnosis", "surf"]
     },
     "poliwrath": {
         "level": 74,
@@ -373,9 +371,8 @@
     },
     "slowpoke": {
         "level": 84,
-        "moves": ["blizzard", "psychic", "rest"],
-        "essentialMoves": ["surf", "thunderwave"],
-        "exclusiveMoves": ["amnesia", "earthquake", "earthquake"],
+        "moves": ["blizzard", "psychic", "surf"],
+        "essentialMoves": ["amnesia", "thunderwave"],
         "comboMoves": ["amnesia", "rest", "surf", "thunderwave"]
     },
     "slowbro": {

--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -1292,7 +1292,7 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"]
+                "movepool": ["explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "reflect", "spikes", "toxic"]
             }
         ]
     },
@@ -1358,7 +1358,11 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["curse", "haze", "hiddenpowerground", "hydropump", "sludgebomb", "spikes"]
+                "movepool": ["haze", "hydropump", "rest", "sleeptalk", "sludgebomb", "spikes"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["curse", "hiddenpowerground", "hydropump", "sludgebomb", "spikes"]
             }
         ]
     },

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -2029,7 +2029,7 @@
                 "abilities": ["Natural Cure"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Staller",
                 "movepool": ["healbell", "hiddenpowerfire", "hiddenpowergrass", "leechseed", "psychic", "recover", "toxic"],
                 "abilities": ["Natural Cure"]
             }

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -2419,7 +2419,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "explosion", "icebeam", "spikes", "taunt"],
                 "abilities": ["Inner Focus"]
             }

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -355,7 +355,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hydropump", "icepunch", "raindance"],
+                "movepool": ["brickbreak", "hydropump", "icebeam", "raindance"],
                 "abilities": ["Swift Swim"]
             },
             {

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -2457,7 +2457,7 @@
         "level": 91,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "icebeam", "spikes", "superfang", "taunt"],
                 "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1667,6 +1667,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"],
                 "abilities": ["Swift Swim"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["dragondance", "ironhead", "outrage", "waterfall"],
+                "abilities": ["Sniper", "Swift Swim"]
             }
         ]
     },
@@ -1896,11 +1901,6 @@
     "blaziken": {
         "level": 75,
         "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["fireblast", "highjumpkick", "knockoff", "protect", "stoneedge"],
-                "abilities": ["Speed Boost"]
-            },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["flareblitz", "highjumpkick", "knockoff", "stoneedge", "swordsdance"],
@@ -2719,7 +2719,7 @@
         "level": 91,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "freezedry", "spikes", "superfang", "taunt"],
                 "abilities": ["Inner Focus"]
             }
@@ -4123,7 +4123,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["darkpulse", "darkvoid", "focusblast", "nastyplot", "sludgebomb", "substitute"],
+                "movepool": ["darkpulse", "darkvoid", "nastyplot", "sludgebomb"],
                 "abilities": ["Bad Dreams"],
                 "preferredTypes": ["Poison"]
             }

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1903,7 +1903,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flareblitz", "highjumpkick", "knockoff", "stoneedge", "swordsdance"],
+                "movepool": ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"],
                 "abilities": ["Speed Boost"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -2126,7 +2126,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flareblitz", "highjumpkick", "knockoff", "stoneedge", "swordsdance"],
+                "movepool": ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"],
                 "abilities": ["Speed Boost"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1889,6 +1889,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"],
                 "abilities": ["Swift Swim"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["dragondance", "ironhead", "outrage", "waterfall"],
+                "abilities": ["Sniper", "Swift Swim"]
             }
         ]
     },
@@ -2119,11 +2124,6 @@
     "blaziken": {
         "level": 78,
         "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["fireblast", "highjumpkick", "knockoff", "protect", "stoneedge"],
-                "abilities": ["Speed Boost"]
-            },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["flareblitz", "highjumpkick", "knockoff", "stoneedge", "swordsdance"],
@@ -2964,7 +2964,7 @@
         "level": 91,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "freezedry", "spikes", "superfang", "taunt"],
                 "abilities": ["Inner Focus"]
             }
@@ -5881,7 +5881,7 @@
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["freezeshock", "fusionbolt", "honeclaws", "outrage", "roost"],
+                "movepool": ["freezeshock", "fusionbolt", "honeclaws", "outrage"],
                 "abilities": ["Teravolt"],
                 "preferredTypes": ["Ice"]
             }
@@ -6257,7 +6257,7 @@
         "level": 85,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["darkpulse", "glare", "hypervoice", "surf", "thunderbolt", "voltswitch"],
                 "abilities": ["Dry Skin"]
             },

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -902,7 +902,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		const scarfReqs = (
 			role !== 'Wallbreaker' &&
-			species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+			species.baseStats.spe >= 60 && species.baseStats.spe <= 109 &&
 			!counter.get('priority') && !moves.has('pursuit')
 		);
 

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -2982,7 +2982,7 @@
               "item": ["Choice Scarf"],
               "nature": "Jolly",
               "evs": {"hp": 4, "atk": 252, "spe": 252},
-              "teraType": ["Dark", "Grass"],
+              "teraType": ["Dark", "Ghost", "Grass"],
               "ability": ["Protean"]
           },
           {
@@ -2997,7 +2997,7 @@
               "item": ["Choice Scarf"],
               "nature": "Jolly",
               "evs": {"hp": 4, "atk": 252, "spe": 252},
-              "teraType": ["Ghost", "Rock"],
+              "teraType": ["Rock"],
               "wantsTera": true,
               "ability": ["Protean"]
           },
@@ -3013,7 +3013,7 @@
               "item": ["Focus Sash"],
               "nature": "Jolly",
               "evs": {"atk": 252, "def": 4, "spe": 252},
-              "teraType": ["Grass"],
+              "teraType": ["Ghost", "Grass"],
               "ability": ["Overgrow"]
           },
           {
@@ -3028,7 +3028,7 @@
               "item": ["Focus Sash"],
               "nature": "Jolly",
               "evs": {"atk": 252, "def": 4, "spe": 252},
-              "teraType": ["Ghost", "Rock"],
+              "teraType": ["Rock"],
               "wantsTera": true,
               "ability": ["Overgrow"]
           },
@@ -3044,7 +3044,7 @@
               "item": ["Choice Band"],
               "nature": "Jolly",
               "evs": {"hp": 4, "atk": 252, "spe": 252},
-              "teraType": ["Grass"],
+              "teraType": ["Ghost", "Grass"],
               "ability": ["Protean"]
           },
           {
@@ -3059,7 +3059,7 @@
               "item": ["Choice Band"],
               "nature": "Jolly",
               "evs": {"hp": 4, "atk": 252, "spe": 252},
-              "teraType": ["Ghost", "Rock"],
+              "teraType": ["Rock"],
               "wantsTera": true,
               "ability": ["Protean"]
           }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -908,10 +908,10 @@
                 "teraTypes": ["Flying"]
             },
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Extreme Speed", "Iron Head", "Protect", "Scale Shot", "Stomping Tantrum", "Tailwind"],
+                "role": "Bulky Protect",
+                "movepool": ["Fire Blast", "Protect", "Scale Shot", "Tailwind"],
                 "abilities": ["Inner Focus"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -1127,7 +1127,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Acrobatics", "Encore", "Helping Hand", "Pollen Puff", "Rage Powder", "Sleep Powder", "Strength Sap", "Tailwind"],
+                "movepool": ["Acrobatics", "Encore", "Pollen Puff", "Rage Powder", "Sleep Powder", "Strength Sap", "Tailwind"],
                 "abilities": ["Infiltrator"],
                 "teraTypes": ["Steel"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -6359,7 +6359,7 @@
             },
             {
                 "role": "Choice Item user",
-                "movepool": ["Dazzling Gleam", "Moonblast", "Mystical Fire", "Shadow Ball"],
+                "movepool": ["Dazzling Gleam", "Icy Wind", "Moonblast", "Shadow Ball"],
                 "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fairy"]
             }

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -1028,7 +1028,7 @@
 				"moves": [["Headlong Rush"], ["Ice Spinner"], ["Rapid Spin"], ["Knock Off", "Close Combat"]]
 			}, {
 				"species": "Great Tusk",
-				"weight": 30,
+				"weight": 40,
 				"item": ["Heavy-Duty Boots", "Rocky Helmet", "Leftovers"],
 				"ability": ["Protosynthesis"],
 				"evs": {"hp": 252, "atk": 4, "spe": 252},
@@ -1037,12 +1037,12 @@
 				"moves": [["Headlong Rush"], ["Ice Spinner"], ["Rapid Spin"], ["Knock Off", "Stealth Rock"]]
 			}, {
 				"species": "Great Tusk",
-				"weight": 30,
+				"weight": 20,
 				"item": ["Booster Energy"],
 				"ability": ["Protosynthesis"],
 				"evs": {"hp": 252, "atk": 4, "spe": 252},
 				"nature": ["Jolly"],
-				"teraType": ["Steel", "Water"],
+				"teraType": ["Steel", "Poison", "Ice"],
 				"moves": [["Headlong Rush"], ["Ice Spinner"], ["Rapid Spin", "Close Combat", "Knock Off"], ["Bulk Up"]]
 			}]
 		},
@@ -1050,16 +1050,7 @@
 			"weight": 9,
 			"sets": [{
 				"species": "Landorus-Therian",
-				"weight": 20,
-				"item": ["Rocky Helmet"],
-				"ability": ["Intimidate"],
-				"evs": {"hp": 252, "atk": 4, "spe": 252},
-				"nature": ["Jolly"],
-				"teraType": ["Water", "Dragon"],
-				"moves": [["Earthquake"], ["U-turn"], ["Stealth Rock"], ["Taunt"]]
-			}, {
-				"species": "Landorus-Therian",
-				"weight": 20,
+				"weight": 50,
 				"item": ["Rocky Helmet"],
 				"ability": ["Intimidate"],
 				"evs": {"hp": 252, "spa": 4, "spe": 252},
@@ -1068,8 +1059,8 @@
 				"moves": [["Earth Power"], ["U-turn"], ["Stealth Rock"], ["Taunt"]]
 			}, {
 				"species": "Landorus-Therian",
-				"weight": 30,
-				"item": ["Soft Sand"],
+				"weight": 20,
+				"item": ["Soft Sand", "Rocky Helmet"],
 				"ability": ["Intimidate"],
 				"evs": {"hp": 8, "atk": 240, "spd": 8, "spe": 252},
 				"nature": ["Jolly"],
@@ -1472,7 +1463,7 @@
 			"weight": 8,
 			"sets": [{
 				"species": "Raging Bolt",
-				"weight": 50,
+				"weight": 80,
 				"item": ["Leftovers", "Booster Energy"],
 				"ability": ["Protosynthesis"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
@@ -1482,7 +1473,7 @@
 				"moves": [["Thunderclap"], ["Calm Mind"], ["Dragon Pulse", "Draco Meteor"], ["Thunderbolt"]]
 			}, {
 				"species": "Raging Bolt",
-				"weight": 50,
+				"weight": 20,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Protosynthesis"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
@@ -1552,7 +1543,7 @@
 			"sets": [{
 				"species": "Ting-Lu",
 				"weight": 100,
-				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"item": ["Leftovers"],
 				"ability": ["Vessel of Ruin"],
 				"evs": {"hp": 252, "def": 4, "spd": 252},
 				"nature": ["Careful"],
@@ -1754,7 +1745,7 @@
 			"sets": [{
 				"species": "Enamorus",
 				"wantsTera": true,
-				"weight": 25,
+				"weight": 40,
 				"item": ["Choice Scarf"],
 				"ability": ["Contrary"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
@@ -1763,7 +1754,7 @@
 				"moves": [["Moonblast"], ["Earth Power"], ["Tera Blast"], ["Healing Wish"]]
 			}, {
 				"species": "Enamorus",
-				"weight": 25,
+				"weight": 40,
 				"item": ["Choice Scarf"],
 				"ability": ["Contrary"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
@@ -1773,7 +1764,7 @@
 				"moves": [["Moonblast"], ["Earth Power"], ["Mystical Fire"], ["Healing Wish"]]
 			}, {
 				"species": "Enamorus",
-				"weight": 25,
+				"weight": 10,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Cute Charm"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
@@ -1783,7 +1774,7 @@
 				"moves": [["Moonblast"], ["Earth Power"], ["Calm Mind"], ["Taunt"]]
 			}, {
 				"species": "Enamorus",
-				"weight": 25,
+				"weight": 10,
 				"item": ["Leftovers"],
 				"ability": ["Cute Charm"],
 				"evs": {"spa": 252, "spd": 4, "spe": 252},
@@ -1797,7 +1788,7 @@
 			"weight": 6,
 			"sets": [{
 				"species": "Hatterene",
-				"weight": 60,
+				"weight": 40,
 				"item": ["Leftovers"],
 				"ability": ["Magic Bounce"],
 				"evs": {"hp": 252, "def": 204, "spe": 52},
@@ -1807,7 +1798,7 @@
 				"moves": [["Calm Mind"], ["Draining Kiss"], ["Psyshock", "Stored Power"], ["Mystical Fire"]]
 			}, {
 				"species": "Hatterene",
-				"weight": 40,
+				"weight": 20,
 				"item": ["Leftovers"],
 				"ability": ["Magic Bounce"],
 				"evs": {"hp": 252, "def": 204, "spe": 52},
@@ -1815,10 +1806,20 @@
 				"nature": ["Bold"],
 				"teraType": ["Water"],
 				"moves": [["Calm Mind"], ["Draining Kiss"], ["Psyshock", "Stored Power"], ["Nuzzle"]]
+			}, {
+				"species": "Hatterene",
+				"weight": 40,
+				"item": ["Assault Vest"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "spa": 140, "spd": 104, "spe": 12},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"teraType": ["Water", "Steel"],
+				"moves": [["Mystical Fire"], ["Draining Kiss"], ["Psyshock"], ["Nuzzle", "Future Sight"]]
 			}]
 		},
 		"ogerpon": {
-			"weight": 6,
+			"weight": 5,
 			"sets": [{
 				"species": "Ogerpon",
 				"weight": 100,
@@ -1874,7 +1875,7 @@
 			}]
 		},
 		"sinistcha": {
-			"weight": 6,
+			"weight": 5,
 			"sets": [{
 				"species": "Sinistcha",
 				"weight": 100,
@@ -1969,7 +1970,7 @@
 			}]
 		},
 		"clodsire": {
-			"weight": 5,
+			"weight": 4,
 			"sets": [{
 				"species": "Clodsire",
 				"weight": 100,
@@ -2069,32 +2070,23 @@
 			}]
 		},
 		"ogerponcornerstone": {
-			"weight": 5,
+			"weight": 4,
 			"sets": [{
 				"species": "Ogerpon-Cornerstone",
-				"weight": 50,
+				"weight": 100,
 				"item": ["Cornerstone Mask"],
 				"ability": ["Sturdy"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": ["Jolly"],
 				"teraType": ["Rock"],
-				"moves": [["Ivy Cudgel"], ["Swords Dance"], ["Power Whip", "Horn Leech"], ["Low Kick"]]
-			}, {
-				"species": "Ogerpon-Cornerstone",
-				"weight": 50,
-				"item": ["Cornerstone Mask"],
-				"ability": ["Sturdy"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": ["Jolly"],
-				"teraType": ["Rock"],
-				"moves": [["Ivy Cudgel"], ["Knock Off"], ["Horn Leech"], ["Spikes"]]
+				"moves": [["Ivy Cudgel"], ["Swords Dance"], ["Power Whip", "Horn Leech"], ["Low Kick", "Knock Off"]]
 			}]
 		},
 		"rillaboom": {
 			"weight": 5,
 			"sets": [{
 				"species": "Rillaboom",
-				"weight": 50,
+				"weight": 80,
 				"item": ["Choice Band"],
 				"ability": ["Grassy Surge"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
@@ -2103,7 +2095,7 @@
 				"moves": [["Grassy Glide"], ["Wood Hammer"], ["U-turn"], ["Knock Off"]]
 			}, {
 				"species": "Rillaboom",
-				"weight": 25,
+				"weight": 10,
 				"item": ["Assault Vest"],
 				"ability": ["Grassy Surge"],
 				"evs": {"hp": 204, "atk": 252, "spe": 52},
@@ -2112,12 +2104,12 @@
 				"moves": [["Grassy Glide"], ["Low Kick"], ["U-turn"], ["Knock Off"]]
 			}, {
 				"species": "Rillaboom",
-				"weight": 25,
+				"weight": 10,
 				"item": ["Assault Vest"],
 				"ability": ["Grassy Surge"],
 				"evs": {"hp": 204, "atk": 252, "spe": 52},
 				"nature": ["Adamant"],
-				"teraType": ["Grass", "Fighting"],
+				"teraType": ["Grass"],
 				"moves": [["Grassy Glide"], ["Wood Hammer"], ["U-turn"], ["Knock Off"]]
 			}]
 		},
@@ -2125,8 +2117,8 @@
 			"weight": 5,
 			"sets": [{
 				"species": "Scizor",
-				"weight": 50,
-				"item": ["Life Orb"],
+				"weight": 20,
+				"item": ["Leftovers", "Heavy-Duty Boots", "Metal Coat"],
 				"ability": ["Technician"],
 				"evs": {"hp": 120, "atk": 252, "spe": 136},
 				"nature": ["Adamant"],
@@ -2134,7 +2126,16 @@
 				"moves": [["Swords Dance"], ["Bullet Punch"], ["Close Combat"], ["Knock Off"]]
 			}, {
 				"species": "Scizor",
-				"weight": 50,
+				"weight": 40,
+				"item": ["Choice Band"],
+				"ability": ["Technician"],
+				"evs": {"hp": 120, "atk": 252, "spe": 136},
+				"nature": ["Adamant"],
+				"teraType": ["Flying"],
+				"moves": [["U-turn"], ["Bullet Punch"], ["Dual Wingbeat"], ["Knock Off"]]
+			}, {
+				"species": "Scizor",
+				"weight": 40,
 				"item": ["Choice Band"],
 				"ability": ["Technician"],
 				"evs": {"hp": 120, "atk": 252, "spe": 136},
@@ -2144,7 +2145,7 @@
 			}]
 		},
 		"skarmory": {
-			"weight": 5,
+			"weight": 4,
 			"sets": [{
 				"species": "Skarmory",
 				"weight": 50,
@@ -2208,7 +2209,7 @@
 			}]
 		},
 		"heatran": {
-			"weight": 4,
+			"weight": 3,
 			"sets": [{
 				"species": "Heatran",
 				"weight": 50,
@@ -2278,17 +2279,17 @@
 			"weight": 4,
 			"sets": [{
 				"species": "Latios",
-				"weight": 35,
+				"weight": 10,
 				"item": ["Choice Specs", "Choice Scarf"],
 				"ability": ["Levitate"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
 				"ivs": {"atk": 0},
 				"nature": ["Timid"],
 				"teraType": ["Fighting", "Dragon"],
-				"moves": [["Draco Meteor"], ["Aura Sphere"], ["Luster Purge"], ["Psyshock", "Trick"]]
+				"moves": [["Draco Meteor"], ["Aura Sphere"], ["Luster Purge"], ["Trick"]]
 			}, {
 				"species": "Latios",
-				"weight": 15,
+				"weight": 10,
 				"item": ["Choice Specs", "Choice Scarf"],
 				"ability": ["Levitate"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
@@ -2297,7 +2298,7 @@
 				"moves": [["Draco Meteor"], ["Aura Sphere"], ["Luster Purge"], ["Flip Turn"]]
 			}, {
 				"species": "Latios",
-				"weight": 50,
+				"weight": 80,
 				"item": ["Soul Dew"],
 				"ability": ["Levitate"],
 				"evs": {"def": 4, "spa": 252, "spe": 252},
@@ -2353,12 +2354,12 @@
 				"ability": ["Protean"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": ["Jolly"],
-				"teraType": ["Grass", "Dark"],
+				"teraType": ["Grass", "Dark", "Ghost"],
 				"moves": [["Flower Trick"], ["Knock Off"], ["Triple Axel"], ["U-turn"]]
 			}]
 		},
 		"pecharunt": {
-			"weight": 4,
+			"weight": 6,
 			"sets": [{
 				"species": "Pecharunt",
 				"weight": 50,
@@ -2382,7 +2383,7 @@
 			}]
 		},
 		"rotomwash": {
-			"weight": 4,
+			"weight": 3,
 			"sets": [{
 				"species": "Rotom-Wash",
 				"weight": 50,
@@ -2429,11 +2430,11 @@
 				"evs": {"hp": 252, "atk": 28, "def": 220, "spe": 8},
 				"nature": ["Impish"],
 				"teraType": ["Steel", "Dragon"],
-				"moves": [["First Impression"], ["U-turn"], ["Will-O-Wisp"], ["Morning Sun"]]
+				"moves": [["First Impression"], ["U-turn"], ["Will-O-Wisp", "Stun Spore"], ["Morning Sun"]]
 			}]
 		},
 		"skeledirge": {
-			"weight": 4,
+			"weight": 3,
 			"sets": [{
 				"species": "Skeledirge",
 				"weight": 50,
@@ -2576,20 +2577,6 @@
 				"moves": [["Foul Play"], ["Toxic"], ["Synthesis"], ["Clear Smog", "Sludge Bomb", "Giga Drain"]]
 			}]
 		},
-		"enamorustherian": {
-			"weight": 2,
-			"sets": [{
-				"species": "Enamorus-Therian",
-				"weight": 100,
-				"item": ["Heavy-Duty Boots"],
-				"ability": ["Overcoat"],
-				"evs": {"hp": 248, "spa": 252, "spd": 8},
-				"ivs": {"atk": 0},
-				"nature": ["Modest"],
-				"teraType": ["Ground", "Poison"],
-				"moves": [["Moonblast", "Draining Kiss"], ["Earth Power"], ["Mystical Fire", "Taunt"], ["Calm Mind"]]
-			}]
-		},
 		"fezandipiti": {
 			"weight": 2,
 			"sets": [{
@@ -2607,7 +2594,7 @@
 			"weight": 2,
 			"sets": [{
 				"species": "Garchomp",
-				"weight": 50,
+				"weight": 80,
 				"item": ["Rocky Helmet"],
 				"ability": ["Rough Skin"],
 				"evs": {"hp": 252, "def": 216, "spe": 40},
@@ -2616,13 +2603,13 @@
 				"moves": [["Earthquake"], ["Dragon Tail"], ["Stealth Rock"], ["Spikes"]]
 			}, {
 				"species": "Garchomp",
-				"weight": 50,
+				"weight": 20,
 				"item": ["Loaded Dice"],
 				"ability": ["Rough Skin"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": ["Jolly"],
 				"teraType": ["Fire"],
-				"moves": [["Earthquake"], ["Scale Shot"], ["Swords Dance"], ["Fire Fang", "Stealth Rock"]]
+				"moves": [["Earthquake"], ["Scale Shot"], ["Swords Dance"], ["Fire Fang", "Stone Edge"]]
 			}]
 		},
 		"goodrahisui": {
@@ -2652,22 +2639,31 @@
 			"weight": 2,
 			"sets": [{
 				"species": "Iron Hands",
-				"weight": 50,
+				"weight": 35,
 				"item": ["Booster Energy"],
 				"ability": ["Quark Drive"],
 				"evs": {"atk": 252, "spd": 172, "spe": 84},
 				"nature": ["Adamant"],
-				"teraType": ["Flying"],
-				"moves": [["Swords Dance"], ["Drain Punch"], ["Supercell Slam", "Thunder Punch"], ["Ice Punch"]]
+				"teraType": ["Flying", "Fire"],
+				"moves": [["Swords Dance"], ["Drain Punch"], ["Thunder Punch"], ["Ice Punch"]]
 			}, {
 				"species": "Iron Hands",
-				"weight": 50,
+				"weight": 35,
 				"item": ["Shuca Berry"],
 				"ability": ["Quark Drive"],
 				"evs": {"atk": 252, "spd": 172, "spe": 84},
 				"nature": ["Adamant"],
-				"teraType": ["Fighting"],
-				"moves": [["Swords Dance"], ["Drain Punch"], ["Supercell Slam", "Thunder Punch"], ["Ice Punch"]]
+				"teraType": ["Fire"],
+				"moves": [["Swords Dance"], ["Drain Punch"], ["Thunder Punch"], ["Ice Punch"]]
+			}, {
+				"species": "Iron Hands",
+				"weight": 30,
+				"item": ["Shuca Berry"],
+				"ability": ["Quark Drive"],
+				"evs": {"atk": 252, "spd": 172, "spe": 84},
+				"nature": ["Adamant"],
+				"teraType": ["Flying", "Fire"],
+				"moves": [["Earthquake"], ["Drain Punch"], ["Thunder Punch"], ["Ice Punch"]]
 			}]
 		},
 		"keldeo": {
@@ -2684,7 +2680,7 @@
 			}]
 		},
 		"mandibuzz": {
-			"weight": 2,
+			"weight": 1,
 			"sets": [{
 				"species": "Mandibuzz",
 				"weight": 50,
@@ -2719,74 +2715,19 @@
 				"moves": [["Psychic Noise"], ["Recover"], ["Knock Off"], ["Focus Blast"]]
 			}]
 		},
-		"azumarill": {
+		"hydreigon": {
 			"weight": 1,
 			"sets": [{
-				"species": "Azumarill",
+				"species": "Hydreigon",
+				"wantsTera": true,
 				"weight": 100,
-				"item": ["Assault Vest"],
-				"ability": ["Huge Power"],
-				"evs": {"hp": 252, "atk": 252, "spd": 4},
-				"nature": ["Adamant"],
-				"teraType": ["Water", "Grass"],
-				"moves": [["Liquidation"], ["Aqua Jet"], ["Play Rough"], ["Knock Off", "Ice Spinner"]]
-			}]
-		},
-		"chansey": {
-			"weight": 1,
-			"sets": [{
-				"species": "Chansey",
-				"weight": 100,
-				"item": ["Eviolite"],
-				"ability": ["Natural Cure"],
-				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
 				"ivs": {"atk": 0},
-				"nature": ["Bold"],
+				"nature": ["Timid"],
 				"teraType": ["Steel"],
-				"moves": [["Seismic Toss"], ["Soft-Boiled"], ["Thunder Wave"], ["Stealth Rock"]]
-			}]
-		},
-		"mamoswine": {
-			"weight": 1,
-			"sets": [{
-				"species": "Mamoswine",
-				"weight": 100,
-				"item": ["Never-Melt Ice", "Life Orb"],
-				"ability": ["Thick Fat", "Oblivious"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": ["Adamant", "Jolly"],
-				"teraType": ["Ice"],
-				"moves": [["Earthquake"], ["Icicle Crash"], ["Ice Shard"], ["Knock Off", "Stealth Rock"]]
-			}]
-		},
-		"sandyshocks": {
-			"weight": 1,
-			"sets": [{
-				"species": "Sandy Shocks",
-				"wantsTera": true,
-				"weight": 100,
-				"item": ["Heavy-Duty Boots"],
-				"ability": ["Protosynthesis"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Timid"],
-				"teraType": ["Ice"],
-				"moves": [["Earth Power"], ["Volt Switch"], ["Tera Blast"], ["Spikes", "Stealth Rock", "Thunderbolt"]]
-			}]
-		},
-		"thundurustherian": {
-			"weight": 1,
-			"sets": [{
-				"species": "Thundurus-Therian",
-				"wantsTera": true,
-				"weight": 100,
-				"item": ["Heavy-Duty Boots"],
-				"ability": ["Volt Absorb"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Timid"],
-				"teraType": ["Ice", "Fairy", "Flying"],
-				"moves": [["Thunderbolt"], ["Nasty Plot"], ["Tera Blast"], ["Agility", "Grass Knot", "Psychic"]]
+				"moves": [["Nasty Plot"], ["Draco Meteor"], ["Flash Cannon"], ["Substitute"]]
 			}]
 		}
 	}, 
@@ -2857,28 +2798,6 @@
 				"nature": ["Jolly"],
 				"teraType": ["Ghost", "Dragon", "Flying"],
 				"moves": [["Close Combat"], ["Volt Switch"], ["Thunder Wave", "Taunt"], ["Stealth Rock"]]
-			}]
-		},
-		"hoopaunbound": {
-			"weight": 8,
-			"sets": [{
-				"species": "Hoopa-Unbound",
-				"weight": 70,
-				"item": ["Choice Scarf"],
-				"ability": ["Magician"],
-				"evs": {"atk": 252, "spa": 4, "spe": 252},
-				"nature": ["Adamant", "Jolly"],
-				"teraType": ["Dark", "Fairy"],
-				"moves": [["Hyperspace Fury"], ["Psychic"], ["Drain Punch"], ["Knock Off", "Thunderbolt", "Gunk Shot"]]
-			}, {
-				"species": "Hoopa-Unbound",
-				"weight": 30,
-				"item": ["Choice Scarf"],
-				"ability": ["Magician"],
-				"evs": {"atk": 252, "spa": 4, "spe": 252},
-				"nature": ["Adamant", "Jolly"],
-				"teraType": ["Dark", "Fairy"],
-				"moves": [["Hyperspace Fury"], ["Psychic"], ["Gunk Shot"], ["Knock Off", "Thunderbolt"]]
 			}]
 		},
 		"lokix": {
@@ -2995,7 +2914,7 @@
 				"weight": 50,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "def": 108, "spa": 136, "spe": 12},
+				"evs": {"hp": 252, "def": 92, "spa": 164},
 				"ivs": {"atk": 0},
 				"nature": ["Modest"],
 				"teraType": ["Steel", "Fairy", "Poison"],
@@ -3320,7 +3239,7 @@
 				"ivs": {"atk": 0},
 				"nature": ["Bold"],
 				"teraType": ["Fairy"],
-				"moves": [["Malignant Chain", "Sludge Bomb"], ["Recover"], ["Hex"], ["Parting Shot"]]
+				"moves": [["Malignant Chain"], ["Recover"], ["Hex"], ["Parting Shot"]]
 			}, {
 				"species": "Pecharunt",
 				"weight": 25,
@@ -3330,27 +3249,17 @@
 				"ivs": {"atk": 0},
 				"nature": ["Calm"],
 				"teraType": ["Fairy"],
-				"moves": [["Malignant Chain", "Sludge Bomb"], ["Recover"], ["Hex"], ["Parting Shot"]]
+				"moves": [["Malignant Chain"], ["Recover"], ["Hex"], ["Parting Shot"]]
 			}, {
 				"species": "Pecharunt",
-				"weight": 25,
+				"weight": 50,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Poison Puppeteer"],
 				"evs": {"hp": 252, "spa": 88, "spd": 96, "spe": 72},
 				"ivs": {"atk": 0},
 				"nature": ["Modest"],
 				"teraType": ["Fairy", "Ghost"],
-				"moves": [["Malignant Chain"], ["Recover"], ["Hex"], ["Nasty Plot"]]
-			}, {
-				"species": "Pecharunt",
-				"weight": 25,
-				"item": ["Heavy-Duty Boots"],
-				"ability": ["Poison Puppeteer"],
-				"evs": {"hp": 252, "spa": 88, "spd": 96, "spe": 72},
-				"ivs": {"atk": 0},
-				"nature": ["Bold"],
-				"teraType": ["Fairy", "Ghost"],
-				"moves": [["Sludge Bomb"], ["Recover"], ["Shadow Ball"], ["Nasty Plot"]]
+				"moves": [["Malignant Chain"], ["Recover"], ["Hex", "Shadow Ball"], ["Nasty Plot"]]
 			}]
 		},
 		"skarmory": {

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1273,7 +1273,7 @@
                 "teraTypes": ["Steel"]
             },
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Acrobatics", "Encore", "Sleep Powder", "Strength Sap", "U-turn"],
                 "abilities": ["Infiltrator"],
                 "teraTypes": ["Steel"]
@@ -1313,7 +1313,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Stealth Rock", "Toxic", "Toxic Spikes"],
+                "movepool": ["Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Spikes", "Toxic"],
+                "abilities": ["Unaware", "Water Absorb"],
+                "teraTypes": ["Flying", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Stealth Rock", "Toxic Spikes"],
                 "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Flying", "Steel"]
             }
@@ -1693,7 +1699,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Population Bomb", "Power Trip", "Shell Smash", "Spore"],
                 "abilities": ["Technician"],
-                "teraTypes": ["Normal"]
+                "teraTypes": ["Ghost", "Normal"]
             }
         ]
     },
@@ -3967,6 +3973,11 @@
                 "movepool": ["Knock Off", "Leaf Blade", "Lunge", "Sticky Web", "Swords Dance"],
                 "abilities": ["Chlorophyll", "Swarm"],
                 "teraTypes": ["Ghost", "Rock"]
+            }, {
+                "role": "Fast Attacker",
+                "movepool": ["Bullet Seed", "Knock Off", "Sticky Web", "Swords Dance", "Triple Axel"],
+                "abilities": ["Chlorophyll"],
+                "teraTypes": ["Ghost", "Rock"]
             }
         ]
     },
@@ -4087,7 +4098,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Nasty Plot", "Psychic", "Sludge Bomb", "Trick", "U-turn"],
+                "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Psychic", "Sludge Bomb", "Trick", "U-turn"],
                 "abilities": ["Illusion"],
                 "teraTypes": ["Poison"]
             },
@@ -4141,12 +4152,6 @@
                 "movepool": ["Dark Pulse", "Focus Blast", "Psychic", "Trick"],
                 "abilities": ["Shadow Tag"],
                 "teraTypes": ["Dark", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Dark Pulse", "Focus Blast", "Psychic Noise", "Thunder Wave"],
-                "abilities": ["Shadow Tag"],
-                "teraTypes": ["Dark", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Steel"]
             }
         ]
     },
@@ -4485,12 +4490,6 @@
                 "movepool": ["Bleakwind Storm", "Focus Blast", "Grass Knot", "Heat Wave", "Nasty Plot", "U-turn"],
                 "abilities": ["Defiant", "Prankster"],
                 "teraTypes": ["Fighting", "Fire", "Flying"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Bleakwind Storm", "Knock Off", "Taunt", "U-turn"],
-                "abilities": ["Prankster"],
-                "teraTypes": ["Dark", "Ground", "Steel"]
             }
         ]
     },
@@ -4575,7 +4574,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Bolt Strike", "Dragon Dance", "Outrage", "Substitute"],
                 "abilities": ["Teravolt"],
-                "teraTypes": ["Electric", "Steel"]
+                "teraTypes": ["Electric", "Fairy", "Grass", "Steel"]
             }
         ]
     },
@@ -6291,7 +6290,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Slam", "Earthquake", "Megahorn", "Psychic Noise", "Thunder Wave", "Thunderbolt"],
+                "movepool": ["Body Slam", "Earthquake", "Megahorn", "Psychic Noise", "Thunder Wave"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             }
@@ -7639,7 +7638,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Dragon Dance", "Heat Crash", "Morning Sun", "Outrage"],
+                "movepool": ["Dragon Dance", "Flare Blitz", "Heat Crash", "Morning Sun", "Outrage"],
                 "abilities": ["Protosynthesis"],
                 "teraTypes": ["Fairy"]
             }

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -88,7 +88,7 @@ const MIXED_SETUP = [
 ];
 // Some moves that only boost Speed:
 const SPEED_SETUP = [
-	'agility', 'autotomize', 'flamecharge', 'rockpolish', 'trailblaze',
+	'agility', 'autotomize', 'flamecharge', 'rockpolish', 'snowscape', 'trailblaze',
 ];
 // Conglomerate for ease of access
 const SETUP = [
@@ -632,7 +632,6 @@ export class RandomTeams {
 		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
 		if (species.id === 'coalossal') this.incompatibleMoves(moves, movePool, 'flamethrower', 'overheat');
-		if (!isDoubles && species.id === 'jumpluff') this.incompatibleMoves(moves, movePool, 'encore', 'strengthsap');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.
@@ -1364,7 +1363,7 @@ export class RandomTeams {
 		if (moves.has('substitute')) return 'Leftovers';
 		if (
 			moves.has('stickyweb') && isLead &&
-			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 235
+			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) <= 235
 		) return 'Focus Sash';
 		if (this.dex.getEffectiveness('Rock', species) >= 1) return 'Heavy-Duty Boots';
 		if (


### PR DESCRIPTION
Ladder updates discussed with and approved by @KrisXV 

-adds three new ladders: Pick-Your-Team Random Battle (B12P6), Broken Cup, and Random Roulette.
-Removes several old ladders: Gen 8 Hackmons Cup, Gen 7 Hackmons Cup, Gen 8 Battle Factory, Gen 7 Battle Factory, Gen 8 Random Doubles, Gen 8 Free-For-All Rands
-Gen 7 Hackmons Cup is now exclusive to the /challenge command and room tournaments
-Gen 8 Metronome Battle no longer exists (consulted with Ivy)

------- Set changes below this line -------
**Gen 9 Random Battle:**
-Clodsire's sets have been split such that it always has either Toxic or a Poison STAB attack.
-Leavanny now has a second set of Fast Attacker with Sticky Web, Bullet Seed, Knock Off, and Triple Axel with Loaded Dice. Runs Swords Dance if the team already has Sticky Web.
-Beartic can no longer get Aqua Jet and Snowscape at the same time.
-Leavanny can now generate Focus Sash in the lead slot on its Leaf Blade set.
-Jumpluff is no longer hardcoded to never get Encore and Strength Sap at the same time, and its role has been changed to Bulky Attacker so that it now always gets Strength Sap on that set. The non-SubSeed set now only sometimes runs Sleep Powder and/or U-turn.
-Wyrdeer: -Thunderbolt
-Morning Sun Gouging Fire: +Flare Blitz (rolled with Heat Crash)
-Setup Smeargle: +Tera Ghost
-Zekrom: +Tera Fairy, +Tera Grass
-Taunt Tornadus was removed due to a drastic decrease in winrate.
-Thunder Wave Gothitelle was removed due to a significant decrease in winrate.
-Due to a significant decrease in winrate, Zoroark's Wallbreaker set no longer runs Nasty Plot. Nasty Plot + Flamethrower and Nasty Plot + Psychic no longer exist. Choice Specs is now more common again.

-The change to remove Body Press Mudsdale is actually good statistically and is staying indefinitely. Sorry.

**Battle Factory:**
-Many weights of non-OU Pokemon were decreased to match their lowered viability rankings.
-Mamoswine, Azumarill, Chansey, Enamorus-T, Thundurus-T, and Sandy Shocks no longer exist in BF OU.
-Tera Steel Hydreigon now exists in BF OU.
-Many inter-set weightings for BF OU Pokemon were adjusted to be more accurate to how common the sets are.
-Hatterene and Iron Hands gained AV sets in BF OU.
-Swords Dance Garchomp now runs Stone Edge in BF OU instead of Stealth Rock.
-Ogerpon-Cornerstone in BF OU no longer runs a Spikes support set.
-Swords Dance Scizor in BF OU now runs Leftovers/Boots/Metal Coat instead of Life Orb
-Latios in BF OU no longer runs Psyshock, because Chansey stopped existing.
-Slither Wing in BF OU now sometimes runs Stun Spore
-Landorus-T in BF OU no longer runs defensive Earthquake. Offensive Earthquake now runs Rocky Helmet sometimes.
-Meowscarada in BF OU runs Tera Ghost sometimes.
-Hoopa-Unbound no longer exists in BF UU
-Pecharunt no longer runs Sludge Bomb variants in BF UU.

**Other Formats:**
-In Random Doubles, Dragonite's Scale Shot set is now Scale Shot/Fire Blast/Protect/Tailwind with Tera Fire.
-In BSS Factory, Tera Blast Meowscarada no longer runs Tera Ghost and non-Tera Blast Meowscarada now runs Tera Ghost sometimes.
-In Gens 6 and 7 Random Battle, Dragon Dance Kingdra now exists.
-In Gens 6 and 7 Random Battle, Glalie no longer gets Focus Sash
-In Gens 6 and 7 Random Battle, Blaziken now always runs Swords Dance
-In Gen 7 Random Battle, Kartana can now run Choice Scarf. Heliolisk's role was changed to accommodate this.
-In Gen 7 Random Battle, Z-Move Kyurem-Black now always runs Fusion Bolt and doesn't run Roost.
-In Gen 6 Random Battle, Darkrai no longer runs Focus Blast or Substitute, in favor of now always having Dark Void.
-In Gen 5 Random Battle, Rain Dance Poliwrath now runs Brick Break + Ice Beam instead of Focus Blast + Ice Punch.
-In Gen 3 Random Battle, Bulky Support Celebi was changed to Staller so it will always get Toxic.
-In Gen 2 Random Battle, Qwilfish's set was split between Curse and non-Curse to better accommodate when the team already has a Spikes setter.
-In Gen 2 Random Battle, Forretress now runs Reflect.