### PR TITLE
[Gen 3] ADV 200: Implement One Boost Passer Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3400,7 +3400,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		name: "[Gen 3] ADV 200",
 		mod: 'gen3rs',
 		// searchShow: false,
-		ruleset: ['Standard'],
+		ruleset: ['Standard', 'One Boost Passer Clause'],
 		banlist: ['Uber', 'Swagger'],
 	},
 


### PR DESCRIPTION
Added at request of PS user FrankMarley and other players who play ADV 200 and mirrors the same Baton Pass regulations as in Gen 3 OU