### PR TITLE
Dexsearch: Allow sorting by Pokedex number

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -743,7 +743,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		water3: 'Water 3',
 	});
 	const allFormes = ['alola', 'galar', 'hisui', 'paldea', 'primal', 'therian', 'totem'];
-	const allStats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'bst', 'weight', 'height', 'gen'];
+	const allStats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'bst', 'weight', 'height', 'gen', 'num'];
 	const allStatAliases: { [k: string]: string } = {
 		attack: 'atk', defense: 'def', specialattack: 'spa', spc: 'spa', special: 'spa', spatk: 'spa',
 		specialdefense: 'spd', spdef: 'spd', speed: 'spe', wt: 'weight', ht: 'height', generation: 'gen',
@@ -1405,6 +1405,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 					monStat = dex[mon].heightm;
 				} else if (stat === 'gen') {
 					monStat = dex[mon].gen;
+				} else if (stat === 'num') {
+					monStat = dex[mon].num;
 				} else {
 					monStat = dex[mon].baseStats[stat as StatID];
 				}
@@ -1462,18 +1464,20 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	const stat = sort?.slice(0, -1);
 
 	function getSortValue(species: Species) {
-		if (!stat) {
-			return 0;
-		} else if (stat === 'bst') {
-			return species.bst;
-		} else if (stat === 'weight') {
-			return species.weighthg;
-		} else if (stat === 'height') {
-			return species.heightm;
-		} else if (stat === 'gen') {
-			return species.gen;
-		} else {
-			return species.baseStats[stat as StatID];
+		if (!stat) return 0;
+		switch (stat) {
+			case 'bst':
+				return species.bst;
+			case 'weight':
+				return species.weighthg;
+			case 'height':
+				return species.heightm;
+			case 'gen':
+				return species.gen;
+			case 'num':
+				return species.num;
+			default:
+				return species.baseStats[stat as StatID];
 		}
 	}
 

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1466,18 +1466,18 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	function getSortValue(species: Species) {
 		if (!stat) return 0;
 		switch (stat) {
-			case 'bst':
-				return species.bst;
-			case 'weight':
-				return species.weighthg;
-			case 'height':
-				return species.heightm;
-			case 'gen':
-				return species.gen;
-			case 'num':
-				return species.num;
-			default:
-				return species.baseStats[stat as StatID];
+		case 'bst':
+			return species.bst;
+		case 'weight':
+			return species.weighthg;
+		case 'height':
+			return species.heightm;
+		case 'gen':
+			return species.gen;
+		case 'num':
+			return species.num;
+		default:
+			return species.baseStats[stat as StatID];
 		}
 	}
 


### PR DESCRIPTION
Alpha order is a sensible default but I think ppl should have this option too