### PR TITLE
BDSP: Fix NU-PU banlist

### DIFF
--- a/data/mods/gen8bdsp/formats-data.ts
+++ b/data/mods/gen8bdsp/formats-data.ts
@@ -103,7 +103,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	sandslash: {
-		tier: "NU",
+		tier: "PU",
 		doublesTier: "DUU",
 	},
 	nidoranf: {
@@ -1241,7 +1241,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		doublesTier: "DUU",
 	},
 	torkoal: {
-		tier: "NU",
+		tier: "PU",
 		doublesTier: "DOU",
 	},
 	spoink: {


### PR DESCRIPTION
I had forgotten to move Sandslash and Torkoal to PU in my other PR.