### PR TITLE
Info: Update /tier Command

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -1889,10 +1889,10 @@ export const commands: Chat.ChatCommands = {
 	async formathelp(target, room, user, connection, cmd) {
 		if (!target && this.runBroadcast()) {
 			return this.sendReplyBox(
-				`- <a href="https://www.smogon.com/tiers/">Smogon Tiers</a><br />` +
-				`- <a href="https://www.smogon.com/forums/threads/3498332/">Tiering FAQ</a><br />` +
-				`- <a href="https://www.smogon.com/xyhub/tiers">The banlists for each tier</a><br />` +
-				"<br /><em>Type /formatshelp <strong>[format|section]</strong> to get details about an available format or group of formats.</em>"
+				`- <a href="https://www.smogon.com/forums/forums/smogon-metagames.725/">Smogon Metagames</a><br />` +
+				`- <a href="https://www.smogon.com/forums/threads/3628026/">Tiering Framework</a><br />` +
+				`- <a href="https://www.smogon.com/forums/threads/3644714/">Tiering FAQ</a><br />` +
+				"<br /><em>Type /tier <strong>[tier name]</strong> to get details, banlists, and helpful resources like sample teams for any tier!</em>"
 			);
 		}
 


### PR DESCRIPTION
Replace outdated (like, since XY outdated) links with current links.

I don't *love* dumping users at the Smogon Metagames forum, but there is no where else I am aware of that has all of our formats listed out.

Also updated the description to explain how /tier works and explain what type of information it contains.