### PR TITLE
Fix Tera Shell + future moves + mid turn switches

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -4860,7 +4860,11 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	terashell: {
 		// effectiveness implemented in sim/pokemon.ts:Pokemon#runEffectiveness
+		// needs two checks to reset between regular moves and future attacks
 		onAnyBeforeMove() {
+			delete this.effectState.resisted;
+		},
+		onAnyAfterMove() {
 			delete this.effectState.resisted;
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, breakable: 1},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -4860,12 +4860,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	terashell: {
 		// effectiveness implemented in sim/pokemon.ts:Pokemon#runEffectiveness
-		onAnyAfterMove() {
-			this.effectState.resisted = false;
-		},
-		onBeforeTurn() {
-			// reset if hit by Future attack
-			this.effectState.resisted = false;
+		onAnyBeforeMove() {
+			delete this.effectState.resisted;
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, breakable: 1},
 		name: "Tera Shell",


### PR DESCRIPTION
My previous solution https://github.com/smogon/pokemon-showdown/pull/10889 won't work if Terapagos switches out after being hit by Future Sight—for example, if it has an Eject Pack and an Intimidate foe switches in.