### PR TITLE
Fix: Protean + Neutralizing Gas interaction

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2878,7 +2878,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		onAnySwitchIn(pokemon) {
 			if (this.event.target === pokemon) {
 				if(['libero', 'protean'].includes(pokemon.getAbility().id)) {
-					console.log('Reset Libero/Protean when Neutralizing Gas is active');
+					this.debug('Reset Libero/Protean when Neutralizing Gas is active');
 					delete pokemon.abilityState.protean;
 				}
 			}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1167,7 +1167,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	embodyaspectcornerstone: {
 		onStart(pokemon) {
-			if (pokemon.baseSpecies.name === 'Ogerpon-Cornerstone-Tera' && this.effectState.embodied !== pokemon.previouslySwitchedIn) {
+			if (pokemon.baseSpecies.name === 'Ogerpon-Cornerstone-Tera' &&
+				this.effectState.embodied !== pokemon.previouslySwitchedIn) {
 				this.effectState.embodied = pokemon.previouslySwitchedIn;
 				this.boost({def: 1}, pokemon);
 			}
@@ -1179,7 +1180,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	embodyaspecthearthflame: {
 		onStart(pokemon) {
-			if (pokemon.baseSpecies.name === 'Ogerpon-Hearthflame-Tera' && this.effectState.embodied !== pokemon.previouslySwitchedIn) {
+			if (pokemon.baseSpecies.name === 'Ogerpon-Hearthflame-Tera' &&
+				this.effectState.embodied !== pokemon.previouslySwitchedIn) {
 				this.effectState.embodied = pokemon.previouslySwitchedIn;
 				this.boost({atk: 1}, pokemon);
 			}
@@ -1191,7 +1193,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	embodyaspectteal: {
 		onStart(pokemon) {
-			if (pokemon.baseSpecies.name === 'Ogerpon-Teal-Tera' && this.effectState.embodied !== pokemon.previouslySwitchedIn) {
+			if (pokemon.baseSpecies.name === 'Ogerpon-Teal-Tera' &&
+				this.effectState.embodied !== pokemon.previouslySwitchedIn) {
 				this.effectState.embodied = pokemon.previouslySwitchedIn;
 				this.boost({spe: 1}, pokemon);
 			}
@@ -1203,7 +1206,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	embodyaspectwellspring: {
 		onStart(pokemon) {
-			if (pokemon.baseSpecies.name === 'Ogerpon-Wellspring-Tera' && this.effectState.embodied !== pokemon.previouslySwitchedIn) {
+			if (pokemon.baseSpecies.name === 'Ogerpon-Wellspring-Tera' &&
+				this.effectState.embodied !== pokemon.previouslySwitchedIn) {
 				this.effectState.embodied = pokemon.previouslySwitchedIn;
 				this.boost({spd: 1}, pokemon);
 			}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2272,17 +2272,17 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	libero: {
 		onPrepareHit(source, target, move) {
-			if (this.effectState.libero) return;
+			if (this.effectState.protean) return;
 			if (move.hasBounced || move.flags['futuremove'] || move.sourceEffect === 'snatch' || move.callsMove) return;
 			const type = move.type;
 			if (type && type !== '???' && source.getTypes().join() !== type) {
 				if (!source.setType(type)) return;
-				this.effectState.libero = true;
+				this.effectState.protean = true;
 				this.add('-start', source, 'typechange', type, '[from] ability: Libero');
 			}
 		},
 		onSwitchIn() {
-			delete this.effectState.libero;
+			delete this.effectState.protean;
 		},
 		flags: {},
 		name: "Libero",
@@ -2875,6 +2875,14 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 				}
 			}
 		},
+		onAnySwitchIn(pokemon) {
+			if (this.event.target === pokemon) {
+				if(['libero', 'protean'].includes(pokemon.getAbility().id)) {
+					console.log('Reset Libero/Protean when Neutralizing Gas is active');
+					delete pokemon.abilityState.protean;
+				}
+			}
+		},
 		onEnd(source) {
 			if (source.transformed) return;
 			for (const pokemon of this.getAllActive()) {
@@ -3425,7 +3433,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 				this.add('-start', source, 'typechange', type, '[from] ability: Protean');
 			}
 		},
-		onSwitchIn(pokemon) {
+		onSwitchIn() {
 			delete this.effectState.protean;
 		},
 		flags: {},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1167,13 +1167,10 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	embodyaspectcornerstone: {
 		onStart(pokemon) {
-			if (pokemon.baseSpecies.name === 'Ogerpon-Cornerstone-Tera' && !this.effectState.embodied) {
-				this.effectState.embodied = true;
+			if (pokemon.baseSpecies.name === 'Ogerpon-Cornerstone-Tera' && this.effectState.embodied !== pokemon.previouslySwitchedIn) {
+				this.effectState.embodied = pokemon.previouslySwitchedIn;
 				this.boost({def: 1}, pokemon);
 			}
-		},
-		onSwitchIn() {
-			delete this.effectState.embodied;
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1},
 		name: "Embody Aspect (Cornerstone)",
@@ -1182,13 +1179,10 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	embodyaspecthearthflame: {
 		onStart(pokemon) {
-			if (pokemon.baseSpecies.name === 'Ogerpon-Hearthflame-Tera' && !this.effectState.embodied) {
-				this.effectState.embodied = true;
+			if (pokemon.baseSpecies.name === 'Ogerpon-Hearthflame-Tera' && this.effectState.embodied !== pokemon.previouslySwitchedIn) {
+				this.effectState.embodied = pokemon.previouslySwitchedIn;
 				this.boost({atk: 1}, pokemon);
 			}
-		},
-		onSwitchIn() {
-			delete this.effectState.embodied;
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1},
 		name: "Embody Aspect (Hearthflame)",
@@ -1197,13 +1191,10 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	embodyaspectteal: {
 		onStart(pokemon) {
-			if (pokemon.baseSpecies.name === 'Ogerpon-Teal-Tera' && !this.effectState.embodied) {
-				this.effectState.embodied = true;
+			if (pokemon.baseSpecies.name === 'Ogerpon-Teal-Tera' && this.effectState.embodied !== pokemon.previouslySwitchedIn) {
+				this.effectState.embodied = pokemon.previouslySwitchedIn;
 				this.boost({spe: 1}, pokemon);
 			}
-		},
-		onSwitchIn() {
-			delete this.effectState.embodied;
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1},
 		name: "Embody Aspect (Teal)",
@@ -1212,13 +1203,10 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	embodyaspectwellspring: {
 		onStart(pokemon) {
-			if (pokemon.baseSpecies.name === 'Ogerpon-Wellspring-Tera' && !this.effectState.embodied) {
-				this.effectState.embodied = true;
+			if (pokemon.baseSpecies.name === 'Ogerpon-Wellspring-Tera' && this.effectState.embodied !== pokemon.previouslySwitchedIn) {
+				this.effectState.embodied = pokemon.previouslySwitchedIn;
 				this.boost({spd: 1}, pokemon);
 			}
-		},
-		onSwitchIn() {
-			delete this.effectState.embodied;
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1},
 		name: "Embody Aspect (Wellspring)",
@@ -2272,17 +2260,14 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	libero: {
 		onPrepareHit(source, target, move) {
-			if (this.effectState.protean) return;
+			if (this.effectState.libero === source.previouslySwitchedIn) return;
 			if (move.hasBounced || move.flags['futuremove'] || move.sourceEffect === 'snatch' || move.callsMove) return;
 			const type = move.type;
 			if (type && type !== '???' && source.getTypes().join() !== type) {
 				if (!source.setType(type)) return;
-				this.effectState.protean = true;
+				this.effectState.libero = source.previouslySwitchedIn;
 				this.add('-start', source, 'typechange', type, '[from] ability: Libero');
 			}
-		},
-		onSwitchIn() {
-			delete this.effectState.protean;
 		},
 		flags: {},
 		name: "Libero",
@@ -2875,11 +2860,6 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 				}
 			}
 		},
-		onAnySwitchIn(pokemon) {
-			if (['libero', 'protean'].includes(pokemon.getAbility().id)) {
-				delete pokemon.abilityState.protean;
-			}
-		},
 		onEnd(source) {
 			if (source.transformed) return;
 			for (const pokemon of this.getAllActive()) {
@@ -3421,17 +3401,14 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	protean: {
 		onPrepareHit(source, target, move) {
-			if (this.effectState.protean) return;
+			if (this.effectState.protean === source.previouslySwitchedIn) return;
 			if (move.hasBounced || move.flags['futuremove'] || move.sourceEffect === 'snatch' || move.callsMove) return;
 			const type = move.type;
 			if (type && type !== '???' && source.getTypes().join() !== type) {
 				if (!source.setType(type)) return;
-				this.effectState.protean = true;
+				this.effectState.protean = source.previouslySwitchedIn;
 				this.add('-start', source, 'typechange', type, '[from] ability: Protean');
 			}
-		},
-		onSwitchIn() {
-			delete this.effectState.protean;
 		},
 		flags: {},
 		name: "Protean",

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2876,11 +2876,9 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			}
 		},
 		onAnySwitchIn(pokemon) {
-			if (this.event.target === pokemon) {
-				if (['libero', 'protean'].includes(pokemon.getAbility().id)) {
-					this.debug('Reset Libero/Protean when Neutralizing Gas is active');
-					delete pokemon.abilityState.protean;
-				}
+			if (this.event.target === pokemon && ['libero', 'protean'].includes(pokemon.getAbility().id)) {
+				this.debug('Reset Libero/Protean when Neutralizing Gas is active');
+				delete pokemon.abilityState.protean;
 			}
 		},
 		onEnd(source) {

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2877,7 +2877,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		},
 		onAnySwitchIn(pokemon) {
 			if (this.event.target === pokemon) {
-				if(['libero', 'protean'].includes(pokemon.getAbility().id)) {
+				if (['libero', 'protean'].includes(pokemon.getAbility().id)) {
 					this.debug('Reset Libero/Protean when Neutralizing Gas is active');
 					delete pokemon.abilityState.protean;
 				}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2876,8 +2876,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			}
 		},
 		onAnySwitchIn(pokemon) {
-			if (this.event.target === pokemon && ['libero', 'protean'].includes(pokemon.getAbility().id)) {
-				this.debug('Reset Libero/Protean when Neutralizing Gas is active');
+			if (['libero', 'protean'].includes(pokemon.getAbility().id)) {
 				delete pokemon.abilityState.protean;
 			}
 		},

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -559,7 +559,6 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				this.add('-start', source, 'typechange', type, '[from] ability: Libero');
 			}
 		},
-		onSwitchIn() {},
 		rating: 4.5,
 	},
 	lightmetal: {
@@ -780,7 +779,6 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				this.add('-start', source, 'typechange', type, '[from] ability: Protean');
 			}
 		},
-		onSwitchIn() {},
 		rating: 4.5,
 	},
 	psychicsurge: {


### PR DESCRIPTION
["If a Protean/Libero Pokemon activates its ability once, switches out, then switches back in while a Neutralizing Gas Pokemon is active, Protean/Libero won't activate even after Neutralizing Gas stops working. This is because Protean/Libero use an event callback to reset the flag, which Neutralizing Gas suppresses."](https://www.smogon.com/forums/threads/protean-libero-switching-in-on-neutralizing-gas-causes-ability-flag-not-to-be-reset.3755469/)