### PR TITLE
Moderation Commands: Add durations to default /ban and /lock messages

### DIFF
--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -21,13 +21,13 @@ const SHAREDIPS_BLACKLIST_FILE = 'config/sharedips-blacklist.tsv';
 const WHITELISTED_NAMES_FILE = 'config/name-whitelist.tsv';
 
 const RANGELOCK_DURATION = 60 * 60 * 1000; // 1 hour
-const LOCK_DURATION = 48 * 60 * 60 * 1000; // 48 hours
+export const LOCK_DURATION = 48 * 60 * 60 * 1000; // 48 hours
 const GLOBALBAN_DURATION = 7 * 24 * 60 * 60 * 1000; // 1 week
 const BATTLEBAN_DURATION = 48 * 60 * 60 * 1000; // 48 hours
 const GROUPCHATBAN_DURATION = 7 * 24 * 60 * 60 * 1000; // 1 week
 const MOBILE_PUNISHMENT_DURATIION = 6 * 60 * 60 * 1000; // 6 hours
 
-const ROOMBAN_DURATION = 48 * 60 * 60 * 1000; // 48 hours
+export const ROOMBAN_DURATION = 48 * 60 * 60 * 1000; // 48 hours
 const BLACKLIST_DURATION = 365 * 24 * 60 * 60 * 1000; // 1 year
 
 const USERID_REGEX = /^[a-z0-9]+$/;


### PR DESCRIPTION
Implements the suggestion ["Clarification on how long a ban lasts"](https://www.smogon.com/forums/threads/clarification-on-how-long-a-ban-lasts.3761482/)

Imports the default durations for locks and room bans from `punishments.ts` and converts them to the appropriate string for the feedback messages. 