### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -157,9 +157,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "roar", "stealthrock", "toxicspikes"],
-                "abilities": ["Poison Point"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["earthquake", "fireblast", "icebeam", "roar", "sludgebomb", "stealthrock", "toxicspikes"],
+                "abilities": ["Poison Point"]
             }
         ]
     },
@@ -168,9 +167,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "stealthrock", "suckerpunch", "thunderbolt"],
-                "abilities": ["Poison Point"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "sludgebomb", "stealthrock", "suckerpunch", "thunderbolt"],
+                "abilities": ["Poison Point"]
             }
         ]
     },
@@ -608,7 +606,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"],
+                "movepool": ["explosion", "fireblast", "haze", "painsplit", "sludgebomb", "willowisp"],
                 "abilities": ["Levitate"]
             },
             {
@@ -2854,11 +2852,6 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["metalburst", "roar", "rockslide", "stealthrock", "toxic"],
-                "abilities": ["Sturdy"]
-            },
-            {
-                "role": "Staller",
                 "movepool": ["metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"],
                 "abilities": ["Sturdy"]
             }

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -67,7 +67,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
 			Poison: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Poison') && (types.has('Grass') || species.id === 'gengar')
+				!counter.get('Poison') && (types.has('Grass') || types.has('Ground') || species.id === 'gengar')
 			),
 			Psychic: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Psychic') && (types.has('Fighting') || movePool.includes('calmmind'))
@@ -224,6 +224,10 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			if (species.id === 'wormadamtrash' && role === 'Staller') {
 				if (movePool.includes('suckerpunch')) this.fastPop(movePool, movePool.indexOf('suckerpunch'));
 				if (moves.size + movePool.length <= this.maxMoveCount) return;
+			}
+			if (species.id === 'bastiodon') {
+				// Enforces Toxic too, for good measure.
+				this.incompatibleMoves(moves, movePool, ['metalburst', 'protect', 'roar'], ['metalburst', 'protect'])
 			}
 		}
 	}

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -227,7 +227,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			}
 			if (species.id === 'bastiodon') {
 				// Enforces Toxic too, for good measure.
-				this.incompatibleMoves(moves, movePool, ['metalburst', 'protect', 'roar'], ['metalburst', 'protect'])
+				this.incompatibleMoves(moves, movePool, ['metalburst', 'protect', 'roar'], ['metalburst', 'protect']);
 			}
 		}
 	}

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -225,10 +225,10 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				if (movePool.includes('suckerpunch')) this.fastPop(movePool, movePool.indexOf('suckerpunch'));
 				if (moves.size + movePool.length <= this.maxMoveCount) return;
 			}
-			if (species.id === 'bastiodon') {
-				// Enforces Toxic too, for good measure.
-				this.incompatibleMoves(moves, movePool, ['metalburst', 'protect', 'roar'], ['metalburst', 'protect']);
-			}
+		}
+		if (species.id === 'bastiodon') {
+			// Enforces Toxic too, for good measure.
+			this.incompatibleMoves(moves, movePool, ['metalburst', 'protect', 'roar'], ['metalburst', 'protect']);
 		}
 	}
 

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -67,7 +67,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
 			Poison: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Poison') && (types.has('Grass') || types.has('Ground') || species.id === 'gengar')
+				!counter.get('Poison') && (['Ghost', 'Grass', 'Ground'].some(type => types.has(type)))
 			),
 			Psychic: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Psychic') && (types.has('Fighting') || movePool.includes('calmmind'))

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -2180,7 +2180,7 @@
         "level": 91,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"],
                 "abilities": ["Thick Fat"]
             },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1230,7 +1230,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["discharge", "dragonpulse", "focusblast", "healbell", "rest", "sleeptalk", "voltswitch"],
+                "movepool": ["discharge", "dragonpulse", "focusblast", "rest", "sleeptalk", "voltswitch"],
                 "abilities": ["Static"]
             }
         ]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -2442,7 +2442,7 @@
         "level": 93,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"],
                 "abilities": ["Thick Fat"]
             }

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -352,6 +352,12 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				movePool, preferredType, role);
 		}
 
