### PR TITLE
Tournaments: Hide toolbox if opponents got disqualified

### DIFF
--- a/server/tournaments/generator-round-robin.ts
+++ b/server/tournaments/generator-round-robin.ts
@@ -115,6 +115,10 @@ export class RoundRobin {
 			p2.score += 1;
 			p2.games += 1;
 			this.totalPendingMatches--;
+			if (this.matchesPerPlayer && p2.games === this.matchesPerPlayer) {
+				p2.sendRoom(`|tournament|update|{"isJoined":false}`);
+				p2.game.updatePlayer(p2, null);
+			}
 		}
 
 		for (const [row, challenges] of this.matches.entries()) {
@@ -127,6 +131,10 @@ export class RoundRobin {
 			p1.score += 1;
 			p1.games += 1;
 			this.totalPendingMatches--;
+			if (this.matchesPerPlayer && p1.games === this.matchesPerPlayer) {
+				p1.sendRoom(`|tournament|update|{"isJoined":false}`);
+				p1.game.updatePlayer(p1, null);
+			}
 		}
 
 		user.game.updatePlayer(user, null);


### PR DESCRIPTION
This PR fixes a problem where a toolbox was displayed when the remaining opponents were disqualified.

Tested and worked well

Improve #9595 