### PR TITLE
Calculator: Fix base prefix logic for zero results

### DIFF
--- a/server/chat-plugins/calculator.ts
+++ b/server/chat-plugins/calculator.ts
@@ -180,7 +180,7 @@ export const commands: Chat.ChatCommands = {
 			const [result, inferredBase] = solveRPN(parseMathematicalExpression(expression));
 			if (!base) base = inferredBase;
 			let baseResult = '';
-			if (result && base !== 10) {
+			if (Number.isFinite(result) && base !== 10) {
 				baseResult = `${BASE_PREFIXES[base]}${result.toString(base).toUpperCase()}`;
 				if (baseResult === expression) baseResult = '';
 			}


### PR DESCRIPTION
Previously, `/calculate` would fail to include the correct base prefix (`0x`, `0b`, `0o`) when the result was `0` because the code used a falsy check (`if (result)`). This commit replaces that condition with `if (Number.isFinite(result))`, ensuring zero is properly displayed in the requested base.