### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -2948,7 +2948,7 @@
                 "abilities": ["Flower Gift"]
             },
             {
-                "role": "Staller",
+                "role": "Bulky Support",
                 "movepool": ["energyball", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"],
                 "abilities": ["Flower Gift"]
             }

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -2946,6 +2946,11 @@
                 "role": "Staller",
                 "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "leechseed", "synthesis", "toxic"],
                 "abilities": ["Flower Gift"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["energyball", "hiddenpowerfire", "hiddenpowerice", "leechseed", "substitute"],
+                "abilities": ["Flower Gift"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -4622,7 +4622,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"],
+                "movepool": ["calmmind", "energyball", "fireblast", "shadowball", "substitute"],
                 "abilities": ["Flame Body", "Flash Fire"]
             }
         ]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -2725,7 +2725,7 @@
         "level": 81,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["irontail", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
                 "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
@@ -5091,7 +5091,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"],
+                "movepool": ["calmmind", "energyball", "fireblast", "shadowball", "substitute"],
                 "abilities": ["Flame Body", "Flash Fire"]
             }
         ]
@@ -5811,6 +5811,11 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aurasphere", "darkpulse", "icebeam", "scald", "uturn", "waterpulse"],
+                "abilities": ["Mega Launcher"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["aurasphere", "darkpulse", "icebeam", "scald", "uturn"],
                 "abilities": ["Mega Launcher"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -5464,7 +5464,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "fireblast", "shadowball", "substitute"],
+                "movepool": ["calmmind", "energyball", "fireblast", "shadowball", "substitute"],
                 "abilities": ["Flame Body", "Flash Fire"]
             }
         ]
@@ -6266,6 +6266,11 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["aurasphere", "darkpulse", "icebeam", "scald", "uturn", "waterpulse"],
+                "abilities": ["Mega Launcher"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["aurasphere", "darkpulse", "icebeam", "scald", "uturn"],
                 "abilities": ["Mega Launcher"]
             }
         ]

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -156,7 +156,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Fire Blast", "Follow Me", "Heal Pulse", "Helping Hand", "Life Dew", "Moonblast"],
+                "movepool": ["Encore", "Fire Blast", "Follow Me", "Helping Hand", "Life Dew", "Moonblast", "Moonlight"],
                 "abilities": ["Unaware"],
                 "teraTypes": ["Fire", "Steel", "Water"]
             }
@@ -266,13 +266,7 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Encore", "Grass Knot", "Hydro Pump", "Ice Beam", "Icy Wind", "Protect", "Psyshock"],
-                "abilities": ["Cloud Nine", "Swift Swim"],
-                "teraTypes": ["Grass", "Water"]
-            },
-            {
-                "role": "Offensive Protect",
-                "movepool": ["Grass Knot", "Hydro Pump", "Ice Beam", "Protect", "Psyshock"],
+                "movepool": ["Encore", "Grass Knot", "Hydro Pump", "Ice Beam", "Icy Wind", "Protect"],
                 "abilities": ["Cloud Nine", "Swift Swim"],
                 "teraTypes": ["Grass", "Water"]
             }
@@ -1317,7 +1311,7 @@
             },
             {
                 "role": "Choice Item user",
-                "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "Knock Off"],
+                "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "U-turn"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Fighting", "Steel", "Water"]
             }
@@ -2378,7 +2372,13 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Aqua Jet", "Crunch", "Ice Spinner", "Protect", "Wave Crash"],
+                "movepool": ["Aqua Jet", "Flip Turn", "Ice Spinner", "Wave Crash"],
+                "abilities": ["Water Veil"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Aqua Jet", "Ice Spinner", "Protect", "Wave Crash"],
                 "abilities": ["Water Veil"],
                 "teraTypes": ["Water"]
             }
@@ -4758,7 +4758,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Hyper Voice", "Instruct", "Psyshock", "Trick Room"],
-                "abilities": ["Telepathy"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Fairy"]
             }
         ]

--- a/data/random-battles/gen9/factory-sets.json
+++ b/data/random-battles/gen9/factory-sets.json
@@ -2439,28 +2439,6 @@
 				"moves": [["First Impression", "Protect"], ["Knock Off"], ["Swords Dance"], ["Sucker Punch"]]
 			}]
 		},