+		// Enforce Destiny Bond on Mega Banette, since that move is its entire reason to exist
+		if (movePool.includes('destinybond') && species.id === 'banettemega') {
+			counter = this.addMove('destinybond', moves, types, abilities, teamDetails, species, isLead,
+				movePool, preferredType, role);
+		}
+
 		// Enforce hazard removal on Bulky Support if the team doesn't already have it
 		if (role === 'Bulky Support' && !teamDetails.defog && !teamDetails.rapidSpin) {
 			if (movePool.includes('rapidspin')) {

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1446,7 +1446,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["discharge", "dragonpulse", "focusblast", "healbell", "rest", "sleeptalk", "voltswitch"],
+                "movepool": ["discharge", "dragonpulse", "focusblast", "rest", "sleeptalk", "voltswitch"],
                 "abilities": ["Static"]
             }
         ]
@@ -1828,6 +1828,11 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "scald"],
+                "abilities": ["Sniper"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["energyball", "fireblast", "gunkshot", "icebeam", "scald", "thunderwave"],
                 "abilities": ["Sniper"]
             }
         ]
@@ -2666,7 +2671,7 @@
         "level": 93,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"],
                 "abilities": ["Thick Fat"]
             },
@@ -6788,6 +6793,11 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "scald", "uturn"],
+                "abilities": ["Schooling"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["icebeam", "rest", "scald", "sleeptalk"],
                 "abilities": ["Schooling"]
             }
         ]

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -535,6 +535,12 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				movePool, preferredType, role);
 		}
 
+		// Enforce Destiny Bond on Mega Banette, since that move is its entire reason to exist
+		if (movePool.includes('destinybond') && species.id === 'banettemega') {
+			counter = this.addMove('destinybond', moves, types, abilities, teamDetails, species, isLead,
+				movePool, preferredType, role);
+		}
+
 		// Enforce hazard removal on Bulky Support if the team doesn't already have it
 		if (role === 'Bulky Support' && !teamDetails.defog && !teamDetails.rapidSpin) {
 			if (movePool.includes('rapidspin')) {

--- a/data/random-battles/gen8/data.json
+++ b/data/random-battles/gen8/data.json
@@ -2233,7 +2233,7 @@
     },
     "tapubulu": {
         "level": 82,
-        "moves": ["closecombat", "hornleech", "megahorn", "stoneedge", "swordsdance", "woodhammer"],
+        "moves": ["closecombat", "highhorsepower", "hornleech", "megahorn", "stoneedge", "swordsdance", "woodhammer"],
         "doublesLevel": 83,
         "doublesMoves": ["closecombat", "hornleech", "protect", "stoneedge", "swordsdance", "woodhammer"]
     },
@@ -2481,7 +2481,7 @@
     },
     "barraskewda": {
         "level": 80,
-        "moves": ["closecombat", "crunch", "liquidation", "poisonjab", "psychicfangs"],
+        "moves": ["closecombat", "crunch", "flipturn", "liquidation"],
         "doublesLevel": 84,
         "doublesMoves": ["closecombat", "drillrun", "flipturn", "liquidation", "poisonjab"]
     },

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -328,7 +328,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Circle Throw", "Close Combat", "Coaching", "Icy Wind", "Knock Off", "Liquidation"],
+                "movepool": ["Close Combat", "Coaching", "Icy Wind", "Knock Off", "Liquidation"],
                 "abilities": ["Water Absorb"],
                 "teraTypes": ["Dragon", "Fire", "Ground", "Steel"]
             }
@@ -775,7 +775,7 @@
             },
             {
                 "role": "Bulky Protect",
-                "movepool": ["Helping Hand", "Icy Wind", "Muddy Water", "Protect", "Scald", "Wish", "Yawn"],
+                "movepool": ["Icy Wind", "Muddy Water", "Protect", "Scald", "Wish", "Yawn"],
                 "abilities": ["Water Absorb"],
                 "teraTypes": ["Dragon", "Fire", "Ground"]
             }
@@ -1485,13 +1485,13 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Calm Mind", "Protect", "Scald", "Shadow Ball", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Protect", "Scald", "Shadow Ball", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Protect",
-                "movepool": ["Electroweb", "Protect", "Scald", "Snarl", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Calm Mind", "Electroweb", "Protect", "Scald", "Snarl", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Water"]
             }
@@ -1748,7 +1748,13 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Disable", "Encore", "Fake Out", "Foul Play", "Knock Off", "Quash", "Recover", "Will-O-Wisp"],
+                "movepool": ["Disable", "Encore", "Fake Out", "Foul Play", "Knock Off", "Thunder Wave"],
+                "abilities": ["Prankster"],
+                "teraTypes": ["Poison", "Steel"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Fake Out", "Foul Play", "Knock Off", "Quash", "Will-O-Wisp"],
                 "abilities": ["Prankster"],
                 "teraTypes": ["Poison", "Steel"]
             }
