### PR TITLE
Gens 1-2: Give Paralysis a more accurate full paralysis chance

### DIFF
--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -18,7 +18,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		inherit: true,
 		onBeforeMovePriority: 2,
 		onBeforeMove(pokemon) {
-			if (this.randomChance(1, 4)) {
+			if (this.randomChance(63, 256)) {
 				this.add('cant', pokemon, 'par');
 				return false;
 			}


### PR DESCRIPTION
Apparently it is actually 63/256 in gens 1 and 2

A major source for gen 1 that was useful for finding it was https://datacrystal.tcrf.net/wiki/Pok%C3%A9mon_Stadium_(International)/ROM_map#Full_Paralysis_check (it just says 63/256)

For Gen 2 it was https://github.com/pret/pokecrystal/blob/3e2121b21a6c511aecdf5733fc95d3d9c689e6c8/macros/data.asm#L23

Floor(25 * 255 / 100) = 63