### PR TITLE
Commands: Update help FAQ and improve !faq fails

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2123,20 +2123,15 @@ export const commands: Chat.ChatCommands = {
 	],
 
 	faq(target, room, user) {
-		if (!this.runBroadcast()) return;
 		target = toID(target);
 		const showAll = target === 'all';
-		if (showAll && this.broadcasting) {
-			return this.sendReplyBox(this.tr`You cannot broadcast all FAQs at once.`);
-		}
-
 		const buffer = [];
 		if (showAll || target === 'staff') {
 			buffer.push(`<a href="https://pokemonshowdown.com/${this.tr`pages/staff`}">${this.tr`Staff FAQ`}</a>`);
 		}
 		if (showAll || target === 'autoconfirmed' || target === 'ac') {
 			buffer.push(this.tr`A user is autoconfirmed when they have won at least one rated battle and have been registered for one week or longer. In order to prevent spamming and trolling, most chatrooms only allow autoconfirmed users to chat. If you are not autoconfirmed, you can politely PM a staff member (staff have %, @, or # in front of their username) in the room you would like to chat and ask them to disable modchat. However, staff are not obligated to disable modchat.`);
-			if (!this.broadcasting) void this.parse(`/regtime`);
+			if (!(this.message.startsWith('!') && showAll)) void this.parse(`/regtime`);
 		}
 		if (showAll || target === 'ladder' || target === 'ladderhelp' || target === 'decay') {
 			buffer.push(`<a href="https://${Config.routes.root}/${this.tr`pages/ladderhelp`}">${this.tr`How the ladder works`}</a>`);
@@ -2172,11 +2167,15 @@ export const commands: Chat.ChatCommands = {
 		if (!target || showAll) {
 			buffer.unshift(`<a href="https://pokemonshowdown.com/${this.tr`pages/faq`}">${this.tr`Frequently Asked Questions`}</a>`);
 		}
+		if (showAll && this.message.startsWith('!')) {
+			return this.errorReply(this.tr`You cannot broadcast all FAQs at once.`);
+		}
+		if (!this.runBroadcast()) return;
 		this.sendReplyBox(buffer.join(`<br />`));
 	},
 	faqhelp: [
-		`/faq [theme] - Provides a link to the FAQ. Add autoconfirmed, badges, proxy, ladder, staff, or tiers for a link to these questions. Add all for all of them.`,
-		`!faq [theme] - Shows everyone a link to the FAQ. Add autoconfirmed, badges, proxy, ladder, staff, or tiers for a link to these questions. Add all for all of them. Requires: + % @ # ~`,
+		`/faq [topic] - Provides a link that answers the FAQ topic. List of FAQ topics: autoconfirmed, badges, customavatar, decay, ladder, lostpassword, privacy, proxy, rng, staff, tiers, tournaments.`,
+		`!faq [topic] - Shows to other users a link that answers the FAQ topic. List of FAQ topics: autoconfirmed, badges, customavatar, decay, ladder, lostpassword, privacy, proxy, rng, staff, tiers, tournaments. Requires: + % @ # ~`,
 	],
 
 	analysis: 'smogdex',

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2125,13 +2125,16 @@ export const commands: Chat.ChatCommands = {
 	faq(target, room, user) {
 		target = toID(target);
 		const showAll = target === 'all';
+		if (showAll && this.shouldBroadcast()) {
+			throw new Chat.ErrorMessage(this.tr`You cannot broadcast all FAQs at once.`);
+		}
 		const buffer = [];
 		if (showAll || target === 'staff') {
 			buffer.push(`<a href="https://pokemonshowdown.com/${this.tr`pages/staff`}">${this.tr`Staff FAQ`}</a>`);
 		}
 		if (showAll || target === 'autoconfirmed' || target === 'ac') {
 			buffer.push(this.tr`A user is autoconfirmed when they have won at least one rated battle and have been registered for one week or longer. In order to prevent spamming and trolling, most chatrooms only allow autoconfirmed users to chat. If you are not autoconfirmed, you can politely PM a staff member (staff have %, @, or # in front of their username) in the room you would like to chat and ask them to disable modchat. However, staff are not obligated to disable modchat.`);
-			if (!(this.message.startsWith('!') && showAll)) void this.parse(`/regtime`);
+			if (!this.shouldBroadcast()) void this.parse(`/regtime`);
 		}
 		if (showAll || target === 'ladder' || target === 'ladderhelp' || target === 'decay') {
 			buffer.push(`<a href="https://${Config.routes.root}/${this.tr`pages/ladderhelp`}">${this.tr`How the ladder works`}</a>`);
@@ -2166,9 +2169,6 @@ export const commands: Chat.ChatCommands = {
 		}
 		if (!target || showAll) {
 			buffer.unshift(`<a href="https://pokemonshowdown.com/${this.tr`pages/faq`}">${this.tr`Frequently Asked Questions`}</a>`);
-		}
-		if (showAll && this.broadcasting) {
-			throw new Chat.ErrorMessage(this.tr`You cannot broadcast all FAQs at once.`);
 		}
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(buffer.join(`<br />`));

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2167,8 +2167,8 @@ export const commands: Chat.ChatCommands = {
 		if (!target || showAll) {
 			buffer.unshift(`<a href="https://pokemonshowdown.com/${this.tr`pages/faq`}">${this.tr`Frequently Asked Questions`}</a>`);
 		}
-		if (showAll && this.message.startsWith('!')) {
-			return this.errorReply(this.tr`You cannot broadcast all FAQs at once.`);
+		if (showAll && this.broadcasting) {
+			throw new Chat.ErrorMessage(this.tr`You cannot broadcast all FAQs at once.`);
 		}
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(buffer.join(`<br />`));


### PR DESCRIPTION
https://www.smogon.com/forums/threads/clean-up-update-error-message-for-faq.3764560/  !faq fails no longer send the failed message message in chat, this is very helpful for room auth who are the users of broadcast commands For whatever reason '!faq all' fails used a replybox? I can't think of a single non dev command that uses visible replyboxes in chat for fails, so changed this for an errorReply. I cleaned up the wording of the /help faq, and I added some topics that were not there previously. Run Broadcast is called for later in the code to fix the issue of !faq sending messages regardless of it being valid or invalid, since fails aren't checked properly before the broadcast is actually sent. 