### PR TITLE
Partners in Crime: Ensure allies don't start innate abilities before the ability holder does

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1448,13 +1448,13 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 				if (!pokemon.m.innate && !BAD_ABILITIES.includes(this.toID(ally.ability))) {
 					pokemon.m.innate = 'ability:' + ally.ability;
 					if (!ngas || ally.getAbility().flags['cantsuppress'] || pokemon.hasItem('Ability Shield')) {
-						pokemon.volatiles[pokemon.m.innate] = this.initEffectState({id: pokemon.m.innate, target: pokemon});
+						pokemon.volatiles[pokemon.m.innate] = this.initEffectState({id: pokemon.m.innate, target: pokemon, isPiC: ally});
 					}
 				}
 				if (!ally.m.innate && !BAD_ABILITIES.includes(this.toID(pokemon.ability))) {
 					ally.m.innate = 'ability:' + pokemon.ability;
 					if (!ngas || pokemon.getAbility().flags['cantsuppress'] || ally.hasItem('Ability Shield')) {
-						ally.volatiles[ally.m.innate] = this.initEffectState({id: ally.m.innate, target: ally});
+						ally.volatiles[ally.m.innate] = this.initEffectState({id: ally.m.innate, target: ally, isPiC: pokemon});
 					}
 				}
 			}

--- a/test/sim/misc/partnersincrime.js
+++ b/test/sim/misc/partnersincrime.js
@@ -41,4 +41,22 @@ describe('Partners in Crime', function () {
 		const pincurchin = battle.p1.active[1];
 		assert.statStage(pincurchin, 'atk', -2, 'Pincurchin should have had its innate Intimidate activate, triggering Mirror Armor');
 	});
+
+	it('should not activate ally\'s innates if the partner faints', function () {
+		battle = common.createBattle({formatid: 'gen9partnersincrime'}, [[
+			{species: 'Shedinja', ability: 'download', moves: ['sleeptalk']},
+			{species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk']},
+			{species: 'Chansey', ability: 'healer', moves: ['sleeptalk']},
+		], [
+			{species: 'Stonjourner', ability: 'powerspot', moves: ['stealthrock']},
+			{species: 'Iron Hands', ability: 'quarkdrive', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		const cresselia = battle.p1.active[1];
+		assert.statStage(cresselia, 'spa', 1);
+		battle.makeChoices('switch 3, move sleeptalk', 'auto');
+		battle.makeChoices('switch 3, move sleeptalk', 'auto');
+		console.log(battle.getDebugLog());
+		assert.statStage(cresselia, 'spa', 1, 'Cresselia should not have gained another Download boost after Shedinja fainted');
+	});
 });

--- a/test/sim/misc/partnersincrime.js
+++ b/test/sim/misc/partnersincrime.js
@@ -56,7 +56,6 @@ describe('Partners in Crime', function () {
 		assert.statStage(cresselia, 'spa', 1);
 		battle.makeChoices('switch 3, move sleeptalk', 'auto');
 		battle.makeChoices('switch 3, move sleeptalk', 'auto');
-		console.log(battle.getDebugLog());
 		assert.statStage(cresselia, 'spa', 1, 'Cresselia should not have gained another Download boost after Shedinja fainted');
 	});
 });


### PR DESCRIPTION
Recent switch refactor introduced a mechanic quirk where allies PiC-shared abilities could proc before hazards. This fixes that.

Approved by Partners in Crime tier leader (me) and the council