### PR TITLE
Remove dead code for Dex initialization

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2595,7 +2595,7 @@ function runLearn(target: string, cmd: string, canAll: boolean, formatid: string
 			// can happen if you hotpatch formats without hotpatching chat
 			return {error: `"${formatid}" is not a supported format.`};
 		}
-		const dex = Dex.mod(formatid).includeData();
+		const dex = Dex.mod(formatid);
 		gen = dex.gen;
 		formatName = `Gen ${gen}`;
 		format = new Dex.Format({mod: formatid, effectType: 'Format', exists: true});

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -72,7 +72,6 @@ export class ExhaustiveRunner {
 
 	async run() {
 		const dex = Dex.forFormat(this.format);
-		dex.loadData(); // FIXME: This is required for `dex.gen` to be set properly...
 
 		const seed = this.prng.seed;
 		const pools = this.createPools(dex);

--- a/test/common.js
+++ b/test/common.js
@@ -21,7 +21,7 @@ const DEFAULT_SEED = [0x09917, 0x06924, 0x0e1c8, 0x06af0];
 class TestTools {
 	constructor(mod = 'base') {
 		this.currentMod = mod;
-		this.dex = Dex.mod(mod).includeData(); // ensure that gen is initialized
+		this.dex = Dex.mod(mod);
 
 		this.modPrefix = this.dex.isBase ? `[gen9] ` : `[${mod}] `;
 	}


### PR DESCRIPTION
As of PR #10641, these are no longer necessary - `Dex.mod` and `Dex.forFormat` already call `.includeData()` on the dex.