### PR TITLE
Neutralizing Gas and Extreme Weather abilities ending after switching out

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -927,7 +927,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const strongWeathers = ['desolateland', 'primordialsea', 'deltastream'];
 			if (this.field.getWeather().id === 'deltastream' && !strongWeathers.includes(weather.id)) return false;
 		},
-		onEnd(pokemon) {
+		onPostEnd(pokemon) {
 			if (this.field.weatherState.source !== pokemon) return;
 			for (const target of this.getAllActive()) {
 				if (target === pokemon) continue;
@@ -951,7 +951,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const strongWeathers = ['desolateland', 'primordialsea', 'deltastream'];
 			if (this.field.getWeather().id === 'desolateland' && !strongWeathers.includes(weather.id)) return false;
 		},
-		onEnd(pokemon) {
+		onPostEnd(pokemon) {
 			if (this.field.weatherState.source !== pokemon) return;
 			for (const target of this.getAllActive()) {
 				if (target === pokemon) continue;
@@ -2871,11 +2871,11 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 					this.add('-end', target, 'Slow Start', '[silent]');
 				}
 				if (strongWeathers.includes(target.getAbility().id)) {
-					this.singleEvent('End', this.dex.abilities.get(target.getAbility().id), target.abilityState, target, pokemon, 'neutralizinggas');
+					this.singleEvent('PostEnd', this.dex.abilities.get(target.getAbility().id), target.abilityState, target, pokemon, 'neutralizinggas');
 				}
 			}
 		},
-		onEnd(source) {
+		onPostEnd(source) {
 			if (source.transformed) return;
 			for (const pokemon of this.getAllActive()) {
 				if (pokemon !== source && pokemon.hasAbility('Neutralizing Gas')) {
@@ -2883,11 +2883,6 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 				}
 			}
 			this.add('-end', source, 'ability: Neutralizing Gas');
-
-			// FIXME this happens before the pokemon switches out, should be the opposite order.
-			// Not an easy fix since we cant use a supported event. Would need some kind of special event that
-			// gathers events to run after the switch and then runs them when the ability is no longer accessible.
-			// (If you're tackling this, do note extreme weathers have the same issue)
 
 			// Mark this pokemon's ability as ending so Pokemon#ignoringAbility skips it
 			if (source.abilityState.ending) return;
@@ -3375,7 +3370,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const strongWeathers = ['desolateland', 'primordialsea', 'deltastream'];
 			if (this.field.getWeather().id === 'primordialsea' && !strongWeathers.includes(weather.id)) return false;
 		},
-		onEnd(pokemon) {
+		onPostEnd(pokemon) {
 			if (this.field.weatherState.source !== pokemon) return;
 			for (const target of this.getAllActive()) {
 				if (target === pokemon) continue;

--- a/data/mods/gen2stadium2/scripts.ts
+++ b/data/mods/gen2stadium2/scripts.ts
@@ -533,6 +533,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (pokemon.side.totalFainted < 100) pokemon.side.totalFainted++;
 				this.runEvent('Faint', pokemon, faintData.source, faintData.effect);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon);
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon);
 				pokemon.clearVolatile(false);
 				pokemon.fainted = true;
 				pokemon.isActive = false;

--- a/data/mods/gen7pokebilities/moves.ts
+++ b/data/mods/gen7pokebilities/moves.ts
@@ -6,6 +6,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			onStart(pokemon) {
 				this.add('-endability', pokemon);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
 				if (pokemon.m.innates) {
 					for (const innate of pokemon.m.innates) {
 						pokemon.removeVolatile("ability" + innate);

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -3099,6 +3099,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				}
 				if (STRONG_WEATHERS.includes(target.getAbility().id)) {
 					this.singleEvent('End', this.dex.abilities.get(target.getAbility().id), target.abilityState, target, pokemon, 'neutralizinggas');
+					this.singleEvent('PostEnd', this.dex.abilities.get(target.getAbility().id), target.abilityState, target, pokemon, 'neutralizinggas');
 				}
 			}
 		},

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -880,6 +880,9 @@ export const Scripts: ModdedBattleScriptsData = {
 
 				oldActive.illusion = null;
 				this.battle.singleEvent('End', oldActive.getAbility(), oldActive.abilityState, oldActive);
+				side.active[pos] = null!;
+				this.battle.add('-switchout', oldActive, oldActive.getDetails);
+				this.battle.singleEvent('PostEnd', oldActive.getAbility(), oldActive.abilityState, oldActive);
 
 				// if a pokemon is forced out by Whirlwind/etc or Eject Button/Pack, it can't use its chosen move
 				this.battle.queue.cancelAction(oldActive);
@@ -892,9 +895,6 @@ export const Scripts: ModdedBattleScriptsData = {
 					pokemon.copyVolatileFrom(oldActive, switchCopyFlag);
 				}
 				if (newMove) pokemon.lastMove = newMove;
-				side.active[pos] = null!;
-				this.battle.add('-switchout', oldActive, oldActive.getDetails);
-				this.battle.singleEvent('PostEnd', oldActive.getAbility(), oldActive.abilityState, oldActive);
 				oldActive.clearVolatile();
 			}
 			if (oldActive) {

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -307,6 +307,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (pokemon.side.totalFainted < 100) pokemon.side.totalFainted++;
 				this.runEvent('Faint', pokemon, faintData.source, faintData.effect);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon);
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon);
 				pokemon.clearVolatile(false);
 				pokemon.fainted = true;
 				pokemon.illusion = null;
@@ -891,6 +892,9 @@ export const Scripts: ModdedBattleScriptsData = {
 					pokemon.copyVolatileFrom(oldActive, switchCopyFlag);
 				}
 				if (newMove) pokemon.lastMove = newMove;
+				side.active[pos] = null!;
+				this.battle.add('-switchout', oldActive, oldActive.getDetails);
+				this.battle.singleEvent('PostEnd', oldActive.getAbility(), oldActive.abilityState, oldActive);
 				oldActive.clearVolatile();
 			}
 			if (oldActive) {

--- a/data/mods/partnersincrime/moves.ts
+++ b/data/mods/partnersincrime/moves.ts
@@ -7,6 +7,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				if (pokemon.hasItem('Ability Shield')) return false;
 				this.add('-endability', pokemon);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
 				const keys = Object.keys(pokemon.volatiles).filter(x => x.startsWith("ability:"));
 				if (keys.length) {
 					for (const abil of keys) {
@@ -136,12 +137,14 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				this.add('-activate', source, 'move: Skill Swap', targetAbility, sourceAbility, '[of] ' + target);
 			}
 			this.singleEvent('End', sourceAbility, source.abilityState, source);
+			this.singleEvent('PostEnd', sourceAbility, source.abilityState, source);
 			if (ally?.m.innate) {
 				ally.removeVolatile(ally.m.innate);
 				delete ally.m.innate;
 			}
 
 			this.singleEvent('End', targetAbility, target.abilityState, target);
+			this.singleEvent('PostEnd', targetAbility, target.abilityState, target);
 			if (foeAlly?.m.innate) {
 				foeAlly.removeVolatile(foeAlly.m.innate);
 				delete foeAlly.m.innate;

--- a/data/mods/partnersincrime/scripts.ts
+++ b/data/mods/partnersincrime/scripts.ts
@@ -276,6 +276,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			if (!this.battle.runEvent('SetAbility', this, source, this.battle.effect, ability)) return false;
 			this.battle.singleEvent('End', this.battle.dex.abilities.get(oldAbility), this.abilityState, this, source);
+			this.battle.singleEvent('PostEnd', this.battle.dex.abilities.get(oldAbility), this.abilityState, this, source);
 			const ally = this.side.active.find(mon => mon && mon !== this && !mon.fainted);
 			if (ally?.m.innate) {
 				ally.removeVolatile(ally.m.innate);

--- a/data/mods/pokebilities/moves.ts
+++ b/data/mods/pokebilities/moves.ts
@@ -6,6 +6,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			onStart(pokemon) {
 				this.add('-endability', pokemon);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
 				if (pokemon.m.innates) {
 					for (const innate of pokemon.m.innates) {
 						pokemon.removeVolatile("ability" + innate);

--- a/data/mods/pokemoves/moves.ts
+++ b/data/mods/pokemoves/moves.ts
@@ -18,6 +18,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			onStart(pokemon) {
 				this.add('-endability', pokemon);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
 				const keys = Object.keys(pokemon.volatiles).filter(x => x.startsWith("ability:"));
 				if (keys.length) {
 					for (const abil of keys) {

--- a/data/mods/sharedpower/moves.ts
+++ b/data/mods/sharedpower/moves.ts
@@ -6,6 +6,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			onStart(pokemon) {
 				this.add('-endability', pokemon);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
 				const keys = Object.keys(pokemon.volatiles).filter(x => x.startsWith("ability:"));
 				if (keys.length) {
 					for (const abil of keys) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -6664,6 +6664,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				if (pokemon.hasItem('Ability Shield')) return false;
 				this.add('-endability', pokemon);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon, pokemon, 'gastroacid');
 			},
 			onCopy(pokemon) {
 				if (pokemon.getAbility().flags['cantsuppress']) pokemon.removeVolatile('gastroacid');
@@ -17212,7 +17213,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				this.add('-activate', source, 'move: Skill Swap', targetAbility, sourceAbility, '[of] ' + target);
 			}
 			this.singleEvent('End', sourceAbility, source.abilityState, source);
+			this.singleEvent('PostEnd', sourceAbility, source.abilityState, source);
 			this.singleEvent('End', targetAbility, target.abilityState, target);
+			this.singleEvent('PostEnd', targetAbility, target.abilityState, target);
 			source.ability = targetAbility.id;
 			target.ability = sourceAbility.id;
 			source.abilityState = {id: this.toID(source.ability), target: source};

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -114,6 +114,9 @@ export class BattleActions {
 				pokemon.copyVolatileFrom(oldActive, switchCopyFlag);
 			}
 			if (newMove) pokemon.lastMove = newMove;
+			side.active[pos] = null!;
+			this.battle.add('-switchout', oldActive, oldActive.getDetails);
+			this.battle.singleEvent('PostEnd', oldActive.getAbility(), oldActive.abilityState, oldActive);
 			oldActive.clearVolatile();
 		}
 		if (oldActive) {

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -102,6 +102,9 @@ export class BattleActions {
 
 			oldActive.illusion = null;
 			this.battle.singleEvent('End', oldActive.getAbility(), oldActive.abilityState, oldActive);
+			side.active[pos] = null!;
+			this.battle.add('-switchout', oldActive, oldActive.getDetails);
+			this.battle.singleEvent('PostEnd', oldActive.getAbility(), oldActive.abilityState, oldActive);
 
 			// if a pokemon is forced out by Whirlwind/etc or Eject Button/Pack, it can't use its chosen move
 			this.battle.queue.cancelAction(oldActive);
@@ -114,9 +117,6 @@ export class BattleActions {
 				pokemon.copyVolatileFrom(oldActive, switchCopyFlag);
 			}
 			if (newMove) pokemon.lastMove = newMove;
-			side.active[pos] = null!;
-			this.battle.add('-switchout', oldActive, oldActive.getDetails);
-			this.battle.singleEvent('PostEnd', oldActive.getAbility(), oldActive.abilityState, oldActive);
 			oldActive.clearVolatile();
 		}
 		if (oldActive) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -553,7 +553,8 @@ export class Battle {
 			this.debug(eventid + ' handler suppressed by Embargo, Klutz or Magic Room');
 			return relayVar;
 		}
-		if (eventid !== 'End' && effect.effectType === 'Ability' && (target instanceof Pokemon) && target.ignoringAbility()) {
+		if (!['End', 'PostEnd'].includes(eventid) && effect.effectType === 'Ability' &&
+			(target instanceof Pokemon) && target.ignoringAbility()) {
 			this.debug(eventid + ' handler suppressed by Gastro Acid or Neutralizing Gas');
 			return relayVar;
 		}
@@ -822,7 +823,7 @@ export class Battle {
 					this.debug(eventid + ' handler suppressed by Embargo, Klutz or Magic Room');
 				}
 				continue;
-			} else if (eventid !== 'End' && effect.effectType === 'Ability' &&
+			} else if (!['End', 'PostEnd'].includes(eventid) && effect.effectType === 'Ability' &&
 					(effectHolder instanceof Pokemon) && effectHolder.ignoringAbility()) {
 				if (eventid !== 'Update') {
 					this.debug(eventid + ' handler suppressed by Gastro Acid or Neutralizing Gas');
@@ -2370,6 +2371,7 @@ export class Battle {
 				if (pokemon.side.totalFainted < 100) pokemon.side.totalFainted++;
 				this.runEvent('Faint', pokemon, faintData.source, faintData.effect);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon);
+				this.singleEvent('PostEnd', pokemon.getAbility(), pokemon.abilityState, pokemon);
 				pokemon.clearVolatile(false);
 				pokemon.fainted = true;
 				pokemon.illusion = null;

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -5,6 +5,7 @@ import {Utils} from '../lib';
 interface AbilityEventMethods {
 	onCheckShow?: (this: Battle, pokemon: Pokemon) => void;
 	onEnd?: (this: Battle, target: Pokemon & Side & Field) => void;
+	onPostEnd?: (this: Battle, target: Pokemon & Side & Field) => void;
 	onPreStart?: (this: Battle, pokemon: Pokemon) => void;
 	onStart?: (this: Battle, target: Pokemon) => void;
 }

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1850,6 +1850,7 @@ export class Pokemon {
 			if (!setAbilityEvent) return setAbilityEvent;
 		}
 		this.battle.singleEvent('End', this.battle.dex.abilities.get(oldAbility), this.abilityState, this, source);
+		this.battle.singleEvent('PostEnd', this.battle.dex.abilities.get(oldAbility), this.abilityState, this, source);
 		if (this.battle.effect && this.battle.effect.effectType === 'Move' && !isFromFormeChange) {
 			this.battle.add('-endability', this, this.battle.dex.abilities.get(oldAbility), '[from] move: ' +
 				this.battle.dex.moves.get(this.battle.effect.id));

--- a/test/sim/abilities/neutralizinggas.js
+++ b/test/sim/abilities/neutralizinggas.js
@@ -256,6 +256,24 @@ describe('Neutralizing Gas', function () {
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 	});
 
+	it(`should wear off after the holder leaves the field`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: "Weezing", ability: 'neutralizinggas', moves: ['sleeptalk']},
+			{species: "Eternatus", moves: ['sleeptalk']},
+			{species: "Bisharp", moves: ['sleeptalk']},
+		], [
+			{species: "Salamence", ability: 'intimidate', moves: ['sleeptalk']},
+			{species: "Diglett", moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('switch bisharp, move sleeptalk', 'auto');
+		const log = battle.getDebugLog();
+		const weezingIndex = log.indexOf('|-unboost|p1a: Weezing|atk|1');
+		const eternatusIndex = log.indexOf('|-unboost|p1b: Eternatus|atk|1');
+		assert(weezingIndex < 0, 'Intimidate should have activated after Weezing left the field');
+		assert(eternatusIndex >= 0, 'Eternats should have been affected by Intimidate');
+	});
+
 	it(`should not prevent Ice Face from blocking damage nor reform Ice Face when leaving the field`, function () {
 		battle = common.createBattle([[
 			{species: 'Eiscue', ability: 'iceface', moves: ['sleeptalk', 'hail']},


### PR DESCRIPTION
@DaWoblefet :
> When Neutralizing Gas leaves the field, the user is still relatively "active" on the field during the pending switchout (e.g. it can have its Attack dropped via Intimidate, its item revealed via Frisk, or its HP restored via Hospitality, even though it's not "on the field" anymore). So it's a bug in the same way that a Pokemon using Volt Switch shouldn't be "on the field" when choosing a target to be replaced.

Added the `PostEnd` event. The client should include the `-switchout` command (purely for aesthetic purposes).

Still missing the Volt Switch part.