### PR TITLE
Add missing HOME dex completion gifts

### DIFF
--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -67177,7 +67177,7 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			aerialace: ["9M", "7M", "6M", "5M"],
 			airslash: ["9M", "8M"],
 			aquajet: ["9L1", "8L1", "7L1", "6L1", "6S2", "6S3", "5L1", "5S0", "5S1"],
-			aquatail: ["9L35", "9S5", "8L35", "7T", "7L37", "6T", "6L37", "5T", "5L37"],
+			aquatail: ["9L35", "9S5", "9S6", "8L35", "7T", "7L37", "6T", "6L37", "5T", "5L37"],
 			aurasphere: ["9M", "8M"],
 			batonpass: ["9M"],
 			bounce: ["8M", "7T", "6T", "5T"],
@@ -67191,7 +67191,7 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			covet: ["7T", "6T", "5T"],
 			cut: ["6M", "5M"],
 			doubleedge: ["9M"],
-			doublekick: ["9L21", "8L21", "7L1", "6L7", "6S2", "6S3", "5L7", "5S0"],
+			doublekick: ["9L21", "9S6", "8L21", "7L1", "6L7", "6S2", "6S3", "5L7", "5S0"],
 			doubleteam: ["7M", "6M", "5M"],
 			endeavor: ["7T", "6T", "5T"],
 			endure: ["9M", "8M"],
@@ -67217,7 +67217,7 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			poisonjab: ["9M", "8M", "7M", "6M", "5M"],
 			protect: ["9M", "8M", "7M", "6M", "5M"],
 			psychup: ["9M", "7M", "6M", "5M"],
-			quickguard: ["9L14", "8L14", "7L55", "6L55", "5L55"],
+			quickguard: ["9L14", "9S6", "8L14", "7L55", "6L55", "5L55"],
 			raindance: ["9M", "8M", "7M", "6M", "5M"],
 			reflect: ["9M", "8M", "7M", "6M", "5M"],
 			rest: ["9M", "8M", "7M", "6M", "5M"],
@@ -67228,7 +67228,7 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			roar: ["9M", "7M", "6M", "5M"],
 			rocksmash: ["6M", "5M"],
 			round: ["8M", "7M", "6M", "5M"],
-			sacredsword: ["9L49", "9S5", "8L49", "8S4", "7L43", "6L43", "5L43", "5S1"],
+			sacredsword: ["9L49", "9S5", "9S6", "8L49", "8S4", "7L43", "6L43", "5L43", "5S1"],
 			safeguard: ["8M", "7M", "6M", "5M"],
 			scald: ["8M", "7M", "6M", "5M"],
 			secretpower: ["6M"],
@@ -67263,6 +67263,7 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			{generation: 6, level: 100, moves: ["aquajet", "leer", "doublekick", "bubblebeam"], pokeball: "cherishball"},
 			{generation: 8, level: 65, moves: ["secretsword", "sacredsword", "swordsdance", "hydropump"]},
 			{generation: 9, level: 50, nature: "Docile", moves: ["retaliate", "aquatail", "takedown", "sacredsword"], pokeball: "cherishball"},
+			{generation: 9, level: 50, shiny: true, nature: "Modest", moves: ["quickguard", "doublekick", "aquatail", "sacredsword"], ivs: {hp: 31, atk: 20, def: 20, spa: 31, spd: 20, spe: 31}, pokeball: "cherishball"},
 		],
 		eventOnly: true,
 	},
