### PR TITLE
National Dex UU: Update Bans

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -5356,7 +5356,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	garganacl: {
 		tier: "OU",
 		doublesTier: "DUU",
-		natDexTier: "UU",
+		natDexTier: "UUBL",
 	},
 	glimmet: {
 		tier: "LC",
@@ -5531,7 +5531,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	ceruledge: {
 		tier: "UUBL",
 		doublesTier: "(DUU)",
-		natDexTier: "UU",
+		natDexTier: "UUBL",
 	},
 	toedscool: {
 		tier: "LC",


### PR DESCRIPTION
These were moved to ND UU in https://github.com/smogon/pokemon-showdown/commit/7d14bef733c8bc42bf67999676668549dab18a35 when they were already banned from ND UU.

Garganacl: https://www.smogon.com/forums/threads/sv-national-dex-uu-stage-2-solar-power-garganacl-manaphy-and-xurkitree-quickbanned.3716024/

Ceruledge: https://www.smogon.com/forums/threads/sv-national-dex-uu-stage-6-1-poltergeist-ceruledge-banned.3734851/