### PR TITLE
fixing gen 3 uubl

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3115,7 +3115,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		ruleset: ['[Gen 3] OU', '!One Boost Passer Clause'],
 		banlist: [
 			'OU', 'Smeargle + Ingrain', 'Baton Pass + Block', 'Baton Pass + Mean Look', 'Baton Pass + Spider Web', 'Flail', 'Reversal',
-			'Baton Pass + Speed Boost', 'Baton Pass + Agility', 'Baton Pass + Dragon Dance',
+			'Baton Pass + Speed Boost', 'Baton Pass + Agility', 'Baton Pass + Dragon Dance', 'Baton Pass + Salac Berry'],
+		unbanlist: ['Soundproof', 'Sand Veil'],
 		],
 	},
 


### PR DESCRIPTION
unbanned sand veil and soundproof in gen 3 uubl, which were never supposed to be banned. also added a ban on salac berry + baton pass which was supposed to be part of speedpass clause but fell through the cracks