### PR TITLE
Fix Gen 1 Wrap

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -228,6 +228,8 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onOverrideAction(pokemon, target, move) {
 			return this.effectState.move;
 		},
+		// attacker still takes PSN damage, etc
+		onBeforeMovePriority: 0,
 		onBeforeMove(pokemon, target, move) {
 			const foe = pokemon.foes()[0];
 			if (!foe || foe !== this.effectState.trapTarget) {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -196,19 +196,23 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onRestart() {
 			this.effectState.duration = 2;
 		},
-		// onDisableMove(target) {
-		// 	target.maybeDisabled = true;
-		// },
+		onLockMove() {
+			// exact move doesn't matter, no move is ever actually used
+			return 'struggle';
+		},
+		onDisableMove(target) {
+			target.maybeLocked = true;
+		},
 	},
-	// fakepartiallytrapped: {
-	// 	name: 'fakepartiallytrapped',
-	// 	// Wrap ended this turn, but you don't know that
-	// 	// until you try to use an attack
-	// 	duration: 2,
-	// 	onDisableMove(target) {
-	// 		target.maybeDisabled = true;
-	// 	},
-	// },
+	fakepartiallytrapped: {
+		name: 'fakepartiallytrapped',
+		// Wrap ended this turn, but you don't know that
+		// until you try to use an attack
+		duration: 2,
+		onDisableMove(target) {
+			target.maybeLocked = true;
+		},
+	},
 	partialtrappinglock: {
 		name: 'partialtrappinglock',
 		durationCallback() {
@@ -240,18 +244,21 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			this.add('move', pokemon, this.effectState.move, foe, `[from] ${this.effectState.move}`);
 			this.damage(this.effectState.damage, foe, pokemon, move);
 			if (this.effectState.duration === 1) {
-				// if (this.effectState.totalDuration !== 5) {
-				// 	pokemon.addVolatile('fakepartiallytrapped');
-				// 	foe.addVolatile('fakepartiallytrapped');
-				// }
+				if (this.effectState.totalDuration !== 5) {
+					pokemon.addVolatile('fakepartiallytrapped');
+					foe.addVolatile('fakepartiallytrapped');
+				}
 			} else {
 				foe.addVolatile('partiallytrapped', pokemon, move);
 			}
 			return false;
 		},
-		// onDisableMove(pokemon) {
-		// 	pokemon.maybeDisabled = true;
-		// },
+		onLockMove() {
+			return this.effectState.move;
+		},
+		onDisableMove(pokemon) {
+			pokemon.maybeLocked = true;
+		},
 	},
 	mustrecharge: {
 		inherit: true,

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -189,7 +189,9 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		// (i.e. if the attacker switches out.)
 		// the full duration is tracked in partialtrappinglock
 		duration: 2,
-		onBeforeMovePriority: 9,
+		// defender still takes PSN damage, etc
+		// TODO: research exact mechanics
+		onBeforeMovePriority: 0,
 		onBeforeMove() {
 			return false;
 		},

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -196,19 +196,19 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onRestart() {
 			this.effectState.duration = 2;
 		},
-		onDisableMove(target) {
-			target.maybeDisabled = true;
-		},
+		// onDisableMove(target) {
+		// 	target.maybeDisabled = true;
+		// },
 	},
-	fakepartiallytrapped: {
-		name: 'fakepartiallytrapped',
-		// Wrap ended this turn, but you don't know that
-		// until you try to use an attack
-		duration: 2,
-		onDisableMove(target) {
-			target.maybeDisabled = true;
-		},
-	},
+	// fakepartiallytrapped: {
+	// 	name: 'fakepartiallytrapped',
+	// 	// Wrap ended this turn, but you don't know that
+	// 	// until you try to use an attack
+	// 	duration: 2,
+	// 	onDisableMove(target) {
+	// 		target.maybeDisabled = true;
+	// 	},
+	// },
 	partialtrappinglock: {
 		name: 'partialtrappinglock',
 		durationCallback() {
@@ -240,18 +240,18 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			this.add('move', pokemon, this.effectState.move, foe, `[from] ${this.effectState.move}`);
 			this.damage(this.effectState.damage, foe, pokemon, move);
 			if (this.effectState.duration === 1) {
-				if (this.effectState.totalDuration !== 5) {
-					pokemon.addVolatile('fakepartiallytrapped');
-					foe.addVolatile('fakepartiallytrapped');
-				}
+				// if (this.effectState.totalDuration !== 5) {
+				// 	pokemon.addVolatile('fakepartiallytrapped');
+				// 	foe.addVolatile('fakepartiallytrapped');
+				// }
 			} else {
 				foe.addVolatile('partiallytrapped', pokemon, move);
 			}
 			return false;
 		},
-		onDisableMove(pokemon) {
-			pokemon.maybeDisabled = true;
-		},
+		// onDisableMove(pokemon) {
+		// 	pokemon.maybeDisabled = true;
+		// },
 	},
 	mustrecharge: {
 		inherit: true,

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -950,7 +950,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		accuracy: 85,
 		ignoreImmunity: true,
-		volatileStatus: 'partiallytrapped',
 		self: {
 			volatileStatus: 'partialtrappinglock',
 		},
@@ -958,19 +957,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			if (target.volatiles['mustrecharge']) {
 				target.removeVolatile('mustrecharge');
 				this.hint("In Gen 1, partial trapping moves negate the recharge turn of Hyper Beam, even if they miss.", true);
-			}
-		},
-		onHit(target, source) {
-			/**
-			 * The duration of the partially trapped must be always renewed to 2
-			 * so target doesn't move on trapper switch out as happens in gen 1.
-			 * However, this won't happen if there's no switch and the trapper is
-			 * about to end its partial trapping.
-			 **/
-			if (target.volatiles['partiallytrapped']) {
-				if (source.volatiles['partialtrappinglock'] && source.volatiles['partialtrappinglock'].duration! > 1) {
-					target.volatiles['partiallytrapped'].duration = 2;
-				}
 			}
 		},
 	},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -76,7 +76,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	bind: {
 		inherit: true,
 		ignoreImmunity: true,
-		volatileStatus: 'partiallytrapped',
 		self: {
 			volatileStatus: 'partialtrappinglock',
 		},
@@ -84,19 +83,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			if (target.volatiles['mustrecharge']) {
 				target.removeVolatile('mustrecharge');
 				this.hint("In Gen 1, partial trapping moves negate the recharge turn of Hyper Beam, even if they miss.", true);
-			}
-		},
-		onHit(target, source) {
-			/**
-			 * The duration of the partially trapped must be always renewed to 2
-			 * so target doesn't move on trapper switch out as happens in gen 1.
-			 * However, this won't happen if there's no switch and the trapper is
-			 * about to end its partial trapping.
-			 **/
-			if (target.volatiles['partiallytrapped']) {
-				if (source.volatiles['partialtrappinglock'] && source.volatiles['partialtrappinglock'].duration! > 1) {
-					target.volatiles['partiallytrapped'].duration = 2;
-				}
 			}
 		},
 	},
