### PR TITLE
Destiny Bond does not get copied by Baton Pass

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -3627,6 +3627,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			return !pokemon.removeVolatile('destinybond');
 		},
 		condition: {
+			noCopy: true, // doesn't get copied by Baton Pass
 			onStart(pokemon) {
 				this.add('-singlemove', pokemon, 'Destiny Bond');
 			},


### PR DESCRIPTION
Appeared as a bug within Relay Race, after doing a quick deep dive into decompilations in checking if this is just pokemon jank(tm) I can confirm this is just never the case.

Sources: 
https://github.com/pret/pokeplatinum/blob/main/include/constants/battle/moves.h#L46 (BATTLE_EFFECT_KO_MON_THAT_DEFEATED_USER notably isn't included)

https://github.com/pret/pokeemerald/blob/4618ba740756547e4534d8d29a6e5651cf8bca8e/src/battle_main.c#L3175 (STATUS2_DESTINY_BOND notably isn't included)