### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -176,8 +176,8 @@
     },
     "jigglypuff": {
         "level": 89,
-        "moves": ["blizzard", "bodyslam", "seismictoss"],
-        "essentialMoves": ["thunderwave"],
+        "moves": ["blizzard", "bodyslam"],
+        "essentialMoves": ["thunderwave", "seismictoss"],
         "exclusiveMoves": ["counter", "sing", "thunderwave"]
     },
     "wigglytuff": {

--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -19,7 +19,7 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "zapcannon"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf"]
             },
             {
                 "role": "Bulky Support",
@@ -1007,6 +1007,7 @@
         ]
     },
     "ariados": {
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Setup",

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -2112,7 +2112,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bellydrum", "extremespeed", "hiddenpowerfighting", "shadowball"],
+                "movepool": ["bellydrum", "extremespeed", "hiddenpowerground", "shadowball"],
                 "abilities": ["Pickup"]
             },
             {

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -3448,7 +3448,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["painsplit", "shadowball", "thunderbolt", "thudnerwave", "willowisp"],
+                "movepool": ["painsplit", "shadowball", "thunderbolt", "thunderwave", "willowisp"],
                 "abilities": ["Levitate"]
             }
         ]

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -3445,6 +3445,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["hiddenpowerfighting", "hiddenpowerice", "shadowball", "thunderbolt", "trick"],
                 "abilities": ["Levitate"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["painsplit", "shadowball", "thunderbolt", "thudnerwave", "willowisp"],
+                "abilities": ["Levitate"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -297,7 +297,12 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"],
+                "movepool": ["earthquake", "honeclaws", "stealthrock", "stoneedge", "suckerpunch"],
+                "abilities": ["Arena Trap"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["doubleedge", "earthquake", "stoneedge", "suckerpunch"],
                 "abilities": ["Arena Trap"]
             }
         ]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -963,7 +963,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "knockoff", "liquidation", "stoneedge", "swordsdance"],
+                "movepool": ["aquajet", "knockoff", "stoneedge", "swordsdance", "waterfall"],
                 "abilities": ["Weak Armor"]
             }
         ]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -306,7 +306,12 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"],
+                "movepool": ["earthquake", "honeclaws", "stealthrock", "stoneedge", "suckerpunch"],
+                "abilities": ["Arena Trap"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["doubleedge", "earthquake", "stoneedge", "suckerpunch"],
                 "abilities": ["Arena Trap"]
             }
         ]
@@ -953,8 +958,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["aquajet", "knockoff", "rapidspin", "stoneedge", "swordsdance", "waterfall"],
+                "movepool": ["aquajet", "knockoff", "rapidspin", "stoneedge", "waterfall"],
                 "abilities": ["Battle Armor", "Swift Swim"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["aquajet", "knockoff", "liquidation", "stoneedge", "swordsdance"],
+                "abilities": ["Weak Armor"]
             }
         ]
     },
@@ -5667,7 +5677,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["darkpulse", "rest", "return", "thunderwave", "toxic", "uturn"],
+                "movepool": ["rest", "return", "thunderwave", "toxic", "uturn"],
                 "abilities": ["Fur Coat"]
             },
             {

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -6797,11 +6797,6 @@
                 "role": "Staller",
                 "movepool": ["banefulbunker", "recover", "scald", "toxic"],
                 "abilities": ["Regenerator"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["knockoff", "recover", "scald", "toxic"],
-                "abilities": ["Regenerator"]
             }
         ]
     },

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -393,7 +393,12 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "memento", "stealthrock", "stoneedge", "suckerpunch"],
+                "movepool": ["earthquake", "honeclaws", "stealthrock", "stoneedge", "suckerpunch"],
+                "abilities": ["Arena Trap"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["doubleedge", "earthquake", "stoneedge", "suckerpunch"],
                 "abilities": ["Arena Trap"]
             }
         ]
@@ -3773,7 +3778,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["boomburst", "chatter", "heatwave", "nastyplot", "substitute"],
+                "movepool": ["boomburst", "chatter", "heatwave", "nastyplot"],
                 "abilities": ["Tangled Feet"]
             }
         ]
@@ -5374,7 +5379,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["knockoff", "protect", "scald", "toxic", "wish"],
+                "movepool": ["protect", "scald", "toxic", "wish"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -6125,7 +6130,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["darkpulse", "rest", "return", "thunderwave", "toxic", "uturn"],
+                "movepool": ["rest", "return", "thunderwave", "toxic", "uturn"],
                 "abilities": ["Fur Coat"]
             },
             {
@@ -6791,6 +6796,11 @@
             {
                 "role": "Staller",
                 "movepool": ["banefulbunker", "recover", "scald", "toxic"],
+                "abilities": ["Regenerator"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["knockoff", "recover", "scald", "toxic"],
                 "abilities": ["Regenerator"]
             }
         ]

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -595,9 +595,15 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Fire Blast", "Gunk Shot", "Haze", "Poison Gas", "Protect", "Strange Steam", "Taunt", "Will-O-Wisp"],
+                "movepool": ["Gunk Shot", "Poison Gas", "Protect", "Strange Steam", "Taunt", "Will-O-Wisp"],
                 "abilities": ["Levitate", "Neutralizing Gas"],
                 "teraTypes": ["Dark", "Steel"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Dazzling Gleam", "Fire Blast", "Gunk Shot", "Protect"],
+                "abilities": ["Levitate", "Neutralizing Gas"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -1150,7 +1156,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Liquidation", "Recover", "Yawn"],
-                "abilities": ["Unaware"],
+                "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Fire", "Poison", "Steel"]
             }
         ]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -89,7 +89,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Alluring Voice", "Encore", "Focus Blast", "Grass Knot", "Knock Off", "Nasty Plot", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Alluring Voice", "Encore", "Focus Blast", "Grass Knot", "Knock Off", "Nasty Plot", "Surf", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Lightning Rod"],
                 "teraTypes": ["Grass", "Water"]
             },
