### PR TITLE
Fix Terastallization base power buff for priority moves called by Encore

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1668,7 +1668,8 @@ export class BattleActions {
 		}
 
 		if (
-			basePower < 60 && source.getTypes(true).includes(move.type) && source.terastallized && move.priority <= 0 &&
+			basePower < 60 && source.getTypes(true).includes(move.type) && source.terastallized &&
+			this.dex.moves.get(move.id).priority <= 0 &&
 			// Hard move.basePower check for moves like Dragon Energy that have variable BP
 			!move.multihit && !((move.basePower === 0 || move.basePower === 150) && move.basePowerCallback)
 		) {

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1667,9 +1667,10 @@ export class BattleActions {
 			basePower = 0;
 		}
 
+		const dexMove = this.dex.moves.get(move.id);
 		if (
 			basePower < 60 && source.getTypes(true).includes(move.type) && source.terastallized &&
-			this.dex.moves.get(move.id).priority <= 0 && !move.multihit &&
+			dexMove.priority <= 0 && !dexMove.multihit &&
 			// Hard move.basePower check for moves like Dragon Energy that have variable BP
 			!((move.basePower === 0 || move.basePower === 150) && move.basePowerCallback)
 		) {

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1669,9 +1669,9 @@ export class BattleActions {
 
 		if (
 			basePower < 60 && source.getTypes(true).includes(move.type) && source.terastallized &&
-			this.dex.moves.get(move.id).priority <= 0 &&
+			this.dex.moves.get(move.id).priority <= 0 && !move.multihit &&
 			// Hard move.basePower check for moves like Dragon Energy that have variable BP
-			!move.multihit && !((move.basePower === 0 || move.basePower === 150) && move.basePowerCallback)
+			!((move.basePower === 0 || move.basePower === 150) && move.basePowerCallback)
 		) {
 			basePower = 60;
 		}

--- a/test/sim/misc/terastal.js
+++ b/test/sim/misc/terastal.js
@@ -166,6 +166,21 @@ describe("Terastallization", function () {
 			battle.makeChoices('move leafage terastallize', 'auto');
 			assert.bounded(arceus.maxhp - arceus.hp, [38, 45], `Should be a 40 BP no-STAB Leafage`);
 		});
+
+		it(`shouldn't boost <60 Base Power priority moves forced via Encore`, function () {
+			battle = common.createBattle([[
+				{species: 'hariyama', moves: ['bulletpunch', 'sleeptalk'], teraType: 'Steel'},
+			], [
+				{species: 'salazzle ', moves: ['encore', 'sleeptalk']},
+			]]);
+
+			battle.makeChoices('move bulletpunch terastallize', 'move sleeptalk');
+			const salazzle = battle.p2.active[0];
+			assert.bounded(salazzle.maxhp - salazzle.hp, [38, 45], `Should be a 40 BP STAB Bullet Punch`);
+			salazzle.hp = salazzle.maxhp;
+			battle.makeChoices('move sleeptalk', 'move encore');
+			assert.bounded(salazzle.maxhp - salazzle.hp, [38, 45], `Should be a 40 BP STAB Bullet Punch`);
+		});
 	});
 
 	it("should combine with Adaptability for an overall STAB of x2.25", () => {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/tera-bp-bump-and-encore.3757856/

"Using a move with priority (like Bullet Punch) forced via Encore will give the move a Tera BP bump to 60 when it should not. This is presumably because Encore is updating the move's priority mid-turn, but Tera BP should be checking the move's priority in move data, not what the move's current priority is."

I don't believe this introduces any collateral bugs.