### PR TITLE
[Gen 3] ADV 200: Re-add Wish Bagon event

### DIFF
--- a/data/mods/gen3rs/learnsets.ts
+++ b/data/mods/gen3rs/learnsets.ts
@@ -7167,6 +7167,7 @@ export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTab
 			toxic: ["3M"],
 			twister: ["3E"],
 			spite: ["3S1"],
+			wish: ["3S1"],
 		},
 	},
 	shelgon: {


### PR DESCRIPTION
It seems as though we forgot to do this in the first PR.