### PR TITLE
Fix freeze lingering after fainting from  pursuit on switch out

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2742,7 +2742,6 @@ export class Battle {
 				// a pokemon fainted from Pursuit before it could switch
 				if (this.gen <= 4) {
 					// in gen 2-4, the switch still happens
-					action.pokemon.status = '';
 					this.hint("Previously chosen switches continue in Gen 2-4 after a Pursuit target faints.");
 					action.priority = -101;
 					this.queue.unshift(action);

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2742,6 +2742,7 @@ export class Battle {
 				// a pokemon fainted from Pursuit before it could switch
 				if (this.gen <= 4) {
 					// in gen 2-4, the switch still happens
+					action.pokemon.status = '';
 					this.hint("Previously chosen switches continue in Gen 2-4 after a Pursuit target faints.");
 					action.priority = -101;
 					this.queue.unshift(action);

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1526,6 +1526,7 @@ export class Pokemon {
 		if (this.fainted || this.faintQueued) return 0;
 		const d = this.hp;
 		this.hp = 0;
+		this.status = '';
 		this.switchFlag = false;
 		this.faintQueued = true;
 		this.battle.faintQueue.push({

--- a/test/sim/misc/statuses.js
+++ b/test/sim/misc/statuses.js
@@ -218,6 +218,31 @@ describe('Freeze', () => {
 		assert.equal(battle.p1.active[0].species.name, 'Shaymin-Sky');
 	});
 
+	it('should not linger after fainting from switch-out', () => {
+		battle = common.createBattle({
+			formatid: 'gen4customgame@@@freezeclausemod',
+		}, [[
+			{ species: 'weavile', moves: ['icebeam', 'pursuit'] },
+		], [
+			{ species: 'gastly', moves: ['splash'] },
+			{ species: 'seaking', moves: ['splash'] },
+		]]);
+		battle.onEvent('ModifyMove', battle.format, function (move) {
+			if (move.secondaries) {
+				this.debug('Freeze test: Guaranteeing secondary');
+				for (const secondary of move.secondaries) {
+					secondary.chance = 100;
+				}
+			}
+		});
+		battle.makeChoices('move icebeam', 'auto');
+		battle.makeChoices('move pursuit', 'switch seaking');
+		// battle.makeChoices('', 'switch seaking'); // in modern gens
+		battle.makeChoices('move icebeam', 'auto');
+		assert.equal(battle.p2.active[0].status, 'frz');
+		assert.equal(battle.p2.active[0].species.name, 'Seaking');
+	});
+
 	it(`should not be possible to burn a frozen target when using a move that thaws that target`, () => {
 		battle = common.createBattle([[
 			{ species: 'wynaut', ability: 'serenegrace', item: 'widelens', moves: ['sleeptalk', 'sacredfire'] },


### PR DESCRIPTION
In Gens 2-4, if a pokemon with the freeze condition faints when switching out from pursuit, the status condition remains and freeze clause is triggered by subsequent freezes.

https://www.smogon.com/forums/threads/pursuit-and-freeze-clause-mod.3759630/

I added a simple clearing of a pokemon's status condition upon fainting from pursuit when switching out. Namely, `action.pokemon.status = '';`. The `clearStatus` and `setStatus` methods were not used due to their requirement of a pokemon having HP, which was not applicable in this case.