@@ -1764,10 +1770,16 @@
                 "teraTypes": ["Fighting", "Fire"]
             },
             {
-                "role": "Doubles Fast Attacker",
+                "role": "Offensive Protect",
                 "movepool": ["Bullet Punch", "Close Combat", "Ice Punch", "Protect", "Zen Headbutt"],
                 "abilities": ["Pure Power"],
                 "teraTypes": ["Fighting", "Fire"]
+            },
+            {
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Close Combat", "Fake Out", "Ice Punch", "Zen Headbutt"],
+                "abilities": ["Pure Power"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -4499,16 +4511,16 @@
         "level": 87,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
+                "role": "Doubles Fast Attacker",
                 "movepool": ["Brave Bird", "Bullet Seed", "Protect", "Tailwind"],
                 "abilities": ["Skill Link"],
-                "teraTypes": ["Grass", "Steel"]
+                "teraTypes": ["Flying", "Steel"]
             },
             {
                 "role": "Bulky Protect",
-                "movepool": ["Beak Blast", "Bullet Seed", "Knock Off", "Protect"],
-                "abilities": ["Skill Link"],
-                "teraTypes": ["Grass", "Steel"]
+                "movepool": ["Brave Bird", "Knock Off", "Protect", "Tailwind"],
+                "abilities": ["Keen Eye"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -4712,7 +4724,7 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Encore", "Fake Out", "Fire Blast", "Heat Wave", "Incinerate", "Poison Gas", "Protect", "Sludge Bomb"],
+                "movepool": ["Encore", "Fake Out", "Fire Blast", "Heat Wave", "Poison Gas", "Protect", "Sludge Bomb"],
                 "abilities": ["Corrosion"],
                 "teraTypes": ["Fire", "Flying", "Water"]
             }
@@ -5812,7 +5824,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Follow Me", "Population Bomb", "Protect", "Taunt", "Thunder Wave"],
+                "movepool": ["Encore", "Follow Me", "Population Bomb", "Protect"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Ghost", "Normal"]
             }
@@ -6181,7 +6193,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Bomb", "Spiky Shield", "Stealth Rock"],
+                "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Bomb", "Spiky Shield"],
                 "abilities": ["Toxic Debris"],
                 "teraTypes": ["Grass", "Water"]
             },
@@ -6725,13 +6737,13 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Gunk Shot", "Icy Wind", "Play Rough", "Roost"],
+                "movepool": ["Gunk Shot", "Icy Wind", "Moonblast", "Roost"],
                 "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Gunk Shot", "Icy Wind", "Play Rough", "U-turn"],
+                "movepool": ["Gunk Shot", "Icy Wind", "Moonblast", "U-turn"],
                 "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -328,12 +328,6 @@
                 "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Morning Sun", "Roar", "Will-O-Wisp"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Fighting", "Normal"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Morning Sun", "Wild Charge"],
-                "abilities": ["Intimidate"],
-                "teraTypes": ["Fighting", "Normal"]
             }
         ]
     },
@@ -1180,7 +1174,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Ice Beam", "Scald", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Volt Absorb"],
-                "teraTypes": ["Flying", "Water"]
+                "teraTypes": ["Flying"]
             }
         ]
     },
@@ -2299,7 +2293,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Dragon Tail", "Flip Turn", "Haze", "Ice Beam", "Recover", "Scald"],
+                "movepool": ["Dragon Tail", "Haze", "Ice Beam", "Recover", "Scald"],
                 "abilities": ["Competitive"],
                 "teraTypes": ["Dragon", "Steel"]
             }
@@ -2604,7 +2598,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Knock Off", "Psychic Noise", "Recover", "Spikes", "Stealth Rock"],
+                "movepool": ["Knock Off", "Psychic Noise", "Recover", "Spikes", "Stealth Rock", "Teleport"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Dark", "Fairy", "Steel"]
             }
@@ -3189,7 +3183,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Leaf Blade", "Night Slash", "Psycho Cut", "Sacred Sword", "Swords Dance"],
+                "movepool": ["Leaf Blade", "Night Slash", "Psycho Cut", "Sacred Sword"],
                 "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
             },
