### PR TITLE
Gen 9 Battle Factory updates

### DIFF
--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -634,43 +634,6 @@
 				"teraType": ["Normal"],
 				"moves": [["Dragon Ascent"], ["Earthquake"], ["Extreme Speed"], ["Swords Dance"]]
 			}]
-		},
-		"skeledirge": {
-			"weight": 3,
-			"sets": [{
-				"species": "Skeledirge",
-				"weight": 100,
-				"item": ["Heavy-Duty Boots"],
-				"ability": ["Unaware"],
-				"evs": {"hp": 252, "def": 252, "spa": 4},
-				"ivs": {"atk": 0},
-				"nature": ["Bold"],
-				"teraType": ["Fairy"],
-				"moves": [["Torch Song"], ["Hex"], ["Will-O-Wisp"], ["Slack Off"]]
-			}]
-		},
-		"toxapex": {
-			"weight": 2,
-			"sets": [{
-				"species": "Toxapex",
-				"weight": 67,
-				"item": ["Rocky Helmet"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "def": 252, "spd": 4},
-				"ivs": {"atk": 0},
-				"nature": ["Bold"],
-				"teraType": ["Fairy"],
-				"moves": [["Toxic"], ["Recover"], ["Haze"], ["Toxic Spikes", "Ice Beam"]]
-			}, {
-				"species": "Toxapex",
-				"weight": 33,
-				"item": ["Rocky Helmet"],
-				"ability": ["Regenerator"],
-				"evs": {"hp": 252, "def": 252, "spd": 4},
-				"nature": ["Impish"],
-				"teraType": ["Fairy"],
-				"moves": [["Toxic"], ["Recover"], ["Haze"], ["Poison Jab"]]
-			}]
 		}
 	},
 	"OU": {
@@ -3014,20 +2977,6 @@
 				"moves": [["Tail Glow"], ["Scald"], ["Ice Beam"], ["Alluring Voice"]]
 			}]
 		},
-		"polteageist": {
-			"weight": 4,
-			"sets": [{
-				"species": "Polteageist",
-				"weight": 100,
-				"item": ["White Herb"],
-				"ability": ["Cursed Body"],
-				"evs": {"hp": 248, "def": 184, "spe": 76},
-				"ivs": {"atk": 0},
-				"nature": ["Bold"],
-				"teraType": ["Steel"],
-				"moves": [["Shell Smash"], ["Shadow Ball"], ["Stored Power"], ["Strength Sap"]]
-			}]
-		},
 		"revavroom": {
 			"weight": 2,
 			"sets": [{
@@ -3455,22 +3404,35 @@
 			"weight": 9,
 			"sets": [{
 				"species": "Slither Wing",
-				"weight": 50,
+				"weight": 100,
 				"item": ["Heavy-Duty Boots"],
 				"ability": ["Protosynthesis"],
 				"evs": {"hp": 252, "atk": 16, "def": 72, "spe": 168},
 				"nature": ["Adamant"],
 				"teraType": ["Steel"],
 				"moves": [["U-turn"], ["Close Combat"], ["First Impression", "Will-O-Wisp"], ["Morning Sun"]]
+			}]
+		},
+		"mamoswine": {
+			"weight": 9,
+			"sets": [{
+				"species": "Mamoswine",
+				"weight": 75,
+				"item": ["Heavy-Duty Boots", "Never-Melt Ice", "Choice Band"],
+				"ability": ["Thick Fat"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire", "Ice"],
+				"moves": [["Earthquake"], ["Icicle Crash"], ["Knock Off"], ["Ice Shard"]]
 			}, {
-				"species": "Slither Wing",
-				"weight": 50,
-				"item": ["Choice Band"],
-				"ability": ["Protosynthesis"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": ["Adamant"],
-				"teraType": ["Steel", "Bug"],
-				"moves": [["U-turn"], ["Close Combat"], ["First Impression"], ["Earthquake", "Heavy Slam"]]
+				"species": "Mamoswine",
+				"weight": 25,
+				"item": ["Loaded Dice"],
+				"ability": ["Thick Fat"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"teraType": ["Fire", "Ice"],
+				"moves": [["Earthquake"], ["Icicle Spear"], ["Knock Off"], ["Ice Shard"]]
 			}]
 		},
 		"empoleon": {
@@ -4024,23 +3986,13 @@
 			"weight": 5,
 			"sets": [{
 				"species": "Weezing-Galar",
-				"weight": 90,
+				"weight": 100,
 				"item": ["Leftovers", "Heavy-Duty Boots"],
 				"ability": ["Levitate"],
 				"evs": {"hp": 252, "def": 216, "spe": 40},
 				"ivs": {"atk": 0},
 				"nature": ["Bold"],
 				"teraType": ["Steel", "Ghost", "Water"],
-				"moves": [["Strange Steam"], ["Pain Split"], ["Will-O-Wisp"], ["Defog", "Flamethrower", "Taunt"]]
-			}, {
-				"species": "Weezing-Galar",
-				"weight": 10,
-				"item": ["Leftovers", "Heavy-Duty Boots"],
-				"ability": ["Neutralizing Gas"],
-				"evs": {"hp": 252, "def": 216, "spe": 40},
-				"ivs": {"atk": 0},
-				"nature": ["Bold"],
-				"teraType": ["Ghost", "Water"],
 				"moves": [["Strange Steam"], ["Pain Split"], ["Will-O-Wisp"], ["Defog", "Flamethrower", "Taunt"]]
 			}]
 		},
@@ -4177,13 +4129,23 @@
 				"moves": [["Dragon Dance"], ["Waterfall"], ["Earthquake"], ["Ice Fang"]]
 			}, {
 				"species": "Gyarados",
-				"weight": 20,
+				"weight": 10,
 				"item": ["Covert Cloak"],
 				"ability": ["Intimidate", "Moxie"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": ["Jolly"],
 				"teraType": ["Ground"],
 				"moves": [["Dragon Dance"], ["Waterfall"], ["Earthquake"], ["Taunt"]]
+			}, {
+				"species": "Gyarados",
+				"wantsTera": true,
+				"weight": 10,
+				"item": ["Chesto Berry"],
+				"ability": ["Moxie"],
+				"evs": {"hp": 176, "atk": 96, "def": 24, "spe": 212},
+				"nature": ["Adamant"],
+				"teraType": ["Flying"],
+				"moves": [["Dragon Dance"], ["Waterfall"], ["Tera Blast"], ["Rest"]]
 			}]
 		},
 		"mienshao": {


### PR DESCRIPTION
-Removes Skeledirge and Toxapex from Ubers. Koraidon enjoyers rejoice, now it has no defensive counterplay at all whatsoever in Ubers. Requested by temp

-Removes Neutralizing Gas Weezing-Galar and Choice Band Slither Wing from RU. Requested by Slikkles.

-Adds some weird rest chesto Gyarados to beat Galarian Zapdos, and adds Mamoswine at weight 8 to RU. Mamoswine runs ice move / shard / knock / eq with an even roll between loaded dice / never melt ice / boots / choice band. Requested by Slikkles.

-Removes Polteageist from UU.
