### PR TITLE
Fixing National Dex 35 Pokes Banlist

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2432,7 +2432,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'!Species Clause', 'Forme Clause', 'Terastal Clause', 'DryPass Clause', 'Z-Move Clause', 'Mega Rayquaza Clause',
 		],
 		banlist: [
-			'ND Uber', 'ND AG', 'ND OU', 'ND UUBL', 'ND UU', 'ND RUBL', 'ND RU', 'ND NFE', 'ND LC',
+			'ND Uber', 'ND AG', 'ND OU', 'ND UUBL', 'ND UU', 'ND RUBL', 'ND RU', 'ND NFE', 'ND LC', 'Hattrem', 
 			'Battle Bond', 'Moody', 'Power Construct', 'Shadow Tag', 'Berserk Gene', 'King\'s Rock', 'Quick Claw', 'Razor Fang', 'Acupressure',
 			'Last Respects', 'Shed Tail', 'Baton Pass + Contrary', 'Baton Pass + Rapid Spin',
 		],


### PR DESCRIPTION
Hattrem currently incorrectly validates in the teambuilder, but it is not legal in the format. The list of pokemon displayed in the teambuilder on play.pokemonshowdown is the correct list. 