@@ -3340,7 +3334,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Drain Punch", "Ice Beam", "Knock Off", "Psychic Noise", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "movepool": ["Drain Punch", "Ice Beam", "Knock Off", "Psychic Noise", "Stealth Rock", "Thunder Wave", "Thunderbolt", "U-turn"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Fighting"]
             }
@@ -4322,6 +4316,12 @@
                 "movepool": ["Ice Beam", "Rapid Spin", "Recover", "Tera Blast"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Freeze-Dry", "Rapid Spin", "Recover", "Tera Blast"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -4592,7 +4592,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Earth Power", "Focus Blast", "Nasty Plot", "Psychic", "Rock Slide", "Sludge Wave", "Stealth Rock"],
                 "abilities": ["Sheer Force"],
-                "teraTypes": ["Ground", "Poison", "Psychic"]
+                "teraTypes": ["Ground", "Poison"]
             }
         ]
     },
@@ -5897,19 +5897,13 @@
         "level": 90,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Alluring Voice", "Calm Mind", "Psychic", "Psyshock", "Recover"],
-                "abilities": ["Aroma Veil"],
-                "teraTypes": ["Poison", "Steel"]
-            },
-            {
                 "role": "Tera Blast user",
                 "movepool": ["Alluring Voice", "Calm Mind", "Recover", "Tera Blast"],
                 "abilities": ["Aroma Veil"],
                 "teraTypes": ["Ground"]
             },
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Setup",
                 "movepool": ["Acid Armor", "Alluring Voice", "Calm Mind", "Dazzling Gleam", "Recover"],
                 "abilities": ["Aroma Veil"],
                 "teraTypes": ["Poison", "Steel"]
@@ -5985,7 +5979,13 @@
                 "role": "Tera Blast user",
                 "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute", "Tera Blast"],
                 "abilities": ["Ice Face"],
