### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -2711,7 +2711,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["brickbreak", "doubleedge", "hiddenpowerflying", "surf", "swordsdance"],
+                "movepool": ["brickbreak", "doubleedge", "hiddenpowerflying", "hiddenpowerghost", "surf", "swordsdance"],
                 "abilities": ["Hyper Cutter"],
                 "preferredTypes": ["Normal"]
             }

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -2198,11 +2198,6 @@
                 "role": "Setup Sweeper",
                 "movepool": ["seedbomb", "suckerpunch", "superpower", "swordsdance"],
                 "abilities": ["Sand Veil"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["focuspunch", "seedbomb", "substitute", "suckerpunch"],
-                "abilities": ["Sand Veil"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -2222,7 +2222,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"],
+                "movepool": ["darkpulse", "gigadrain", "spikes", "suckerpunch", "superpower"],
                 "abilities": ["Water Absorb"]
             },
             {

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -5673,12 +5673,12 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulletpunch", "drainpunch", "gunkshot", "icepunch", "knockoff", "superpower"],
+                "movepool": ["drainpunch", "gunkshot", "icepunch", "knockoff", "superpower"],
                 "abilities": ["Iron Fist"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bulletpunch", "drainpunch", "knockoff", "swordsdance"],
+                "movepool": ["drainpunch", "gunkshot", "knockoff", "swordsdance"],
                 "abilities": ["Iron Fist"]
             }
         ]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -505,8 +505,8 @@
         "level": 81,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["calmmind", "fireblast", "psyshock", "scald", "slackoff"],
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "psyshock", "scald", "slackoff"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -2479,7 +2479,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"],
+                "movepool": ["darkpulse", "gigadrain", "spikes", "suckerpunch", "superpower"],
                 "abilities": ["Water Absorb"]
             },
             {
@@ -5673,9 +5673,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["drainpunch", "gunkshot", "icepunch", "knockoff", "partingshot", "superpower", "swordsdance"],
-                "abilities": ["Iron Fist", "Scrappy"],
-                "preferredTypes": ["Poison"]
+                "movepool": ["bulletpunch", "drainpunch", "gunkshot", "icepunch", "knockoff", "superpower"],
+                "abilities": ["Iron Fist"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["bulletpunch", "drainpunch", "knockoff", "swordsdance"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -6030,7 +6034,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "glare", "outrage", "substitute"],
+                "movepool": ["dragondance", "earthquake", "extremespeed", "glare", "outrage", "stoneedge", "substitute"],
                 "abilities": ["Aura Break"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -646,8 +646,8 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["calmmind", "fireblast", "psyshock", "scald", "slackoff"],
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "psyshock", "scald", "slackoff"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -2714,7 +2714,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "focusblast", "gigadrain", "spikes", "suckerpunch"],
+                "movepool": ["darkpulse", "gigadrain", "spikes", "suckerpunch", "superpower"],
                 "abilities": ["Water Absorb"]
             },
             {
@@ -6121,9 +6121,14 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulletpunch", "drainpunch", "gunkshot", "icepunch", "knockoff", "partingshot", "superpower", "swordsdance"],
-                "abilities": ["Iron Fist", "Scrappy"],
+                "movepool": ["bulletpunch", "drainpunch", "gunkshot", "icepunch", "knockoff", "superpower"],
+                "abilities": ["Iron Fist"],
                 "preferredTypes": ["Poison"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["bulletpunch", "drainpunch", "knockoff", "swordsdance"],
+                "abilities": ["Iron Fist"]
             }
         ]
     },
@@ -6782,7 +6787,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "scald"],
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "scald", "uturn"],
                 "abilities": ["Schooling"]
             }
         ]
