### PR TITLE
/ds: Param to expand collapsible datasearches by default

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -731,6 +731,7 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 		attack: 'atk', defense: 'def', specialattack: 'spa', spc: 'spa', special: 'spa', spatk: 'spa',
 		specialdefense: 'spd', spdef: 'spd', speed: 'spe', wt: 'weight', ht: 'height', generation: 'gen',
 	};
+	let showAll = false;
 	let sort = null;
 	let megaSearch = null;
 	let gmaxSearch = null;
@@ -1010,6 +1011,13 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 				break;
 			}
 
+			if (target === 'all') {
+				if (parameters.length > 1) return { error: "The parameter 'all' cannot have alternative parameters." };
+				showAll = true;
+				orGroup.skip = true;
+				break;
+			}
+
 			if (target.substr(0, 6) === 'random' && cmd === 'randpoke') {
 				// Validation for this is in the /randpoke command
 				randomOutput = parseInt(target.substr(6));
@@ -1249,11 +1257,11 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 		}
 	}
 	if (
-		searches.length === 0 && singleTypeSearch === null &&
+		showAll && searches.length === 0 && singleTypeSearch === null &&
 		megaSearch === null && gmaxSearch === null && fullyEvolvedSearch === null && restrictedSearch === null && sort === null
 	) {
 		return {
-			error: "No search parameters were found. Try '/help dexsearch' for more information on this command.",
+			error: "No search parameters other than all were found. Try '/help dexsearch' for more information on this command.",
 		};
 	}
 
