### PR TITLE
Better support for challenge codes for past 35 Pokes metagames

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2286,28 +2286,37 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'Sleep Clause Mod', 'Forme Clause', 'Z-Move Clause', 'Terastal Clause', 'Mega Rayquaza Clause',
 		],
 		banlist: [
-			'ND Uber', 'ND AG', 'ND OU', 'ND UUBL', 'ND UU', 'ND RUBL', 'ND RU', 'ND NFE', 'ND LC',
 			'Battle Bond', 'Moody', 'Shadow Tag', 'Berserk Gene', 'King\'s Rock', 'Quick Claw', 'Razor Fang', 'Acupressure', 'Last Respects',
 		],
-		unbanlist: [
-			'Appletun', 'Aurorus', 'Avalugg-Base', 'Banette-Base', 'Cacturne', 'Carracosta', 'Celebi', 'Cetitan', 'Chandelure', 'Cryogonal', 'Dipplin',
-			'Garbodor', 'Golem-Alola', 'Guzzlord', 'Jumpluff', 'Luvdisc', 'Magmortar', 'Mawile-Base', 'Milotic', 'Morpeko', 'Pachirisu', 'Perrserker',
-			'Primarina', 'Pupitar', 'Pyukumuku', 'Ribombee', 'Roserade', 'Rotom-Frost', 'Scovillain', 'Toxicroak', 'Walrein', 'Wo-Chien', 'Wugtrio',
-			'Yanmega', 'Zoroark-Base',
-		],
 		// Stupid hardcode
-		onValidateSet(set, format, setHas, teamHas) {
+		onValidateSet(set) {
+			const allowedPokemon: string[] = [
+				'Appletun', 'Aurorus', 'Avalugg', 'Banette', 'Cacturne', 'Carracosta', 'Celebi', 'Cetitan', 'Chandelure', 'Cryogonal', 'Dipplin',
+				'Garbodor', 'Golem-Alola', 'Guzzlord', 'Jumpluff', 'Luvdisc', 'Magmortar', 'Mawile', 'Milotic', 'Morpeko', 'Pachirisu', 'Perrserker',
+				'Primarina', 'Pupitar', 'Pyukumuku', 'Ribombee', 'Roserade', 'Rotom-Frost', 'Scovillain', 'Toxicroak', 'Walrein', 'Wo-Chien', 'Wugtrio',
+				'Yanmega', 'Zoroark',
+			];
+			const problems: string[] = [];
+			// To be called by the client build script.
+			if(this.gen === 0) {
+				if(!allowedPokemon.includes(set.species)) problems.push('bad');
+				return problems.length ? problems : undefined;
+			}
+			const species = this.dex.species.get(set.species);
+			if(!this.ruleTable.has('-pokemontag:allpokemon')) {
+				if(!allowedPokemon.includes(set.species)) problems.push(`${set.species} is not part of this month's roster.`);
+			}
 			if (set.item) {
 				const item = this.dex.items.get(set.item);
 				if (item.megaEvolves && !(this.ruleTable.has(`+item:${item.id}`) || this.ruleTable.has(`+pokemontag:mega`))) {
-					return [`Mega Evolution is banned.`];
+					problems.push(`Mega Evolution is banned.`);
 				}
 			}
-			const species = this.dex.species.get(set.species);
 			if (set.moves.map(x => this.toID(this.dex.moves.get(x).realMove) || x).includes('hiddenpower') &&
 				species.baseSpecies !== 'Unown' && !this.ruleTable.has(`+move:hiddenpower`)) {
-				return [`Hidden Power is banned.`];
+				problems.push(`Hidden Power is banned.`);
 			}
+			if(problems.length) return problems;
 		},
 	},
 	{


### PR DESCRIPTION
Currently the challenge codes used for challenging to a past 35 Pokes meta look like so: ([a couple more samples in this tour post](https://www.smogon.com/forums/threads/natdex-35-pokes-trios-week-2-replays-required.3756027/))

`/challenge gen9nationaldex35pokes @@@ -All Pokemon, +mabosstiff, +eelektross, +camerupt, +grapploct, +drifblim, +ampharos, +lurantis, +gyarados, +hypno, +druddigon, +durant, +chesnaught, +gastrodon, +eldegoss, +pelipper, +dodrio, +wailord, +emolga, +dachsbun, +drampa, +trevenant, +passimian, +beautifly, +tyranitar, +regirock, +stunfisk-galar, +morpeko, +jumpluff, +heatmor, +froslass, +audino, +cetitan, +pincurchin, +cradily, +ninetales, -Golem-Alola, -Zoroark, -Pyukumuku, -Guzzlord, -Wugtrio, -Garbodor, -Aurorus, -Walrein, -Roserade, -Ribombee, -Carracosta, -Perrserker, -Appletun, -Primarina, -Pachirisu, -Banette, -Celebi, -Avalugg, -Wo-Chien, -Pupitar, -Milotic, -Scovillain, -Dipplin, -Chandelure, -Toxicroak, -Magmortar, -Yanmega, -Cacturne, -Luvdisc, -Mawile, -Rotom-Frost`

Pokemon in the current month's roster (that don't overlap with the target meta) have to be individually banned. Considering that most tours take place between 2 months, these challenge codes will have to be adapted according to the next month's roster. It's not convenient for the hosts and the players.

The `-allpokemon` tag intentionally has the lowest priority in validation, so its default behavior is insufficient for this purpose. This PR does the following:

- Adds logic handling `-allpokemon` to the 35 Pokes validator. Its purpose is to allow shorter (and date independant) challenge codes in the form of `/challenge gen9nationaldex35pokes @@@ -All Pokemon, +mabosstiff, +eelektross, +camerupt, +grapploct, +drifblim, +ampharos, +lurantis, +gyarados, +hypno, +druddigon, +durant, +chesnaught, +gastrodon, +eldegoss, +pelipper, +dodrio, +wailord, +emolga, +dachsbun, +drampa, +trevenant, +passimian, +beautifly, +tyranitar, +regirock, +stunfisk-galar, +morpeko, +jumpluff, +heatmor, +froslass, +audino, +cetitan, +pincurchin, +cradily, +ninetales`

- Moves the unbanlist definition to the new logic. This is necessary because `unbanlist` interferes with the challenge code before the validation is reached. Pokemon in `unbanlist` are interpreted as `+pokemon` in the rule table, and so `+pokemon` in the challenge code is removed if present. For instance, Garbodor is part of this month's roster, and that of November 2023 as well. If this month someone was to challenge someone else to Nov 2023 using a code like `@@@ -All Pokemon, +Mismagius, +Garbodor, +Swampert, ...`, their code would be interpreted as `@@@ -All Pokemon, +Mismagius, +Swampert, ...`, and any validator logic would be unaware of the player initially specifying `+Garbodor`.

- Provide an alternative filter for the client build script. It was previously relying on `unbanlist`.

This PR makes the 35 Pokes teambuilder display nothing if built again until the complementary patch is applied. I'll link it shortly.

Thank you for checking. Happy holidays!