### PR TITLE
/ds: Add rule functionality

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -669,6 +669,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 	const mod = Dex.mod(usedMod || 'base');
 	const rule = Dex.data.Rulesets[usedRule];
+	const convergenceSearch = usedRule === 'convergencelegality';
 	const allTiers: { [k: string]: TierTypes.Singles | TierTypes.Other } = Object.assign(Object.create(null), {
 		anythinggoes: 'AG', ag: 'AG',
 		uber: 'Uber', ubers: 'Uber', ou: 'OU',
@@ -1194,8 +1195,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	// These only ever get accessed if there are moves to filter by.
 	let validator;
 	let pokemonSource;
-	if (Object.values(searches).some(search => Object.keys(search.moves).length !== 0) ||
-		usedRule === 'convergencelegality') {
+	if (Object.values(searches).some(search => Object.keys(search.moves).length !== 0) || convergenceSearch) {
 		validator = prepareDexsearchValidator(usedMod, rule, nationalSearch);
 	}
 
@@ -1354,8 +1354,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			for (const ability in alts.abilities) {
 				if (Object.values(dex[mon].abilities).includes(ability) === alts.abilities[ability] ||
-					(usedRule === 'convergencelegality' && validator && !rule?.onValidateSet?.call( // Convergence runs O(n^2)
-						validator, { name: dex[mon].name, species: dex[mon].id, item: '', ability } as PokemonSet, validator.format, {}, {}))) {
+					(convergenceSearch && validator && !rule.onValidateSet?.call(validator, { name: dex[mon].name,
+						species: dex[mon].id, item: '', ability } as PokemonSet, validator.format, {}, {}) === alts.abilities[ability])) {
 					matched = true;
 					break;
 				}
@@ -1407,8 +1407,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			for (const move of altsMoves) {
 				pokemonSource = validator?.allSources();
 				if ((rule && usedRule.endsWith('legality') && validator?.ruleTable?.checkCanLearn &&
-					!validator.ruleTable.checkCanLearn[0].call(validator, move, dex[mon], pokemonSource, {} as Partial<PokemonSet>)) ||
-					!validator?.checkCanLearn(move, dex[mon], pokemonSource)) {
+					!validator.ruleTable.checkCanLearn[0].call(validator, move, dex[mon], pokemonSource, {}) === alts.moves[move.id]) ||
+					!validator?.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
 					matched = true;
 					break;
 				}

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1252,7 +1252,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		) {
 			let newSpecies = species;
 			for (const rule of rules) {
-				newSpecies  = rule?.onModifySpecies?.call({ dex: mod, clampIntRange: Utils.clampIntRange, toID } as Battle,
+				newSpecies = rule?.onModifySpecies?.call({ dex: mod, clampIntRange: Utils.clampIntRange, toID } as Battle,
 					newSpecies) || newSpecies;
 			}
 			dex[newSpecies.id] = newSpecies;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -55,15 +55,15 @@ const RESULTS_MAX_LENGTH = 10;
 const MAX_RANDOM_RESULTS = 30;
 const dexesHelpMods = Object.keys((global.Dex?.dexes || {})).filter(x => x !== 'sourceMaps').join('</code>, <code>');
 const supportedDexsearchRules: { [k: string]: string[] } = Object.assign(Object.create(null), {
+	movevalidation: ['stabmonsmovelegality', 'alphabetcupmovelegality'],
+	statmodification: ['350cupmod', 'flippedmod', 'scalemonsmod', 'badnboostedmod', 'reevolutionmod'],
 	banlist: [
 		'hoennpokedex', 'sinnohpokedex', 'oldunovapokedex', 'newunovapokedex', 'kalospokedex', 'oldalolapokedex',
 		'newalolapokedex', 'galarpokedex', 'isleofarmorpokedex', 'crowntundrapokedex', 'galarexpansionpokedex',
 		'paldeapokedex', 'kitakamipokedex', 'blueberrypokedex',
 	],
-	movevalidation: ['stabmonsmovelegality', 'alphabetcupmovelegality'],
-	statmodification: ['350cupmod', 'flippedmod', 'scalemonsmod', 'badnboostedmod', 'reevolutionmod'],
 });
-const dexsearchHelpRules = Object.values((supportedDexsearchRules || {})).filter(arr => arr).join('</code>, <code>');
+const dexsearchHelpRules = Object.values((supportedDexsearchRules)).flat().filter(x => x).join('</code>, <code>');
 
 function toListString(arr: string[]) {
 	if (!arr.length) return '';

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1463,12 +1463,12 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			mon.baseSpecies !== "Pikachu";
 		const maskForm = mon.baseSpecies === "Ogerpon" && !mon.forme.endsWith("Tera");
 		const allowGmax = (gmaxSearch || tierSearch);
-		if (!isRegionalForm && !maskForm && mon.baseSpecies && results.includes(dex[mon.baseSpecies]) &&
-			getSortValue(mon) === getSortValue(dex[mon.baseSpecies])) continue;
+		if (!isRegionalForm && !maskForm && mon.baseSpecies && results.includes(Dex.species.get(mon.baseSpecies)) &&
+			getSortValue(mon) === getSortValue(Dex.species.get(mon.baseSpecies))) continue;
 		const teraFormeChangesFrom = mon.forme.endsWith("Tera") ? !Array.isArray(mon.battleOnly) ?
 			mon.battleOnly! : null : null;
-		if (teraFormeChangesFrom && results.includes(dex[teraFormeChangesFrom]) &&
-			getSortValue(mon) === getSortValue(dex[teraFormeChangesFrom])) continue;
+		if (teraFormeChangesFrom && results.includes(Dex.species.get(teraFormeChangesFrom)) &&
+			getSortValue(mon) === getSortValue(Dex.species.get(teraFormeChangesFrom))) continue;
 		if (mon.isNonstandard === 'Gigantamax' && !allowGmax) continue;
 		results.push(mon);
 	}
@@ -1516,7 +1516,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	} else {
 		resultsStr += "No Pok&eacute;mon found.";
 	}
-	if (isTest) return { results, reply: resultsStr };
+	if (isTest) return { results: results.map(species => species.name), reply: resultsStr };
 	return { reply: resultsStr };
 }
 

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -672,9 +672,9 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		return { error: `You can't run searches for multiple mods.` };
 	}
 	for (const str of splitTarget) {
-		const sanatizedStr = str.toLowerCase().replace(/[^a-z0-9=]+/g, '');
-		if (sanatizedStr.startsWith('mod=') || sanatizedStr.startsWith('rule=')) {
-			return { error: `${sanatizedStr.split('=')[1]} is an invalid mod or rule, see /dexsearchhelp.` };
+		const sanitizedStr = str.toLowerCase().replace(/[^a-z0-9=]+/g, '');
+		if (sanitizedStr.startsWith('mod=') || sanitizedStr.startsWith('rule=')) {
+			return { error: `${sanitizedStr.split('=')[1]} is an invalid mod or rule, see /dexsearchhelp.` };
 		}
 	}
 	const mod = Dex.mod(usedMod || 'base');
@@ -1215,7 +1215,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	}
 
 	const dex: { [k: string]: Species } = {};
-	for (let species of mod.species.all()) {
+	for (const species of mod.species.all()) {
 		const megaSearchResult = megaSearch === null || megaSearch === !!species.isMega;
 		const gmaxSearchResult = gmaxSearch === null || gmaxSearch === species.name.endsWith('-Gmax');
 		const fullyEvolvedSearchResult = fullyEvolvedSearch === null || fullyEvolvedSearch !== species.nfe;
@@ -1250,11 +1250,12 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			restrictedSearchResult &&
 			ruleResult
 		) {
+			let newSpecies = species;
 			for (const rule of rules) {
-				species = rule?.onModifySpecies?.call({ dex: mod, clampIntRange: Utils.clampIntRange, toID } as Battle,
-					species) || species;
+				newSpecies  = rule?.onModifySpecies?.call({ dex: mod, clampIntRange: Utils.clampIntRange, toID } as Battle,
+					newSpecies) || newSpecies;
 			}
-			dex[species.id] = species;
+			dex[newSpecies.id] = newSpecies;
 		}
 	}
 

--- a/test/server/chat-plugins/datasearch.js
+++ b/test/server/chat-plugins/datasearch.js
@@ -111,4 +111,36 @@ describe("Datasearch Plugin", () => {
 		search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
 		assert.false(search.reply.includes('Eiscue-Noice'));
 	});
+
+	it('should include Pokemon capable of learning normally unobtainable moves under the provided rulsets', () => {
+		const cmd = 'ds';
+		const target = 'mod=gen8, rule=stabmonsmovelegality, rule=alphabetcupmovelegality, calm mind, boomburst, steel';
+		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		assert(search.reply.includes('Metagross'));
+	});
+
+	it('should exclude Pokemon capable of learning moves under normal circumstances or the provided rulesets', () => {
+		const cmd = 'ds';
+		const target = 'mod=gen9, rule=stabmonsmovelegality, !wish';
+		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		assert.false(search.reply.includes('Alomomola'));
+		assert.false(search.reply.includes('Altaria'));
+	});
+
+	it('should include only Pokemon allowed by the provided rulesets', () => {
+		const cmd = 'ds';
+		const target = 'mod=gen8, rule=kalospokedex, rule=hoennpokedex, water, ground';
+		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		assert(search.reply.includes('Whiscash'));
+		assert.false(search.reply.includes('Swampert'));
+		assert.false(search.reply.includes('Quagsire'));
+		assert.false(search.reply.includes('Gastrodon'));
+	});
+
+	it('should sort Pokemon with modified stats based on rulesets', () => {
+		const cmd = 'ds';
+		const target = 'mod=gen8, rule=reevolutionmod, water, bst desc';
+		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		assert(search.reply.includes('Milotic'));
+	});
 });


### PR DESCRIPTION
Implements the suggestion [Add (metagame) rule functionality to /ds](https://www.smogon.com/forums/threads/add-metagame-rule-functionality-to-ds.3761436/) which I was asked about a few days ago.

Provides support for most applicable metagame rules except for convergence. Users can use the command as `/ds rule=alphabetcupmovelegality, v-create` and recieve a list of Pokemon which learn V-Create under that format. Similarily users can use other rule parameters to sort mons by their modified stats in a given metagame, or to see the list of mons provided by the format block lists/allow lists.