### PR TITLE
Bugfix for Rand Datasearch Commands

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1248,14 +1248,6 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 			searches.push(orGroup);
 		}
 	}
-	if (
-		searches.length === 0 && singleTypeSearch === null &&
-		megaSearch === null && gmaxSearch === null && fullyEvolvedSearch === null && restrictedSearch === null && sort === null
-	) {
-		return {
-			error: "No search parameters were found. Try '/help dexsearch' for more information on this command.",
-		};
-	}
 
 	// Prepare move validator and pokemonSource outside the hot loop
 	// but don't prepare them at all if there are no moves to check...
@@ -2009,11 +2001,6 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 		if (!orGroup.skip) {
 			searches.push(orGroup);
 		}
-	}
-	if (!searches.length && !targetMons.length && !sort) {
-		return {
-			error: "No search parameters were found. Try '/help movesearch' for more information on this command.",
-		};
 	}
 
 	// Since we assume we have no target mons at first


### PR DESCRIPTION
Bug: https://www.smogon.com/forums/threads/bug-report-chat.3762954/

Fixes a bug caused by removing all as a search parameter for datasearch commands. Cases catching user input with only all were incorrectly updated breaking the random datasearch commands such as a randpoke or randitem. Without all as a parameter they are unnecessary to have as without any parameters /ds and like commands just bring up the help context for the command.