### PR TITLE
Fix inherit for in-game mods

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -24,6 +24,7 @@ export const Scripts: ModdedBattleScriptsData = {
 	},
 	// BattlePokemon scripts.
 	pokemon: {
+		inherit: true,
 		getStat(statName, unmodified) {
 			// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
 			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
@@ -120,6 +121,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 	},
 	actions: {
+		inherit: true,
 		// This function is the main one when running a move.
 		// It deals with the beforeMove event.
 		// It also deals with how PP reduction works on gen 1.

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -20,6 +20,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		}
 	},
 	actions: {
+		inherit: true,
 		canMegaEvo(pokemon) {
 			return checkMegaForme(pokemon.baseSpecies, 'Mega', this.battle);
 		},

--- a/data/mods/gen8bdsp/scripts.ts
+++ b/data/mods/gen8bdsp/scripts.ts
@@ -2,6 +2,7 @@ export const Scripts: ModdedBattleScriptsData = {
 	gen: 8,
 	inherit: 'gen8',
 	side: {
+		inherit: true,
 		canDynamaxNow() {
 			// Dynamaxing is not in BDSP
 			return false;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -260,6 +260,7 @@ interface ModdedBattleActions {
 }
 
 interface ModdedBattleSide {
+	inherit?: true;
 	canDynamaxNow?: (this: Side) => boolean;
 	chooseSwitch?: (this: Side, slotText?: string) => any;
 	getChoice?: (this: Side) => string;
@@ -328,10 +329,12 @@ interface ModdedBattlePokemon {
 }
 
 interface ModdedBattleQueue extends Partial<BattleQueue> {
+	inherit?: true;
 	resolveAction?: (this: BattleQueue, action: ActionChoice, midTurn?: boolean) => Action[];
 }
 
 interface ModdedField extends Partial<Field> {
+	inherit?: true;
 	suppressingWeather?: (this: Field) => boolean;
 }
 


### PR DESCRIPTION
We were modifying some scripts for `gen4` when we noticed that the changes were not propagating to `gen1`. I don't think it makes sense for in-game mods not to inherit on a method-by-method basis (since they are basically a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph)), and I confirmed that there were no conflicts with `gen1`. Override table:

![image](https://github.com/user-attachments/assets/636bcdfe-64b9-4d3d-a2d4-1b1dfe3d1216)

`gen7letsgo` didn't have any problems because the scripts don't change between `gen9` and `gen7`. However, if a future generation requires overriding some scripts, it will break `gen7letsgo`.