@@ -137,7 +123,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		accuracy: 75,
 		pp: 10,
-		volatileStatus: 'partiallytrapped',
 		self: {
 			volatileStatus: 'partialtrappinglock',
 		},
@@ -145,19 +130,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			if (target.volatiles['mustrecharge']) {
 				target.removeVolatile('mustrecharge');
 				this.hint("In Gen 1, partial trapping moves negate the recharge turn of Hyper Beam, even if they miss.", true);
-			}
-		},
-		onHit(target, source) {
-			/**
-			 * The duration of the partially trapped must be always renewed to 2
-			 * so target doesn't move on trapper switch out as happens in gen 1.
-			 * However, this won't happen if there's no switch and the trapper is
-			 * about to end its partial trapping.
-			 **/
-			if (target.volatiles['partiallytrapped']) {
-				if (source.volatiles['partialtrappinglock'] && source.volatiles['partialtrappinglock'].duration! > 1) {
-					target.volatiles['partiallytrapped'].duration = 2;
-				}
 			}
 		},
 	},
@@ -320,7 +292,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		accuracy: 70,
 		basePower: 15,
-		volatileStatus: 'partiallytrapped',
 		self: {
 			volatileStatus: 'partialtrappinglock',
 		},
@@ -328,19 +299,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			if (target.volatiles['mustrecharge']) {
 				target.removeVolatile('mustrecharge');
 				this.hint("In Gen 1, partial trapping moves negate the recharge turn of Hyper Beam, even if they miss.", true);
-			}
-		},
-		onHit(target, source) {
-			/**
-			 * The duration of the partially trapped must be always renewed to 2
-			 * so target doesn't move on trapper switch out as happens in gen 1.
-			 * However, this won't happen if there's no switch and the trapper is
-			 * about to end its partial trapping.
-			 **/
-			if (target.volatiles['partiallytrapped']) {
-				if (source.volatiles['partialtrappinglock'] && source.volatiles['partialtrappinglock'].duration! > 1) {
-					target.volatiles['partiallytrapped'].duration = 2;
-				}
 			}
 		},
 	},

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -1947,7 +1947,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			if (this.requestState === 'move') {
 				if (pokemon.trapped) {
-					const includeRequest = this.updateRequestForPokemon(pokemon, req => {
+					return this.emitChoiceError(`Can't switch: The active Pokémon is trapped`, { pokemon, update: req => {
 						let updated = false;
 						if (req.maybeTrapped) {
 							delete req.maybeTrapped;
@@ -1958,10 +1958,7 @@ export const Scripts: ModdedBattleScriptsData = {
 							updated = true;
 						}
 						return updated;
-					});
-					const status = this.emitChoiceError(`Can't switch: The active Pokémon is trapped`, includeRequest);
-					if (includeRequest) this.emitRequest(this.activeRequest!);
-					return status;
+					} });
 				} else if (pokemon.maybeTrapped) {
 					this.choice.cantUndo = this.choice.cantUndo || pokemon.isLastActive();
 				}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1066,7 +1066,7 @@ export class Pokemon {
 
 		if (isLastActive) {
 			if (this.maybeDisabled) {
-				data.maybeDisabled = true;
+				data.maybeDisabled = this.maybeDisabled;
 			}
 			if (canSwitchIn) {
 				if (this.trapped === true) {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -127,6 +127,8 @@ export class Pokemon {
 	trapped: boolean | "hidden";
 	maybeTrapped: boolean;
 	maybeDisabled: boolean;
+	/** true = locked,  */
+	maybeLocked: boolean | null;
 
 	illusion: Pokemon | null;
 	transformed: boolean;
@@ -418,6 +420,7 @@ export class Pokemon {
 		this.trapped = false;
 		this.maybeTrapped = false;
 		this.maybeDisabled = false;
+		this.maybeLocked = false;
 
 		this.illusion = null;
 		this.transformed = false;
@@ -1048,7 +1051,7 @@ export class Pokemon {
 	}
 
 	getMoveRequestData() {
-		let lockedMove = this.getLockedMove();
+		let lockedMove = this.maybeLocked ? null : this.getLockedMove();
 
 		// Information should be restricted for the last active Pokémon
 		const isLastActive = this.isLastActive();
@@ -1067,6 +1070,9 @@ export class Pokemon {
 		if (isLastActive) {
 			if (this.maybeDisabled) {
 				data.maybeDisabled = this.maybeDisabled;
+			}
+			if (this.maybeLocked) {
+				data.maybeLocked = this.maybeLocked;
 			}
 			if (canSwitchIn) {
 				if (this.trapped === true) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -643,9 +643,9 @@ export class Side {
 				targetLoc: lockedMoveTargetLoc,
 				moveid: lockedMoveID,
 			});
-			if (moveid === 'fight') this.choice.cantUndo = true;
+			if (moveid === 'testfight') this.choice.cantUndo = true;
 			return true;
-		} else if (moveid === 'fight') {
+		} else if (moveid === 'testfight') {
 			// test fight button
 			if (!pokemon.maybeLocked) {
 				return this.emitChoiceError(`Can't move: ${pokemon.name}'s Fight button is known to be safe`);
@@ -1054,6 +1054,10 @@ export class Side {
 		for (const choiceString of choiceStrings) {
 			let [choiceType, data] = Utils.splitFirst(choiceString.trim(), ' ');
 			data = data.trim();
+			if (choiceType === 'testfight') {
+				choiceType = 'move';
+				data = 'testfight';
+			}
 
 			switch (choiceType) {
 			case 'move':

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -575,7 +575,11 @@ export class Side {
 				}
 			}
 			if (!targetType) {
-				return this.emitChoiceError(`Can't move: Your ${pokemon.name} doesn't have a move matching ${moveid}`);
+				if (moveid === 'testfight') {
+					targetType = 'normal';
+				} else {
+					return this.emitChoiceError(`Can't move: Your ${pokemon.name} doesn't have a move matching ${moveid}`);
+				}
 			}
 		}
 


### PR DESCRIPTION
Supersedes #10924

There's no need for complicated Fight button mechanics, we have to deal with the same thing in newer generations and `maybeDisabled` fully covers it.

Changes:
- `maybeDisabled` (move choices can't be cancelled) is in effect for all turns except the last of a 5-turn Wrap
  - Wrap no longer leaks when it's ended
- Wrap no longer misses or consumes PP on turns after the first
- Wrap does the same damage on all turns as the first
- If the foe switches, Wrap ends but the attacker is forced into using Wrap again (with miss chance and deducting PP)
- The text shown is now accurate (no "move failed" and no "pokemon used Wrap" on subsequent Wrap turns)