### PR TITLE
Moderation: Clarify duration of default roombans

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -793,8 +793,10 @@ export const commands: Chat.ChatCommands = {
 			);
 		}
 
-		const durationText = week ? ' for 1 week' : ' for 2 days';
-		this.addModAction(`${name} was banned${durationText} from ${room.title} by ${user.name}.${publicReason ? ` (${publicReason})` : ``}`);
+		this.addModAction(
+			`${name} was banned${week ? ' for 1 week' : ' for 2 days'} from ${room.title}` +
+			` by ${user.name}.${publicReason ? ` (${publicReason})` : ``}`
+		);
 
 		const time = week ? Date.now() + 7 * 24 * 60 * 60 * 1000 : null;
 		const affected = Punishments.roomBan(room, targetUser, time, null, privateReason);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -793,7 +793,8 @@ export const commands: Chat.ChatCommands = {
 			);
 		}
 
-		this.addModAction(`${name} was banned${week ? ' for a week' : ''} from ${room.title} by ${user.name}.${publicReason ? ` (${publicReason})` : ``}`);
+		const durationText = week ? ' for 1 week' : ' for 2 days';
+		this.addModAction(`${name} was banned${durationText} from ${room.title} by ${user.name}.${publicReason ? ` (${publicReason})` : ``}`);
 
 		const time = week ? Date.now() + 7 * 24 * 60 * 60 * 1000 : null;
 		const affected = Punishments.roomBan(room, targetUser, time, null, privateReason);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -786,7 +786,7 @@ export const commands: Chat.ChatCommands = {
 		if (targetUser.id in room.users || user.can('lock')) {
 			targetUser.popup(
 				`|modal||html|<p>${Utils.escapeHTML(user.name)} has banned you from the room ${room.roomid} ` +
-				`${(room.subRooms ? ` and its subrooms` : ``)}${week ? ' for a week' : ''}.` +
+				`${(room.subRooms ? ` and its subrooms` : ``)}${week ? ' for 1 week' : ' for 2 days'}.` +
 				`</p>${(publicReason ? `<p>Reason: ${Utils.escapeHTML(publicReason)}</p>` : ``)}` +
 				`<p>To appeal the ban, PM the staff member that banned you${room.persist ? ` or a room owner. ` +
 				`</p><p><button name="send" value="/roomauth ${room.roomid}">List Room Staff</button></p>` : `.</p>`}`


### PR DESCRIPTION
https://www.smogon.com/forums/threads/clarification-on-how-long-a-ban-lasts.3761482/ 

2 day bans do not say the amount of time which can be confusing to new users as they think a room ban is permanent. This commit does so without influencing week room ban text logs which already do note the 1 week time limit. This is an approved suggestion on the forums as well.