### PR TITLE
Collapsible Datasearches

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1514,23 +1514,35 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		results = Utils.shuffle(results).slice(0, randomOutput);
 	}
 
-	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${Utils.escapeHTML(message)}:</span><br />`);
+	let resultsStr = (message === "" ? message :
+		`<span style="color:#999999;">${Utils.escapeHTML(message)}:</span><br/>`);
 	if (results.length > 1) {
 		results.sort();
 		if (sort) {
 			const direction = sort.slice(-1);
 			Utils.sortBy(results, species => getSortValue(species) * (direction === '+' ? 1 : -1));
 		}
-		let notShown = 0;
+
 		if (!showAll && results.length > MAX_RANDOM_RESULTS) {
-			notShown = results.length - RESULTS_MAX_LENGTH;
-			results = results.slice(0, RESULTS_MAX_LENGTH);
-		}
-		resultsStr += results.map(
-			result => `<a href="//${Config.routes.dex}/pokemon/${toID(result.name)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon pokemon="${result.name}" style="vertical-align:-7px;margin:-2px" />${result.name}</a>`
-		).join(", ");
-		if (notShown) {
-			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+			const notShown = results.length - RESULTS_MAX_LENGTH;
+			const amountStr = `${results.length} Results (${notShown} Hidden)`;
+
+			resultsStr = message === "" ? amountStr :
+				`<span style="color:#999999;">${Utils.escapeHTML(message + `: ${amountStr}`)}</span><br/>`;
+
+			const resultsSummary = results.slice(0, RESULTS_MAX_LENGTH).map(
+				result => `<a href="//${Config.routes.dex}/pokemon/${toID(result.name)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon pokemon="${result.name}" style="vertical-align:-7px;margin:-2px" />${result.name}</a>`
+			).join(", ") + ', ';
+
+			const resultsHidden = results.slice(RESULTS_MAX_LENGTH).map(
+				result => `<a href="//${Config.routes.dex}/pokemon/${toID(result.name)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon pokemon="${result.name}" style="vertical-align:-7px;margin:-2px" />${result.name}</a>`
+			).join(", ");
+
+			resultsStr += `<details class="readmore"><summary style="display: inline" readmore-text="[${notShown} Hidden]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+		} else {
+			resultsStr += results.map(
+				result => `<a href="//${Config.routes.dex}/pokemon/${toID(result.name)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon pokemon="${result.name}" style="vertical-align:-7px;margin:-2px" />${result.name}</a>`
+			).join(", ");
 		}
 	} else if (results.length === 1) {
 		return { dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}` };

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1505,9 +1505,9 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 
 		if (results.length > MAX_RANDOM_RESULTS) {
 			const notShown = results.length - RESULTS_MAX_LENGTH;
-			resultsStr = `<div class="datasearch" style="cursor: pointer"><span style="color:#999999">${Utils.escapeHTML(message)}<button class="subtle" style="float: right">[+]</button></span><br/>`;
 			const resultsSummary = `${mapPokemonResults(results.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapPokemonResults(results);
+			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">[+]</button>${message === "" ? "" : `</span><br/>`}`;
 			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapPokemonResults(results);
@@ -2242,9 +2242,9 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 
 		if (results.length > MAX_RANDOM_RESULTS) {
 			const notShown = results.length - RESULTS_MAX_LENGTH;
-			resultsStr = `<div class="datasearch" style="cursor: pointer"><span style="color:#999999">${Utils.escapeHTML(message)}<button class="subtle" style="float: right">[+]</button></span><br/>`;
 			const resultsSummary = `${mapMoveResults(results.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapMoveResults(results);
+			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">[+]</button>${message === "" ? "" : `</span><br/>`}`;
 			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapMoveResults(results);
@@ -2523,9 +2523,9 @@ function runItemsearch(target: string, cmd: string, message: string) {
 		foundItems.sort();
 		if (foundItems.length > MAX_RANDOM_RESULTS) {
 			const notShown = foundItems.length - RESULTS_MAX_LENGTH;
-			resultsStr = `<div class="datasearch" style="cursor: pointer"><span style="color:#999999">${Utils.escapeHTML(message)}<button class="subtle" style="float: right">[+]</button></span><br/>`;
 			const resultsSummary = `${mapItemResults(foundItems.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapItemResults(foundItems);
+			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">[+]</button>${message === "" ? "" : `</span><br/>`}`;
 			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapItemResults(foundItems);
@@ -2709,9 +2709,9 @@ function runAbilitysearch(target: string, cmd: string, message: string) {
 		foundAbilities.sort();
 		if (foundAbilities.length > MAX_RANDOM_RESULTS) {
 			const notShown = foundAbilities.length - RESULTS_MAX_LENGTH;
-			resultsStr = `<div class="datasearch" style="cursor: pointer"><span style="color:#999999">${Utils.escapeHTML(message)}<button class="subtle" style="float: right">[+]</button></span><br/>`;
 			const resultsSummary = `${mapAbilityResults(foundAbilities.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapAbilityResults(foundAbilities);
+			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">[+]</button>${message === "" ? "" : `</span><br/>`}`;
 			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapAbilityResults(foundAbilities);

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1512,7 +1512,7 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 
 			const resultsSummary = mapPokemonResults(results.slice(0, RESULTS_MAX_LENGTH)) + ', ';
 			const resultsHidden = mapPokemonResults(results.slice(RESULTS_MAX_LENGTH));
-			resultsStr += `<details class="searchresults"><summary style="display: inline" show-hidden-results-text="[${notShown} Hidden]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+			resultsStr += `<details class="readmore"><summary style="display: inline" show-text="[${notShown} Hidden]" hide-text="[-]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
 		} else {
 			resultsStr += mapPokemonResults(results);
 		}
@@ -2254,7 +2254,7 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 			const resultsSummary = mapMoves(results.slice(0, RESULTS_MAX_LENGTH)) + ', ';
 			const resultsHidden = mapMoves(results.slice(RESULTS_MAX_LENGTH));
 
-			resultsStr += `<details class="searchresults"><summary style="display: inline" show-hidden-results-text="[${notShown} Hidden]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+			resultsStr += `<details class="readmore"><summary style="display: inline" show-text="[${notShown} Hidden]" hide-text="[-]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
 		} else {
 			resultsStr += mapMoves(results);
 		}
@@ -2540,7 +2540,7 @@ function runItemsearch(target: string, cmd: string, message: string) {
 			const resultsSummary = mapItemResults(foundItems.slice(0, RESULTS_MAX_LENGTH)) + ', ';
 			const resultsHidden = mapItemResults(foundItems.slice(RESULTS_MAX_LENGTH));
 
-			resultsStr += `<details class="searchresults"><summary style="display: inline" show-hidden-results-text="[${notShown} Hidden]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+			resultsStr += `<details class="readmore"><summary style="display: inline" show-text="[${notShown} Hidden]" hide-text="[-]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
 		} else {
 			resultsStr += mapItemResults(foundItems);
 		}
@@ -2731,7 +2731,7 @@ function runAbilitysearch(target: string, cmd: string, message: string) {
 			const resultsSummary = mapAbilityResults(foundAbilities.slice(0, RESULTS_MAX_LENGTH)) + ', ';
 			const resultsHidden = mapAbilityResults(foundAbilities.slice(RESULTS_MAX_LENGTH));
 
-			resultsStr += `<details class="searchresults"><summary style="display: inline" show-hidden-results-text="[${notShown} Hidden]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+			resultsStr += `<details class="readmore"><summary style="display: inline" show-text="[${notShown} Hidden]" hide-text="[-]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
 		} else {
 			resultsStr += mapAbilityResults(foundAbilities);
 		}

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1505,14 +1505,10 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 
 		if (results.length > MAX_RANDOM_RESULTS) {
 			const notShown = results.length - RESULTS_MAX_LENGTH;
-			const amountStr = `${results.length} Results (${notShown} Hidden)`;
-
-			resultsStr = message === "" ? amountStr :
-				`<span style="color:#999999;">${Utils.escapeHTML(message + `: ${amountStr}`)}</span><br/>`;
-
-			const resultsSummary = mapPokemonResults(results.slice(0, RESULTS_MAX_LENGTH)) + ', ';
-			const resultsHidden = mapPokemonResults(results.slice(RESULTS_MAX_LENGTH));
-			resultsStr += `<details class="readmore"><summary style="display: inline" show-text="[${notShown} Hidden]" hide-text="[-]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+			resultsStr = `<div class="datasearch" style="cursor: pointer"><span style="color:#999999">${Utils.escapeHTML(message)}<button class="subtle" style="float: right">[+]</button></span><br/>`;
+			const resultsSummary = `${mapPokemonResults(results.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
+			const resultsHidden = mapPokemonResults(results);
+			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapPokemonResults(results);
 		}
@@ -2234,7 +2230,7 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 			});
 		}
 
-		function mapMoves(inputArray: string[]) {
+		function mapMoveResults(inputArray: string[]) {
 			return inputArray.map(
 				result => `<a href="//${Config.routes.dex}/moves/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>` +
 					(sort ?
@@ -2246,17 +2242,12 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 
 		if (results.length > MAX_RANDOM_RESULTS) {
 			const notShown = results.length - RESULTS_MAX_LENGTH;
-			const amountStr = `${results.length} Results (${notShown} Hidden)`;
-
-			resultsStr = message === "" ? amountStr :
-				`<span style="color:#999999;">${Utils.escapeHTML(message + `: ${amountStr}`)}</span><br/>`;
-
-			const resultsSummary = mapMoves(results.slice(0, RESULTS_MAX_LENGTH)) + ', ';
-			const resultsHidden = mapMoves(results.slice(RESULTS_MAX_LENGTH));
-
-			resultsStr += `<details class="readmore"><summary style="display: inline" show-text="[${notShown} Hidden]" hide-text="[-]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+			resultsStr = `<div class="datasearch" style="cursor: pointer"><span style="color:#999999">${Utils.escapeHTML(message)}<button class="subtle" style="float: right">[+]</button></span><br/>`;
+			const resultsSummary = `${mapMoveResults(results.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
+			const resultsHidden = mapMoveResults(results);
+			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
 		} else {
-			resultsStr += mapMoves(results);
+			resultsStr += mapMoveResults(results);
 		}
 	} else if (results.length === 1) {
 		return { dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}` };
@@ -2532,15 +2523,10 @@ function runItemsearch(target: string, cmd: string, message: string) {
 		foundItems.sort();
 		if (foundItems.length > MAX_RANDOM_RESULTS) {
 			const notShown = foundItems.length - RESULTS_MAX_LENGTH;
-			const amountStr = `${foundItems.length} Results (${notShown} Hidden)`;
-
-			resultsStr = message === "" ? amountStr :
-				`<span style="color:#999999;">${Utils.escapeHTML(message + `: ${amountStr}`)}</span><br/>`;
-
-			const resultsSummary = mapItemResults(foundItems.slice(0, RESULTS_MAX_LENGTH)) + ', ';
-			const resultsHidden = mapItemResults(foundItems.slice(RESULTS_MAX_LENGTH));
-
-			resultsStr += `<details class="readmore"><summary style="display: inline" show-text="[${notShown} Hidden]" hide-text="[-]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+			resultsStr = `<div class="datasearch" style="cursor: pointer"><span style="color:#999999">${Utils.escapeHTML(message)}<button class="subtle" style="float: right">[+]</button></span><br/>`;
+			const resultsSummary = `${mapItemResults(foundItems.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
+			const resultsHidden = mapItemResults(foundItems);
+			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapItemResults(foundItems);
 		}
@@ -2723,15 +2709,10 @@ function runAbilitysearch(target: string, cmd: string, message: string) {
 		foundAbilities.sort();
 		if (foundAbilities.length > MAX_RANDOM_RESULTS) {
 			const notShown = foundAbilities.length - RESULTS_MAX_LENGTH;
-			const amountStr = `${foundAbilities.length} Results (${notShown} Hidden)`;
-
-			resultsStr = message === "" ? amountStr :
-				`<span style="color:#999999;">${Utils.escapeHTML(message + `: ${amountStr}`)}</span><br/>`;
-
-			const resultsSummary = mapAbilityResults(foundAbilities.slice(0, RESULTS_MAX_LENGTH)) + ', ';
-			const resultsHidden = mapAbilityResults(foundAbilities.slice(RESULTS_MAX_LENGTH));
-
-			resultsStr += `<details class="readmore"><summary style="display: inline" show-text="[${notShown} Hidden]" hide-text="[-]">${resultsSummary}</br></summary>${resultsHidden}</details>`;
+			resultsStr = `<div class="datasearch" style="cursor: pointer"><span style="color:#999999">${Utils.escapeHTML(message)}<button class="subtle" style="float: right">[+]</button></span><br/>`;
+			const resultsSummary = `${mapAbilityResults(foundAbilities.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
+			const resultsHidden = mapAbilityResults(foundAbilities);
+			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapAbilityResults(foundAbilities);
 		}


### PR DESCRIPTION
Implements [Improve how !ds all displays](https://www.smogon.com/forums/threads/improve-how-ds-all-displays.3654308/)

Requires the client-side changes from [this PR](https://github.com/smogon/pokemon-showdown-client/pull/2338) 

Replaces the `all` parameter and the restriction on broadcasting datasearches with the ability to expand and collapse the results of a datasearch over the 30 item limit by clicking it. Subtle button text and the pointer cursor while hovering the results are to make it clear to users that they can interact with the results. The results will not expand or collapse when clicking a link in the results. This would have been implemented using the existing readmore option which uses the `<details><summary>` tags with an inline display, but Chrome creates a linebreak after the summary results preventing them from properly joining together with the rest of the results. 

![image](https://github.com/user-attachments/assets/9cc8d742-f109-4e33-8baa-2a61daa69902)
![image](https://github.com/user-attachments/assets/34279050-7420-46fe-9dd0-99b1b9990289)