-                "teraTypes": ["Electric", "Ground"]
+                "teraTypes": ["Electric"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Belly Drum", "Ice Spinner", "Substitute", "Tera Blast"],
+                "abilities": ["Ice Face"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -6780,7 +6780,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Dazzling Gleam", "Lumina Crash", "Shadow Ball", "U-turn"],
+                "movepool": ["Dazzling Gleam", "Lumina Crash", "Trick", "U-turn"],
                 "abilities": ["Speed Boost"],
                 "teraTypes": ["Fairy", "Psychic"]
             },
@@ -7000,7 +7000,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Draco Meteor", "Hydro Pump", "Nasty Plot", "Rapid Spin", "Surf"],
+                "movepool": ["Draco Meteor", "Nasty Plot", "Rapid Spin", "Surf"],
+                "abilities": ["Storm Drain"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Draco Meteor", "Hydro Pump", "Nasty Plot", "Rapid Spin"],
                 "abilities": ["Storm Drain"],
                 "teraTypes": ["Water"]
             }

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -101,7 +101,7 @@ const SPEED_CONTROL = [
 ];
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
-	'accelerock', 'aquajet', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'circlethrow', 'clearsmog', 'covet',
+	'accelerock', 'aquajet', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
 	'dragontail', 'doomdesire', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'futuresight',
 	'grassyglide', 'iceshard', 'icywind', 'incinerate', 'infestation', 'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit',
 	'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skydrop', 'snarl', 'strugglebug', 'suckerpunch', 'uturn',
@@ -624,12 +624,18 @@ export class RandomTeams {
 
 		if (!abilities.includes('Prankster')) this.incompatibleMoves(moves, movePool, 'thunderwave', 'yawn');
 
-		// This space reserved for assorted hardcodes that otherwise make little sense out of context
+		// This space reserved for assorted hardcodes that otherwise make little sense out of context:
+		// To force Close Combat on Barraskewda without locking it to Tera Fighting
 		if (species.id === 'barraskewda') {
 			this.incompatibleMoves(moves, movePool, ['psychicfangs', 'throatchop'], ['poisonjab', 'throatchop']);
 		}
+		// To force Toxic on Quagsire
+		if (species.id === 'quagsire') this.incompatibleMoves(moves, movePool, 'spikes', 'icebeam');
+		// Taunt/Knock should be Cyclizar's flex moveslot
 		if (species.id === 'cyclizar') this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
+		// To force Stealth Rock on Camerupt
 		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
+		// nothing else rolls these lol
 		if (species.id === 'coalossal') this.incompatibleMoves(moves, movePool, 'flamethrower', 'overheat');
 	}
 
@@ -1230,6 +1236,7 @@ export class RandomTeams {
 		if (moves.has('acrobatics') && ability !== 'Protosynthesis') return '';
 		if (moves.has('auroraveil') || moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
 		if (ability === 'Gluttony') return `${this.sample(['Aguav', 'Figy', 'Iapapa', 'Mago', 'Wiki'])} Berry`;
+		if (species.id === 'giratina' && !isDoubles && moves.has('rest') && !moves.has('sleeptalk')) return 'Leftovers';
 		if (
 			moves.has('rest') && !moves.has('sleeptalk') &&
 			ability !== 'Natural Cure' && ability !== 'Shed Skin'

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -2044,7 +2044,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Lunge", "Rapid Spin", "Rock Blast", "Spikes", "Stealth Rock", "Toxic Spikes"],
+                "movepool": ["Pin Missile", "Rapid Spin", "Rock Blast", "Spikes", "Stealth Rock", "Toxic Spikes"],
                 "abilities": ["Sturdy"],
                 "teraTypes": ["Ghost"]
             }

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1281,7 +1281,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Dazzling Gleam", "Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic"],
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Draining Kiss", "Mystical Fire", "Psychic"],
                 "abilities": ["Magic Bounce"],
                 "teraTypes": ["Fairy", "Steel"]
             }

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1246,7 +1246,7 @@
                 "teraTypes": ["Dark", "Grass"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Bullet Seed", "Fire Punch", "Gunk Shot", "Swords Dance"],
                 "abilities": ["Sticky Hold"],
                 "teraTypes": ["Fire", "Grass", "Poison"]
@@ -1275,13 +1275,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draining Kiss", "Mystical Fire", "Nuzzle", "Psychic"],
+                "movepool": ["Dazzling Gleam", "Draining Kiss", "Mystical Fire", "Nuzzle", "Psychic"],
                 "abilities": ["Magic Bounce"],
                 "teraTypes": ["Electric", "Fairy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic"],
+                "movepool": ["Dazzling Gleam", "Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic"],
                 "abilities": ["Magic Bounce"],
                 "teraTypes": ["Fairy", "Steel"]
             }
@@ -1437,7 +1437,7 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Flamethrower", "Pain Split", "Sludge Bomb", "Toxic Spikes", "Will-O-Wisp"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
@@ -1487,16 +1487,16 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Body Slam", "Bulldoze", "Curse", "Play Rough"],
-                "abilities": ["Thick Fat"],
-                "teraTypes": ["Fairy", "Ground"]
-            },
-            {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Bullet Seed", "Double-Edge", "Play Rough", "Thief", "Yawn"],
                 "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Grass"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Slam", "Curse", "Rest", "Sleep Talk"],
+                "abilities": ["Thick Fat"],
+                "teraTypes": ["Fairy"]  
             }
         ]
     },
@@ -1579,7 +1579,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Cross Chop", "Fire Blast", "Flare Blitz", "Thunder Punch", "Will-O-Wisp"],
+                "movepool": ["Cross Chop", "Fire Blast", "Flare Blitz", "Thunder Punch"],
                 "abilities": ["Flame Body", "Vital Spirit"],
                 "teraTypes": ["Electric", "Fire", "Grass"]
             },
@@ -2630,7 +2630,7 @@
                 "teraTypes": ["Fairy", "Fighting", "Normal"]
             },
             {
-                "role": "Wallbreaker",
+                "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Hammer Arm", "Slack Off", "Throat Chop"],
                 "abilities": ["Truant"],
                 "teraTypes": ["Ghost", "Poison"]
