### PR TITLE
SSB: Fix null reference error in 'Drifting' ability

### DIFF
--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -1722,7 +1722,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		},
 		onModifyAtkPriority: 5,
 		onModifyAtk(atk, attacker, defender) {
-			if (!defender.activeTurns) {
+			if (defender && !defender.activeTurns) {
 				this.debug('Stakeout boost');
 				return this.chainModify(2);
 			}

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -1729,7 +1729,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		},
 		onModifySpAPriority: 5,
 		onModifySpA(atk, attacker, defender) {
-			if (!defender.activeTurns) {
+			if (defender && !defender.activeTurns) {
 				this.debug('Stakeout boost');
 				return this.chainModify(2);
 			}


### PR DESCRIPTION
Fixed a crash caused by a `TypeError` when the `defender` is `null` in the `Drifting` ability.

**Stack Trace:**
```TS
A battle crashed: TypeError: Cannot read properties of null (reading 'activeTurns')
at Battle.onModifyAtk (/home/ps/main/data/mods/gen9ssb/abilities.ts:1725:18)
at Battle.runEvent (/home/ps/main/sim/battle.ts:845:34)
at Pokemon.getStat (/home/ps/main/sim/pokemon.ts:602:23)
at Battle.onModifyMove (/home/ps/main/data/mods/gen9ssb/moves.ts:6018:16)
at Battle.singleEvent (/home/ps/main/sim/battle.ts:585:25)
at BattleActions.useMoveInner (/home/ps/main/data/mods/gen9ssb/scripts.ts:1308:16)
at BattleActions.useMove (/home/ps/main/sim/battle-actions.ts:386:27)
at BattleActions.runMove (/home/ps/main/data/mods/gen9ssb/scripts.ts:1216:34)
at Battle.runAction (/home/ps/main/data/mods/gen9ssb/scripts.ts:443:17)
at Battle.turnLoop (/home/ps/main/sim/battle.ts:2802:9)
```