@@ -7655,8 +7660,8 @@
                 "abilities": ["Volt Absorb"]
             },
             {
-                "role": "AV Pivot",
-                "movepool": ["closecombat", "grassknot", "hiddenpowerice", "knockoff", "plasmafists", "voltswitch"],
+                "role": "Fast Attacker",
+                "movepool": ["closecombat", "grassknot", "hiddenpowerice", "knockoff", "plasmafists", "taunt", "voltswitch"],
                 "abilities": ["Volt Absorb"],
                 "preferredTypes": ["Fighting"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -2615,8 +2615,14 @@
         "level": 85,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Fire Blast", "Heat Wave", "Knock Off", "Protect", "Thunderbolt"],
+                "role": "Choice Item user",
+                "movepool": ["Fire Blast", "Focus Blast", "Heat Wave", "Scorching Sands", "Thunderbolt"],
+                "abilities": ["Flame Body"],
+                "teraTypes": ["Fire", "Fighting", "Grass"]
+            },
+            {
+                "role": "Bulky Protect",
+                "movepool": ["Fire Blast", "Focus Blast", "Follow Me", "Heat Wave", "Knock Off", "Protect", "Thunderbolt", "Will-O-Wisp"],
                 "abilities": ["Flame Body"],
                 "teraTypes": ["Fire", "Grass"]
             }
@@ -2939,12 +2945,6 @@
         "level": 78,
         "sets": [
             {
-                "role": "Bulky Protect",
-                "movepool": ["Earth Power", "Magma Storm", "Protect", "Will-O-Wisp"],
-                "abilities": ["Flash Fire"],
-                "teraTypes": ["Fairy", "Grass"]
-            },
-            {
                 "role": "Tera Blast user",
                 "movepool": ["Earth Power", "Flash Cannon", "Heat Wave", "Protect", "Tera Blast"],
                 "abilities": ["Flash Fire"],
@@ -2997,7 +2997,7 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Draco Meteor", "Poltergeist", "Shadow Force", "Shadow Sneak", "Will-O-Wisp"],
+                "movepool": ["Draco Meteor", "Poltergeist", "Protect", "Shadow Force", "Shadow Sneak", "Will-O-Wisp"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Dragon", "Fairy", "Ghost", "Poison", "Steel"]
             }
@@ -4907,6 +4907,12 @@
         "level": 74,
         "sets": [
             {
+                "role": "Doubles Setup Sweeper",
+                "movepool": ["Meteor Beam", "Moongeist Beam", "Photon Geyser", "Trick Room"],
+                "abilities": ["Prism Armor"],
+                "teraTypes": ["Dark"]
+            },
+            {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Moongeist Beam", "Photon Geyser", "Protect", "Trick Room"],
                 "abilities": ["Prism Armor"],
@@ -6418,7 +6424,7 @@
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["High Horsepower", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Quark Drive"],
-                "teraTypes": ["Fire", "Ground", "Steel"]
+                "teraTypes": ["Flying", "Ground", "Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -2618,7 +2618,7 @@
                 "role": "Choice Item user",
                 "movepool": ["Fire Blast", "Focus Blast", "Heat Wave", "Scorching Sands", "Thunderbolt"],
                 "abilities": ["Flame Body"],
-                "teraTypes": ["Fire", "Fighting", "Grass"]
+                "teraTypes": ["Fighting", "Fire", "Grass"]
             },
             {
                 "role": "Bulky Protect",

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1749,7 +1749,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Scald", "Substitute", "Thunderbolt"],
                 "abilities": ["Pressure"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Grass", "Water"]
             },
             {
                 "role": "Bulky Attacker",
@@ -2267,7 +2267,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Hydro Pump", "Ice Beam", "Spikes", "Stealth Rock"],
                 "abilities": ["Oblivious"],
-                "teraTypes": ["Poison", "Steel"]
+                "teraTypes": ["Ghost", "Poison", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
@@ -2604,7 +2604,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Knock Off", "Psychic Noise", "Recover", "Spikes", "Stealth Rock", "Teleport"],
+                "movepool": ["Knock Off", "Psychic Noise", "Recover", "Spikes", "Stealth Rock"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Dark", "Fairy", "Steel"]
             }
@@ -3008,13 +3008,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Dire Claw", "Gunk Shot", "Throat Chop", "U-turn"],
+                "movepool": ["Close Combat", "Dire Claw", "Throat Chop", "U-turn"],
                 "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Acrobatics", "Close Combat", "Gunk Shot", "Swords Dance"],
+                "movepool": ["Acrobatics", "Close Combat", "Dire Claw", "Gunk Shot", "Swords Dance"],
                 "abilities": ["Unburden"],
                 "teraTypes": ["Flying"]
             }
@@ -3150,7 +3150,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Knock Off", "Protect", "Toxic", "Toxic Spikes", "U-turn"],
+                "movepool": ["Earthquake", "Knock Off", "Protect", "Toxic", "Toxic Spikes"],
                 "abilities": ["Poison Heal"],
                 "teraTypes": ["Water"]
             }
@@ -3305,7 +3305,7 @@
         "level": 87,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Attacker",
                 "movepool": ["Leaf Storm", "Nasty Plot", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Grass"]
@@ -4939,7 +4939,7 @@
                 "role": "AV Pivot",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Knock Off", "Power Whip", "Scald", "Sludge Bomb"],
                 "abilities": ["Sap Sipper"],
-                "teraTypes": ["Fire", "Grass", "Ground", "Poison", "Water"]
+                "teraTypes": ["Fire", "Grass", "Ground", "Poison", "Steel", "Water"]
             }
         ]
     },
@@ -5525,13 +5525,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Close Combat", "Flame Charge", "Knock Off", "Psychic", "Sunsteel Strike"],
+                "movepool": ["Close Combat", "Earthquake", "Flame Charge", "Knock Off", "Psychic", "Sunsteel Strike"],
                 "abilities": ["Full Metal Body"],
-                "teraTypes": ["Dark", "Fighting"]
+                "teraTypes": ["Dark", "Fighting", "Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Morning Sun", "Psychic Fangs", "Sunsteel Strike"],
+                "movepool": ["Close Combat", "Earthquake", "Flare Blitz", "Knock Off", "Morning Sun", "Psychic Fangs", "Sunsteel Strike"],
                 "abilities": ["Full Metal Body"],
                 "teraTypes": ["Water"]
             }
@@ -6061,7 +6061,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Shadow Ball", "Thunderbolt", "U-turn"],
+                "movepool": ["Draco Meteor", "Fire Blast", "Shadow Ball", "U-turn"],
                 "abilities": ["Infiltrator"],
                 "teraTypes": ["Dragon", "Fire", "Ghost"]
             },

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -2731,6 +2731,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
+                "movepool": ["Bug Buzz", "Icicle Spear", "Rest", "Sleep Talk"],
+                "abilities": ["Ice Scales"],
+                "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Bulky Support",
                 "movepool": ["Bug Buzz", "Icy Wind", "Rest", "Sleep Talk"],
                 "abilities": ["Ice Scales"],
                 "teraTypes": ["Steel", "Water"]
@@ -2951,12 +2957,6 @@
                 "movepool": ["Acid Spray", "Discharge", "Muddy Water", "Thunder Wave", "Volt Switch"],
                 "abilities": ["Static"],
                 "teraTypes": ["Water"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Rain Dance", "Thunder", "Volt Switch", "Weather Ball"],
-                "abilities": ["Static"],
-                "teraTypes": ["Water"]
             }
         ]
     },
