### PR TITLE
Fix weird Dream World incompatibilities

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2673,7 +2673,9 @@ export class TeamValidator {
 					// DW moves:
 					//   only if that was the source
 					moveSources.add(learned + species.id);
-					moveSources.dreamWorldMoveCount++;
+					// If a DW move can be learned through some means other than DW,
+					// it should not be treated as a DW move
+					if (!moveSources.sourcesBefore) moveSources.dreamWorldMoveCount++;
 				} else if (learned.charAt(1) === 'V' && this.minSourceGen < learnedGen) {
 					// Virtual Console or Let's Go transfer moves:
 					//   only if that was the source

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2617,15 +2617,12 @@ export class TeamValidator {
 					if (learnedGen === dex.gen && learned.charAt(1) !== 'R') {
 						// current-gen level-up, TM or tutor moves:
 						//   always available
-						if (!(learnedGen >= 8 && learned.charAt(1) === 'E') && babyOnly) {
-							if (setSources.isFromPokemonGo && species.evoLevel) {
-								cantLearnReason = `is from a prevo, which is incompatible with its Pokemon GO origin.`;
-								continue;
-							} else {
-								setSources.babyOnly = babyOnly;
-							}
+						if (!(learnedGen >= 8 && learned.charAt(1) === 'E') && babyOnly &&
+							setSources.isFromPokemonGo && species.evoLevel) {
+							cantLearnReason = `is from a prevo, which is incompatible with its Pokemon GO origin.`;
+							continue;
 						}
-						if (!moveSources.moveEvoCarryCount && !setSources.babyOnly) return null;
+						if (!moveSources.moveEvoCarryCount && !babyOnly) return null;
 					}
 					// past-gen level-up, TM, or tutor moves:
 					//   available as long as the source gen was or was before this gen


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-report-validator.3759104/

This is something that should've always been in #10574. Setting setSources.babyOnly becomes useless here because it eventually gets set after validating a move is complete.