### PR TITLE
Tools: reference dist in team-gen-benchmark script

### DIFF
--- a/tools/team-generation-benchmark.js
+++ b/tools/team-generation-benchmark.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const {Teams} = require('../sim');
-const {Dex} = require('../sim/dex');
+const {Teams} = require('../dist/sim');
+const {Dex} = require('../dist/sim/dex');
 
 
 if (!process.argv[2]) {


### PR DESCRIPTION
This PR addresses [#10644](https://github.com/smogon/pokemon-showdown/issues/10644).

Developers just need to run `node build` to rebuild the `dist` folder whenever the `.ts` files in `sim/` change.

## Other Considerations
- Add a watch script to rebuild when ``.ts``  files change.
    - ``npx tsc --watch`` 
- Convert the script itself to TypeScript & compile it with ``tsc``.
- Convert the script itself to TypeScript & use ``ts-node``  + ``nodemon``.