### PR TITLE
Movesearch Trap

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2115,9 +2115,9 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 					// This is slightly hacky, but none of the proper trapping moves in moves.ts mechanically use 'trapped' as
 					// a volatilestatus despite it being one.
 					(('trapped' === searchStatus) &&
-						(move.onHit && /\b(?:target|pokemon)\.addVolatile\("trapped",/.test(move.onHit.toString())) ||
-						(move.secondary?.onHit && /\b(?:target|pokemon)\.addVolatile\("trapped",/.test(move.secondary.onHit.toString())) ||
-						(move.self?.onHit && /\b(?:target|pokemon)\.addVolatile\("trapped",/.test(move.self.onHit.toString())))
+						((move.onHit && /\b(?:target|pokemon)\.addVolatile\("trapped",/.test(move.onHit.toString())) ||
+							(move.secondary?.onHit && /\b(?:target|pokemon)\.addVolatile\("trapped",/.test(move.secondary.onHit.toString())) ||
+							(move.self?.onHit && /\b(?:target|pokemon)\.addVolatile\("trapped",/.test(move.self.onHit.toString()))))
 				);
 				if (searchStatus === 'partiallytrapped') {
 					canStatus = canStatus || moveid === 'gmaxcentiferno' || moveid === 'gmaxsandblast';

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1851,10 +1851,9 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 				orGroup.volatileStatus[target] = !isNotSearch;
 				continue;
 			} else if (target === 'trap' || target === 'trapping') {
-				orGroup.volatileStatus['partiallytrapped'] =
-					orGroup.volatileStatus['partiallytrapped'] ? orGroup.volatileStatus['partiallytrapped'] : !isNotSearch;
-				orGroup.volatileStatus['trapped'] =
-					orGroup.volatileStatus['trapped'] ? orGroup.volatileStatus['trapped'] : !isNotSearch;
+				for (const trappingType of ['partiallytrapped', 'trapped']) {
+					if (!orGroup.volatileStatus[trappingType]) orGroup.volatileStatus[trappingType] = !isNotSearch;
+				}
 				continue;
 			}
 
@@ -2101,7 +2100,6 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 				if (searchStatus === 'brn' || searchStatus === 'frz' || searchStatus === 'par') {
 					canStatus = canStatus || moveid === 'triattack';
 				}
-
 				if (canStatus === alts.status[searchStatus]) {
 					matched = true;
 					break;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2029,7 +2029,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 					onHitString = move.self.onHit.toString();
 				}
 				const trapping = move.volatileStatus === 'partiallytrapped' || move.condition?.onTrapPokemon ||
-					(onHitString && /\b(?:target|pokemon)\.addVolatile\("(partially){0,1}trapped",/.test(onHitString));
+					(onHitString && /\b(?:target|pokemon)\.addVolatile\("(?:partially){0,1}trapped",/.test(onHitString));
 				if (trapping && alts.other.trapping || !(trapping || alts.other.trapping)) matched = true;
 			}
 			if (matched) continue;


### PR DESCRIPTION
Implements the suggestion: https://www.smogon.com/forums/threads/ms-trap.3674078/

Adds `trapped` as a volatilestatus option which shows all of the non-`partiallytrapped` trapping moves which users would expect to find. The parameter `trap` or `trapping` will join the two together to show all moves which inflict either `trapped` or `partiallytrapped`. This also fixes G-Max Sandblast and G-Max Centiferno not showing up alongside the other `partiallytrapped` moves.