### PR TITLE
DPP PU + ZU teambuilder + dex support + corrections

### DIFF
--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -3,7 +3,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	ivysaur: {
-		tier: "NFE",
+		tier: "ZU",
 	},
 	venusaur: {
 		tier: "UU",
@@ -33,7 +33,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	butterfree: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	weedle: {
 		tier: "LC",
@@ -42,7 +42,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	beedrill: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	pidgey: {
 		tier: "LC",
@@ -51,37 +51,37 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	pidgeot: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	rattata: {
 		tier: "LC",
 	},
 	raticate: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	spearow: {
 		tier: "LC",
 	},
 	fearow: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	ekans: {
 		tier: "LC",
 	},
 	arbok: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	pichu: {
 		tier: "LC",
 	},
 	pichuspikyeared: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	pikachu: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	raichu: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	sandshrew: {
 		tier: "LC",
@@ -129,13 +129,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	wigglytuff: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	zubat: {
 		tier: "LC",
 	},
 	golbat: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	crobat: {
 		tier: "UUBL",
@@ -144,19 +144,19 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	gloom: {
-		tier: "NFE",
+		tier: "ZU",
 	},
 	vileplume: {
 		tier: "NU",
 	},
 	bellossom: {
-		tier: "NU",
+		tier: "PU",
 	},
 	paras: {
 		tier: "LC",
 	},
 	parasect: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	venonat: {
 		tier: "LC",
@@ -165,7 +165,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NU",
 	},
 	diglett: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	dugtrio: {
 		tier: "UU",
@@ -174,13 +174,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	persian: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	psyduck: {
 		tier: "LC",
 	},
 	golduck: {
-		tier: "NU",
+		tier: "PU",
 	},
 	mankey: {
 		tier: "LC",
@@ -204,13 +204,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NU",
 	},
 	politoed: {
-		tier: "NU",
+		tier: "PU",
 	},
 	abra: {
 		tier: "LC",
 	},
 	kadabra: {
-		tier: "NU",
+		tier: "PU",
 	},
 	alakazam: {
 		tier: "UU",
@@ -219,7 +219,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	machoke: {
-		tier: "NU",
+		tier: "PU",
 	},
 	machamp: {
 		tier: "Uber",
@@ -231,7 +231,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	victreebel: {
-		tier: "NU",
+		tier: "PU",
 	},
 	tentacool: {
 		tier: "LC",
@@ -252,7 +252,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	rapidash: {
-		tier: "NU",
+		tier: "PU",
 	},
 	slowpoke: {
 		tier: "LC",
@@ -273,7 +273,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "OU",
 	},
 	farfetchd: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	doduo: {
 		tier: "LC",
@@ -285,13 +285,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	dewgong: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	grimer: {
 		tier: "LC",
 	},
 	muk: {
-		tier: "NU",
+		tier: "PU",
 	},
 	shellder: {
 		tier: "LC",
@@ -324,7 +324,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	kingler: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	voltorb: {
 		tier: "LC",
@@ -342,7 +342,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	marowak: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	tyrogue: {
 		tier: "LC",
@@ -372,7 +372,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	rhydon: {
-		tier: "NFE",
+		tier: "PU",
 	},
 	rhyperior: {
 		tier: "UU",
@@ -387,7 +387,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "OU",
 	},
 	tangela: {
-		tier: "NU",
+		tier: "PU",
 	},
 	tangrowth: {
 		tier: "UU",
@@ -399,7 +399,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	seadra: {
-		tier: "NFE",
+		tier: "ZU",
 	},
 	kingdra: {
 		tier: "OU",
@@ -408,7 +408,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	seaking: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	staryu: {
 		tier: "LC",
@@ -420,7 +420,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	mrmime: {
-		tier: "NU",
+		tier: "PU",
 	},
 	scyther: {
 		tier: "UU",
@@ -438,7 +438,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	electabuzz: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	electivire: {
 		tier: "(OU)",
@@ -447,13 +447,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	magmar: {
-		tier: "NFE",
+		tier: "PU",
 	},
 	magmortar: {
 		tier: "NU",
 	},
 	pinsir: {
-		tier: "NU",
+		tier: "PU",
 	},
 	tauros: {
 		tier: "NU",
@@ -465,10 +465,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "OU",
 	},
 	lapras: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	ditto: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	eevee: {
 		tier: "LC",
@@ -480,7 +480,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "(OU)",
 	},
 	flareon: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	espeon: {
 		tier: "NUBL",
@@ -492,7 +492,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UU",
 	},
 	glaceon: {
-		tier: "NU",
+		tier: "PU",
 	},
 	porygon: {
 		tier: "LC",
@@ -504,7 +504,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UUBL",
 	},
 	omanyte: {
-		tier: "LC",
+		tier: "ZU",
 	},
 	omastar: {
 		tier: "UU",
@@ -525,7 +525,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "(OU)",
 	},
 	articuno: {
-		tier: "NU",
+		tier: "PUBL",
 	},
 	zapdos: {
 		tier: "OU",
@@ -537,7 +537,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	dragonair: {
-		tier: "NU",
+		tier: "PU",
 	},
 	dragonite: {
 		tier: "OU",
@@ -579,25 +579,25 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	furret: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	hoothoot: {
 		tier: "LC",
 	},
 	noctowl: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	ledyba: {
 		tier: "LC",
 	},
 	ledian: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	spinarak: {
 		tier: "LC",
 	},
 	ariados: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	chinchou: {
 		tier: "LC",
@@ -609,7 +609,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	togetic: {
-		tier: "NU",
+		tier: "NFE",
 	},
 	togekiss: {
 		tier: "(OU)",
@@ -618,7 +618,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	xatu: {
-		tier: "NU",
+		tier: "PU",
 	},
 	mareep: {
 		tier: "LC",
@@ -627,7 +627,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	ampharos: {
-		tier: "NU",
+		tier: "PU",
 	},
 	azurill: {
 		tier: "LC",
@@ -642,7 +642,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	sudowoodo: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	hoppip: {
 		tier: "LC",
@@ -663,10 +663,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	sunflora: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	yanma: {
-		tier: "NU",
+		tier: "LC",
 	},
 	yanmega: {
 		tier: "UUBL",
@@ -675,22 +675,22 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	quagsire: {
-		tier: "NU",
+		tier: "PU",
 	},
 	murkrow: {
-		tier: "NU",
+		tier: "PU",
 	},
 	honchkrow: {
 		tier: "UUBL",
 	},
 	misdreavus: {
-		tier: "NU",
+		tier: "PU",
 	},
 	mismagius: {
 		tier: "UU",
 	},
 	unown: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	wynaut: {
 		tier: "Uber",
@@ -699,7 +699,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "Uber",
 	},
 	girafarig: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	pineco: {
 		tier: "LC",
@@ -708,7 +708,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "OU",
 	},
 	dunsparce: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	gligar: {
 		tier: "NU",
@@ -721,19 +721,19 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	granbull: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	qwilfish: {
 		tier: "UU",
 	},
 	shuckle: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	heracross: {
 		tier: "UUBL",
 	},
 	sneasel: {
-		tier: "NU",
+		tier: "PU",
 	},
 	weavile: {
 		tier: "OU",
@@ -748,7 +748,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	magcargo: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	swinub: {
 		tier: "LC",
@@ -760,22 +760,22 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "(OU)",
 	},
 	corsola: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	remoraid: {
 		tier: "LC",
 	},
 	octillery: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	delibird: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	mantyke: {
 		tier: "LC",
 	},
 	mantine: {
-		tier: "NU",
+		tier: "PU",
 	},
 	skarmory: {
 		tier: "OU",
@@ -793,7 +793,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UU",
 	},
 	stantler: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	smeargle: {
 		tier: "(OU)",
@@ -832,7 +832,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	grovyle: {
-		tier: "NFE",
+		tier: "ZU",
 	},
 	sceptile: {
 		tier: "UU",
@@ -859,13 +859,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	mightyena: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	zigzagoon: {
 		tier: "LC",
 	},
 	linoone: {
-		tier: "NU",
+		tier: "PUBL",
 	},
 	wurmple: {
 		tier: "LC",
@@ -874,13 +874,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	beautifly: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	cascoon: {
 		tier: "NFE",
 	},
 	dustox: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	lotad: {
 		tier: "LC",
@@ -910,7 +910,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	pelipper: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	ralts: {
 		tier: "LC",
@@ -928,7 +928,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	masquerain: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	shroomish: {
 		tier: "LC",
@@ -940,10 +940,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	vigoroth: {
-		tier: "NU",
+		tier: "NFE",
 	},
 	slaking: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	nincada: {
 		tier: "LC",
@@ -952,7 +952,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "(OU)",
 	},
 	shedinja: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	whismur: {
 		tier: "LC",
@@ -961,7 +961,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	exploud: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	makuhita: {
 		tier: "LC",
@@ -973,25 +973,25 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	probopass: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	skitty: {
 		tier: "LC",
 	},
 	delcatty: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	sableye: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	mawile: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	aron: {
 		tier: "LC",
 	},
 	lairon: {
-		tier: "NFE",
+		tier: "ZU",
 	},
 	aggron: {
 		tier: "UU",
@@ -1009,22 +1009,22 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NU",
 	},
 	plusle: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	minun: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	volbeat: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	illumise: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	budew: {
 		tier: "LC",
 	},
 	roselia: {
-		tier: "NU",
+		tier: "PUBL",
 	},
 	roserade: {
 		tier: "OU",
@@ -1033,7 +1033,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	swalot: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	carvanha: {
 		tier: "LC",
@@ -1045,25 +1045,25 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	wailord: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	numel: {
 		tier: "LC",
 	},
 	camerupt: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	torkoal: {
-		tier: "NU",
+		tier: "PU",
 	},
 	spoink: {
 		tier: "LC",
 	},
 	grumpig: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	spinda: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	trapinch: {
 		tier: "LC",
@@ -1087,28 +1087,28 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UU",
 	},
 	zangoose: {
-		tier: "NU",
+		tier: "PU",
 	},
 	seviper: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	lunatone: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	solrock: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	barboach: {
 		tier: "LC",
 	},
 	whiscash: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	corphish: {
 		tier: "LC",
 	},
 	crawdaunt: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	baltoy: {
 		tier: "LC",
@@ -1126,7 +1126,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	armaldo: {
-		tier: "NU",
+		tier: "PU",
 	},
 	feebas: {
 		tier: "LC",
@@ -1135,19 +1135,19 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UU",
 	},
 	castform: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	castformsunny: {},
 	castformrainy: {},
 	castformsnowy: {},
 	kecleon: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	shuppet: {
 		tier: "LC",
 	},
 	banette: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	duskull: {
 		tier: "LC",
@@ -1159,13 +1159,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "(OU)",
 	},
 	tropius: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	chingling: {
 		tier: "LC",
 	},
 	chimecho: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	absol: {
 		tier: "UU",
@@ -1174,7 +1174,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	glalie: {
-		tier: "NU",
+		tier: "PU",
 	},
 	froslass: {
 		tier: "UUBL",
@@ -1186,28 +1186,28 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	walrein: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	clamperl: {
-		tier: "NU",
+		tier: "LC",
 	},
 	huntail: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	gorebyss: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	relicanth: {
-		tier: "NU",
+		tier: "PU",
 	},
 	luvdisc: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	bagon: {
 		tier: "LC",
 	},
 	shelgon: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	salamence: {
 		tier: "Uber",
@@ -1216,7 +1216,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	metang: {
-		tier: "NU",
+		tier: "PU",
 	},
 	metagross: {
 		tier: "OU",
@@ -1264,7 +1264,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	grotle: {
-		tier: "NFE",
+		tier: "ZU",
 	},
 	torterra: {
 		tier: "UU",
@@ -1273,7 +1273,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	monferno: {
-		tier: "NU",
+		tier: "PU",
 	},
 	infernape: {
 		tier: "OU",
@@ -1300,13 +1300,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	bibarel: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	kricketot: {
 		tier: "LC",
 	},
 	kricketune: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	shinx: {
 		tier: "LC",
@@ -1315,43 +1315,43 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NFE",
 	},
 	luxray: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	cranidos: {
 		tier: "LC",
 	},
 	rampardos: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	shieldon: {
 		tier: "LC",
 	},
 	bastiodon: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	burmy: {
 		tier: "LC",
 	},
 	wormadam: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	wormadamsandy: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	wormadamtrash: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	mothim: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	combee: {
 		tier: "LC",
 	},
 	vespiquen: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	pachirisu: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	buizel: {
 		tier: "LC",
@@ -1363,7 +1363,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	cherrim: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	cherrimsunshine: {
 	},
@@ -1371,7 +1371,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	gastrodon: {
-		tier: "NU",
+		tier: "PU",
 	},
 	drifloon: {
 		tier: "LC",
@@ -1383,13 +1383,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	lopunny: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	glameow: {
 		tier: "LC",
 	},
 	purugly: {
-		tier: "NU",
+		tier: "PU",
 	},
 	stunky: {
 		tier: "LC",
@@ -1404,7 +1404,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "OU",
 	},
 	chatot: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	spiritomb: {
 		tier: "UU",
@@ -1413,7 +1413,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	gabite: {
-		tier: "NU",
+		tier: "PU",
 	},
 	garchomp: {
 		tier: "Uber",
@@ -1443,13 +1443,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UU",
 	},
 	carnivine: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	finneon: {
 		tier: "LC",
 	},
 	lumineon: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	snover: {
 		tier: "NUBL",
@@ -1494,7 +1494,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "OU",
 	},
 	regigigas: {
-		tier: "NU",
+		tier: "ZUBL",
 	},
 	giratina: {
 		tier: "Uber",
@@ -1505,7 +1505,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UUBL",
 	},
 	phione: {
-		tier: "NU",
+		tier: "ZU",
 	},
 	manaphy: {
 		tier: "Uber",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/dpp-pu.3730821/ https://www.smogon.com/forums/threads/zu-old-gens-hub-gsc-quickban-slate-359.3646944/#post-8034682
Adds teambuilder support for PU and ZU while fixing incorrect Pokemon placements like Diglett and Togetic in NU.