### PR TITLE
Remove "Nintendo Cup 2000 Move Legality" from [Gen 2] Nintendo Cup 2000

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -4256,7 +4256,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		searchShow: false,
 		ruleset: [
 			'Picked Team Size = 3', 'Min Level = 50', 'Max Level = 55', 'Max Total Level = 155',
-			'Obtainable', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Item Clause = 1', 'Endless Battle Clause', 'Cancel Mod', 'Event Moves Clause', 'Nickname Clause', 'Team Preview', 'NC 2000 Move Legality',
+			'Obtainable', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Item Clause = 1', 'Endless Battle Clause', 'Cancel Mod', 'Event Moves Clause', 'Nickname Clause', 'Team Preview',
 		],
 		banlist: ['Uber'],
 	},


### PR DESCRIPTION
Recent discoveries have made this clause inaccurate to how the format was played in the IRL tournaments. This should make it accurate??? Confirmed with Shellnuts