@@ -1589,11 +1597,12 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 		}
 
 		if (results.length > MAX_RANDOM_RESULTS) {
+			showAll = showAll && message !== "";
 			const notShown = results.length - RESULTS_MAX_LENGTH;
 			const resultsSummary = `${mapPokemonResults(results.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapPokemonResults(results);
-			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">[+]</button>${message === "" ? "" : `</span><br/>`}`;
-			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
+			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">${showAll ? '[-]' : '[+]'}</button>${message === "" ? "" : `</span><br/>`}`;
+			resultsStr += `<div class="datasearch-body" style="display: ${showAll ? 'none' : 'block'}">${resultsSummary}</div><div class="datasearch-body" style="display: ${showAll ? 'block' : 'none'}>${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapPokemonResults(results);
 		}
@@ -1651,6 +1660,7 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 	for (const type of mod.types.all()) {
 		allTypes[type.id] = type.name;
 	}
+	let showAll = false;
 	let sort: string | null = null;
 	const targetMons: { name: string, shouldBeExcluded: boolean }[] = [];
 	let nationalSearch = null;
@@ -1758,6 +1768,13 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 					return { error: `A search cannot both exclude and include '${target}'.` };
 				}
 				orGroup.gens[targetInt] = !isNotSearch;
+				continue;
+			}
+
+			if (target === 'all') {
+				if (parameters.length > 1) return { error: "The parameter 'all' cannot have alternative parameters." };
+				showAll = true;
+				orGroup.skip = true;
 				continue;
 			}
 
@@ -2010,9 +2027,9 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 			searches.push(orGroup);
 		}
 	}
-	if (!searches.length && !targetMons.length && !sort) {
+	if (showAll && !searches.length && !targetMons.length && !sort) {
 		return {
-			error: "No search parameters were found. Try '/help movesearch' for more information on this command.",
+			error: "No search parameters other than all were found. Try '/help movesearch' for more information on this command.",
 		};
 	}
 
@@ -2326,11 +2343,12 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 		}
 
 		if (results.length > MAX_RANDOM_RESULTS) {
+			showAll = showAll && message !== "";
 			const notShown = results.length - RESULTS_MAX_LENGTH;
 			const resultsSummary = `${mapMoveResults(results.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapMoveResults(results);
-			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">[+]</button>${message === "" ? "" : `</span><br/>`}`;
-			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
+			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">${showAll ? '[-]' : '[+]'}</button>${message === "" ? "" : `</span><br/>`}`;
+			resultsStr += `<div class="datasearch-body" style="display: ${showAll ? 'none' : 'block'}">${resultsSummary}</div><div class="datasearch-body" style="display: ${showAll ? 'block' : 'none'}>${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapMoveResults(results);
 		}
@@ -2344,11 +2362,16 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 }
 
 function runItemsearch(target: string, cmd: string, message: string) {
+	let showAll = false;
 	let maxGen = 0;
 	let gen = 0;
 	let randomOutput = 0;
 
 	const targetSplit = target.split(',');
+	if (targetSplit[targetSplit.length - 1].trim() === 'all') {
+		showAll = true;
+		targetSplit.pop();
+	}
 
 	const sanitizedTargets = [];
 	for (const index of targetSplit.keys()) {
@@ -2607,11 +2630,12 @@ function runItemsearch(target: string, cmd: string, message: string) {
 	if (foundItems.length > 0) {
 		foundItems.sort();
 		if (foundItems.length > MAX_RANDOM_RESULTS) {
+			showAll = showAll && message !== "";
 			const notShown = foundItems.length - RESULTS_MAX_LENGTH;
 			const resultsSummary = `${mapItemResults(foundItems.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapItemResults(foundItems);
-			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">[+]</button>${message === "" ? "" : `</span><br/>`}`;
-			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
+			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">${showAll ? '[-]' : '[+]'}</button>${message === "" ? "" : `</span><br/>`}`;
+			resultsStr += `<div class="datasearch-body" style="display: ${showAll ? 'none' : 'block'}">${resultsSummary}</div><div class="datasearch-body" style="display: ${showAll ? 'block' : 'none'}>${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapItemResults(foundItems);
 		}
@@ -2623,11 +2647,16 @@ function runItemsearch(target: string, cmd: string, message: string) {
 
 function runAbilitysearch(target: string, cmd: string, message: string) {
 	// based heavily on runItemsearch()
+	let showAll = false;
 	let maxGen = 0;
 	let gen = 0;
 	let randomOutput = 0;
 
 	const targetSplit = target.split(',');
+	if (targetSplit[targetSplit.length - 1].trim() === 'all') {
+		showAll = true;
+		targetSplit.pop();
+	}
 
 	const sanitizedTargets = [];
 	for (const index of targetSplit.keys()) {
@@ -2793,11 +2822,12 @@ function runAbilitysearch(target: string, cmd: string, message: string) {
 	if (foundAbilities.length > 0) {
 		foundAbilities.sort();
 		if (foundAbilities.length > MAX_RANDOM_RESULTS) {
+			showAll = showAll && message !== "";
 			const notShown = foundAbilities.length - RESULTS_MAX_LENGTH;
 			const resultsSummary = `${mapAbilityResults(foundAbilities.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapAbilityResults(foundAbilities);
-			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">[+]</button>${message === "" ? "" : `</span><br/>`}`;
-			resultsStr += `<div class="datasearch-body" style="display: block">${resultsSummary}</div><div class="datasearch-body" style="display: none">${resultsHidden}</div></div>`;
+			resultsStr = `<div class="datasearch" style="cursor: pointer">${message === "" ? "" : `<span style="color:#999999">${Utils.escapeHTML(message)}`}<button class="subtle" style="float: right">${showAll ? '[-]' : '[+]'}</button>${message === "" ? "" : `</span><br/>`}`;
+			resultsStr += `<div class="datasearch-body" style="display: ${showAll ? 'none' : 'block'}">${resultsSummary}</div><div class="datasearch-body" style="display: ${showAll ? 'block' : 'none'}>${resultsHidden}</div></div>`;
 		} else {
 			resultsStr += mapAbilityResults(foundAbilities);
 		}

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1597,7 +1597,7 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 		}
 
 		if (results.length > MAX_RANDOM_RESULTS) {
-			showAll = showAll && message !== "";
+			showAll = showAll && message !== "" && !message.startsWith('!');
 			const notShown = results.length - RESULTS_MAX_LENGTH;
 			const resultsSummary = `${mapPokemonResults(results.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapPokemonResults(results);
@@ -2343,7 +2343,7 @@ function runMovesearch(target: string, cmd: string, message: string, isTest: boo
 		}
 
 		if (results.length > MAX_RANDOM_RESULTS) {
-			showAll = showAll && message !== "";
+			showAll = showAll && message !== "" && !message.startsWith('!');
 			const notShown = results.length - RESULTS_MAX_LENGTH;
 			const resultsSummary = `${mapMoveResults(results.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapMoveResults(results);
@@ -2630,7 +2630,7 @@ function runItemsearch(target: string, cmd: string, message: string) {
 	if (foundItems.length > 0) {
 		foundItems.sort();
 		if (foundItems.length > MAX_RANDOM_RESULTS) {
-			showAll = showAll && message !== "";
+			showAll = showAll && message !== "" && !message.startsWith('!');
 			const notShown = foundItems.length - RESULTS_MAX_LENGTH;
 			const resultsSummary = `${mapItemResults(foundItems.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapItemResults(foundItems);
@@ -2822,7 +2822,7 @@ function runAbilitysearch(target: string, cmd: string, message: string) {
 	if (foundAbilities.length > 0) {
 		foundAbilities.sort();
 		if (foundAbilities.length > MAX_RANDOM_RESULTS) {
-			showAll = showAll && message !== "";
+			showAll = showAll && message !== "" && !message.startsWith('!');
 			const notShown = foundAbilities.length - RESULTS_MAX_LENGTH;
 			const resultsSummary = `${mapAbilityResults(foundAbilities.slice(0, RESULTS_MAX_LENGTH))}, and ${notShown} more. <button class="subtle">Click to show all results.</button>`;
 			const resultsHidden = mapAbilityResults(foundAbilities);

--- a/test/server/chat-plugins/datasearch.js
+++ b/test/server/chat-plugins/datasearch.js
@@ -12,14 +12,14 @@ describe("Datasearch Plugin", () => {
 	it('should return pokemon with pivot moves', async () => {
 		const cmd = 'ds';
 		const target = 'pivot|batonpass, mod=gen8';
-		const dexSearch = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const dexSearch = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`, true);
 		assert(dexSearch.results.includes('Absol'));
 	});
 
 	it('should return pokemon with pivot moves, but not baton pass', async () => {
 		const cmd = 'ds';
 		const target = 'pivot, mod=gen8';
-		const dexSearch = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const dexSearch = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`, true);
 		assert.false(dexSearch.results.includes('Absol'));
 		assert(dexSearch.results.includes('Abra'));
 	});
@@ -27,102 +27,102 @@ describe("Datasearch Plugin", () => {
 	it('should return pivot moves', async () => {
 		const cmd = 'ms';
 		const target = 'pivot';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert(moveSearch.results.includes('U-turn'));
 	});
 
 	it('should not return pivot moves', async () => {
 		const cmd = 'ms';
 		const target = '!pivot';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert.false(moveSearch.results.includes('U-turn'));
 	});
 
 	it('should error', async () => {
 		const cmd = 'ms';
 		const target = 'pivot|!pivot';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert(moveSearch.error);
 	});
 
 	it('should return recoil moves', async () => {
 		const cmd = 'ms';
 		const target = 'recoil';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert(moveSearch.results.includes('Brave Bird'));
 	});
 
 	it('should not return recoil moves', async () => {
 		const cmd = 'ms';
 		const target = '!recoil';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert.false(moveSearch.results.includes('Brave Bird'));
 	});
 
 	it('should return recovery moves', async () => {
 		const cmd = 'ms';
 		const target = 'recovery';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert(moveSearch.results.includes('Absorb'));
 	});
 
 	it('should not return recovery moves', async () => {
 		const cmd = 'ms';
 		const target = '!recovery';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert.false(moveSearch.results.includes('Absorb'));
 	});
 
 	it('should return zrecovery moves', async () => {
 		const cmd = 'ms';
 		const target = 'zrecovery';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert(moveSearch.results.includes('Belly Drum'));
 	});
 
 	it('should not return zrecovery moves', async () => {
 		const cmd = 'ms';
 		const target = '!zrecovery';
-		const moveSearch = datasearch.testables.runMovesearch(target, cmd, true, `/${cmd} ${target}`, true);
+		const moveSearch = datasearch.testables.runMovesearch(target, cmd, `/${cmd} ${target}`, true);
 		assert.false(moveSearch.results.includes('Belly Drum'));
 	});
 
 	it('should include result where query string in ability is adjacent to special character', () => {
 		const cmd = 'as';
 		const target = 'water';
-		const abilitySearch = datasearch.testables.runAbilitysearch(target, cmd, true, `/${cmd} ${target}`);
+		const abilitySearch = datasearch.testables.runAbilitysearch(target, cmd, `/${cmd} ${target}`);
 		assert(abilitySearch.reply.includes('Steam Engine'));
 	});
 
 	it('should exclude formes where the base Pokemon is included', () => {
 		const cmd = 'ds';
 		const target = 'ice, monotype';
-		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		const search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
 		assert.false(search.reply.includes('Eiscue-Noice'));
 	});
 
 	it('should include formes if a sort differentiates them from the base Pokemon', () => {
 		const cmd = 'ds';
 		let target = 'ice, monotype, spe desc';
-		let search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		let search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
 		assert(search.reply.includes('Eiscue-Noice'));
 
 		target = 'ice, monotype, hp desc';
-		search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
 		assert.false(search.reply.includes('Eiscue-Noice'));
 	});
 
 	it('should include Pokemon capable of learning normally unobtainable moves under the provided rulsets', () => {
 		const cmd = 'ds';
 		const target = 'mod=gen8, rule=stabmonsmovelegality, rule=alphabetcupmovelegality, calm mind, boomburst, steel';
-		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		const search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
 		assert(search.reply.includes('Metagross'));
 	});
 
 	it('should exclude Pokemon capable of learning moves under normal circumstances or the provided rulesets', () => {
 		const cmd = 'ds';
 		const target = 'mod=gen9, rule=stabmonsmovelegality, !wish';
-		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		const search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
 		assert.false(search.reply.includes('Alomomola'));
 		assert.false(search.reply.includes('Altaria'));
 	});
@@ -130,7 +130,7 @@ describe("Datasearch Plugin", () => {
 	it('should include only Pokemon allowed by the provided rulesets', () => {
 		const cmd = 'ds';
 		const target = 'mod=gen8, rule=kalospokedex, rule=hoennpokedex, water, ground';
-		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		const search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
 		assert(search.reply.includes('Whiscash'));
 		assert.false(search.reply.includes('Swampert'));
 		assert.false(search.reply.includes('Quagsire'));
@@ -140,7 +140,31 @@ describe("Datasearch Plugin", () => {
 	it('should sort Pokemon with modified stats based on rulesets', () => {
 		const cmd = 'ds';
 		const target = 'mod=gen8, rule=reevolutionmod, water, bst desc';
-		const search = datasearch.testables.runDexsearch(target, cmd, true, `/${cmd} ${target}`);
+		const search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
 		assert(search.reply.includes('Milotic'));
+	});
+
+	it('should collapse results by default when broadcasting a large datasearch with all as a parameter', () => {
+		let cmd = 'ds';
+		let target = 'mod=gen8, water, all';
+		let search = datasearch.testables.runDexsearch(target, cmd, `!${cmd} ${target}`);
+		assert(search.reply.includes('[+]'));
+
+		cmd = 'ms';
+		target = 'mod=gen8, water, all';
+		search = datasearch.testables.runDexsearch(target, cmd, `!${cmd} ${target}`);
+		assert(search.reply.includes('[+]'));
+	});
+
+	it('should expand results by default when not broadcasting a large datasearch with all as a parameter', () => {
+		let cmd = 'ds';
+		let target = 'mod=gen8, water, all';
+		let search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
+		assert(search.reply.includes('[-]'));
+
+		cmd = 'ms';
+		target = 'mod=gen8, water, all';
+		search = datasearch.testables.runDexsearch(target, cmd, `/${cmd} ${target}`);
+		assert(search.reply.includes('[-]'));
 	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/please-keep-the-dexsearch-or-ds-search-parameter-all-as-it-was.3762947/

Updates the behaviour of the collapsible datasearch results when using `/` commands to allow for the `all` parameter to expand it by default rather than always starting collapsed. When broadcast with `!`, the results will remain collapsed by default even when using `all` as a parameter.

Removes the `canAll` param from tests and adds tests for ensuring the results are properly collapsed/expanded when broadcast with `all` and when used as a `/` command with `all`.

This PR also fixes the bug with `randpoke` so I will be closing https://github.com/smogon/pokemon-showdown/pull/11019