### PR TITLE
RoomGame: Check Game Exists Before Notification

### DIFF
--- a/server/room-game.ts
+++ b/server/room-game.ts
@@ -89,7 +89,9 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
 		this.getUser()?.send(data);
 	}
 	sendRoom(data: string) {
-		this.getUser()?.sendTo(this.game.roomid, data);
+		if (this.game) {
+			this.getUser()?.sendTo(this.game.roomid, data);
+		}
 	}
 }
 


### PR DESCRIPTION
Added a null check for `this.game` in the `sendRoom` method within `room-game.ts` to prevent a `TypeError` when attempting to access the `roomid` property of a null game object.

**Changes:**
- Updated `room-game.ts` Line 92 to include a check for `this.game` before sending messages to the room.

**Potential Root Cause:**
The error likely originates from the order of operations in the UNO game logic within uno.ts. Specifically, room notifications may be sent after modifying the game state (e.g., setting this.game to null or removing a player). This sequence can result in some players having a null game reference when notifications are dispatched, leading to the observed TypeError.

**Stack Trace:**
```JS
A chat command crashed: TypeError: Cannot read properties of null (reading 'roomid')
at UNOPlayer.sendRoom (/home/ps/main/server/room-game.ts:92:36)
at UNO.sendToRoom (/home/ps/main/server/chat-plugins/uno.ts:255:12)
at UNO.leaveGame (/home/ps/main/server/chat-plugins/uno.ts:182:9)
at CommandContext.leave [as handler] (/home/ps/main/server/chat-plugins/uno.ts:766:14)
at CommandContext.run (/home/ps/main/server/chat.ts:712:29)
at CommandContext.parse (/home/ps/main/server/chat.ts:610:20)
at Object.parse (/home/ps/main/server/chat.ts:1896:26)
at User.chat (/home/ps/main/server/users.ts:1461:9)
at Object.socketReceive (/home/ps/main/server/users.ts:1739:12)
at Object.onSpawn (/home/ps/main/server/sockets.ts:53:11)
```