### PR TITLE
Fix claim button text for text tickets

### DIFF
--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1845,7 +1845,7 @@ export const pages: Chat.PageTable = {
 					if (title) {
 						title = `title="Staff notes:&#10;${title}"`;
 					}
-					buf += `<a class="button" ${title} href="/view-help-text-${ticket.userid}">${ticket.claimed ? `Claim` : `View`}</a>`;
+					buf += `<a class="button" ${title} href="/view-help-text-${ticket.userid}">${!ticket.claimed && ticket.open ? `Claim` : `View`}</a>`;
 				} else if (room) {
 					const ticketGame = room.getGame(HelpTicket)!;
 					buf += `<a href="/${roomid}"><button class="button" ${ticketGame.getPreview()}>${this.tr(!ticket.claimed && ticket.open ? 'Claim' : 'View')}</button></a> `;


### PR DESCRIPTION
Nitpick; the button to check out a text ticket shows as "Claim" when someone else is already looking at the ticket or it is already closed, which doesn't really make sense.