### PR TITLE
Sim: Emit requests after updates

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -145,6 +145,7 @@ export class Battle {
 	readonly messageLog: string[];
 	sentLogPos: number;
 	sentEnd: boolean;
+	sentRequests = true;
 
 	requestState: RequestState;
 	turn: number;
@@ -1329,8 +1330,9 @@ export class Battle {
 
 		const requests = this.getRequests(type);
 		for (let i = 0; i < this.sides.length; i++) {
-			this.sides[i].emitRequest(requests[i]);
+			this.sides[i].activeRequest = requests[i];
 		}
+		this.sentRequests = false;
 
 		if (this.sides.every(side => side.isChoiceDone())) {
 			throw new Error(`Choices are done immediately after a request`);
@@ -3211,6 +3213,10 @@ export class Battle {
 	sendUpdates() {
 		if (this.sentLogPos >= this.log.length) return;
 		this.send('update', this.log.slice(this.sentLogPos));
+		if (!this.sentRequests) {
+			for (const side of this.sides) side.emitRequest();
+			this.sentRequests = true;
+		}
 		this.sentLogPos = this.log.length;
 
 		if (!this.sentEnd && this.ended) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -483,7 +483,7 @@ export class Side {
 		this.battle.send('sideupdate', `${this.id}\n${sideUpdate}`);
 	}
 
-	emitRequest(update: ChoiceRequest) {
+	emitRequest(update: ChoiceRequest = this.activeRequest!) {
 		this.battle.send('sideupdate', `${this.id}\n|request|${JSON.stringify(update)}`);
 		this.activeRequest = update;
 	}
@@ -495,7 +495,7 @@ export class Side {
 		const updated = update ? this.updateRequestForPokemon(update.pokemon, update.update) : null;
 		const type = `[${updated ? 'Unavailable' : 'Invalid'} choice]`;
 		this.battle.send('sideupdate', `${this.id}\n|error|${type} ${message}`);
-		if (updated) this.emitRequest(this.activeRequest!);
+		if (updated) this.emitRequest();
 		if (this.battle.strictChoices) throw new Error(`${type} ${message}`);
 		return false;
 	}

--- a/test/server/room-battle.js
+++ b/test/server/room-battle.js
@@ -53,16 +53,16 @@ describe('Simulator abstraction layer features', () => {
 				'>player p1 {"name":"p1","avatar":"ethan","team":"","rating":1507,"seed":[59512,58581,51338,7861]}\n' +
 				'>player p2 {"name":"p2","avatar":"dawn","team":"","rating":1447,"seed":[33758,53485,62378,29757]}\n'
 			);
+			assert((await stream.read()).includes('|switch|'));
 			assert((await stream.read()).startsWith('sideupdate\np1\n|request|'));
 			assert((await stream.read()).startsWith('sideupdate\np2\n|request|'));
-			assert((await stream.read()).includes('|switch|'));
 			stream.write(
 				'>p1 move 1\n' +
 				'>p2 move 1\n'
 			);
+			assert((await stream.read()).includes('|move|'));
 			assert((await stream.read()).startsWith('sideupdate\np1\n|request|'));
 			assert((await stream.read()).startsWith('sideupdate\np2\n|request|'));
-			assert((await stream.read()).includes('|move|'));
 			stream.destroy();
 			assert.equal(PM.processes[0].getLoad(), 0);
 


### PR DESCRIPTION
Fixes #8546

Requests are currently sent before the turn update is sent. Specifically, you might expect something like:

    |move|SCIZOR|U-turn
    |request|switch|SCIZOR

but instead it's

    |request|switch|SCIZOR
    |move|SCIZOR|U-turn

Which is pretty annoying for many consumers. So this fixes that.

Another nice consequence of delaying sending requests, is that redundant requests are not sent if you send in an inputlog all at once; only the most recent request (that the inputlog doesn't already choose for) will get sent out.