-		"weavile": {
-			"weight": 8,
-			"sets": [{
-				"species": "Weavile",
-				"weight": 80,
-				"item": ["Heavy-Duty Boots"],
-				"ability": ["Pickpocket"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": ["Jolly"],
-				"teraType": ["Ghost", "Dark"],
-				"moves": [["Swords Dance"], ["Triple Axel", "Icicle Crash"], ["Knock Off"], ["Ice Shard", "Low Kick"]]
-			}, {
-				"species": "Weavile",
-				"weight": 20,
-				"item": ["Heavy-Duty Boots"],
-				"ability": ["Pickpocket"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": ["Jolly"],
-				"teraType": ["Ice"],
-				"moves": [["Swords Dance"], ["Triple Axel"], ["Knock Off"], ["Ice Shard"]]
-			}]
-		},
 		"greninja": {
 			"weight": 5,
 			"sets": [{
@@ -2879,28 +2857,6 @@
 				"nature": ["Impish"],
 				"teraType": ["Dragon", "Water"],
 				"moves": [["Body Press"], ["Roost"], ["Spikes"], ["Brave Bird"]]
-			}]
-		},
-		"tinkaton": {
-			"weight": 5,
-			"sets": [{
-				"species": "Tinkaton",
-				"weight": 50,
-				"item": ["Leftovers"],
-				"ability": ["Mold Breaker"],
-				"evs": {"hp": 252, "def": 232, "spe": 24},
-				"nature": ["Impish"],
-				"teraType": ["Flying", "Ghost", "Dark", "Dragon"],
-				"moves": [["Gigaton Hammer"], ["Encore"], ["Knock Off"], ["Stealth Rock", "Thunder Wave"]]
-			}, {
-				"species": "Tinkaton",
-				"weight": 50,
-				"item": ["Air Balloon"],
-				"ability": ["Pickpocket"],
-				"evs": {"hp": 252, "def": 232, "spe": 24},
-				"nature": ["Impish"],
-				"teraType": ["Ghost", "Dark", "Dragon"],
-				"moves": [["Gigaton Hammer"], ["Encore"], ["Knock Off"], ["Stealth Rock", "Thunder Wave"]]
 			}]
 		},
 		"enamorustherian": {
@@ -3993,67 +3949,6 @@
 				"nature": ["Bold"],
 				"teraType": ["Steel", "Ghost", "Water"],
 				"moves": [["Strange Steam"], ["Pain Split"], ["Will-O-Wisp"], ["Defog", "Flamethrower", "Taunt"]]
-			}]
-		},
-		"zoroarkhisui": {
-			"weight": 7,
-			"sets": [{
-				"species": "Zoroark-Hisui",
-				"weight": 20,
-				"item": ["Choice Specs"],
-				"ability": ["Illusion"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Timid"],
-				"teraType": ["Fairy"],
-				"moves": [["Shadow Ball"], ["Tera Blast"], ["Flamethrower"], ["Trick", "Grass Knot"]]
-			}, {
-				"species": "Zoroark-Hisui",
-				"weight": 10,
-				"item": ["Choice Specs"],
-				"ability": ["Illusion"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": ["Timid"],
-				"teraType": ["Fairy"],
-				"moves": [["Shadow Ball"], ["Tera Blast"], ["Flamethrower"], ["U-turn"]]
-			}, {
-				"species": "Zoroark-Hisui",
-				"weight": 20,
-				"item": ["Choice Specs"],
-				"ability": ["Illusion"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Timid"],
-				"teraType": ["Ghost"],
-				"moves": [["Shadow Ball"], ["Hyper Voice"], ["Flamethrower"], ["Trick", "Grass Knot"]]
-			}, {
-				"species": "Zoroark-Hisui",
-				"weight": 10,
-				"item": ["Choice Specs"],
-				"ability": ["Illusion"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": ["Timid"],
-				"teraType": ["Ghost"],
-				"moves": [["Shadow Ball"], ["Hyper Voice"], ["Flamethrower"], ["U-turn"]]
-			}, {
-				"species": "Zoroark-Hisui",
-				"weight": 20,
-				"item": ["Choice Scarf"],
-				"ability": ["Illusion"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Timid"],
-				"teraType": ["Ghost"],
-				"moves": [["Shadow Ball"], ["Hyper Voice"], ["Flamethrower"], ["Trick"]]
-			}, {
-				"species": "Zoroark-Hisui",
-				"weight": 20,
-				"item": ["Choice Scarf"],
-				"ability": ["Illusion"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"nature": ["Timid"],
-				"teraType": ["Ghost"],
-				"moves": [["Shadow Ball"], ["Hyper Voice"], ["U-turn"], ["Trick"]]
 			}]
 		},
 		"amoonguss": {
@@ -5283,28 +5178,6 @@
 				"moves": [["Tera Blast"], ["Tri Attack"], ["Shadow Ball"], ["Agility"]]
 			}]
 		},
-		"registeel": {
-			"weight": 5,
-			"sets": [{
-				"species": "Registeel",
-				"weight": 50,
-				"item": ["Leftovers"],
-				"ability": ["Clear Body"],
-				"evs": {"hp": 252, "def": 4, "spd": 252},
-				"nature": ["Careful"],
-				"teraType": ["Ghost", "Fairy", "Dragon", "Water"],
-				"moves": [["Heavy Slam"], ["Stealth Rock"], ["Earthquake"], ["Thunder Wave"]]
-			}, {
-				"species": "Registeel",
-				"weight": 50,
-				"item": ["Leftovers"],
-				"ability": ["Clear Body"],
-				"evs": {"hp": 252, "def": 4, "spd": 252},
-				"nature": ["Careful"],
-				"teraType": ["Ghost", "Fairy", "Dragon", "Water"],
-				"moves": [["Heavy Slam"], ["Stealth Rock"], ["Body Press"], ["Iron Defense", "Thunder Wave"]]
-			}]
-		},
 		"scyther": {
 			"weight": 4,
 			"sets": [{
@@ -6482,40 +6355,6 @@
 				"moves": [["Gunk Shot"], ["Knock Off"], ["Sucker Punch"], ["Taunt", "Toxic", "Toxic Spikes"]]
 			}]
 		},
-		"toxtricity": {
-			"weight": 7,
-			"sets": [{
-				"species": "Toxtricity",
-				"weight": 35,
-				"item": ["Throat Spray"],
-				"ability": ["Punk Rock"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Modest"],
-				"teraType": ["Normal"],
-				"moves": [["Overdrive"], ["Boomburst"], ["Shift Gear"], ["Sludge Bomb", "Snarl"]]
-			}, {
-				"species": "Toxtricity",
-				"weight": 35,
-				"item": ["Choice Specs"],
-				"ability": ["Punk Rock"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Modest"],
-				"teraType": ["Normal"],
-				"moves": [["Overdrive"], ["Boomburst"], ["Volt Switch"], ["Snarl"]]
-			}, {
-				"species": "Toxtricity",
-				"weight": 30,
-				"item": ["Choice Scarf"],
-				"ability": ["Punk Rock"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": ["Timid"],
-				"teraType": ["Normal"],
-				"moves": [["Overdrive"], ["Boomburst"], ["Volt Switch"], ["Snarl", "Sludge Bomb"]]
-			}]
-		},
 		"bruxish": {
 			"weight": 4,
 			"sets": [{
@@ -6545,37 +6384,6 @@
 				"nature": ["Jolly"],
 				"teraType": ["Water"],
 				"moves": [["Psychic Fangs"], ["Swords Dance"], ["Wave Crash"], ["Aqua Jet"]]
-			}]
-		},
-		"copperajah": {
-			"weight": 5,
-			"sets": [{
-				"species": "Copperajah",
-				"weight": 25,
-				"item": ["Leftovers"],
-				"ability": ["Heavy Metal"],
-				"evs": {"hp": 252, "atk": 4, "spd": 252},
-				"nature": ["Careful"],
-				"teraType": ["Ghost", "Water"],
-				"moves": [["Heavy Slam"], ["Whirlwind"], ["Knock Off"], ["Stealth Rock", "Protect"]]
-			}, {
-				"species": "Copperajah",
-				"weight": 25,
-				"item": ["Leftovers"],
-				"ability": ["Heavy Metal"],
-				"evs": {"hp": 252, "atk": 4, "spd": 252},
-				"nature": ["Careful"],
-				"teraType": ["Ground", "Ghost", "Water"],
-				"moves": [["Heavy Slam"], ["Whirlwind", "Stealth Rock", "Protect"], ["Knock Off"], ["Earthquake"]]
-			}, {
-				"species": "Copperajah",
-				"weight": 50,
-				"item": ["Assault Vest"],
-				"ability": ["Sheer Force"],
-				"evs": {"atk": 192, "spd": 192, "spe": 124},
-				"nature": ["Adamant"],
-				"teraType": ["Fairy", "Ground"],
-				"moves": [["Iron Head"], ["Knock Off"], ["Earthquake"], ["Play Rough"]]
 			}]
 		},
 		"goodra": {

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -440,7 +440,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Fairy", "Water"]
+                "teraTypes": ["Fairy", "Poison"]
             },
             {
                 "role": "AV Pivot",
@@ -1032,7 +1032,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Fire Blast", "Nasty Plot", "Psystrike", "Recover"],
-                "abilities": ["Unnerve"],
+                "abilities": ["Pressure", "Unnerve"],
                 "teraTypes": ["Dark", "Fighting", "Fire", "Psychic"]
             }
         ]
@@ -3025,14 +3025,14 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Discharge", "Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Body Press", "Discharge", "Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Analytic", "Magnet Pull"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Discharge", "Flash Cannon", "Iron Defense", "Thunderbolt"],
-                "abilities": ["Magnet Pull"],
+                "abilities": ["Analytic", "Magnet Pull"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3426,7 +3426,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Flash Cannon", "Heavy Slam", "Lava Plume", "Magma Storm", "Stealth Rock"],
                 "abilities": ["Flash Fire"],
-                "teraTypes": ["Flying", "Grass", "Steel"]
+                "teraTypes": ["Flying", "Grass"]
             }
         ]
     },
@@ -4316,12 +4316,6 @@
                 "movepool": ["Ice Beam", "Rapid Spin", "Recover", "Tera Blast"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Freeze-Dry", "Rapid Spin", "Recover", "Tera Blast"],
-                "abilities": ["Levitate"],
-                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -4772,7 +4766,7 @@
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bug Buzz", "Hurricane", "Quiver Dance", "Sleep Powder"],
                 "abilities": ["Compound Eyes"],
-                "teraTypes": ["Flying"]
+                "teraTypes": ["Flying", "Steel"]
             },
             {
                 "role": "Tera Blast user",
@@ -5300,8 +5294,14 @@
         "level": 81,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Accelerock", "Close Combat", "Psychic Fangs", "Stone Edge", "Swords Dance", "Throat Chop"],
+                "role": "Setup Sweeper",
+                "movepool": ["Accelerock", "Close Combat", "Psychic Fangs", "Stone Edge", "Swords Dance"],
+                "abilities": ["Tough Claws"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Accelerock", "Close Combat", "Psychic Fangs", "Stone Edge", "Throat Chop"],
                 "abilities": ["Tough Claws"],
                 "teraTypes": ["Fighting"]
             }
@@ -5979,13 +5979,7 @@
                 "role": "Tera Blast user",
                 "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute", "Tera Blast"],
                 "abilities": ["Ice Face"],
-                "teraTypes": ["Electric"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Belly Drum", "Ice Spinner", "Substitute", "Tera Blast"],
-                "abilities": ["Ice Face"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Electric", "Ground"]
             }
         ]
     },
@@ -6456,7 +6450,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Curse", "Rest", "Sleep Talk"],
-                "abilities": ["Thick Fat"],
+                "abilities": ["Aroma Veil", "Thick Fat"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -6780,7 +6774,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Dazzling Gleam", "Lumina Crash", "Trick", "U-turn"],
+                "movepool": ["Dazzling Gleam", "Lumina Crash", "Shadow Ball", "U-turn"],
                 "abilities": ["Speed Boost"],
                 "teraTypes": ["Fairy", "Psychic"]
             },
@@ -6887,7 +6881,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Heavy Slam", "Rest", "Shed Tail", "Spikes", "Stealth Rock"],
+                "movepool": ["Body Press", "Heavy Slam", "Shed Tail", "Spikes", "Stealth Rock"],
                 "abilities": ["Earth Eater"],
                 "teraTypes": ["Electric", "Fighting", "Ghost", "Poison"]
             }
@@ -7224,7 +7218,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Volt Switch"],
                 "abilities": ["Quark Drive"],
-                "teraTypes": ["Ground", "Steel"]
+                "teraTypes": ["Dragon", "Ghost", "Water"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -237,7 +237,7 @@
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Stone Edge", "Sucker Punch", "Throat Chop"],
                 "abilities": ["Arena Trap"],
-                "teraTypes": ["Dark", "Fairy", "Flying", "Ghost", "Ground"]
+                "teraTypes": ["Dark", "Ground"]
             }
         ]
     },

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1267,7 +1267,7 @@ export class RandomTeams {
 			['Doubles Fast Attacker', 'Doubles Wallbreaker', 'Doubles Setup Sweeper', 'Offensive Protect'].some(m => role === m)
 		);
 		const doublesLeftoversHardcodes = (
-			moves.has('acidarmor') || moves.has('wish') || ['eternatus', 'garganacl', 'regigigas', 'toxapex'].includes(species.id))
+			moves.has('acidarmor') || moves.has('wish') || ['eternatus', 'garganacl', 'regigigas', 'toxapex'].includes(species.id)
 		);
 
 		if (species.id === 'ursalunabloodmoon' && moves.has('protect')) return 'Silk Scarf';

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1267,7 +1267,7 @@ export class RandomTeams {
 			['Doubles Fast Attacker', 'Doubles Wallbreaker', 'Doubles Setup Sweeper', 'Offensive Protect'].some(m => role === m)
 		);
 		const doublesLeftoversHardcodes = (
-			moves.has('acidarmor') || moves.has('wish') || ['eternatus', 'garganacl', 'regigigas', 'toxapex'].some(m => species.id === m)
+			moves.has('acidarmor') || moves.has('wish') || ['eternatus', 'garganacl', 'regigigas', 'toxapex'].includes(species.id))
 		);
 
 		if (species.id === 'ursalunabloodmoon' && moves.has('protect')) return 'Silk Scarf';

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -539,14 +539,13 @@ export class RandomTeams {
 				[['fierydance', 'fireblast'], 'heatwave'],
 				['dazzlinggleam', ['fleurcannon', 'moonblast']],
 				['poisongas', ['toxicspikes', 'willowisp']],
-				[RECOVERY_MOVES, 'healpulse'],
-				['lifedew', 'healpulse'],
+				[RECOVERY_MOVES, ['healpulse', 'lifedew']],
+				['healpulse', 'lifedew'],
 				['haze', 'icywind'],
 				[['hydropump', 'muddywater'], ['muddywater', 'scald']],
 				['disable', 'encore'],
 				['freezedry', 'icebeam'],
 				['energyball', 'leafstorm'],
-				['wildcharge', 'thunderbolt'],
 				['earthpower', 'sandsearstorm'],
 				['coaching', ['helpinghand', 'howl']],
 			];
