### PR TITLE
Add test and fix gen 7 onSwitchInPriority

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -91,7 +91,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		onSwitchIn(pokemon) {
 			// Air Lock does not activate when Skill Swapped or when Neutralizing Gas leaves the field
 			this.add('-ability', pokemon, 'Air Lock');
-			((this.effect as any).onStart as (p: Pokemon) => void).call(this, pokemon);
+			this.singleEvent('Start', this.effect, this.effectState, pokemon);
 		},
 		onStart(pokemon) {
 			pokemon.abilityState.ending = false; // Clear the ending flag
@@ -538,7 +538,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		onSwitchIn(pokemon) {
 			// Cloud Nine does not activate when Skill Swapped or when Neutralizing Gas leaves the field
 			this.add('-ability', pokemon, 'Cloud Nine');
-			((this.effect as any).onStart as (p: Pokemon) => void).call(this, pokemon);
+			this.singleEvent('Start', this.effect, this.effectState, pokemon);
 		},
 		onStart(pokemon) {
 			pokemon.abilityState.ending = false; // Clear the ending flag
@@ -598,10 +598,10 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	commander: {
 		onAnySwitchInPriority: -2,
 		onAnySwitchIn() {
-			((this.effect as any).onUpdate as (p: Pokemon) => void).call(this, this.effectState.target);
+			this.singleEvent('Update', this.effect, this.effectState, this.effectState.target);
 		},
 		onStart(pokemon) {
-			((this.effect as any).onUpdate as (p: Pokemon) => void).call(this, pokemon);
+			this.singleEvent('Update', this.effect, this.effectState, pokemon);
 		},
 		onUpdate(pokemon) {
 			if (this.gameType !== 'doubles') return;
@@ -3121,7 +3121,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			}
 		},
 		onAnySwitchIn() {
-			((this.effect as any).onStart as (p: Pokemon) => void).call(this, this.effectState.target);
+			this.singleEvent('Start', this.effect, this.effectState, this.effectState.target);
 		},
 		onSetStatus(status, target, source, effect) {
 			if (!['psn', 'tox'].includes(status.id)) return;

--- a/data/items.ts
+++ b/data/items.ts
@@ -616,7 +616,7 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		onSwitchInPriority: -2,
 		onStart(pokemon) {
 			this.effectState.started = true;
-			((this.effect as any).onUpdate as (p: Pokemon) => void).call(this, pokemon);
+			this.singleEvent('Update', this.effect, this.effectState, pokemon);
 		},
 		onUpdate(pokemon) {
 			if (!this.effectState.started || pokemon.transformed) return;
@@ -7193,10 +7193,10 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		},
 		onAnySwitchInPriority: -2,
 		onAnySwitchIn() {
-			((this.effect as any).onUpdate as (p: Pokemon) => void).call(this, this.effectState.target);
+			this.singleEvent('Update', this.effect, this.effectState, this.effectState.target);
 		},
 		onStart(pokemon) {
-			((this.effect as any).onUpdate as (p: Pokemon) => void).call(this, pokemon);
+			this.singleEvent('Update', this.effect, this.effectState, pokemon);
 		},
 		onUpdate(pokemon) {
 			let activate = false;

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -383,7 +383,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		condition: {
 			duration: 2,
-			onSwitchInPriority: 1,
 			onSwitchIn(target) {
 				if (!target.fainted) {
 					target.heal(target.maxhp);
@@ -610,7 +609,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		condition: {
 			duration: 2,
-			onSwitchInPriority: 1,
 			onSwitchIn(target) {
 				if (!target.fainted) {
 					target.heal(target.maxhp);

--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -174,14 +174,12 @@ export class BattleQueue {
 				beforeTurnMove: 5,
 				revivalblessing: 6,
 
-				runSwitch: 101,
-				switch: 103,
-				megaEvo: 104,
-				megaEvoX: 104,
-				megaEvoY: 104,
-				runDynamax: 105,
-				terastallize: 106,
-				priorityChargeMove: 107,
+				runSwitch: 100,
+				switch: 101,
+				megaEvo: 102, megaEvoX: 102, megaEvoY: 102,
+				runDynamax: 103,
+				terastallize: 104,
+				priorityChargeMove: 105,
 
 				shift: 200,
 				// default is 200 (for moves)

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -920,6 +920,7 @@ export class Battle {
 			// https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/page-59#post-8685465
 			const effectTypeOrder: {[k in EffectType]?: number} = {
 				// Z-Move: 1,
+				Move: 2,
 				Condition: 2,
 				// Slot Condition: 3,
 				// Side Condition: 4,
@@ -948,7 +949,7 @@ export class Battle {
 					handler.subOrder = 5;
 				}
 			} else if (handler.effect.effectType === 'Ability') {
-				if (handler.effect.name === 'Poison Touch' || handler.effect.name === 'Perish Body') {
+				if (['Perish Body', 'Poison Touch'].includes(handler.effect.name)) {
 					handler.subOrder = 6;
 				} else if (handler.effect.name === 'Stall') {
 					handler.subOrder = 9;

--- a/test/sim/abilities/magician.js
+++ b/test/sim/abilities/magician.js
@@ -29,4 +29,14 @@ describe('Magician', function () {
 		battle.makeChoices();
 		assert.false.holdsItem(battle.p1.active[0], 'Klefki should not have stolen Weakness Policy.');
 	});
+
+	it(`should not steal an item on the turn Throat Spray activates`, function () {
+		battle = common.createBattle([[
+			{species: 'klefki', ability: 'magician', item: 'throatspray', moves: ['psychicnoise']},
+		], [
+			{species: 'hatterene', item: 'tr69', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.false.holdsItem(battle.p1.active[0], 'Klefki should not have stolen an item.');
+	});
 });


### PR DESCRIPTION
I had this PR directly on the branch before the SwitchIn overhaul merge.

I'm not sure if all the changes are correct, particularly whether the `Move: 2` is necessary. I changed the method calls to `singleEvent` simply because that's how it is done across all the other effects.

Healing Wish and Lunar Dance need their `onSwitchInPriority` updated in the Gen 7 mod to match Gen 9.

I also added a test for the Throat Spray/Magician race condition reported [here](https://www.smogon.com/forums/threads/throat-spray-and-magician.3736298/).