### PR TITLE
Have invalid !rfaq fail over to !faq 

### DIFF
--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -166,8 +166,27 @@ export const commands: Chat.ChatCommands = {
 		if (!topic) {
 			return this.parse(`/join view-roomfaqs-${room.roomid}`);
 		}
-		if (!roomFaqs[room.roomid][topic]) throw new Chat.ErrorMessage("Invalid topic.");
 		topic = getAlias(room.roomid, topic) || topic;
+
+		if (!roomFaqs[room.roomid][topic]) {
+		// tries to find a FAQ of same topic if RFAQ topic fails
+		const faqCommand = Chat.commands['faq'] as Chat.ChatHandler;
+		if (typeof faqCommand === 'function') {
+			const normalized = toID(target);
+			const validTopics = [
+				'staff', 'autoconfirmed', 'ac', 'ladder', 'ladderhelp', 'decay',
+				'tiering', 'tiers', 'tier', 'badge', 'badges', 'badgeholders',
+				'rng', 'tournaments', 'tournament', 'tours', 'tour', 'vpn',
+				'proxy', 'ca', 'customavatar', 'customavatars', 'privacy',
+				'lostpassword', 'password', 'lostpass',];
+		if (!validTopics.includes(normalized)) {
+			return this.errorReply(`'${target}' is an invalid topic.`);
+		}
+		if (!this.runBroadcast()) return;
+			return faqCommand.call(this, target, room, user, connection, 'faq', '!');
+		}
+			return this.errorReply("Invalid topic.");
+		}
 
 		if (!this.runBroadcast()) return;
 		const rfaq = roomFaqs[room.roomid][topic];


### PR DESCRIPTION
Approved Suggestion: https://www.smogon.com/forums/threads/have-rfaq-fail-over-to-faq-if-a-match-is-not-found.3687458/ 

Code calls for RFAQ topics if that fails it checks the FAQ topic list. Sounds straightforward until you realize the faq broadcast fail command is archaic and for some reason the failed FAQ broadcast message still goes through on top of the actual faq error return message, along with the faq help, it's very messy I might just fix that next because this thoroughly got on my nerves. This commit bypasses this issue by having the run broadcast call AFTER the topic is read as valid, so none of this nonsense can happen.