### PR TITLE
Implement searching for tiers by inequality to /ds

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -628,15 +628,15 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		cap: 'CAP', caplc: 'CAP LC', capnfe: 'CAP NFE',
 	});
 	const singlesTiersValues: { [k: string]: number } = Object.assign(Object.create(null), {
-		'AG': 14, 'Uber': 13,
-		'OU': 12, 'CAP': 12,
-		'UUBL': 11, 'UU': 10,
-		'RUBL': 9, 'RU': 8,
-		'NUBL': 7, 'NU': 6,
-		'PUBL': 5, 'PU': 4,
-		'ZUBL': 3, 'ZU': 2,
-		'NFE': 1, 'CAP NFE': 1,
-		'LC': 0, 'CAP LC': 0,
+		AG: 14, Uber: 13,
+		OU: 12, CAP: 12,
+		UUBL: 11, UU: 10,
+		RUBL: 9, RU: 8,
+		NUBL: 7, NU: 6,
+		PUBL: 5, PU: 4,
+		ZUBL: 3, ZU: 2,
+		NFE: 1, 'CAP NFE': 1,
+		LC: 0, 'CAP LC': 0,
 	});
 	const allDoublesTiers: { [k: string]: TierTypes.Singles | TierTypes.Other } = Object.assign(Object.create(null), {
 		doublesubers: 'DUber', doublesuber: 'DUber', duber: 'DUber', dubers: 'DUber',

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -689,11 +689,14 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	let fullyEvolvedSearch = null;
 	let singleTypeSearch = null;
 	let randomOutput = 0;
+	let tierInequalitySearch = false;
 	const validParameter = (cat: string, param: string, isNotSearch: boolean, input: string) => {
 		const uniqueTraits = ['colors', 'gens'];
+		const tierTraits = ['tiers', 'doubles tiers'];
 		for (const group of searches) {
 			const g = group[cat as keyof DexOrGroup];
 			if (g === undefined) continue;
+			if (tierTraits.includes(cat) && tierInequalitySearch) continue;
 			if (typeof g !== 'boolean' && g[param] === undefined) {
 				if (uniqueTraits.includes(cat)) {
 					for (const currentParam in g) {
@@ -726,14 +729,16 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 				target = target.substr(1);
 			}
 
-			let tierInequality: boolean[] = [];
+			let isTierInequalityParam = false;
+			const tierInequality: boolean[] = [];
 			if (target.startsWith('tier')) {
 				if (isNotSearch) return { error: "You cannot use the negation symbol '!' with inequality tier searches." };
 				target = target.substr(4).trim();
 				if (!target.startsWith('>') && !target.startsWith('<')) {
 					return { error: "You must use an inequality operator '>' or '<' with performing tier inequality searchs." };
 				}
-				tierInequality = [];
+				isTierInequalityParam = true;
+				tierInequalitySearch = true;
 				tierInequality[0] = target.startsWith('>');
 				target = target.substr(1).trim();
 				tierInequality[1] = target.startsWith('=');
@@ -757,7 +762,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 				const invalid = validParameter("tiers", target, isNotSearch, target);
 				if (invalid) return { error: invalid };
 				tierSearch = tierSearch || !isNotSearch;
-				if (tierInequality[0] != null) {
+				if (isTierInequalityParam) {
 					const tierValue = singlesTiersValues[target];
 					const entires = Object.entries(singlesTiersValues);
 					for (const [key, value] of entires) {
@@ -779,7 +784,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 				const invalid = validParameter("doubles tiers", target, isNotSearch, target);
 				if (invalid) return { error: invalid };
 				tierSearch = tierSearch || !isNotSearch;
-				if (tierInequality[0] != null) {
+				if (isTierInequalityParam) {
 					const tierValue = doublesTiersValues[target];
 					const entires = Object.entries(doublesTiersValues);
 					for (const [key, value] of entires) {

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -628,8 +628,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		cap: 'CAP', caplc: 'CAP LC', capnfe: 'CAP NFE',
 	});
 	const singlesTiersValues: { [k: string]: number } = Object.assign(Object.create(null), {
-		'AG': 15, 'Uber': 14,
-		'OU': 13, 'CAP': 12,
+		'AG': 14, 'Uber': 13,
+		'OU': 12, 'CAP': 12,
 		'UUBL': 11, 'UU': 10,
 		'RUBL': 9, 'RU': 8,
 		'NUBL': 7, 'NU': 6,

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -646,8 +646,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		doublesnu: '(DUU)', dnu: '(DUU)',
 	});
 	const doublesTiersValues: { [k: string]: number } = Object.assign(Object.create(null), {
-		'DUber': 4, 'DOU': 3,
-		'DBL': 2, 'DUU': 1,
+		DUber: 4, DOU: 3,
+		DBL: 2, DUU: 1,
 		'(DUU)': 0,
 	});
 	const allTypes = Object.create(null);


### PR DESCRIPTION
Implemented the duplicate suggestions: https://www.smogon.com/forums/threads/allow-ds-to-search-for-pokemon-above-below-a-tier.3675711/ and https://www.smogon.com/forums/threads/allow-use-of-for-tiers-in-dexsearch.3679995/

A user can use `/ds tier > ou` to see all mons in singles formats higher than OU. Similarly a user can use `/ds tier <= duu` to see all mons in doubles formats DUU or lower. 

CAP is treated as part of the singles tiering structure as equivalent to OU, CAP NFE to NFE, and CAP LC to LC. CAP mons will be excluded from results unless a CAP tier is specified in the inequality such as in `/ds tier <= capnfe` which will show all mons available in CAP NFE or lower (CAP NFE, NFE, CAP LC, and LC). 