@@ -570,6 +569,7 @@ export class RandomTeams {
 			['curse', ['irondefense', 'rapidspin']],
 			['dragondance', 'dracometeor'],
 			['yawn', 'roar'],
+			['trick', 'uturn'],
 
 			// These attacks are redundant with each other
 			[['psychic', 'psychicnoise'], ['psyshock', 'psychicnoise']],
@@ -578,7 +578,7 @@ export class RandomTeams {
 			['aquajet', 'flipturn'],
 			['gigadrain', 'leafstorm'],
 			['powerwhip', 'hornleech'],
-			[['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']],
+			['airslash', 'hurricane'],
 			['knockoff', 'foulplay'],
 			['throatchop', ['crunch', 'lashout']],
 			['doubleedge', ['bodyslam', 'headbutt']],
@@ -589,7 +589,6 @@ export class RandomTeams {
 			['gunkshot', ['direclaw', 'poisonjab', 'sludgebomb']],
 			['aurasphere', 'focusblast'],
 			['closecombat', 'drainpunch'],
-			['bugbite', 'pounce'],
 			[['dragonpulse', 'spacialrend'], 'dracometeor'],
 			['heavyslam', 'flashcannon'],
 			['alluringvoice', 'dazzlinggleam'],
@@ -608,10 +607,8 @@ export class RandomTeams {
 			['toxic', 'clearsmog'],
 			// Chansey and Blissey
 			['healbell', 'stealthrock'],
-			// Azelf and Zoroarks
-			['trick', 'uturn'],
-			// Araquanid
-			['mirrorcoat', 'hydropump'],
+			// Araquanid and Magnezone
+			['mirrorcoat', ['hydropump', 'bodypress']],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
@@ -1270,7 +1267,7 @@ export class RandomTeams {
 			['Doubles Fast Attacker', 'Doubles Wallbreaker', 'Doubles Setup Sweeper', 'Offensive Protect'].some(m => role === m)
 		);
 		const doublesLeftoversHardcodes = (
-			moves.has('acidarmor') || species.id === 'eternatus' || species.id === 'regigigas' || moves.has('wish')
+			moves.has('acidarmor') || moves.has('wish') || ['eternatus', 'garganacl', 'regigigas', 'toxapex'].some(m => species.id === m)
 		);
 
 		if (species.id === 'ursalunabloodmoon' && moves.has('protect')) return 'Silk Scarf';
@@ -1278,7 +1275,6 @@ export class RandomTeams {
 			moves.has('flipturn') && moves.has('protect') && (moves.has('aquajet') || (moves.has('jetpunch')))
 		) return 'Mystic Water';
 		if (counter.get('speedsetup') && role === 'Doubles Bulky Setup') return 'Weakness Policy';
-		if (species.id === 'toxapex') return 'Binding Band';
 		if (moves.has('blizzard') && ability !== 'Snow Warning' && !teamDetails.snow) return 'Blunder Policy';
 
 		if (role === 'Choice Item user') {
@@ -1300,6 +1296,9 @@ export class RandomTeams {
 		) {
 			return (scarfReqs) ? 'Choice Scarf' : 'Choice Specs';
 		}
+		if (
+			species.baseStats.spe <= 70 && (moves.has('ragepowder') || moves.has('followme'))
+		) return 'Rocky Helmet';
 		if (
 			(role === 'Bulky Protect' && counter.get('setup')) || moves.has('substitute') || moves.has('irondefense') ||
 			moves.has('coil') || doublesLeftoversHardcodes


### PR DESCRIPTION
`**Gen 9 Random Battle**
-Lycanroc-Dusk has been split into two sets; Swords Dance will no longer run Throat Chop, and Choice Band will now always run Accelerock.
-Rest Oinkologne-F: +Aroma Veil
-Mewtwo: +Pressure
-Iron Defense Magnezone: +Analytic
-AV Magnezone: +Body Press, rolled with Mirror Coat
-Support Orthworm: -Rest
-Bulky Attacker Slowbro: -Tera Water, +Tera Poison
-Heatran: -Tera Steel
-Iron Treads: -Tera Ground, -Tera Steel, +Tera Water, +Tera Ghost, +Tera Dragon
-Bug Buzz Vivillon: +Tera Steel
-Choice Band Dugtrio: -all teras other than Dark and Ground
-Several unnecessary bits of leftover code have been removed.

Reversions of past changes due to performing poorly in win rates:
-Cryogonal no longer runs Tera Blast Fire.
-Eiscue's changes to its Tera Blast set(s) have been reverted. It's now only one Tera Blast set again.
-Specs Espathra: -Trick, +Shadow Ball

**Gen 9 Random Doubles**:
-Pokemon with redirecting moves (Follow Me, Rage Powder) and a base Speed stat of 70 or below now get Rocky Helmet.
-Floatzel: Has two sets: Choice Band with Flip Turn, Aqua Jet, and Ice Spinner, and Life Orb with Protect, Aqua Jet, and Ice Spinner.
-Golduck: Removed redundant Offensive Protect set, and removed Psyshock.
-Oranguru: -Telepathy, +Inner Focus
-Doubles Support Clefable: -Heal Pulse, +Moonlight (does not coincide with Life Dew)
-Choice Band Scizor: -Knock Off, +U-turn

**Old Gens**:
-In Gens 5-7, Calm Mind Chandelure now sometimes runs Energy Ball.
-In Gens 6-7, Clawitzer now has an additional Assault Vest set.
-In Gen 6, Mega Absol now always has Sucker Punch.
-In Gen 4, Cherrim now runs an additional set of SubSeed with Hidden Power Fire/Ice.

**Battle Factory**:
-Pokemon no longer in their respective tiers have been removed. Further set additions and updates to be announced later.