### PR TITLE
Fix incorrect tests

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -955,7 +955,10 @@ export class Battle {
 				}
 			}
 		}
-		if (callbackName.endsWith('SwitchIn') || callbackName.endsWith('RedirectTarget')) {
+		if (callbackName.endsWith('SwitchIn') || callbackName.endsWith('RedirectTarget') ||
+			// quick fix: can't allow all Residual events because of Destiny Bond (and possibly others)
+			(callbackName.endsWith('Residual') && handler.effect.effectType === 'Condition' &&
+			(handler.state?.target instanceof Side || handler.state?.target instanceof Field))) {
 			// If multiple hazards are present on one side, their event handlers all perfectly tie in speed, priority,
 			// and subOrder. They should activate in the order they were created, which is where effectOrder comes in.
 			// This also applies to speed ties for which ability like Lightning Rod redirects moves.

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -955,10 +955,7 @@ export class Battle {
 				}
 			}
 		}
-		if (callbackName.endsWith('SwitchIn') || callbackName.endsWith('RedirectTarget') ||
-			// quick fix: can't allow all Residual events because of Destiny Bond (and possibly others)
-			(callbackName.endsWith('Residual') && handler.effect.effectType === 'Condition' &&
-			(handler.state?.target instanceof Side || handler.state?.target instanceof Field))) {
+		if (callbackName.endsWith('SwitchIn') || callbackName.endsWith('RedirectTarget')) {
 			// If multiple hazards are present on one side, their event handlers all perfectly tie in speed, priority,
 			// and subOrder. They should activate in the order they were created, which is where effectOrder comes in.
 			// This also applies to speed ties for which ability like Lightning Rod redirects moves.

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -358,7 +358,7 @@ describe(`Emergency Exit`, function () {
 		const golisopod = battle.p2.active[0];
 		let maxHP = golisopod.maxhp;
 		let expectedHP = maxHP - Math.floor(maxHP / 2) - Math.floor(maxHP / 8);
-		assert.equal(golisopod.hp, expectedHP, `Golisopod should have only taken Volcalith damage`);
+		assert.equal(golisopod.hp, expectedHP, `Golisopod should have only taken Sea of Fire damage`);
 
 		const amoonguss = battle.p2.active[1];
 		maxHP = amoonguss.maxhp;

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -357,8 +357,8 @@ describe(`Emergency Exit`, function () {
 
 		const golisopod = battle.p2.active[0];
 		let maxHP = golisopod.maxhp;
-		let expectedHP = maxHP - Math.floor(maxHP / 2) - Math.floor(maxHP / 8);
-		assert.equal(golisopod.hp, expectedHP, `Golisopod should have only taken Sea of Fire damage`);
+		let expectedHP = maxHP - Math.floor(maxHP / 2) - Math.floor(maxHP / 6);
+		assert.equal(golisopod.hp, expectedHP, `Golisopod should have only taken Volcalith damage`);
 
 		const amoonguss = battle.p2.active[1];
 		maxHP = amoonguss.maxhp;

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -337,7 +337,7 @@ describe(`Emergency Exit`, function () {
 	});
 
 	it.skip(`should request switchout between residual damage`, function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'Coalossal', level: 1, item: 'Eject Button', moves: ['rockthrow', 'sleeptalk'], gigantamax: true},
 			{species: 'Wynaut', level: 1, moves: ['sleeptalk', 'grasspledge']},
 			{species: 'Wynaut', level: 1, moves: ['sleeptalk', 'firepledge']},
@@ -357,7 +357,7 @@ describe(`Emergency Exit`, function () {
 
 		const golisopod = battle.p2.active[0];
 		let maxHP = golisopod.maxhp;
-		let expectedHP = maxHP - Math.floor(maxHP / 2) - Math.floor(maxHP / 6);
+		let expectedHP = maxHP - Math.floor(maxHP / 2) - Math.floor(maxHP / 8);
 		assert.equal(golisopod.hp, expectedHP, `Golisopod should have only taken Volcalith damage`);
 
 		const amoonguss = battle.p2.active[1];

--- a/test/sim/abilities/soulheart.js
+++ b/test/sim/abilities/soulheart.js
@@ -38,6 +38,7 @@ describe('Soul-Heart', function () {
 			{species: 'Wynaut', ability: 'soulheart', level: 1, moves: ['sleeptalk']},
 			{species: 'Roggenrola', moves: ['sleeptalk']},
 		]]);
+		battle.makeChoices();
 
 		const log = battle.getDebugLog();
 		const soulHeartIndex = log.indexOf('|Soul-Heart');
@@ -52,6 +53,7 @@ describe('Soul-Heart', function () {
 			{species: 'Magearna', ability: 'soulheart', level: 1, moves: ['sleeptalk']},
 			{species: 'Lugia', moves: ['sleeptalk']},
 		]]);
+		battle.makeChoices();
 
 		const log = battle.getDebugLog();
 		const soulHeartIndex = log.indexOf('|Soul-Heart');


### PR DESCRIPTION
In the test `Emergency Exit should request switchout between residual damage`, Volcalith should activate before Sea of Fire. However, `effectOrder` for `Residual` events is not currently implemented. This fix adds `effectOrder` to Slot, Side, and Field conditions for `Residual` events. The test is fixed and unskipped in this PR https://github.com/smogon/pokemon-showdown/pull/10902. That PR applies the same changes to `resolvePriority`.