### PR TITLE
ADV UUBL: Update bans

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3115,7 +3115,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		ruleset: ['[Gen 3] OU', '!One Boost Passer Clause'],
 		banlist: [
 			'OU', 'Smeargle + Ingrain', 'Baton Pass + Block', 'Baton Pass + Mean Look', 'Baton Pass + Spider Web', 'Flail', 'Reversal',
-			'Baton Pass + Speed Boost', 'Baton Pass + Agility', 'Baton Pass + Dragon Dance', 'Baton Pass + Salac Berry'],
+			'Baton Pass + Speed Boost', 'Baton Pass + Agility', 'Baton Pass + Dragon Dance', 'Baton Pass + Salac Berry',
+		],
 		unbanlist: ['Soundproof', 'Sand Veil'],
 	},
 


### PR DESCRIPTION
- Added a 'Baton Pass + Salac Berry' ban, which was always intended to be included but was missed
- Unbanned Sand Veil and Soundproof, which are bans carried over from OU which should not apply to UUBL