### PR TITLE
Gen 4 LC: Add Evasion Abilities Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -4017,7 +4017,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		name: "[Gen 4] LC",
 		mod: 'gen4',
 		searchShow: false,
-		ruleset: ['Standard', 'Little Cup', 'Sleep Moves Clause'],
+		ruleset: ['Standard', 'Little Cup', 'Evasion Abilities Clause', 'Sleep Moves Clause'],
 		banlist: [
 			'Meditite', 'Misdreavus', 'Murkrow', 'Scyther', 'Sneasel', 'Tangela', 'Yanma',
 			'Berry Juice', 'Deep Sea Tooth', 'Dragon Rage', 'Sonic Boom', 'Swagger',


### PR DESCRIPTION
https://www.smogon.com/forums/threads/sand-veil-in-dpp-lc.3752834/#post-10373970

Implementing Evasion Abilities Clause is functionally the same thing as the bans of Sand Veil and Snow Cloak, so I thought that this would be an equivalent solution that informs battlers in the future.