### PR TITLE
Fix cc2v2 oger tera

### DIFF
--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1993,8 +1993,9 @@ export class RandomTeams {
 			};
 			if (this.gen === 9) {
 				// Tera type
-				if (species.forceTeraType) {
-					set.teraType = species.forceTeraType;
+				if (species.forceTeraType) set.teraType = species.forceTeraType;
+				if (this.forceTeraType) {
+					set.teraType = this.forceTeraType;
 				} else {
 					set.teraType = this.sample(this.dex.types.names());
 				}


### PR DESCRIPTION
Addressing: https://www.smogon.com/forums/threads/ogerpon-terapagos-tera-types-in-challenge-cup.3757204/

In `data/random-battles/gen9/teams.ts`, the check for a forced tera type is incorrectly done against the `RandomTeams` class instead of the `Species` class for CC2v2. See the below two images for an example:
 
<img width="479" alt="ogerpon1" src="https://github.com/user-attachments/assets/101ee6cb-84e2-48c2-98c4-4822c6f9f10f" />
<img width="481" alt="ogerpon2" src="https://github.com/user-attachments/assets/ffb26fcc-fe3a-4c54-9d53-594d1f88a688" />

After the changes:

<img width="479" alt="oger1" src="https://github.com/user-attachments/assets/44a66f5d-9b7b-4086-b5c7-411767a4ac01" />
<img width="480" alt="oger2" src="https://github.com/user-attachments/assets/b17f6c22-b7ba-4575-81fc-033ef1b77606" />
<img width="481" alt="oger3" src="https://github.com/user-attachments/assets/262debc4-6c39-4505-9a18-628430edf696" />
The example Waterpons may be illegal due to how the pokemon generation was hardcoded.
Unit tests may need to be added.