@@ -1824,6 +1824,12 @@
                 "movepool": ["Aeroblast", "Calm Mind", "Earth Power", "Recover"],
                 "abilities": ["Multiscale"],
                 "teraTypes": ["Ground", "Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aeroblast", "Calm Mind", "Psychic Noise", "Recover"],
+                "abilities": ["Multiscale"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -2665,9 +2671,15 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "Quick Attack", "U-turn"],
+                "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "U-turn"],
                 "abilities": ["Reckless"],
-                "teraTypes": ["Fighting", "Flying"]
+                "teraTypes": ["Fighting", "Flying", "Normal"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "Quick Attack"],
+                "abilities": ["Reckless"],
+                "teraTypes": ["Fighting", "Flying", "Normal"]
             }
         ]
     },
@@ -4722,6 +4734,12 @@
                 "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Toxic Spikes", "U-turn"],
                 "abilities": ["Protean"],
                 "teraTypes": ["Dark", "Poison", "Water"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "U-turn"],
+                "abilities": ["Protean"],
+                "teraTypes": ["Poison"]
             }
         ]
     },
@@ -5169,6 +5187,12 @@
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Earthquake", "Knock Off", "U-turn"],
                 "abilities": ["Adaptability", "Stakeout"],
+                "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Double-Edge", "Earthquake", "Knock Off", "Trailblaze"],
+                "abilities": ["Adaptability"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -7508,13 +7532,13 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Beat Up", "Gunk Shot", "Heat Wave", "Play Rough", "U-turn"],
+                "movepool": ["Beat Up", "Gunk Shot", "Heat Wave", "Moonblast", "U-turn"],
                 "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Beat Up", "Gunk Shot", "Play Rough", "Roost", "U-turn"],
+                "movepool": ["Beat Up", "Gunk Shot", "Moonblast", "Roost", "U-turn"],
                 "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -5188,12 +5188,6 @@
                 "movepool": ["Double-Edge", "Earthquake", "Knock Off", "U-turn"],
                 "abilities": ["Adaptability", "Stakeout"],
                 "teraTypes": ["Ground"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Double-Edge", "Earthquake", "Knock Off", "Trailblaze"],
-                "abilities": ["Adaptability"],
-                "teraTypes": ["Ground"]
             }
         ]
     },

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1169,7 +1169,9 @@ export class RandomTeams {
 		if (role === 'AV Pivot') return 'Assault Vest';
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'regieleki') return 'Magnet';
-		if (types.includes('Normal') && moves.has('doubleedge') && moves.has('fakeout')) return 'Silk Scarf';
+		if (
+			types.includes('Normal') && moves.has('doubleedge') && (moves.has('fakeout') || moves.has('trailblaze'))
+		) return 'Silk Scarf';
 		if (
 			species.id === 'froslass' || moves.has('populationbomb') ||
 			(ability === 'Hustle' && counter.get('setup') && !isDoubles && this.randomChance(1, 2))

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1169,9 +1169,7 @@ export class RandomTeams {
 		if (role === 'AV Pivot') return 'Assault Vest';
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'regieleki') return 'Magnet';
-		if (
-			types.includes('Normal') && moves.has('doubleedge') && (moves.has('fakeout') || moves.has('trailblaze'))
-		) return 'Silk Scarf';
+		if (types.includes('Normal') && moves.has('doubleedge') && moves.has('fakeout')) return 'Silk Scarf';
 		if (
 			species.id === 'froslass' || moves.has('populationbomb') ||
 			(ability === 'Hustle' && counter.get('setup') && !isDoubles && this.randomChance(1, 2))


### PR DESCRIPTION
Later than usual due to the holiday break

**Gen 9 Random Battle**:
-Fast Support Raichu: -Nuzzle.
-Lugia now runs a second Calm Mind set with Psychic Noise instead of Earth Power.
-Staraptor has been set split to always have Close Combat and Double-Edge, and runs Tera Normal as an option.
-Protean Greninja now has a second set without Dark Pulse. It is Tera Poison to enforce Gunk Shot, and runs Spikes instead of Toxic Spikes.
-Fezandipiti's non-SD sets run Moonblast instead of Play Rough since it is more accurate and their damage output is similar.

**Gen 9 Random Doubles Battle**:
-Weezing-Galar has been split into two sets: Life Orb 3 attacks + Protect, and a Sitrus Berry set with support moves.
-Quagsire runs Water Absorb sometimes.

**Old Gens**:
-In Gen 7, Alomomola no longer runs Knock Off and always has Toxic.
-In Gen 7, Nasty Plot Chatot no longer runs Substitute.
-In Gens 6-7, Furfrou no longer runs Dark Pulse.
-In Gens 5-7, Dugtrio's Choice Band set runs Double-Edge instead of Memento, and its Life Orb/Focus Sash (in lead) set runs either Stealth Rock or Hone Claws.
-In Gen 6, Swords Dance Kabutops is now Weak Armor, like in Gen 7, despite only giving +1 Spe.
-In Gen 4, Rotom (base) now has a Leftovers set with Thunderbolt, Shadow Ball, Pain Split, and Wisp/Twave.
-In Gen 3, Belly Drum Linnone is always Hidden Power Ground instead of Hidden Power Fighting, because Hidden Power Ground provides additional coverage against targets with Static/Flame Body/Poison Point.
-In Gen 2, Ariados is now level 81 instead of 77, because it is considered weak, especially after removing Baton Pass + Spider Web.
-In Gen 2, Blastoise no longer runs Zap Cannon.
-In Gen 1, Jigglypuff always runs Seismic Toss.