### PR TITLE
Booster Energy activates on weather/terrain changes

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -615,7 +615,22 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 30,
 		},
 		onStart() {
+			// don't trigger before hazards
 			this.effectState.started = true;
+		},
+		onWeatherChange(pokemon) {
+			if (pokemon.transformed) return;
+
+			if (pokemon.hasAbility('protosynthesis') && (this.field.isWeather('sunnyday') || pokemon.useItem())) {
+				pokemon.addVolatile('protosynthesis');
+			}
+		},
+		onTerrainChange(pokemon) {
+			if (pokemon.transformed) return;
+
+			if (pokemon.hasAbility('quarkdrive') && (this.field.isTerrain('electricterrain') || pokemon.useItem())) {
+				pokemon.addVolatile('quarkdrive');
+			}
 		},
 		onUpdate(pokemon) {
 			if (!this.effectState.started || pokemon.transformed) return;

--- a/test/sim/items/boosterenergy.js
+++ b/test/sim/items/boosterenergy.js
@@ -24,4 +24,19 @@ describe('Booster Energy', function () {
 		assert.equal(bundle.volatiles['quarkdrive'].bestStat, 'spa',
 			`Iron Bundle's Speed should have been lowered before Booster Energy activated, boosting its SpA instead.`);
 	});
+
+	it(`should activate right after weather changes`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Ninetales-Alola', ability: 'snowwarning', moves: ['sleeptalk']},
+			{species: 'Roaring Moon', item: 'boosterenergy', ability: 'protosynthesis', moves: ['sleeptalk']},
+		], [
+			{species: 'Incineroar', ability: 'intimidate', moves: ['sleeptalk']},
+			{species: 'Torkoal', ability: 'drought', moves: ['sleeptalk']},
+		]]);
+
+		const roaringMoon = battle.p1.active[1];
+		assert(roaringMoon.volatiles['protosynthesis'].fromBooster);
+		assert.equal(roaringMoon.volatiles['protosynthesis'].bestStat, 'atk');
+		assert.equal(battle.field.weather, 'sunnyday');
+	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-10411500

Ninetales-Alola, Roaring Moon, Incineroar and Torkoal switch in:
1. Ninetales' Snow Warning activates.
2. Roaring Moon's Booster Energy activates, boosting its Attack.
3. Incineroar's Intimidate activates.
4. Torkoal's Drought activates.