### PR TITLE
ZU NFE fixes.ts

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1518,7 +1518,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 		tier: "LC",
 	},
 	ursaring: {
-		tier: "ZU",
+		tier: "NFE",
 		doublesTier: "NFE",
 		natDexTier: "NFE",
 	},
@@ -3060,7 +3060,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 		tier: "LC",
 	},
 	gurdurr: {
-		tier: "ZU",
+		tier: "NFE",
 		doublesTier: "NFE",
 		natDexTier: "NFE",
 	},
@@ -4888,7 +4888,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 		tier: "LC",
 	},
 	hattrem: {
-		tier: "NFE",
+		tier: "ZU",
 	},
 	hatterene: {
 		tier: "OU",


### PR DESCRIPTION
Ursaring and Gurdurr did not see an average of 4.52% usage in ZU across January, February, and March. Hattrem did. 

Ursaring: (2.02 + 3.21 + 6.36) / 3 = 3.87 < 4.52
Gurdurr: (1.77 + 6.52 + 4.56) / 3 = 4.26 < 4.52
Hattrem: (8.22 + 9.41 + 2.91) / 3 = 6.85 > 4.52

https://www.smogon.com/stats/2025-01/gen9zu-1630.txt https://www.smogon.com/stats/2025-02/gen9zu-1630.txt https://www.smogon.com/stats/2025-03/gen9zu-1630.txt