@@ -81466,13 +81467,13 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 	},
 	meltan: {
 		learnset: {
-			acidarmor: ["8L32", "8V", "7L36"],
+			acidarmor: ["9S0", "8L32", "8V", "7L36"],
 			endure: ["8M"],
 			facade: ["8M"],
-			flashcannon: ["8M", "8L40", "8V", "7M", "7L45"],
+			flashcannon: ["9S0", "8M", "8L40", "8V", "7M", "7L45"],
 			gyroball: ["8M"],
 			harden: ["8L1", "8V", "7L1"],
-			headbutt: ["8L16", "8V", "7M", "7L1"],
+			headbutt: ["9S0", "8L16", "8V", "7M", "7L1"],
 			irondefense: ["8M"],
 			protect: ["8M", "8V", "7M"],
 			rest: ["8M", "8V", "7M"],
@@ -81484,9 +81485,12 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			tailwhip: ["8L8", "8V", "7L9"],
 			thunderbolt: ["8M", "8V", "7M"],
 			thundershock: ["8L1", "8V", "7L27"],
-			thunderwave: ["8M", "8L24", "8V", "7M", "7L18"],
+			thunderwave: ["9S0", "8M", "8L24", "8V", "7M", "7L18"],
 			toxic: ["8V", "7M"],
 		},
+		eventData: [
+			{generation: 9, level: 50, shiny: true, nature: "Adamant", moves: ["headbutt", "acidarmor", "thunderwave", "flashcannon"], pokeball: "cherishball"}
+		]
 	},
 	melmetal: {
 		learnset: {
@@ -86839,6 +86843,7 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			astonish: ["9L1"],
 			bodyslam: ["9M"],
 			calmmind: ["9M"],
+			crunch: ["9S1"],
 			dazzlinggleam: ["9M", "9L40"],
 			disarmingvoice: ["9M"],
 			drainingkiss: ["9M", "9L20", "9S1"],
@@ -86888,7 +86893,7 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 		},
 		eventData: [
 			{generation: 8, level: 70, perfectIVs: 3, moves: ["extrasensory", "moonblast", "springtidestorm"], pokeball: "strangeball"}, // Legends: Arceus
-			{generation: 9, level: 50, shiny: true, nature: "Naive", ivs: {hp: 20, atk: 31, def: 20, spa: 31, spd: 20, spe: 31}, moves: ["drainingkiss", "extrasensory", "moonblast"], pokeball: "cherishball"},
+			{generation: 9, level: 50, shiny: true, nature: "Naive", ivs: {hp: 20, atk: 31, def: 20, spa: 31, spd: 20, spe: 31}, moves: ["drainingkiss", "extrasensory", "crunch", "moonblast"], pokeball: "cherishball"},
 		],
 		eventOnly: true,
 	},

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -86843,7 +86843,6 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			astonish: ["9L1"],
 			bodyslam: ["9M"],
 			calmmind: ["9M"],
-			crunch: ["9S1"],
 			dazzlinggleam: ["9M", "9L40"],
 			disarmingvoice: ["9M"],
 			drainingkiss: ["9M", "9L20", "9S1"],
@@ -86893,7 +86892,7 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 		},
 		eventData: [
 			{generation: 8, level: 70, perfectIVs: 3, moves: ["extrasensory", "moonblast", "springtidestorm"], pokeball: "strangeball"}, // Legends: Arceus
-			{generation: 9, level: 50, shiny: true, nature: "Naive", ivs: {hp: 20, atk: 31, def: 20, spa: 31, spd: 20, spe: 31}, moves: ["drainingkiss", "extrasensory", "crunch", "moonblast"], pokeball: "cherishball"},
+			{generation: 9, level: 50, shiny: true, nature: "Naive", ivs: {hp: 20, atk: 31, def: 20, spa: 31, spd: 20, spe: 31}, moves: ["drainingkiss", "extrasensory", "moonblast"], pokeball: "cherishball"},
 		],
 		eventOnly: true,
 	},


### PR DESCRIPTION
Added:
- Keldeo https://projectpokemon.org/home/files/file/5605-swsh-dex-completion-shiny-keldeo/
- Meltan: https://projectpokemon.org/home/files/file/5606-lgpe-dex-completion-shiny-meltan/

~~Updated:~~
~~- Enamorus (missing Crunch): https://projectpokemon.org/home/files/file/5579-pla-dex-completion-shiny-enamorus/~~

Should be an easy change but sanity check my work please.