### PR TITLE
Make "All Pokemon" rules more convenient

### DIFF
--- a/config/CUSTOM-RULES.md
+++ b/config/CUSTOM-RULES.md
@@ -83,9 +83,19 @@ Syntax is identical to bans, just replace `-` with `+`, like:
 
 More specific always trumps less specific:
 
-`- all Pokemon, + Uber, - Giratina, + Giratina-Altered` - allow only Ubers other than Giratina-Origin
+`- all pokemon, + Uber, - Giratina, + Giratina-Altered` - allow only Ubers other than Giratina-Origin
+
+`- all pokemon, + Giratina-Altered, - Giratina, + Uber` - allow only Ubers other than Giratina-Origin
 
 `- Nonexistent, + Necturna` - don't allow anything from outside the game, except the CAP Necturna
+
+Except `all pokemon`, which removes all bans/unbans of pokemon before it:
+
+`- all pokemon, + Pikachu, + Raichu` - allow Pikachu and Raichu
+
+`+ Pikachu, - all pokemon, + Raichu` - allow only Raichu
+
+(Note that `all pokemon` does not affect obtainability rules. `+ all pokemon` will not allow CAPs or anything like that.)
 
 For equally specific rules, the last rule wins:
 
@@ -128,7 +138,7 @@ Whitelisting
 
 Instead of a banlist, you can have a list of allowed things:
 
-`- all Pokemon, + Charmander, + Squirtle, + Bulbasaur` - allow only Kanto starters
+`- all pokemon, + Charmander, + Squirtle, + Bulbasaur` - allow only Kanto starters
 
 `- all moves, + move: Metronome` - allow only the move Metronome
 

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2695,7 +2695,6 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		team: 'randomHC',
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['CAP', 'LGPE', 'MissingNo.', 'Pikachu-Cosplay', 'Pichu-Spiky-eared', 'Pokestar Smeargle', 'Pokestar UFO', 'Pokestar UFO-2', 'Pokestar Brycen-Man', 'Pokestar MT', 'Pokestar MT2', 'Pokestar Transport', 'Pokestar Giant', 'Pokestar Humanoid', 'Pokestar Monster', 'Pokestar F-00', 'Pokestar F-002', 'Pokestar Spirit', 'Pokestar Black Door', 'Pokestar White Door', 'Pokestar Black Belt', 'Pokestar UFO-PropU2', 'Xerneas-Neutral'],
-		unbanlist: ['All Pokemon'],
 	},
 	{
 		name: "[Gen 9] Doubles Hackmons Cup",

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2613,7 +2613,6 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 		effectType: 'ValidatorRule',
 		name: "Hackmons Forme Legality",
 		desc: `Enforces proper forme legality for hackmons-based metagames.`,
-		unbanlist: ['All Pokemon'],
 		banlist: ['CAP', 'LGPE', 'Future'],
 		onChangeSet(set, format, setHas, teamHas) {
 			let species = this.dex.species.get(set.species);

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -778,6 +778,7 @@ export class DexFormats {
 				continue;
 			}
 
+			// ^ is undocumented because I really don't want it used outside of tests
 			const noWarn = ruleSpec.startsWith('^');
 			if (noWarn) ruleSpec = ruleSpec.slice(1);
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -47,8 +47,11 @@ assert.atMost = function (value, threshold, message) {
 	});
 };
 
