### PR TITLE
Fix bug letting Gen-2 OHKO moves skip level check

### DIFF
--- a/data/mods/gen2/scripts.ts
+++ b/data/mods/gen2/scripts.ts
@@ -206,6 +206,11 @@ export const Scripts: ModdedBattleScriptsData = {
 				return false;
 			}
 
+			if (move.ohko && pokemon.level < target.level) {
+				this.battle.add('-immune', target, '[ohko]');
+				return false;
+			}
+
 			let accuracy = move.accuracy;
 			if (move.alwaysHit) {
 				accuracy = true;
@@ -216,13 +221,8 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (accuracy !== true) {
 				accuracy = Math.floor(accuracy * 255 / 100);
 				if (move.ohko) {
-					if (pokemon.level >= target.level) {
-						accuracy += (pokemon.level - target.level) * 2;
-						accuracy = Math.min(accuracy, 255);
-					} else {
-						this.battle.add('-immune', target, '[ohko]');
-						return false;
-					}
+					accuracy += (pokemon.level - target.level) * 2;
+					accuracy = Math.min(accuracy, 255);
 				}
 				if (!move.ignoreAccuracy) {
 					if (pokemon.boosts.accuracy > 0) {

--- a/test/sim/moves/lockon.js
+++ b/test/sim/moves/lockon.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const assert = require("./../../assert");
+const common = require("./../../common");
+
+let battle;
+
+describe(`Lock-On`, () => {
+	afterEach(() => {
+		battle.destroy();
+	});
+
+	it(`should not allow OHKO moves to hit a higher level in Gen 2`, () => {
+		battle = common.gen(2).createBattle([[
+			{ species: 'smeargle', level: 1, moves: ['lockon', 'guillotine'] },
+		], [
+			{ species: 'alakazam', level: 100, moves: ['curse'] },
+		]]);
+		battle.makeChoices('move lockon', 'move curse');
+		const alakazam = battle.p2.active[0];
+		battle.makeChoices('move guillotine', 'move curse');
+		assert.false.fainted(alakazam);
+	});
+});


### PR DESCRIPTION
Addresses #10983 
I shifted the code that compared Pokémon levels for OHKO moves to be before checking for accuracy, so now OHKO moves should fail regardless of Lock-On.