### PR TITLE
Allow Users to Broadcast !avatar

### DIFF
--- a/server/chat-commands/avatars.tsx
+++ b/server/chat-commands/avatars.tsx
@@ -689,7 +689,6 @@ export const commands: Chat.ChatCommands = {
 		this.runBroadcast();
 		if (!this.broadcasting) {
 			user.avatar = avatar;
-
 			if (user.id in customAvatars && !avatar.endsWith('xmas')) {
 				Avatars.setDefault(user.id, avatar);
 			}

--- a/server/chat-commands/avatars.tsx
+++ b/server/chat-commands/avatars.tsx
@@ -676,9 +676,7 @@ for (const avatar of OFFICIAL_AVATARS_SELENA) OFFICIAL_AVATARS.add(avatar);
 
 export const commands: Chat.ChatCommands = {
 	avatar(target, room, user) {
-		const shouldBroadcast = this.shouldBroadcast();
-
-		if (!target && !shouldBroadcast) return this.parse(`${this.cmdToken}avatars`);
+		if (!target) return this.parse(`${this.cmdToken}avatars`);
 
 		const [maybeAvatar, silent] = !target ? [user.avatar.toString(), false] : target.split(',');
 		const avatar = Avatars.userCanUse(user, maybeAvatar);
@@ -699,16 +697,9 @@ export const commands: Chat.ChatCommands = {
 		}
 		if (!silent || this.broadcasting) {
 			if (!this.broadcasting) {
-				this.sendReply(
-					`${this.tr`Avatar changed to:`}\n` +
-					Chat.html`|raw|${Avatars.img(avatar)}`
-				);
-			} else {
-				this.sendReply(
-					`${this.tr`${avatar}:`}\n` +
-					Chat.html`|raw|${Avatars.img(avatar)}`
-				);
+				this.sendReply(`${this.tr`Avatar changed to:`}`);
 			}
+			this.sendReply(Chat.html`|raw|${Avatars.img(avatar)}`);
 			if (OFFICIAL_AVATARS_BELIOT419.has(avatar)) {
 				this.sendReply(`|raw|(${this.tr`Artist: `}<a href="https://www.deviantart.com/beliot419">Beliot419</a>)`);
 			}

--- a/server/chat-commands/avatars.tsx
+++ b/server/chat-commands/avatars.tsx
@@ -678,7 +678,7 @@ export const commands: Chat.ChatCommands = {
 	avatar(target, room, user) {
 		if (!target) return this.parse(`${this.cmdToken}avatars`);
 
-		const [maybeAvatar, silent] = !target ? [user.avatar.toString(), false] : target.split(',');
+		const [maybeAvatar, silent] = target.split(',');
 		const avatar = Avatars.userCanUse(user, maybeAvatar);
 
 		if (!avatar) {

--- a/server/chat-commands/avatars.tsx
+++ b/server/chat-commands/avatars.tsx
@@ -677,7 +677,6 @@ for (const avatar of OFFICIAL_AVATARS_SELENA) OFFICIAL_AVATARS.add(avatar);
 export const commands: Chat.ChatCommands = {
 	avatar(target, room, user) {
 		if (!target) return this.parse(`${this.cmdToken}avatars`);
-
 		const [maybeAvatar, silent] = target.split(',');
 		const avatar = Avatars.userCanUse(user, maybeAvatar);
 


### PR DESCRIPTION
Depends on https://github.com/smogon/pokemon-showdown-client/pull/2335

Server end of implementing the suggestion: https://www.smogon.com/forums/threads/avatar-avatar-to-be-broadcastable-showing-the-avatar-sprite-and-the-credit.3759095/

Allows users to broadcast with the avatar command with '!' which will display the corresponding avatar in the chat with credits if applicable. This will not set the user's avatar, only using the command with the '/' prefix will do such.