@@ -2987,7 +2987,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Crunch", "Earthquake", "Facade", "Swords Dance"],
+                "movepool": ["Close Combat", "Crunch", "Facade", "Swords Dance"],
                 "abilities": ["Quick Feet"],
                 "teraTypes": ["Normal"]
             }


### PR DESCRIPTION
**Gen 9 Random Battle:**
-SubCM Raikou: +Tera Grass
-Hazards Whiscash: +Tera Ghost
-Deo-D: -Teleport
-Sneasler is now always Dire Claw on Choice Band and 50% Dire Claw on Swords Dance (reducing Gunk Shot from 75% to 25% overall)
-Bulky Support Gliscor: -U-turn, to force either Toxic or Toxic Spikes
-Rotom-Mow: Fast Attacker -> Bulky Attacker to generate Leftovers instead of Life Orb
-Goodra: +Tera Steel
-Solgaleo: +Earthquake (both sets), +Tera Ground on Weakness Policy
-Specs Dragapult: -Thunderbolt

**Gen 9 Random Doubles Battle:**
-Magmortar runs two sets: Choice Specs/Scarf and Bulky Protect with Sitrus Berry
-Heatran no longer runs its Magma Storm set
-Giratina-O: +Protect
-Necrozma-Dawn-Wings runs a set 3 with Meteor Beam and Trick Room
-Iron Treads: -Tera Fire, +Tera Flying

**Gen 9 Baby Random Battle**:
-Snom runs a second set with Icicle Spear instead of Icy Wind
-Tadbulb no longer runs Rain Dance
-Teddiursa: -Earthquake, +Close Combat

**Old Gens**:
-In Gen 7, Zeraora now runs Life Orb/Expert Belt instead of Assault Vest on its mixed set, which can also roll Taunt
-In Gen 7, Wishiwashi now runs U-turn and rolls between Scald/Hydro Pump on its Specs set
-In Gens 6-7, Pangoro no longer runs Parting Shot, and it has been set split so that Swords Dance is always Drain Punch and (in Gen 7) Bullet Punch
-In Gens 6-7, Mega Slowbro always runs Calm Mind and no longer runs Fire Blast
-In Gens 5-7, Wallbreaker Cacturne: -Focus Blast, +Superpower
-In Gen 6, Zygarde: +Stone Edge
-In Gen 4, Cacturne no longer runs a SubPunch set since we realised it learns Superpower
-In Gen 3, Wallbreaker (Swords Dance/Choice Band) Crawdaunt can now run HP Ghost