### PR TITLE
Fix: Protosynthesis + Cloud Nine interaction

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3441,8 +3441,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			// Protosynthesis is not affected by Utility Umbrella
 			if (this.field.isWeather('sunnyday')) {
 				pokemon.addVolatile('protosynthesis');
-			} else if (!pokemon.volatiles['protosynthesis']?.fromBooster && this.field.weather !== 'sunnyday') {
-				// Protosynthesis will not deactivite if Sun is suppressed, hence the direct ID check (isWeather respects supression)
+			} else if (!pokemon.volatiles['protosynthesis']?.fromBooster && !this.field.isWeather('sunnyday')) {
 				pokemon.removeVolatile('protosynthesis');
 			}
 		},

--- a/data/mods/gen9dlc1/abilities.ts
+++ b/data/mods/gen9dlc1/abilities.ts
@@ -9,6 +9,15 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	protosynthesis: {
 		inherit: true,
+		onWeatherChange(pokemon) {
+			// Protosynthesis is not affected by Utility Umbrella
+			if (this.field.isWeather('sunnyday')) {
+				pokemon.addVolatile('protosynthesis');
+			} else if (!pokemon.volatiles['protosynthesis']?.fromBooster && this.field.weather !== 'sunnyday') {
+				// Protosynthesis will not deactivite if Sun is suppressed, hence the direct ID check (isWeather respects supression)
+				pokemon.removeVolatile('protosynthesis');
+			}
+		},
 		condition: {
 			noCopy: true,
 			onStart(pokemon, source, effect) {

--- a/test/sim/abilities/protosynthesis.js
+++ b/test/sim/abilities/protosynthesis.js
@@ -77,7 +77,7 @@ describe('Protosynthesis', function () {
 		assert.equal(tail.volatiles['protosynthesis'].bestStat, 'spd', `Scream Tail's SpD should have been boosted by Protosynthesis in Sun while holding Utility Umbrella`);
 	});
 
-	it(`should not be deactiviated by weather suppressing abilities`, function () {
+	it(`should be deactiviated by weather suppressing abilities`, function () {
 		battle = common.createBattle([[
 			{species: 'Scream Tail', ability: 'protosynthesis', moves: ['splash']},
 		], [
@@ -88,7 +88,7 @@ describe('Protosynthesis', function () {
 		const tail = battle.p1.active[0];
 		battle.makeChoices('move splash', 'switch 2');
 
-		assert.equal(tail.volatiles['protosynthesis'].bestStat, 'spd', `Scream Tail's SpD should have remained boosted by Protosynthesis in Sun even though a weather supressing ability was activated`);
+		assert(!battle.p1.active[0].volatiles['protosynthesis'], `Scream Tail should not have remained boosted by Protosynthesis because a weather supressing ability started even though Sun was active`);
 	});
 
 	it(`should not activate if weather is suppressed`, function () {


### PR DESCRIPTION
Fixes #9469 
Fixes #10155 
Fixes https://www.smogon.com/forums/threads/protosynthesis-should-be-deactiviated-by-cloud-nine.3742163/

I believe this interaction was resolved alongside the Protosynthesis + Neutralizing Gas interaction. In older videos, Cloud Nine wouldn’t suppress Protosynthesis, but now it does.