### PR TITLE
Random Normal moves don't require target in Simulation

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1,6 +1,6 @@
 import { Dex, toID } from './dex';
 
-const CHOOSABLE_TARGETS = new Set(['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'adjacentFoe']);
+const CHOOSABLE_TARGETS = new Set(['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'adjacentFoe','randomNormal']);
 
 export class BattleActions {
 	battle: Battle;
@@ -236,7 +236,11 @@ export class BattleActions {
 		} else if (maxMove) {
 			move = this.getActiveMaxMove(baseMove, pokemon);
 		}
-
+		//console.log(move)
+		if (move.target === 'randomNormal'){
+			target = this.battle.getRandomTarget(pokemon, move);
+		}
+			
 		move.isExternal = externalMove;
 
 		this.battle.setActiveMove(move, pokemon, target);

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -228,6 +228,14 @@ export class BattleActions {
 				baseMove.priority = priority;
 				if (pranksterBoosted) baseMove.pranksterBoosted = pranksterBoosted;
 				target = this.battle.getRandomTarget(pokemon, baseMove);
+				if (changedMove) {
+					try {
+						baseMove = this.dex.getActiveMove(changedMove);
+					} catch {
+						this.battle.add('-error', `Invalid move override: ${changedMove}`);
+						return;
+					}
+				}
 			}
 		}
 		// Fetch the move data
@@ -254,6 +262,14 @@ export class BattleActions {
 			if (typeof targetLoc === 'undefined') {
 				return this.battle.add('-error', pokemon.side.id, `You must specify a target for ${move.name}`);
 			}
+		}
+
+		if (CHOOSABLE_TARGETS.has(move.target) && move.target !== 'randomNormal' && targetLoc === undefined) {
+			return this.battle.add('-error', 'You must specify a target');
+		}
+
+		if (!target && move.target === 'randomNormal') {
+			return this.battle.add('-error', `${pokemon.name}'s move failed because there were no valid targets`);
 		}
 
 		// Additional safeguard: if the move normally requires targeting but `target` still ends up undefined,


### PR DESCRIPTION
This pull request adds a try/catch block around the getActiveMove call when handling changedMove overrides in BattleActions#runMove. This prevents the battle from crashing when an invalid or malformed move ID is returned from OverrideAction. If an invalid override is detected, an error message is displayed in the battle log and execution is halted.