### PR TITLE
PRNG: Remove 'TODO: benchmark' comment

### DIFF
--- a/sim/prng.ts
+++ b/sim/prng.ts
@@ -194,8 +194,6 @@ export class SodiumRNG implements RNG {
 		this.seed = buf.slice(0, 32);
 		// reading big-endian
 		return buf.slice(32, 36).reduce((a, b) => a * 256 + b);
-		// alternative, probably slower (TODO: benchmark)
-		// return parseInt(Utils.bufReadHex(buf, 32, 36), 16);
 	}
 }
 


### PR DESCRIPTION
The alternative big-endian read impl is indeed slower. (if you're curious, in a loop it was about 4x slower).

Also, PRNG code currently accounts for very, very little of the execution time for a battle.