### PR TITLE
Mafia: add maximum role length.

### DIFF
--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -521,7 +521,8 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 			this.theme = null;
 		}
 
-		if (Math.max(...roles.map(role => role.length)) > MAX_ROLE_LENGTH) return this.sendUser(user, `|error|Some role exceeds the maximum role length of ${MAX_ROLE_LENGTH}.`);
+		if (Math.max(...roles.map(role => role.length)) > MAX_ROLE_LENGTH)
+			return this.sendUser(user, `|error|Some role exceeds the maximum role length of ${MAX_ROLE_LENGTH}.`);
 
 		if (roles.length < this.playerCount) {
 			return this.sendUser(user, `|error|You have not provided enough roles for the players.`);
@@ -2769,7 +2770,8 @@ export const commands: Chat.ChatCommands = {
 					return this.parse('/help mafia revealas');
 				} else {
 					const roleName = args.pop()!.trim();
-					if (roleName.length > MAX_ROLE_LENGTH) return this.sendReply(`|error|Role exceeds the maximum role length of ${MAX_ROLE_LENGTH}.`);
+					if (roleName.length > MAX_ROLE_LENGTH)
+						return this.sendReply(`|error|Role exceeds the maximum role length of ${MAX_ROLE_LENGTH}.`);
 					revealedRole = Mafia.parseRole(roleName);
 					const color = MafiaData.alignments[revealedRole.role.alignment].color;
 					revealAs = `<span style="font-weight:bold;color:${color}">${revealedRole.role.safeName}</span>`;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -127,6 +127,8 @@ const hostQueue: ID[] = [];
 
 const IDEA_TIMER = 60 * 1000;
 
+const MAX_ROLE_LENGTH = 1000;
+
 function readFile(path: string) {
 	try {
 		const json = FS(path).readIfExistsSync();
@@ -519,6 +521,8 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 			this.theme = null;
 		}
 
+		if (Math.max(...roles.map(role => role.length)) > MAX_ROLE_LENGTH) return this.sendUser(user, `|error|Some role exceeds the maximum role length of ${MAX_ROLE_LENGTH}.`);
+
 		if (roles.length < this.playerCount) {
 			return this.sendUser(user, `|error|You have not provided enough roles for the players.`);
 		} else if (roles.length > this.playerCount) {
@@ -641,8 +645,8 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 			.split(' ')
 			.map(toID);
 
-		let iters = 0;
 		outer: while (roleWords.length) {
+			let iters = 0;
 			const currentWord = roleWords.slice();
 
 			while (currentWord.length) {
@@ -2764,7 +2768,9 @@ export const commands: Chat.ChatCommands = {
 				if (!args[0]) {
 					return this.parse('/help mafia revealas');
 				} else {
-					revealedRole = Mafia.parseRole(args.pop()!);
+					const roleName = args.pop()!.trim();
+					if (roleName.length > MAX_ROLE_LENGTH) return this.sendReply(`|error|Role exceeds the maximum role length of ${MAX_ROLE_LENGTH}.`);
+					revealedRole = Mafia.parseRole(roleName);
 					const color = MafiaData.alignments[revealedRole.role.alignment].color;
 					revealAs = `<span style="font-weight:bold;color:${color}">${revealedRole.role.safeName}</span>`;
 				}


### PR DESCRIPTION
Today, a bug was found where using revealas on a long role crashed PS!

I alleviated this by adding a maximum role length (instead of having it be uncapped, as currently people could spam PS using unlimited length roles) and moving the 'infinite loop' check to not be triggered by long roles.

This was implemented in both setroles and revealas.