@@ -3033,7 +3033,7 @@
         ]
     },
     "tinkatink": {
-        "level": 7,
+        "level": 6,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3085,6 +3085,12 @@
                 "movepool": ["Dragon Dance", "Ice Punch", "Liquidation", "Trailblaze"],
                 "abilities": ["Sheer Force"],
                 "teraTypes": ["Grass", "Water"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Crunch", "Dragon Dance", "Ice Punch", "Liquidation"],
+                "abilities": ["Sheer Force"],
+                "teraTypes": ["Dark", "Water"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -156,7 +156,7 @@ export class RandomBabyTeams extends RandomTeams {
 			['bodyslam', 'doubleedge'],
 			['gunkshot', 'poisonjab'],
 			[['hydropump', 'liquidation'], 'surf'],
-			['psychic', 'psyshock']
+			['psychic', 'psyshock'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -156,6 +156,7 @@ export class RandomBabyTeams extends RandomTeams {
 			['bodyslam', 'doubleedge'],
 			['gunkshot', 'poisonjab'],
 			[['hydropump', 'liquidation'], 'surf'],
+			['psychic', 'psyshock']
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);


### PR DESCRIPTION
**Gen 9 Random Battle**

-Tatsugiri has been split into two Fast Support sets, each with a different Water move, in order to remove Life Orb Tatsugiri from existence.
-Tera Blast Eiscue has been split into two Tera Blast user sets, each with a different Tera Type, in order to remove Liquidation from Tera Ground.
-Cryogonal has gained a second Tera Blast user set with Tera Blast Fire and Freeze-Dry.
-Alcremie's Psychic set has been removed; the Acid Armor set has been renamed to Bulky Setup.
-Arcanine's Fast Attacker set has been removed; it no longer runs Choice Band or Wild Charge.
-Rest non-Sleep Talk Giratina now runs Leftovers instead of Chesto Berry.
-Spidops now has a 75% chance for Knock Off and a 75% chance for Circle Throw instead of 100%/50% respectively. Spidops can now also sometimes run Circle Throw as its only attack again.
-Quagsire now always runs Toxic.
-Bulky Attacker Mesprit: +Stealth Rock
-Support Deoxys-Defense: +Teleport (due to statistical analysis)
-Espathra: -Shadow Ball, +Trick
-Milotic: -Flip Turn
-Gallade: -Swords Dance
-Lanturn: -Tera Water
-Landorus-Incarnate: -Tera Psychic

**Gen 9 Random Doubles**
-Medicham now has a third set of Doubles Wallbreaker with Fake Out and Clear Amulet. Its Doubles Fast Attacker set has been changed to Offensive Protect to enforce Protect.
-Sableye has been reworked; it now has one set with Quash/Dark move/Will-O-Wisp/Fake Out, and one set with Thunder Wave/Dark move/Fake Out/one of Encore or Disable.
-Toucannon has been reworked; it no longer runs Tera Grass or Beak Blast, it always runs Tailwind and Protect, and one of its sets is Life Orb.
-Calm Mind Raikou has been moved from its Offensive Protect set to its Bulky Protect set so that it does not get Life Orb Calm Mind anymore.
-Poliwrath: -Circle Throw (to enable the Spidops change above)
-Maushold: -Taunt, -Thunder Wave
-Glimmora: -Stealth Rock
-Salazzle: -Incinerate
-WishTect Vaporeon: -Helping Hand
-Fezandipiti (both sets): -Play Rough, +Moonblast

**Baby Random Battle** (credit to bobomania for this changelog portion)
-Lechonk’s Bulky Setup set has been changed to be RestTalk instead of coverage. 
-Totodile now has an additional set with Crunch and Tera Dark. 
-Gulpin now gets Eviolite instead of Life Orb on its Swords Dance set. 
-Koffing has been changed from Bulky Support to Bulky Attacker 
-Removed Will-O-Wisp from Fast Attacker Magby. 
-Added Dazzling Gleam to both of Hatenna’s sets. 
-Lunge has been replaced with Pin Missile on Pineco. 
-Tinkatink has had its level reduced to 6. 
-Slakoth erroneously had two Wallbreaker sets; The one with Slack Off has been corrected to Bulky Attacker. 
-Fixed Girafarig from unintentionally having Psychic and Psyshock on the same set.

**Old Gens**
-In Gen 8, Barraskewda now always runs Close Combat, Liquidation, Flip Turn, and Crunch.
-In Gen 8, Tapu Bulu can now run High Horsepower.
-In Gens 6-7, Mega Ampharos no longer runs Heal Bell
-In Gens 6-7, Mega Banette now always runs Destiny Bond, because that's kind of the entire point of the mon.
-In Gens 5-7, Bulky Support Grumpig is now Bulky Attacker to enforce Focus Blast.
-In Gen 7, Wishiwashi now has an additional RestTalk Scald Ice Beam set.
-In Gen 7, Octillery now sometimes runs its Bulky Attacker Thunder Wave set from Gen 6.
-In Gen 4, Bastiodon now always runs Toxic and Stealth Rock.
-In Gen 4, the Nidos now run Sludge Bomb and no longer always have Ice Beam.
-In Gen 4, Weezing now runs Explosion.
