### PR TITLE
Fix Receiver's interaction with Soul-Heart

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3308,12 +3308,25 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 211,
 	},
 	powerofalchemy: {
-		onAllyFaint(target) {
-			if (!this.effectState.target.hp) return;
+		onAllyFaint(target, source, effect) {
+			const pokemon: Pokemon = this.effectState.target;
+			if (!pokemon.hp) return;
 			const ability = target.getAbility();
 			if (ability.flags['noreceiver'] || ability.id === 'noability') return;
-			if (this.effectState.target.setAbility(ability)) {
-				this.add('-ability', this.effectState.target, ability, '[from] ability: Power of Alchemy', '[of] ' + target);
+			if (pokemon.setAbility(ability)) {
+				this.add('-ability', pokemon, ability, '[from] ability: Power of Alchemy', '[of] ' + target);
+				const handlers: any[] = [];
+				for (const event of ['AllyFaint', 'AnyFaint']) {
+					const callbackName = 'on' + event;
+					// @ts-ignore - dynamic lookup
+					const callback = ability[`onAlly${eventName}`];
+					if (callback !== undefined) {
+						handlers.push(this.resolvePriority({
+							effect: ability, callback, state: pokemon.abilityState, end: pokemon.clearAbility, effectHolder: pokemon,
+						}, callbackName));
+					}
+				}
+				this.runHandlers(handlers, 'Faint', target, source, effect);
 			}
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1},
@@ -3697,12 +3710,25 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 155,
 	},
 	receiver: {
-		onAllyFaint(target) {
-			if (!this.effectState.target.hp) return;
+		onAllyFaint(target, source, effect) {
+			const pokemon: Pokemon = this.effectState.target;
+			if (!pokemon.hp) return;
 			const ability = target.getAbility();
 			if (ability.flags['noreceiver'] || ability.id === 'noability') return;
-			if (this.effectState.target.setAbility(ability)) {
-				this.add('-ability', this.effectState.target, ability, '[from] ability: Receiver', '[of] ' + target);
+			if (pokemon.setAbility(ability)) {
+				this.add('-ability', pokemon, ability, '[from] ability: Receiver', '[of] ' + target);
+				const handlers: any[] = [];
+				for (const event of ['AllyFaint', 'AnyFaint']) {
+					const callbackName = 'on' + event;
+					// @ts-ignore - dynamic lookup
+					const callback = ability[callbackName];
+					if (callback !== undefined) {
+						handlers.push(this.resolvePriority({
+							effect: ability, callback, state: pokemon.abilityState, end: pokemon.clearAbility, effectHolder: pokemon,
+						}, callbackName));
+					}
+				}
+				this.runHandlers(handlers, 'Faint', target, source, effect);
 			}
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1},

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -750,6 +750,22 @@ export class Battle {
 				}, `on${eventid}`));
 			}
 		}
+		return this.runHandlers(handlers, eventid, target, source, sourceEffect, relayVar, fastExit);
+	}
+
+	runHandlers(
+		handlers: EventListener[], eventid: string, target?: Pokemon | Pokemon[] | Side | Battle | null,
+		source?: string | Pokemon | false | null, sourceEffect?: Effect | null, relayVar?: any, fastExit?: boolean
+	) {
+		if (this.eventDepth >= 8) {
+			// oh fuck
+			this.add('message', 'STACK LIMIT EXCEEDED');
+			this.add('message', 'PLEASE REPORT IN BUG THREAD');
+			this.add('message', 'Event: ' + eventid);
+			this.add('message', 'Parent event: ' + this.event.id);
+			throw new Error("Stack overflow");
+		}
+		if (!target) target = this;
 
 		if (['Invulnerability', 'TryHit', 'DamagingHit', 'EntryHazard'].includes(eventid)) {
 			handlers.sort(Battle.compareLeftToRightOrder);

--- a/test/sim/abilities/receiver.js
+++ b/test/sim/abilities/receiver.js
@@ -10,7 +10,7 @@ describe(`Receiver`, function () {
 		battle.destroy();
 	});
 
-	it.skip(`should gain a boost immediately if taking over a KO boost Ability`, function () {
+	it(`should gain a boost immediately if taking over a KO boost Ability`, function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'whimsicott', ability: 'soulheart', moves: ['memento']},
 			{species: 'passimian', ability: 'receiver', moves: ['sleeptalk']},
@@ -23,7 +23,7 @@ describe(`Receiver`, function () {
 		assert.statStage(passimian, 'spa', 1);
 	});
 
-	it.skip(`should do weird stuff with multiple Soul-Heart and multiple Receiver`, function () {
+	it(`should do weird stuff with multiple Soul-Heart and multiple Receiver`, function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Passimian', ability: 'receiver', moves: ['earthquake']},
 			{species: 'Magearna', ability: 'soulheart', level: 1, moves: ['sleeptalk']},


### PR DESCRIPTION
This solution is currently excessive because (1) Soul-Heart is the only ability affected by an `AllyFaint` or `AnyFaint` event, and (2) we don’t know whether new abilities will activate upon being 'received' in the future.

The advantage is that the `runHandlers` function could prove useful later on.

Let me know what you prefer. For now, we could simply hardcode Soul-Heart or call two separate `singleEvent`'s without considering priorities.