-assert.legalTeam = function (team, format, message) {
-	const actual = require('../dist/sim/team-validator').TeamValidator.get(format).validateTeam(team);
+assert.legalTeam = function (team, formatName, message) {
+	require('../dist/sim/dex').Dex.formats.validate(formatName);
+	const format = require('../dist/sim/team-validator').TeamValidator.get(formatName);
+	// console.log(`${formatName}: ${[...format.ruleTable.keys()].join(', ')}`);
+	const actual = format.validateTeam(team);
 	if (actual === null) return;
 	throw new AssertionError({
 		message: message || "Expected team to be valid, but it was rejected because:\n" + actual.join("\n"),

--- a/test/common.js
+++ b/test/common.js
@@ -49,19 +49,19 @@ class TestTools {
 		}
 
 		const gameType = Dex.toID(options.gameType || 'singles');
+		let basicFormat = this.currentMod === 'base' && gameType === 'singles' ? 'Anything Goes' : 'Custom Game';
 		const customRules = [
-			options.pokemon && '-Nonexistent',
-			options.legality && 'Obtainable',
-			!options.preview && '!Team Preview',
+			!options.pokemon && '+Nonexistent',
+			options.legality ? '^Obtainable' : '^!Obtainable',
+			options.preview ? '^Team Preview' : '^!Team Preview',
 			options.sleepClause && 'Sleep Clause Mod',
 			!options.cancel && '!Cancel Mod',
-			options.endlessBattleClause && 'Endless Battle Clause',
+			options.endlessBattleClause ? '^Endless Battle Clause' : '^!Endless Battle Clause',
 			options.inverseMod && 'Inverse Mod',
 			options.overflowStatMod && 'Overflow Stat Mod',
 		].filter(Boolean);
 		const customRulesID = customRules.length ? `@@@${customRules.join(',')}` : ``;
 
-		let basicFormat = this.currentMod === 'base' && gameType === 'singles' ? 'Anything Goes' : 'Custom Game';
 		let modPrefix = this.modPrefix;
 		if (this.currentMod === 'gen1stadium') basicFormat = 'OU';
 		if (gameType === 'multi') {
@@ -76,7 +76,7 @@ class TestTools {
 		let format = formatsCache.get(formatName);
 		if (format) return format;
 
-		format = Dex.formats.get(formatName);
+		format = Dex.formats.get(formatName, true);
 		if (format.effectType !== 'Format') throw new Error(`Unidentified format: ${formatName}`);
 
 		formatsCache.set(formatName, format);

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -100,17 +100,18 @@ describe('value rule support (slow)', () => {
 
 	for (const format of Dex.formats.all()) {
 		if (!format.team) continue;
-		if (Dex.formats.getRuleTable(format).has('adjustleveldown') || Dex.formats.getRuleTable(format).has('adjustlevel')) continue; // already adjusts level
+		it(`${format.name} should support Adjust Level`, () => {
+			const ruleTable = Dex.formats.getRuleTable(format);
+			if (ruleTable.has('adjustleveldown') || ruleTable.has('adjustlevel')) return; // already adjusts level
 
-		for (const level of [1, 99999]) {
-			it(`${format.name} should support Adjust Level = ${level}`, () => {
+			for (const level of [1, 99999]) {
 				testTeam({ format: `${format.id}@@@Adjust Level = ${level}`, rounds: 50 }, team => {
 					for (const set of team) {
 						assert.equal(set.level, level);
 					}
 				});
-			});
-		}
+			}
+		});
 	}
 });
 

--- a/test/sim/team-validator/custom-rules.js
+++ b/test/sim/team-validator/custom-rules.js
@@ -61,6 +61,27 @@ describe("Custom Rules", () => {
 			{ species: 'tyrantrum', ability: 'strongjaw', moves: ['protect'], evs: { hp: 1 } },
 		];
 		assert.false.legalTeam(team, 'gen8nationaldex@@@-allpokemon');
+
+		// whitelist should not override -obtainable
+		team = [
+			{ species: 'pikachu-belle', ability: 'lightningrod', moves: ['thunderbolt'], evs: { hp: 1 } },
+		];
+		assert.false.legalTeam(team, 'gen7ou@@@-allpokemon,+pikachu');
+	});
+
+	it('should allow Pokemon to be force-whitelisted', () => {
+		// allpokemon should override all previous bans/unbans
+		let team = [
+			{ species: 'cloyster', ability: 'skilllink', moves: ['iciclespear'], evs: { hp: 1 } },
+		];
+		assert.legalTeam(team, 'gen5monotype');
+		assert.false.legalTeam(team, 'gen5monotype@@@-allpokemon,+pikachu');
+
+		team = [
+			{ species: 'pikachu', ability: 'lightningrod', moves: ['thunderbolt'], evs: { hp: 1 } },
+		];
+		assert.legalTeam(team, 'gen9ou@@@-allpokemon,+pikachu');
+		assert.false.legalTeam(team, 'gen9ou@@@+pikachu,-allpokemon');
 	});
 
 	it('should support banning/unbanning tag combinations', () => {

--- a/test/sim/team-validator/custom-rules.js
+++ b/test/sim/team-validator/custom-rules.js
@@ -89,6 +89,17 @@ describe("Custom Rules", () => {
 		assert.throws(() => Dex.formats.validate('gen9ou@@@+pikachu,-allpokemon'));
 	});
 
+	it('should warn when rules do nothing', () => {
+		assert.throws(() => Dex.formats.validate('gen9anythinggoes@@@obtainable'));
+		Dex.formats.validate('gen9anythinggoes@@@!obtainable');
+
+		assert.throws(() => Dex.formats.validate('gen9customgame@@@!obtainable'));
+		Dex.formats.validate('gen9customgame@@@obtainable');
+
+		assert.throws(() => Dex.formats.validate('gen9customgame@@@+cloyster,-allpokemon'));
+		Dex.formats.validate('gen9customgame@@@-allpokemon,+cloyster');
+	});
+
 	it('should support banning/unbanning tag combinations', () => {
 		let team = [
 			{ species: 'Crucibelle-Mega', ability: 'Regenerator', moves: ['protect'], evs: { hp: 1 } },

--- a/test/sim/team-validator/custom-rules.js
+++ b/test/sim/team-validator/custom-rules.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('../../assert');
+const Dex = require('../../../dist/sim/dex').Dex;
 
 describe("Custom Rules", () => {
 	it('should support legality tags', () => {
@@ -57,12 +58,13 @@ describe("Custom Rules", () => {
 		];
 		assert.false.legalTeam(team, 'gen7ubers@@@-allpokemon,+giratinaaltered');
 
+		// -allpokemon should override +past
 		team = [
 			{ species: 'tyrantrum', ability: 'strongjaw', moves: ['protect'], evs: { hp: 1 } },
 		];
 		assert.false.legalTeam(team, 'gen8nationaldex@@@-allpokemon');
 
-		// whitelist should not override -obtainable
+		// +pikachu should not override -past
 		team = [
 			{ species: 'pikachu-belle', ability: 'lightningrod', moves: ['thunderbolt'], evs: { hp: 1 } },
 		];
@@ -70,18 +72,21 @@ describe("Custom Rules", () => {
 	});
 
 	it('should allow Pokemon to be force-whitelisted', () => {
-		// allpokemon should override all previous bans/unbans
+		// -allpokemon should override +cloyster before it, but not after it
 		let team = [
 			{ species: 'cloyster', ability: 'skilllink', moves: ['iciclespear'], evs: { hp: 1 } },
 		];
+
 		assert.legalTeam(team, 'gen5monotype');
-		assert.false.legalTeam(team, 'gen5monotype@@@-allpokemon,+pikachu');
+		assert.false.legalTeam(team, 'gen5monotype@@@-allpokemon');
+		assert.throws(() => Dex.formats.validate('gen5monotype@@@+cloyster,-allpokemon'));
+		assert.legalTeam(team, 'gen5monotype@@@-allpokemon,+cloyster');
 
 		team = [
 			{ species: 'pikachu', ability: 'lightningrod', moves: ['thunderbolt'], evs: { hp: 1 } },
 		];
 		assert.legalTeam(team, 'gen9ou@@@-allpokemon,+pikachu');
-		assert.false.legalTeam(team, 'gen9ou@@@+pikachu,-allpokemon');
+		assert.throws(() => Dex.formats.validate('gen9ou@@@+pikachu,-allpokemon'));
 	});
 
 	it('should support banning/unbanning tag combinations', () => {

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -49,7 +49,7 @@ describe('Team Validator', () => {
 		team = [
 			{ species: 'raichualola', ability: 'surgesurfer', moves: ['fakeout'], evs: { hp: 1 } },
 		];
-		assert.legalTeam(team, 'gen9anythinggoes@@@minsourcegen=9');
+		assert.legalTeam(team, 'gen9anythinggoes');
 	});
 
 	it('should prevent Pokemon that don\'t evolve via level-up and evolve from a Pokemon that does evolve via level-up from being underleveled.', () => {


### PR DESCRIPTION
Previously, "+All Pokemon" did nothing except override "-All Pokemon", which switched from a default-allow to default-deny system.

They still do that, but they now also override all previous pokemon bans/unbans. This makes it easier to replace a banlist/whitelist from an inherited ruleset without needing to reverse every previous ban/unban.

This also adds an error if you use `+All Pokemon` in a ruleset where it doesn't do anything.

Fixes #10772