### PR TITLE
Fix the comment pointing to Early Bird's implementation

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1110,7 +1110,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	earlybird: {
 		flags: {},
 		name: "Early Bird",
-		// Implemented in statuses.js
+		// Implemented in conditions.ts
 		rating: 1.5,
 		num: 48,
 	},


### PR DESCRIPTION
The comment in `ability.ts` was outdated, now it references the correct file.