### PR TITLE
Add rule to automatically display Pokemon information

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -374,7 +374,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'ccapm2024',
 		team: 'randomCPM',
 		searchShow: false,
-		ruleset: ['HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Terastal Clause'],
+		ruleset: ['HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Terastal Clause', 'Data Mod'],
 		onBegin() {
 			this.add(`raw|<div class='broadcast-green'><b>Need help with all of the new Pokemon and their wacky abilities?<br />Then make sure to use the <a href="https://docs.google.com/spreadsheets/d/1nLcxshlfbqC2Vqu6oc-wJsRE2gMi29j6Htkm2IQe9CM/edit?usp=sharing" target="_blank">CCAPM Spreadsheet</a> or use /dt!</b></div>`);
 			this.add('-message', `Welcome to CCAPM 2024 Random Battle!`);

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -374,7 +374,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'ccapm2024',
 		team: 'randomCPM',
 		searchShow: false,
-		ruleset: ['HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Terastal Clause', 'Data Mod'],
+		ruleset: ['HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Terastal Clause', 'Data Preview'],
 		onBegin() {
 			this.add(`raw|<div class='broadcast-green'><b>Need help with all of the new Pokemon and their wacky abilities?<br />Then make sure to use the <a href="https://docs.google.com/spreadsheets/d/1nLcxshlfbqC2Vqu6oc-wJsRE2gMi29j6Htkm2IQe9CM/edit?usp=sharing" target="_blank">CCAPM Spreadsheet</a> or use /dt!</b></div>`);
 			this.add('-message', `Welcome to CCAPM 2024 Random Battle!`);

--- a/data/mods/ccapm2024/formats-data.ts
+++ b/data/mods/ccapm2024/formats-data.ts
@@ -189,4131 +189,4131 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "OU",
 	},
 	bulbasaur: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ivysaur: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	venusaur: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	venusaurmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	venusaurgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	charmander: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	charmeleon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	charizard: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	charizardmegax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	charizardmegay: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	charizardgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	squirtle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wartortle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blastoise: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blastoisemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blastoisegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	caterpie: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	metapod: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	butterfree: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	butterfreegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	weedle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kakuna: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	beedrill: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	beedrillmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pidgey: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pidgeotto: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pidgeot: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pidgeotmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rattata: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rattataalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	raticate: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	raticatealola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	raticatealolatotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spearow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fearow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ekans: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arbok: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pichu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pichuspikyeared: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachucosplay: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachurockstar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachubelle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachupopstar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachuphd: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachulibre: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachuoriginal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachuhoenn: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachusinnoh: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachuunova: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachukalos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachualola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachupartner: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachustarter: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachugmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikachuworld: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	raichu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	raichualola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandshrew: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandshrewalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandslash: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandslashalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nidoranf: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nidorina: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nidoqueen: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nidoranm: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nidorino: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nidoking: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cleffa: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	clefairy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	clefable: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vulpix: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vulpixalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ninetales: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ninetalesalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	igglybuff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	jigglypuff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wigglytuff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zubat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	golbat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	crobat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oddish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gloom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vileplume: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bellossom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	paras: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	parasect: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	venonat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	venomoth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	diglett: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	diglettalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dugtrio: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dugtrioalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meowth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meowthalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meowthgalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meowthgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	persian: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	persianalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	perrserker: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	psyduck: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	golduck: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mankey: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	primeape: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	growlithe: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	growlithehisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arcanine: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arcaninehisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	poliwag: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	poliwhirl: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	poliwrath: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	politoed: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	abra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kadabra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	alakazam: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	alakazammega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	machop: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	machoke: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	machamp: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	machampgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bellsprout: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	weepinbell: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	victreebel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tentacool: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tentacruel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	geodude: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	geodudealola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	graveler: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	graveleralola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	golem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	golemalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ponyta: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ponytagalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rapidash: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rapidashgalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slowpoke: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slowpokegalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slowbro: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slowbromega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slowbrogalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slowking: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slowkinggalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magnemite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magneton: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magnezone: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	farfetchd: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	farfetchdgalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sirfetchd: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	doduo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dodrio: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	seel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dewgong: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grimer: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grimeralola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	muk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mukalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shellder: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cloyster: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gastly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	haunter: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gengar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gengarmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gengargmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	onix: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	steelix: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	steelixmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drowzee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hypno: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	krabby: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kingler: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kinglergmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	voltorb: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	voltorbhisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	electrode: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	electrodehisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	exeggcute: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	exeggutor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	exeggutoralola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cubone: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	marowak: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	marowakalola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	marowakalolatotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tyrogue: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hitmonlee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hitmonchan: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hitmontop: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lickitung: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lickilicky: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	koffing: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	weezing: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	weezinggalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rhyhorn: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rhydon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rhyperior: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	happiny: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chansey: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blissey: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tangela: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tangrowth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kangaskhan: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kangaskhanmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	horsea: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	seadra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kingdra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	goldeen: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	seaking: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	staryu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	starmie: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mimejr: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mrmime: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mrmimegalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mrrime: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scyther: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scizor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scizormega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kleavor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	smoochum: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	jynx: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	elekid: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	electabuzz: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	electivire: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magby: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magmar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magmortar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pinsir: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pinsirmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tauros: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	taurospaldeacombat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	taurospaldeablaze: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	taurospaldeaaqua: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magikarp: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gyarados: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gyaradosmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lapras: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	laprasgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ditto: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eevee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eeveestarter: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eeveegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vaporeon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	jolteon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flareon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	espeon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	umbreon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	leafeon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	glaceon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sylveon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	porygon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	porygon2: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	porygonz: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	omanyte: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	omastar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kabuto: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kabutops: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aerodactyl: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aerodactylmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	munchlax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snorlax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snorlaxgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	articuno: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	articunogalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zapdos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zapdosgalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	moltres: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	moltresgalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dratini: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dragonair: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dragonite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mewtwo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mewtwomegax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mewtwomegay: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mew: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chikorita: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bayleef: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meganium: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cyndaquil: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	quilava: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	typhlosion: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	typhlosionhisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	totodile: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	croconaw: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	feraligatr: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sentret: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	furret: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hoothoot: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	noctowl: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ledyba: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ledian: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spinarak: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ariados: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chinchou: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lanturn: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	togepi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	togetic: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	togekiss: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	natu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	xatu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mareep: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flaaffy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ampharos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ampharosmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	azurill: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	marill: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	azumarill: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bonsly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sudowoodo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hoppip: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skiploom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	jumpluff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aipom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ambipom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sunkern: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sunflora: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	yanma: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	yanmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wooper: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wooperpaldea: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	quagsire: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	murkrow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	honchkrow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	misdreavus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mismagius: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	unown: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wynaut: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wobbuffet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	girafarig: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	farigiraf: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pineco: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	forretress: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dunsparce: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dudunsparce: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gligar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gliscor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snubbull: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	granbull: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	qwilfish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	qwilfishhisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	overqwil: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shuckle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	heracross: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	heracrossmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sneasel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sneaselhisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	weavile: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sneasler: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	teddiursa: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ursaring: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ursaluna: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ursalunabloodmoon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slugma: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magcargo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swinub: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	piloswine: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mamoswine: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	corsola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	corsolagalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cursola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	remoraid: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	octillery: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	delibird: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mantyke: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mantine: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skarmory: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	houndour: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	houndoom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	houndoommega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	phanpy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	donphan: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stantler: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wyrdeer: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	smeargle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	miltank: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	raikou: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	entei: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	suicune: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	larvitar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pupitar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tyranitar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tyranitarmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lugia: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hooh: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	celebi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	treecko: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grovyle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sceptile: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sceptilemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	torchic: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	combusken: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blaziken: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blazikenmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mudkip: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	marshtomp: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swampert: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swampertmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	poochyena: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mightyena: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zigzagoon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zigzagoongalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	linoone: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	linoonegalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	obstagoon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wurmple: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silcoon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	beautifly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cascoon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dustox: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lotad: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lombre: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ludicolo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	seedot: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nuzleaf: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shiftry: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	taillow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swellow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wingull: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pelipper: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ralts: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kirlia: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gardevoir: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gardevoirmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gallade: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gallademega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	surskit: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	masquerain: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shroomish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	breloom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slakoth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vigoroth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slaking: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nincada: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ninjask: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shedinja: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	whismur: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	loudred: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	exploud: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	makuhita: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hariyama: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nosepass: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	probopass: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skitty: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	delcatty: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sableye: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sableyemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mawile: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mawilemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aron: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lairon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aggron: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aggronmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meditite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	medicham: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	medichammega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	electrike: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	manectric: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	manectricmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	plusle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	minun: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	volbeat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	illumise: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	budew: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	roselia: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	roserade: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gulpin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swalot: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	carvanha: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sharpedo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sharpedomega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wailmer: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wailord: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	numel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	camerupt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cameruptmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	torkoal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spoink: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grumpig: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spinda: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	trapinch: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vibrava: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flygon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cacnea: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cacturne: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swablu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	altaria: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	altariamega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zangoose: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	seviper: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lunatone: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	solrock: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	barboach: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	whiscash: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	corphish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	crawdaunt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	baltoy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	claydol: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lileep: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cradily: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	anorith: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	armaldo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	feebas: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	milotic: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	castform: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	castformsunny: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	castformrainy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	castformsnowy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kecleon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shuppet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	banette: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	banettemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	duskull: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dusclops: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dusknoir: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tropius: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chingling: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chimecho: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	absol: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	absolmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snorunt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	glalie: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	glaliemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	froslass: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spheal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sealeo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	walrein: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	clamperl: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	huntail: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gorebyss: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	relicanth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	luvdisc: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bagon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shelgon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	salamence: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	salamencemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	beldum: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	metang: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	metagross: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	metagrossmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	regirock: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	regice: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	registeel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	latias: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	latiasmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	latios: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	latiosmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kyogre: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kyogreprimal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	groudon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	groudonprimal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rayquaza: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rayquazamega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	jirachi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	deoxys: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	deoxysattack: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	deoxysdefense: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	deoxysspeed: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	turtwig: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grotle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	torterra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chimchar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	monferno: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	infernape: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	piplup: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	prinplup: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	empoleon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	starly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	staravia: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	staraptor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bidoof: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bibarel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kricketot: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kricketune: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shinx: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	luxio: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	luxray: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cranidos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rampardos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shieldon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bastiodon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	burmy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wormadam: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wormadamsandy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wormadamtrash: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mothim: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	combee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vespiquen: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pachirisu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	buizel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	floatzel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cherubi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cherrim: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cherrimsunshine: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shellos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gastrodon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drifloon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drifblim: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	buneary: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lopunny: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lopunnymega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	glameow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	purugly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stunky: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skuntank: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bronzor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bronzong: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chatot: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spiritomb: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gible: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gabite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	garchomp: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	garchompmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	riolu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lucario: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lucariomega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hippopotas: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hippowdon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skorupi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drapion: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	croagunk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toxicroak: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	carnivine: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	finneon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lumineon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snover: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	abomasnow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	abomasnowmega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rotom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rotomheat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rotomwash: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rotomfrost: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rotomfan: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rotommow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	uxie: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mesprit: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	azelf: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dialga: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dialgaorigin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	palkia: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	palkiaorigin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	heatran: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	regigigas: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	giratina: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	giratinaorigin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cresselia: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	phione: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	manaphy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	darkrai: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shaymin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shayminsky: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arceus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	victini: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snivy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	servine: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	serperior: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tepig: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pignite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	emboar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oshawott: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dewott: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	samurott: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	samurotthisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	patrat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	watchog: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lillipup: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	herdier: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stoutland: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	purrloin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	liepard: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pansage: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	simisage: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pansear: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	simisear: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	panpour: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	simipour: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	munna: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	musharna: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pidove: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tranquill: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	unfezant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blitzle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zebstrika: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	roggenrola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	boldore: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gigalith: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	woobat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swoobat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drilbur: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	excadrill: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	audino: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	audinomega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	timburr: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gurdurr: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	conkeldurr: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tympole: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	palpitoad: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	seismitoad: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	throh: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sawk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sewaddle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swadloon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	leavanny: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	venipede: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	whirlipede: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scolipede: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cottonee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	whimsicott: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	petilil: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lilligant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lilliganthisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	basculin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	basculegion: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	basculegionf: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandile: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	krokorok: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	krookodile: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	darumaka: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	darumakagalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	darmanitan: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	darmanitanzen: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	darmanitangalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	darmanitangalarzen: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	maractus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dwebble: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	crustle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scraggy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scrafty: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sigilyph: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	yamask: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	yamaskgalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cofagrigus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	runerigus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tirtouga: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	carracosta: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	archen: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	archeops: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	trubbish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	garbodor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	garbodorgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zorua: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zoruahisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zoroark: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zoroarkhisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	minccino: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cinccino: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gothita: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gothorita: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gothitelle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	solosis: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	duosion: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	reuniclus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ducklett: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swanna: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vanillite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vanillish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vanilluxe: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	deerling: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sawsbuck: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	emolga: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	karrablast: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	escavalier: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	foongus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	amoonguss: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	frillish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	jellicent: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	alomomola: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	joltik: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	galvantula: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ferroseed: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ferrothorn: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	klink: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	klang: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	klinklang: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tynamo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eelektrik: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eelektross: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	elgyem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	beheeyem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	litwick: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lampent: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chandelure: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	axew: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fraxure: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	haxorus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cubchoo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	beartic: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cryogonal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shelmet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	accelgor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stunfisk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stunfiskgalar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mienfoo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mienshao: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	druddigon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	golett: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	golurk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pawniard: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bisharp: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bouffalant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rufflet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	braviary: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	braviaryhisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vullaby: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mandibuzz: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	heatmor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	durant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	deino: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zweilous: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hydreigon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	larvesta: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	volcarona: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cobalion: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	terrakion: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	virizion: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tornadus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tornadustherian: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	thundurus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	thundurustherian: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	reshiram: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zekrom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	landorus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	landorustherian: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kyurem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kyuremblack: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kyuremwhite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	keldeo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meloetta: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	genesect: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	genesectburn: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	genesectchill: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	genesectdouse: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	genesectshock: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chespin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	quilladin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chesnaught: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fennekin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	braixen: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	delphox: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	froakie: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	frogadier: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	greninja: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	greninjaash: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bunnelby: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	diggersby: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fletchling: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fletchinder: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	talonflame: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scatterbug: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spewpa: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vivillon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	litleo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pyroar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flabebe: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	floette: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	floetteeternal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	florges: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skiddo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gogoat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pancham: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pangoro: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	furfrou: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	espurr: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meowstic: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	honedge: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	doublade: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aegislash: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aegislashblade: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spritzee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aromatisse: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swirlix: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slurpuff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	inkay: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	malamar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	binacle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	barbaracle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skrelp: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dragalge: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	clauncher: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	clawitzer: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	helioptile: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	heliolisk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tyrunt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tyrantrum: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	amaura: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aurorus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hawlucha: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dedenne: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	carbink: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	goomy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sliggoo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sliggoohisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	goodra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	goodrahisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	klefki: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	phantump: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	trevenant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pumpkaboo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pumpkaboosmall: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pumpkaboolarge: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pumpkaboosuper: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gourgeist: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gourgeistsmall: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gourgeistlarge: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gourgeistsuper: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bergmite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	avalugg: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	avalugghisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	noibat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	noivern: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	xerneas: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	xerneasneutral: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	yveltal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zygarde: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zygarde10: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zygardecomplete: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	diancie: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dianciemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hoopa: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hoopaunbound: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	volcanion: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rowlet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dartrix: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	decidueye: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	decidueyehisui: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	litten: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	torracat: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	incineroar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	popplio: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	brionne: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	primarina: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pikipek: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	trumbeak: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toucannon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	yungoos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gumshoos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gumshoostotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grubbin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	charjabug: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vikavolt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	vikavolttotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	crabrawler: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	crabominable: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oricorio: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oricoriopompom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oricoriopau: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oricoriosensu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cutiefly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ribombee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ribombeetotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rockruff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rockruffdusk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lycanroc: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lycanrocmidnight: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lycanrocdusk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wishiwashi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wishiwashischool: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mareanie: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toxapex: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mudbray: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mudsdale: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dewpider: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	araquanid: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	araquanidtotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fomantis: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lurantis: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lurantistotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	morelull: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shiinotic: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	salandit: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	salazzle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	salazzletotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stufful: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bewear: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bounsweet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	steenee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tsareena: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	comfey: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oranguru: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	passimian: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wimpod: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	golisopod: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandygast: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	palossand: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pyukumuku: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	typenull: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvally: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallybug: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallydark: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallydragon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyelectric: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyfairy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyfighting: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyfire: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyflying: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyghost: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallygrass: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyground: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyice: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallypoison: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallypsychic: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallyrock: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallysteel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silvallywater: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	minior: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	komala: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	turtonator: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	togedemaru: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	togedemarutotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mimikyu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mimikyutotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mimikyubustedtotem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bruxish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drampa: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dhelmise: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	jangmoo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hakamoo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kommoo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kommoototem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tapukoko: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tapulele: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tapubulu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tapufini: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cosmog: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cosmoem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	solgaleo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lunala: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nihilego: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	buzzwole: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pheromosa: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	xurkitree: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	celesteela: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kartana: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	guzzlord: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	necrozma: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	necrozmaduskmane: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	necrozmadawnwings: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	necrozmaultra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	magearna: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	marshadow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	poipole: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	naganadel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stakataka: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blacephalon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zeraora: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meltan: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	melmetal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	melmetalgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grookey: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	thwackey: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rillaboom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rillaboomgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scorbunny: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	raboot: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cinderace: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cinderacegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sobble: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drizzile: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	inteleon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	inteleongmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skwovet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	greedent: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rookidee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	corvisquire: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	corviknight: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	corviknightgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	blipbug: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dottler: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	orbeetle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	orbeetlegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nickit: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	thievul: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gossifleur: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eldegoss: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wooloo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dubwool: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chewtle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drednaw: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drednawgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	yamper: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	boltund: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rolycoly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	carkol: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	coalossal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	coalossalgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	applin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flapple: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flapplegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	appletun: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	appletungmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dipplin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	silicobra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandaconda: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandacondagmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cramorant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arrokuda: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	barraskewda: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toxel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toxtricity: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toxtricitygmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toxtricitylowkeygmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sizzlipede: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	centiskorch: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	centiskorchgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	clobbopus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grapploct: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sinistea: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	polteageist: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hatenna: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hattrem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hatterene: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hatterenegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	impidimp: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	morgrem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grimmsnarl: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grimmsnarlgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	milcery: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	alcremie: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	alcremiegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	falinks: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pincurchin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	frosmoth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stonjourner: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eiscue: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	indeedee: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	indeedeef: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	morpeko: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cufant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	copperajah: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	copperajahgmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dracozolt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arctozolt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dracovish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arctovish: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	duraludon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	duraludongmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dreepy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	drakloak: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dragapult: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zacian: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zaciancrowned: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zamazenta: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zamazentacrowned: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eternatus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	eternatuseternamax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kubfu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	urshifu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	urshifurapidstrike: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	urshifugmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	urshifurapidstrikegmax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	zarude: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	regieleki: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	regidrago: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	glastrier: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spectrier: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	calyrex: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	calyrexice: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	calyrexshadow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	enamorus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	enamorustherian: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sprigatito: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	floragato: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	meowscarada: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fuecoco: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	crocalor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	skeledirge: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	quaxly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	quaxwell: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	quaquaval: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lechonk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oinkologne: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	oinkolognef: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tarountula: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	spidops: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nymble: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	lokix: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rellor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rabsca: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	greavard: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	houndstone: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flittle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	espathra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wiglett: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wugtrio: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dondozo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	veluza: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	finizen: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	palafin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	smoliv: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dolliv: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arboliva: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	capsakid: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scovillain: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tadbulb: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bellibolt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	varoom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	revavroom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	orthworm: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tandemaus: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	maushold: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cetoddle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cetitan: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	frigibax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arctibax: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	baxcalibur: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tatsugiri: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cyclizar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pawmi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pawmo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pawmot: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wattrel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kilowattrel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bombirdier: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	squawkabilly: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flamigo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	klawf: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nacli: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	naclstack: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	garganacl: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	glimmet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	glimmora: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shroodle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	grafaiai: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fidough: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dachsbun: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	maschiff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mabosstiff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	bramblin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	brambleghast: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gimmighoul: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gimmighoulroaming: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gholdengo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	greattusk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	brutebonnet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sandyshocks: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	screamtail: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fluttermane: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	slitherwing: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	roaringmoon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	irontreads: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironmoth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironhands: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironjugulis: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironthorns: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironbundle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironvaliant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tinglu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chienpao: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	wochien: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chiyu: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	koraidon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	miraidon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tinkatink: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tinkatuff: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tinkaton: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	charcadet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	armarouge: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ceruledge: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toedscool: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	toedscruel: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kingambit: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	clodsire: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	annihilape: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	walkingwake: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironleaves: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	poltchageist: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	sinistcha: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	okidogi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	munkidori: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fezandipiti: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ogerpon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ogerponwellspring: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ogerponhearthflame: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ogerponcornerstone: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	archaludon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hydrapple: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	gougingfire: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ragingbolt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironboulder: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ironcrown: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	terapagos: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	terapagosstellar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pecharunt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	missingno: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	syclar: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	syclant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	revenankh: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	embirch: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	flarelm: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pyroak: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	breezi: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fidgit: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	rebble: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tactite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	stratagem: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	privatyke: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	arghonaut: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	nohface: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kitsunoh: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	monohm: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	duohm: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cyclohm: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	dorsoil: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	colossoil: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	protowatt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	krilowatt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	voodoll: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	voodoom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scratchet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	tomohawk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	necturine: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	necturna: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mollux: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cupra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	argalis: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	aurumoth: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	brattler: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	malaconda: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cawdet: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cawmodore: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	volkritter: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	volkraken: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snugglow: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	plasmanta: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	floatoy: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	caimanoe: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	naviathan: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	crucibelle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	crucibellemega: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pluffle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	kerfluffle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pajantom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	mumbao: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	jumbao: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	fawnifer: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	electrelk: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	caribolt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	smogecko: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	smoguana: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	smokomodo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	swirlpool: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	coribalis: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	snaelstrom: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	justyke: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	equilibra: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	solotl: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	astrolotl: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	miasmite: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	miasmaw: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chromera: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	venomicon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	venomiconepilogue: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	saharascal: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	saharaja: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	ababo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	scattervein: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	hemogoblin: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	cresceidon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chuggon: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	draggalong: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	chuggalong: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	shox: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarsmeargle: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarufo: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarufo2: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarbrycenman: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarmt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarmt2: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestartransport: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestargiant: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarhumanoid: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarmonster: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarf00: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarf002: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarspirit: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarblackdoor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarwhitedoor: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarblackbelt: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 	pokestarufopropu2: {
-		tier: "Illegal"
+		tier: "Illegal",
 	},
 };

--- a/data/mods/ccapm2024/formats-data.ts
+++ b/data/mods/ccapm2024/formats-data.ts
@@ -188,4 +188,4132 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	underhazard: {
 		tier: "OU",
 	},
+	bulbasaur: {
+		tier: "Illegal"
+	},
+	ivysaur: {
+		tier: "Illegal"
+	},
+	venusaur: {
+		tier: "Illegal"
+	},
+	venusaurmega: {
+		tier: "Illegal"
+	},
+	venusaurgmax: {
+		tier: "Illegal"
+	},
+	charmander: {
+		tier: "Illegal"
+	},
+	charmeleon: {
+		tier: "Illegal"
+	},
+	charizard: {
+		tier: "Illegal"
+	},
+	charizardmegax: {
+		tier: "Illegal"
+	},
+	charizardmegay: {
+		tier: "Illegal"
+	},
+	charizardgmax: {
+		tier: "Illegal"
+	},
+	squirtle: {
+		tier: "Illegal"
+	},
+	wartortle: {
+		tier: "Illegal"
+	},
+	blastoise: {
+		tier: "Illegal"
+	},
+	blastoisemega: {
+		tier: "Illegal"
+	},
+	blastoisegmax: {
+		tier: "Illegal"
+	},
+	caterpie: {
+		tier: "Illegal"
+	},
+	metapod: {
+		tier: "Illegal"
+	},
+	butterfree: {
+		tier: "Illegal"
+	},
+	butterfreegmax: {
+		tier: "Illegal"
+	},
+	weedle: {
+		tier: "Illegal"
+	},
+	kakuna: {
+		tier: "Illegal"
+	},
+	beedrill: {
+		tier: "Illegal"
+	},
+	beedrillmega: {
+		tier: "Illegal"
+	},
+	pidgey: {
+		tier: "Illegal"
+	},
+	pidgeotto: {
+		tier: "Illegal"
+	},
+	pidgeot: {
+		tier: "Illegal"
+	},
+	pidgeotmega: {
+		tier: "Illegal"
+	},
+	rattata: {
+		tier: "Illegal"
+	},
+	rattataalola: {
+		tier: "Illegal"
+	},
+	raticate: {
+		tier: "Illegal"
+	},
+	raticatealola: {
+		tier: "Illegal"
+	},
+	raticatealolatotem: {
+		tier: "Illegal"
+	},
+	spearow: {
+		tier: "Illegal"
+	},
+	fearow: {
+		tier: "Illegal"
+	},
+	ekans: {
+		tier: "Illegal"
+	},
+	arbok: {
+		tier: "Illegal"
+	},
+	pichu: {
+		tier: "Illegal"
+	},
+	pichuspikyeared: {
+		tier: "Illegal"
+	},
+	pikachu: {
+		tier: "Illegal"
+	},
+	pikachucosplay: {
+		tier: "Illegal"
+	},
+	pikachurockstar: {
+		tier: "Illegal"
+	},
+	pikachubelle: {
+		tier: "Illegal"
+	},
+	pikachupopstar: {
+		tier: "Illegal"
+	},
+	pikachuphd: {
+		tier: "Illegal"
+	},
+	pikachulibre: {
+		tier: "Illegal"
+	},
+	pikachuoriginal: {
+		tier: "Illegal"
+	},
+	pikachuhoenn: {
+		tier: "Illegal"
+	},
+	pikachusinnoh: {
+		tier: "Illegal"
+	},
+	pikachuunova: {
+		tier: "Illegal"
+	},
+	pikachukalos: {
+		tier: "Illegal"
+	},
+	pikachualola: {
+		tier: "Illegal"
+	},
+	pikachupartner: {
+		tier: "Illegal"
+	},
+	pikachustarter: {
+		tier: "Illegal"
+	},
+	pikachugmax: {
+		tier: "Illegal"
+	},
+	pikachuworld: {
+		tier: "Illegal"
+	},
+	raichu: {
+		tier: "Illegal"
+	},
+	raichualola: {
+		tier: "Illegal"
+	},
+	sandshrew: {
+		tier: "Illegal"
+	},
+	sandshrewalola: {
+		tier: "Illegal"
+	},
+	sandslash: {
+		tier: "Illegal"
+	},
+	sandslashalola: {
+		tier: "Illegal"
+	},
+	nidoranf: {
+		tier: "Illegal"
+	},
+	nidorina: {
+		tier: "Illegal"
+	},
+	nidoqueen: {
+		tier: "Illegal"
+	},
+	nidoranm: {
+		tier: "Illegal"
+	},
+	nidorino: {
+		tier: "Illegal"
+	},
+	nidoking: {
+		tier: "Illegal"
+	},
+	cleffa: {
+		tier: "Illegal"
+	},
+	clefairy: {
+		tier: "Illegal"
+	},
+	clefable: {
+		tier: "Illegal"
+	},
+	vulpix: {
+		tier: "Illegal"
+	},
+	vulpixalola: {
+		tier: "Illegal"
+	},
+	ninetales: {
+		tier: "Illegal"
+	},
+	ninetalesalola: {
+		tier: "Illegal"
+	},
+	igglybuff: {
+		tier: "Illegal"
+	},
+	jigglypuff: {
+		tier: "Illegal"
+	},
+	wigglytuff: {
+		tier: "Illegal"
+	},
+	zubat: {
+		tier: "Illegal"
+	},
+	golbat: {
+		tier: "Illegal"
+	},
+	crobat: {
+		tier: "Illegal"
+	},
+	oddish: {
+		tier: "Illegal"
+	},
+	gloom: {
+		tier: "Illegal"
+	},
+	vileplume: {
+		tier: "Illegal"
+	},
+	bellossom: {
+		tier: "Illegal"
+	},
+	paras: {
+		tier: "Illegal"
+	},
+	parasect: {
+		tier: "Illegal"
+	},
+	venonat: {
+		tier: "Illegal"
+	},
+	venomoth: {
+		tier: "Illegal"
+	},
+	diglett: {
+		tier: "Illegal"
+	},
+	diglettalola: {
+		tier: "Illegal"
+	},
+	dugtrio: {
+		tier: "Illegal"
+	},
+	dugtrioalola: {
+		tier: "Illegal"
+	},
+	meowth: {
+		tier: "Illegal"
+	},
+	meowthalola: {
+		tier: "Illegal"
+	},
+	meowthgalar: {
+		tier: "Illegal"
+	},
+	meowthgmax: {
+		tier: "Illegal"
+	},
+	persian: {
+		tier: "Illegal"
+	},
+	persianalola: {
+		tier: "Illegal"
+	},
+	perrserker: {
+		tier: "Illegal"
+	},
+	psyduck: {
+		tier: "Illegal"
+	},
+	golduck: {
+		tier: "Illegal"
+	},
+	mankey: {
+		tier: "Illegal"
+	},
+	primeape: {
+		tier: "Illegal"
+	},
+	growlithe: {
+		tier: "Illegal"
+	},
+	growlithehisui: {
+		tier: "Illegal"
+	},
+	arcanine: {
+		tier: "Illegal"
+	},
+	arcaninehisui: {
+		tier: "Illegal"
+	},
+	poliwag: {
+		tier: "Illegal"
+	},
+	poliwhirl: {
+		tier: "Illegal"
+	},
+	poliwrath: {
+		tier: "Illegal"
+	},
+	politoed: {
+		tier: "Illegal"
+	},
+	abra: {
+		tier: "Illegal"
+	},
+	kadabra: {
+		tier: "Illegal"
+	},
+	alakazam: {
+		tier: "Illegal"
+	},
+	alakazammega: {
+		tier: "Illegal"
+	},
+	machop: {
+		tier: "Illegal"
+	},
+	machoke: {
+		tier: "Illegal"
+	},
+	machamp: {
+		tier: "Illegal"
+	},
+	machampgmax: {
+		tier: "Illegal"
+	},
+	bellsprout: {
+		tier: "Illegal"
+	},
+	weepinbell: {
+		tier: "Illegal"
+	},
+	victreebel: {
+		tier: "Illegal"
+	},
+	tentacool: {
+		tier: "Illegal"
+	},
+	tentacruel: {
+		tier: "Illegal"
+	},
+	geodude: {
+		tier: "Illegal"
+	},
+	geodudealola: {
+		tier: "Illegal"
+	},
+	graveler: {
+		tier: "Illegal"
+	},
+	graveleralola: {
+		tier: "Illegal"
+	},
+	golem: {
+		tier: "Illegal"
+	},
+	golemalola: {
+		tier: "Illegal"
+	},
+	ponyta: {
+		tier: "Illegal"
+	},
+	ponytagalar: {
+		tier: "Illegal"
+	},
+	rapidash: {
+		tier: "Illegal"
+	},
+	rapidashgalar: {
+		tier: "Illegal"
+	},
+	slowpoke: {
+		tier: "Illegal"
+	},
+	slowpokegalar: {
+		tier: "Illegal"
+	},
+	slowbro: {
+		tier: "Illegal"
+	},
+	slowbromega: {
+		tier: "Illegal"
+	},
+	slowbrogalar: {
+		tier: "Illegal"
+	},
+	slowking: {
+		tier: "Illegal"
+	},
+	slowkinggalar: {
+		tier: "Illegal"
+	},
+	magnemite: {
+		tier: "Illegal"
+	},
+	magneton: {
+		tier: "Illegal"
+	},
+	magnezone: {
+		tier: "Illegal"
+	},
+	farfetchd: {
+		tier: "Illegal"
+	},
+	farfetchdgalar: {
+		tier: "Illegal"
+	},
+	sirfetchd: {
+		tier: "Illegal"
+	},
+	doduo: {
+		tier: "Illegal"
+	},
+	dodrio: {
+		tier: "Illegal"
+	},
+	seel: {
+		tier: "Illegal"
+	},
+	dewgong: {
+		tier: "Illegal"
+	},
+	grimer: {
+		tier: "Illegal"
+	},
+	grimeralola: {
+		tier: "Illegal"
+	},
+	muk: {
+		tier: "Illegal"
+	},
+	mukalola: {
+		tier: "Illegal"
+	},
+	shellder: {
+		tier: "Illegal"
+	},
+	cloyster: {
+		tier: "Illegal"
+	},
+	gastly: {
+		tier: "Illegal"
+	},
+	haunter: {
+		tier: "Illegal"
+	},
+	gengar: {
+		tier: "Illegal"
+	},
+	gengarmega: {
+		tier: "Illegal"
+	},
+	gengargmax: {
+		tier: "Illegal"
+	},
+	onix: {
+		tier: "Illegal"
+	},
+	steelix: {
+		tier: "Illegal"
+	},
+	steelixmega: {
+		tier: "Illegal"
+	},
+	drowzee: {
+		tier: "Illegal"
+	},
+	hypno: {
+		tier: "Illegal"
+	},
+	krabby: {
+		tier: "Illegal"
+	},
+	kingler: {
+		tier: "Illegal"
+	},
+	kinglergmax: {
+		tier: "Illegal"
+	},
+	voltorb: {
+		tier: "Illegal"
+	},
+	voltorbhisui: {
+		tier: "Illegal"
+	},
+	electrode: {
+		tier: "Illegal"
+	},
+	electrodehisui: {
+		tier: "Illegal"
+	},
+	exeggcute: {
+		tier: "Illegal"
+	},
+	exeggutor: {
+		tier: "Illegal"
+	},
+	exeggutoralola: {
+		tier: "Illegal"
+	},
+	cubone: {
+		tier: "Illegal"
+	},
+	marowak: {
+		tier: "Illegal"
+	},
+	marowakalola: {
+		tier: "Illegal"
+	},
+	marowakalolatotem: {
+		tier: "Illegal"
+	},
+	tyrogue: {
+		tier: "Illegal"
+	},
+	hitmonlee: {
+		tier: "Illegal"
+	},
+	hitmonchan: {
+		tier: "Illegal"
+	},
+	hitmontop: {
+		tier: "Illegal"
+	},
+	lickitung: {
+		tier: "Illegal"
+	},
+	lickilicky: {
+		tier: "Illegal"
+	},
+	koffing: {
+		tier: "Illegal"
+	},
+	weezing: {
+		tier: "Illegal"
+	},
+	weezinggalar: {
+		tier: "Illegal"
+	},
+	rhyhorn: {
+		tier: "Illegal"
+	},
+	rhydon: {
+		tier: "Illegal"
+	},
+	rhyperior: {
+		tier: "Illegal"
+	},
+	happiny: {
+		tier: "Illegal"
+	},
+	chansey: {
+		tier: "Illegal"
+	},
+	blissey: {
+		tier: "Illegal"
+	},
+	tangela: {
+		tier: "Illegal"
+	},
+	tangrowth: {
+		tier: "Illegal"
+	},
+	kangaskhan: {
+		tier: "Illegal"
+	},
+	kangaskhanmega: {
+		tier: "Illegal"
+	},
+	horsea: {
+		tier: "Illegal"
+	},
+	seadra: {
+		tier: "Illegal"
+	},
+	kingdra: {
+		tier: "Illegal"
+	},
+	goldeen: {
+		tier: "Illegal"
+	},
+	seaking: {
+		tier: "Illegal"
+	},
+	staryu: {
+		tier: "Illegal"
+	},
+	starmie: {
+		tier: "Illegal"
+	},
+	mimejr: {
+		tier: "Illegal"
+	},
+	mrmime: {
+		tier: "Illegal"
+	},
+	mrmimegalar: {
+		tier: "Illegal"
+	},
+	mrrime: {
+		tier: "Illegal"
+	},
+	scyther: {
+		tier: "Illegal"
+	},
+	scizor: {
+		tier: "Illegal"
+	},
+	scizormega: {
+		tier: "Illegal"
+	},
+	kleavor: {
+		tier: "Illegal"
+	},
+	smoochum: {
+		tier: "Illegal"
+	},
+	jynx: {
+		tier: "Illegal"
+	},
+	elekid: {
+		tier: "Illegal"
+	},
+	electabuzz: {
+		tier: "Illegal"
+	},
+	electivire: {
+		tier: "Illegal"
+	},
+	magby: {
+		tier: "Illegal"
+	},
+	magmar: {
+		tier: "Illegal"
+	},
+	magmortar: {
+		tier: "Illegal"
+	},
+	pinsir: {
+		tier: "Illegal"
+	},
+	pinsirmega: {
+		tier: "Illegal"
+	},
+	tauros: {
+		tier: "Illegal"
+	},
+	taurospaldeacombat: {
+		tier: "Illegal"
+	},
+	taurospaldeablaze: {
+		tier: "Illegal"
+	},
+	taurospaldeaaqua: {
+		tier: "Illegal"
+	},
+	magikarp: {
+		tier: "Illegal"
+	},
+	gyarados: {
+		tier: "Illegal"
+	},
+	gyaradosmega: {
+		tier: "Illegal"
+	},
+	lapras: {
+		tier: "Illegal"
+	},
+	laprasgmax: {
+		tier: "Illegal"
+	},
+	ditto: {
+		tier: "Illegal"
+	},
+	eevee: {
+		tier: "Illegal"
+	},
+	eeveestarter: {
+		tier: "Illegal"
+	},
+	eeveegmax: {
+		tier: "Illegal"
+	},
+	vaporeon: {
+		tier: "Illegal"
+	},
+	jolteon: {
+		tier: "Illegal"
+	},
+	flareon: {
+		tier: "Illegal"
+	},
+	espeon: {
+		tier: "Illegal"
+	},
+	umbreon: {
+		tier: "Illegal"
+	},
+	leafeon: {
+		tier: "Illegal"
+	},
+	glaceon: {
+		tier: "Illegal"
+	},
+	sylveon: {
+		tier: "Illegal"
+	},
+	porygon: {
+		tier: "Illegal"
+	},
+	porygon2: {
+		tier: "Illegal"
+	},
+	porygonz: {
+		tier: "Illegal"
+	},
+	omanyte: {
+		tier: "Illegal"
+	},
+	omastar: {
+		tier: "Illegal"
+	},
+	kabuto: {
+		tier: "Illegal"
+	},
+	kabutops: {
+		tier: "Illegal"
+	},
+	aerodactyl: {
+		tier: "Illegal"
+	},
+	aerodactylmega: {
+		tier: "Illegal"
+	},
+	munchlax: {
+		tier: "Illegal"
+	},
+	snorlax: {
+		tier: "Illegal"
+	},
+	snorlaxgmax: {
+		tier: "Illegal"
+	},
+	articuno: {
+		tier: "Illegal"
+	},
+	articunogalar: {
+		tier: "Illegal"
+	},
+	zapdos: {
+		tier: "Illegal"
+	},
+	zapdosgalar: {
+		tier: "Illegal"
+	},
+	moltres: {
+		tier: "Illegal"
+	},
+	moltresgalar: {
+		tier: "Illegal"
+	},
+	dratini: {
+		tier: "Illegal"
+	},
+	dragonair: {
+		tier: "Illegal"
+	},
+	dragonite: {
+		tier: "Illegal"
+	},
+	mewtwo: {
+		tier: "Illegal"
+	},
+	mewtwomegax: {
+		tier: "Illegal"
+	},
+	mewtwomegay: {
+		tier: "Illegal"
+	},
+	mew: {
+		tier: "Illegal"
+	},
+	chikorita: {
+		tier: "Illegal"
+	},
+	bayleef: {
+		tier: "Illegal"
+	},
+	meganium: {
+		tier: "Illegal"
+	},
+	cyndaquil: {
+		tier: "Illegal"
+	},
+	quilava: {
+		tier: "Illegal"
+	},
+	typhlosion: {
+		tier: "Illegal"
+	},
+	typhlosionhisui: {
+		tier: "Illegal"
+	},
+	totodile: {
+		tier: "Illegal"
+	},
+	croconaw: {
+		tier: "Illegal"
+	},
+	feraligatr: {
+		tier: "Illegal"
+	},
+	sentret: {
+		tier: "Illegal"
+	},
+	furret: {
+		tier: "Illegal"
+	},
+	hoothoot: {
+		tier: "Illegal"
+	},
+	noctowl: {
+		tier: "Illegal"
+	},
+	ledyba: {
+		tier: "Illegal"
+	},
+	ledian: {
+		tier: "Illegal"
+	},
+	spinarak: {
+		tier: "Illegal"
+	},
+	ariados: {
+		tier: "Illegal"
+	},
+	chinchou: {
+		tier: "Illegal"
+	},
+	lanturn: {
+		tier: "Illegal"
+	},
+	togepi: {
+		tier: "Illegal"
+	},
+	togetic: {
+		tier: "Illegal"
+	},
+	togekiss: {
+		tier: "Illegal"
+	},
+	natu: {
+		tier: "Illegal"
+	},
+	xatu: {
+		tier: "Illegal"
+	},
+	mareep: {
+		tier: "Illegal"
+	},
+	flaaffy: {
+		tier: "Illegal"
+	},
+	ampharos: {
+		tier: "Illegal"
+	},
+	ampharosmega: {
+		tier: "Illegal"
+	},
+	azurill: {
+		tier: "Illegal"
+	},
+	marill: {
+		tier: "Illegal"
+	},
+	azumarill: {
+		tier: "Illegal"
+	},
+	bonsly: {
+		tier: "Illegal"
+	},
+	sudowoodo: {
+		tier: "Illegal"
+	},
+	hoppip: {
+		tier: "Illegal"
+	},
+	skiploom: {
+		tier: "Illegal"
+	},
+	jumpluff: {
+		tier: "Illegal"
+	},
+	aipom: {
+		tier: "Illegal"
+	},
+	ambipom: {
+		tier: "Illegal"
+	},
+	sunkern: {
+		tier: "Illegal"
+	},
+	sunflora: {
+		tier: "Illegal"
+	},
+	yanma: {
+		tier: "Illegal"
+	},
+	yanmega: {
+		tier: "Illegal"
+	},
+	wooper: {
+		tier: "Illegal"
+	},
+	wooperpaldea: {
+		tier: "Illegal"
+	},
+	quagsire: {
+		tier: "Illegal"
+	},
+	murkrow: {
+		tier: "Illegal"
+	},
+	honchkrow: {
+		tier: "Illegal"
+	},
+	misdreavus: {
+		tier: "Illegal"
+	},
+	mismagius: {
+		tier: "Illegal"
+	},
+	unown: {
+		tier: "Illegal"
+	},
+	wynaut: {
+		tier: "Illegal"
+	},
+	wobbuffet: {
+		tier: "Illegal"
+	},
+	girafarig: {
+		tier: "Illegal"
+	},
+	farigiraf: {
+		tier: "Illegal"
+	},
+	pineco: {
+		tier: "Illegal"
+	},
+	forretress: {
+		tier: "Illegal"
+	},
+	dunsparce: {
+		tier: "Illegal"
+	},
+	dudunsparce: {
+		tier: "Illegal"
+	},
+	gligar: {
+		tier: "Illegal"
+	},
+	gliscor: {
+		tier: "Illegal"
+	},
+	snubbull: {
+		tier: "Illegal"
+	},
+	granbull: {
+		tier: "Illegal"
+	},
+	qwilfish: {
+		tier: "Illegal"
+	},
+	qwilfishhisui: {
+		tier: "Illegal"
+	},
+	overqwil: {
+		tier: "Illegal"
+	},
+	shuckle: {
+		tier: "Illegal"
+	},
+	heracross: {
+		tier: "Illegal"
+	},
+	heracrossmega: {
+		tier: "Illegal"
+	},
+	sneasel: {
+		tier: "Illegal"
+	},
+	sneaselhisui: {
+		tier: "Illegal"
+	},
+	weavile: {
+		tier: "Illegal"
+	},
+	sneasler: {
+		tier: "Illegal"
+	},
+	teddiursa: {
+		tier: "Illegal"
+	},
+	ursaring: {
+		tier: "Illegal"
+	},
+	ursaluna: {
+		tier: "Illegal"
+	},
+	ursalunabloodmoon: {
+		tier: "Illegal"
+	},
+	slugma: {
+		tier: "Illegal"
+	},
+	magcargo: {
+		tier: "Illegal"
+	},
+	swinub: {
+		tier: "Illegal"
+	},
+	piloswine: {
+		tier: "Illegal"
+	},
+	mamoswine: {
+		tier: "Illegal"
+	},
+	corsola: {
+		tier: "Illegal"
+	},
+	corsolagalar: {
+		tier: "Illegal"
+	},
+	cursola: {
+		tier: "Illegal"
+	},
+	remoraid: {
+		tier: "Illegal"
+	},
+	octillery: {
+		tier: "Illegal"
+	},
+	delibird: {
+		tier: "Illegal"
+	},
+	mantyke: {
+		tier: "Illegal"
+	},
+	mantine: {
+		tier: "Illegal"
+	},
+	skarmory: {
+		tier: "Illegal"
+	},
+	houndour: {
+		tier: "Illegal"
+	},
+	houndoom: {
+		tier: "Illegal"
+	},
+	houndoommega: {
+		tier: "Illegal"
+	},
+	phanpy: {
+		tier: "Illegal"
+	},
+	donphan: {
+		tier: "Illegal"
+	},
+	stantler: {
+		tier: "Illegal"
+	},
+	wyrdeer: {
+		tier: "Illegal"
+	},
+	smeargle: {
+		tier: "Illegal"
+	},
+	miltank: {
+		tier: "Illegal"
+	},
+	raikou: {
+		tier: "Illegal"
+	},
+	entei: {
+		tier: "Illegal"
+	},
+	suicune: {
+		tier: "Illegal"
+	},
+	larvitar: {
+		tier: "Illegal"
+	},
+	pupitar: {
+		tier: "Illegal"
+	},
+	tyranitar: {
+		tier: "Illegal"
+	},
+	tyranitarmega: {
+		tier: "Illegal"
+	},
+	lugia: {
+		tier: "Illegal"
+	},
+	hooh: {
+		tier: "Illegal"
+	},
+	celebi: {
+		tier: "Illegal"
+	},
+	treecko: {
+		tier: "Illegal"
+	},
+	grovyle: {
+		tier: "Illegal"
+	},
+	sceptile: {
+		tier: "Illegal"
+	},
+	sceptilemega: {
+		tier: "Illegal"
+	},
+	torchic: {
+		tier: "Illegal"
+	},
+	combusken: {
+		tier: "Illegal"
+	},
+	blaziken: {
+		tier: "Illegal"
+	},
+	blazikenmega: {
+		tier: "Illegal"
+	},
+	mudkip: {
+		tier: "Illegal"
+	},
+	marshtomp: {
+		tier: "Illegal"
+	},
+	swampert: {
+		tier: "Illegal"
+	},
+	swampertmega: {
+		tier: "Illegal"
+	},
+	poochyena: {
+		tier: "Illegal"
+	},
+	mightyena: {
+		tier: "Illegal"
+	},
+	zigzagoon: {
+		tier: "Illegal"
+	},
+	zigzagoongalar: {
+		tier: "Illegal"
+	},
+	linoone: {
+		tier: "Illegal"
+	},
+	linoonegalar: {
+		tier: "Illegal"
+	},
+	obstagoon: {
+		tier: "Illegal"
+	},
+	wurmple: {
+		tier: "Illegal"
+	},
+	silcoon: {
+		tier: "Illegal"
+	},
+	beautifly: {
+		tier: "Illegal"
+	},
+	cascoon: {
+		tier: "Illegal"
+	},
+	dustox: {
+		tier: "Illegal"
+	},
+	lotad: {
+		tier: "Illegal"
+	},
+	lombre: {
+		tier: "Illegal"
+	},
+	ludicolo: {
+		tier: "Illegal"
+	},
+	seedot: {
+		tier: "Illegal"
+	},
+	nuzleaf: {
+		tier: "Illegal"
+	},
+	shiftry: {
+		tier: "Illegal"
+	},
+	taillow: {
+		tier: "Illegal"
+	},
+	swellow: {
+		tier: "Illegal"
+	},
+	wingull: {
+		tier: "Illegal"
+	},
+	pelipper: {
+		tier: "Illegal"
+	},
+	ralts: {
+		tier: "Illegal"
+	},
+	kirlia: {
+		tier: "Illegal"
+	},
+	gardevoir: {
+		tier: "Illegal"
+	},
+	gardevoirmega: {
+		tier: "Illegal"
+	},
+	gallade: {
+		tier: "Illegal"
+	},
+	gallademega: {
+		tier: "Illegal"
+	},
+	surskit: {
+		tier: "Illegal"
+	},
+	masquerain: {
+		tier: "Illegal"
+	},
+	shroomish: {
+		tier: "Illegal"
+	},
+	breloom: {
+		tier: "Illegal"
+	},
+	slakoth: {
+		tier: "Illegal"
+	},
+	vigoroth: {
+		tier: "Illegal"
+	},
+	slaking: {
+		tier: "Illegal"
+	},
+	nincada: {
+		tier: "Illegal"
+	},
+	ninjask: {
+		tier: "Illegal"
+	},
+	shedinja: {
+		tier: "Illegal"
+	},
+	whismur: {
+		tier: "Illegal"
+	},
+	loudred: {
+		tier: "Illegal"
+	},
+	exploud: {
+		tier: "Illegal"
+	},
+	makuhita: {
+		tier: "Illegal"
+	},
+	hariyama: {
+		tier: "Illegal"
+	},
+	nosepass: {
+		tier: "Illegal"
+	},
+	probopass: {
+		tier: "Illegal"
+	},
+	skitty: {
+		tier: "Illegal"
+	},
+	delcatty: {
+		tier: "Illegal"
+	},
+	sableye: {
+		tier: "Illegal"
+	},
+	sableyemega: {
+		tier: "Illegal"
+	},
+	mawile: {
+		tier: "Illegal"
+	},
+	mawilemega: {
+		tier: "Illegal"
+	},
+	aron: {
+		tier: "Illegal"
+	},
+	lairon: {
+		tier: "Illegal"
+	},
+	aggron: {
+		tier: "Illegal"
+	},
+	aggronmega: {
+		tier: "Illegal"
+	},
+	meditite: {
+		tier: "Illegal"
+	},
+	medicham: {
+		tier: "Illegal"
+	},
+	medichammega: {
+		tier: "Illegal"
+	},
+	electrike: {
+		tier: "Illegal"
+	},
+	manectric: {
+		tier: "Illegal"
+	},
+	manectricmega: {
+		tier: "Illegal"
+	},
+	plusle: {
+		tier: "Illegal"
+	},
+	minun: {
+		tier: "Illegal"
+	},
+	volbeat: {
+		tier: "Illegal"
+	},
+	illumise: {
+		tier: "Illegal"
+	},
+	budew: {
+		tier: "Illegal"
+	},
+	roselia: {
+		tier: "Illegal"
+	},
+	roserade: {
+		tier: "Illegal"
+	},
+	gulpin: {
+		tier: "Illegal"
+	},
+	swalot: {
+		tier: "Illegal"
+	},
+	carvanha: {
+		tier: "Illegal"
+	},
+	sharpedo: {
+		tier: "Illegal"
+	},
+	sharpedomega: {
+		tier: "Illegal"
+	},
+	wailmer: {
+		tier: "Illegal"
+	},
+	wailord: {
+		tier: "Illegal"
+	},
+	numel: {
+		tier: "Illegal"
+	},
+	camerupt: {
+		tier: "Illegal"
+	},
+	cameruptmega: {
+		tier: "Illegal"
+	},
+	torkoal: {
+		tier: "Illegal"
+	},
+	spoink: {
+		tier: "Illegal"
+	},
+	grumpig: {
+		tier: "Illegal"
+	},
+	spinda: {
+		tier: "Illegal"
+	},
+	trapinch: {
+		tier: "Illegal"
+	},
+	vibrava: {
+		tier: "Illegal"
+	},
+	flygon: {
+		tier: "Illegal"
+	},
+	cacnea: {
+		tier: "Illegal"
+	},
+	cacturne: {
+		tier: "Illegal"
+	},
+	swablu: {
+		tier: "Illegal"
+	},
+	altaria: {
+		tier: "Illegal"
+	},
+	altariamega: {
+		tier: "Illegal"
+	},
+	zangoose: {
+		tier: "Illegal"
+	},
+	seviper: {
+		tier: "Illegal"
+	},
+	lunatone: {
+		tier: "Illegal"
+	},
+	solrock: {
+		tier: "Illegal"
+	},
+	barboach: {
+		tier: "Illegal"
+	},
+	whiscash: {
+		tier: "Illegal"
+	},
+	corphish: {
+		tier: "Illegal"
+	},
+	crawdaunt: {
+		tier: "Illegal"
+	},
+	baltoy: {
+		tier: "Illegal"
+	},
+	claydol: {
+		tier: "Illegal"
+	},
+	lileep: {
+		tier: "Illegal"
+	},
+	cradily: {
+		tier: "Illegal"
+	},
+	anorith: {
+		tier: "Illegal"
+	},
+	armaldo: {
+		tier: "Illegal"
+	},
+	feebas: {
+		tier: "Illegal"
+	},
+	milotic: {
+		tier: "Illegal"
+	},
+	castform: {
+		tier: "Illegal"
+	},
+	castformsunny: {
+		tier: "Illegal"
+	},
+	castformrainy: {
+		tier: "Illegal"
+	},
+	castformsnowy: {
+		tier: "Illegal"
+	},
+	kecleon: {
+		tier: "Illegal"
+	},
+	shuppet: {
+		tier: "Illegal"
+	},
+	banette: {
+		tier: "Illegal"
+	},
+	banettemega: {
+		tier: "Illegal"
+	},
+	duskull: {
+		tier: "Illegal"
+	},
+	dusclops: {
+		tier: "Illegal"
+	},
+	dusknoir: {
+		tier: "Illegal"
+	},
+	tropius: {
+		tier: "Illegal"
+	},
+	chingling: {
+		tier: "Illegal"
+	},
+	chimecho: {
+		tier: "Illegal"
+	},
+	absol: {
+		tier: "Illegal"
+	},
+	absolmega: {
+		tier: "Illegal"
+	},
+	snorunt: {
+		tier: "Illegal"
+	},
+	glalie: {
+		tier: "Illegal"
+	},
+	glaliemega: {
+		tier: "Illegal"
+	},
+	froslass: {
+		tier: "Illegal"
+	},
+	spheal: {
+		tier: "Illegal"
+	},
+	sealeo: {
+		tier: "Illegal"
+	},
+	walrein: {
+		tier: "Illegal"
+	},
+	clamperl: {
+		tier: "Illegal"
+	},
+	huntail: {
+		tier: "Illegal"
+	},
+	gorebyss: {
+		tier: "Illegal"
+	},
+	relicanth: {
+		tier: "Illegal"
+	},
+	luvdisc: {
+		tier: "Illegal"
+	},
+	bagon: {
+		tier: "Illegal"
+	},
+	shelgon: {
+		tier: "Illegal"
+	},
+	salamence: {
+		tier: "Illegal"
+	},
+	salamencemega: {
+		tier: "Illegal"
+	},
+	beldum: {
+		tier: "Illegal"
+	},
+	metang: {
+		tier: "Illegal"
+	},
+	metagross: {
+		tier: "Illegal"
+	},
+	metagrossmega: {
+		tier: "Illegal"
+	},
+	regirock: {
+		tier: "Illegal"
+	},
+	regice: {
+		tier: "Illegal"
+	},
+	registeel: {
+		tier: "Illegal"
+	},
+	latias: {
+		tier: "Illegal"
+	},
+	latiasmega: {
+		tier: "Illegal"
+	},
+	latios: {
+		tier: "Illegal"
+	},
+	latiosmega: {
+		tier: "Illegal"
+	},
+	kyogre: {
+		tier: "Illegal"
+	},
+	kyogreprimal: {
+		tier: "Illegal"
+	},
+	groudon: {
+		tier: "Illegal"
+	},
+	groudonprimal: {
+		tier: "Illegal"
+	},
+	rayquaza: {
+		tier: "Illegal"
+	},
+	rayquazamega: {
+		tier: "Illegal"
+	},
+	jirachi: {
+		tier: "Illegal"
+	},
+	deoxys: {
+		tier: "Illegal"
+	},
+	deoxysattack: {
+		tier: "Illegal"
+	},
+	deoxysdefense: {
+		tier: "Illegal"
+	},
+	deoxysspeed: {
+		tier: "Illegal"
+	},
+	turtwig: {
+		tier: "Illegal"
+	},
+	grotle: {
+		tier: "Illegal"
+	},
+	torterra: {
+		tier: "Illegal"
+	},
+	chimchar: {
+		tier: "Illegal"
+	},
+	monferno: {
+		tier: "Illegal"
+	},
+	infernape: {
+		tier: "Illegal"
+	},
+	piplup: {
+		tier: "Illegal"
+	},
+	prinplup: {
+		tier: "Illegal"
+	},
+	empoleon: {
+		tier: "Illegal"
+	},
+	starly: {
+		tier: "Illegal"
+	},
+	staravia: {
+		tier: "Illegal"
+	},
+	staraptor: {
+		tier: "Illegal"
+	},
+	bidoof: {
+		tier: "Illegal"
+	},
+	bibarel: {
+		tier: "Illegal"
+	},
+	kricketot: {
+		tier: "Illegal"
+	},
+	kricketune: {
+		tier: "Illegal"
+	},
+	shinx: {
+		tier: "Illegal"
+	},
+	luxio: {
+		tier: "Illegal"
+	},
+	luxray: {
+		tier: "Illegal"
+	},
+	cranidos: {
+		tier: "Illegal"
+	},
+	rampardos: {
+		tier: "Illegal"
+	},
+	shieldon: {
+		tier: "Illegal"
+	},
+	bastiodon: {
+		tier: "Illegal"
+	},
+	burmy: {
+		tier: "Illegal"
+	},
+	wormadam: {
+		tier: "Illegal"
+	},
+	wormadamsandy: {
+		tier: "Illegal"
+	},
+	wormadamtrash: {
+		tier: "Illegal"
+	},
+	mothim: {
+		tier: "Illegal"
+	},
+	combee: {
+		tier: "Illegal"
+	},
+	vespiquen: {
+		tier: "Illegal"
+	},
+	pachirisu: {
+		tier: "Illegal"
+	},
+	buizel: {
+		tier: "Illegal"
+	},
+	floatzel: {
+		tier: "Illegal"
+	},
+	cherubi: {
+		tier: "Illegal"
+	},
+	cherrim: {
+		tier: "Illegal"
+	},
+	cherrimsunshine: {
+		tier: "Illegal"
+	},
+	shellos: {
+		tier: "Illegal"
+	},
+	gastrodon: {
+		tier: "Illegal"
+	},
+	drifloon: {
+		tier: "Illegal"
+	},
+	drifblim: {
+		tier: "Illegal"
+	},
+	buneary: {
+		tier: "Illegal"
+	},
+	lopunny: {
+		tier: "Illegal"
+	},
+	lopunnymega: {
+		tier: "Illegal"
+	},
+	glameow: {
+		tier: "Illegal"
+	},
+	purugly: {
+		tier: "Illegal"
+	},
+	stunky: {
+		tier: "Illegal"
+	},
+	skuntank: {
+		tier: "Illegal"
+	},
+	bronzor: {
+		tier: "Illegal"
+	},
+	bronzong: {
+		tier: "Illegal"
+	},
+	chatot: {
+		tier: "Illegal"
+	},
+	spiritomb: {
+		tier: "Illegal"
+	},
+	gible: {
+		tier: "Illegal"
+	},
+	gabite: {
+		tier: "Illegal"
+	},
+	garchomp: {
+		tier: "Illegal"
+	},
+	garchompmega: {
+		tier: "Illegal"
+	},
+	riolu: {
+		tier: "Illegal"
+	},
+	lucario: {
+		tier: "Illegal"
+	},
+	lucariomega: {
+		tier: "Illegal"
+	},
+	hippopotas: {
+		tier: "Illegal"
+	},
+	hippowdon: {
+		tier: "Illegal"
+	},
+	skorupi: {
+		tier: "Illegal"
+	},
+	drapion: {
+		tier: "Illegal"
+	},
+	croagunk: {
+		tier: "Illegal"
+	},
+	toxicroak: {
+		tier: "Illegal"
+	},
+	carnivine: {
+		tier: "Illegal"
+	},
+	finneon: {
+		tier: "Illegal"
+	},
+	lumineon: {
+		tier: "Illegal"
+	},
+	snover: {
+		tier: "Illegal"
+	},
+	abomasnow: {
+		tier: "Illegal"
+	},
+	abomasnowmega: {
+		tier: "Illegal"
+	},
+	rotom: {
+		tier: "Illegal"
+	},
+	rotomheat: {
+		tier: "Illegal"
+	},
+	rotomwash: {
+		tier: "Illegal"
+	},
+	rotomfrost: {
+		tier: "Illegal"
+	},
+	rotomfan: {
+		tier: "Illegal"
+	},
+	rotommow: {
+		tier: "Illegal"
+	},
+	uxie: {
+		tier: "Illegal"
+	},
+	mesprit: {
+		tier: "Illegal"
+	},
+	azelf: {
+		tier: "Illegal"
+	},
+	dialga: {
+		tier: "Illegal"
+	},
+	dialgaorigin: {
+		tier: "Illegal"
+	},
+	palkia: {
+		tier: "Illegal"
+	},
+	palkiaorigin: {
+		tier: "Illegal"
+	},
+	heatran: {
+		tier: "Illegal"
+	},
+	regigigas: {
+		tier: "Illegal"
+	},
+	giratina: {
+		tier: "Illegal"
+	},
+	giratinaorigin: {
+		tier: "Illegal"
+	},
+	cresselia: {
+		tier: "Illegal"
+	},
+	phione: {
+		tier: "Illegal"
+	},
+	manaphy: {
+		tier: "Illegal"
+	},
+	darkrai: {
+		tier: "Illegal"
+	},
+	shaymin: {
+		tier: "Illegal"
+	},
+	shayminsky: {
+		tier: "Illegal"
+	},
+	arceus: {
+		tier: "Illegal"
+	},
+	victini: {
+		tier: "Illegal"
+	},
+	snivy: {
+		tier: "Illegal"
+	},
+	servine: {
+		tier: "Illegal"
+	},
+	serperior: {
+		tier: "Illegal"
+	},
+	tepig: {
+		tier: "Illegal"
+	},
+	pignite: {
+		tier: "Illegal"
+	},
+	emboar: {
+		tier: "Illegal"
+	},
+	oshawott: {
+		tier: "Illegal"
+	},
+	dewott: {
+		tier: "Illegal"
+	},
+	samurott: {
+		tier: "Illegal"
+	},
+	samurotthisui: {
+		tier: "Illegal"
+	},
+	patrat: {
+		tier: "Illegal"
+	},
+	watchog: {
+		tier: "Illegal"
+	},
+	lillipup: {
+		tier: "Illegal"
+	},
+	herdier: {
+		tier: "Illegal"
+	},
+	stoutland: {
+		tier: "Illegal"
+	},
+	purrloin: {
+		tier: "Illegal"
+	},
+	liepard: {
+		tier: "Illegal"
+	},
+	pansage: {
+		tier: "Illegal"
+	},
+	simisage: {
+		tier: "Illegal"
+	},
+	pansear: {
+		tier: "Illegal"
+	},
+	simisear: {
+		tier: "Illegal"
+	},
+	panpour: {
+		tier: "Illegal"
+	},
+	simipour: {
+		tier: "Illegal"
+	},
+	munna: {
+		tier: "Illegal"
+	},
+	musharna: {
+		tier: "Illegal"
+	},
+	pidove: {
+		tier: "Illegal"
+	},
+	tranquill: {
+		tier: "Illegal"
+	},
+	unfezant: {
+		tier: "Illegal"
+	},
+	blitzle: {
+		tier: "Illegal"
+	},
+	zebstrika: {
+		tier: "Illegal"
+	},
+	roggenrola: {
+		tier: "Illegal"
+	},
+	boldore: {
+		tier: "Illegal"
+	},
+	gigalith: {
+		tier: "Illegal"
+	},
+	woobat: {
+		tier: "Illegal"
+	},
+	swoobat: {
+		tier: "Illegal"
+	},
+	drilbur: {
+		tier: "Illegal"
+	},
+	excadrill: {
+		tier: "Illegal"
+	},
+	audino: {
+		tier: "Illegal"
+	},
+	audinomega: {
+		tier: "Illegal"
+	},
+	timburr: {
+		tier: "Illegal"
+	},
+	gurdurr: {
+		tier: "Illegal"
+	},
+	conkeldurr: {
+		tier: "Illegal"
+	},
+	tympole: {
+		tier: "Illegal"
+	},
+	palpitoad: {
+		tier: "Illegal"
+	},
+	seismitoad: {
+		tier: "Illegal"
+	},
+	throh: {
+		tier: "Illegal"
+	},
+	sawk: {
+		tier: "Illegal"
+	},
+	sewaddle: {
+		tier: "Illegal"
+	},
+	swadloon: {
+		tier: "Illegal"
+	},
+	leavanny: {
+		tier: "Illegal"
+	},
+	venipede: {
+		tier: "Illegal"
+	},
+	whirlipede: {
+		tier: "Illegal"
+	},
+	scolipede: {
+		tier: "Illegal"
+	},
+	cottonee: {
+		tier: "Illegal"
+	},
+	whimsicott: {
+		tier: "Illegal"
+	},
+	petilil: {
+		tier: "Illegal"
+	},
+	lilligant: {
+		tier: "Illegal"
+	},
+	lilliganthisui: {
+		tier: "Illegal"
+	},
+	basculin: {
+		tier: "Illegal"
+	},
+	basculegion: {
+		tier: "Illegal"
+	},
+	basculegionf: {
+		tier: "Illegal"
+	},
+	sandile: {
+		tier: "Illegal"
+	},
+	krokorok: {
+		tier: "Illegal"
+	},
+	krookodile: {
+		tier: "Illegal"
+	},
+	darumaka: {
+		tier: "Illegal"
+	},
+	darumakagalar: {
+		tier: "Illegal"
+	},
+	darmanitan: {
+		tier: "Illegal"
+	},
+	darmanitanzen: {
+		tier: "Illegal"
+	},
+	darmanitangalar: {
+		tier: "Illegal"
+	},
+	darmanitangalarzen: {
+		tier: "Illegal"
+	},
+	maractus: {
+		tier: "Illegal"
+	},
+	dwebble: {
+		tier: "Illegal"
+	},
+	crustle: {
+		tier: "Illegal"
+	},
+	scraggy: {
+		tier: "Illegal"
+	},
+	scrafty: {
+		tier: "Illegal"
+	},
+	sigilyph: {
+		tier: "Illegal"
+	},
+	yamask: {
+		tier: "Illegal"
+	},
+	yamaskgalar: {
+		tier: "Illegal"
+	},
+	cofagrigus: {
+		tier: "Illegal"
+	},
+	runerigus: {
+		tier: "Illegal"
+	},
+	tirtouga: {
+		tier: "Illegal"
+	},
+	carracosta: {
+		tier: "Illegal"
+	},
+	archen: {
+		tier: "Illegal"
+	},
+	archeops: {
+		tier: "Illegal"
+	},
+	trubbish: {
+		tier: "Illegal"
+	},
+	garbodor: {
+		tier: "Illegal"
+	},
+	garbodorgmax: {
+		tier: "Illegal"
+	},
+	zorua: {
+		tier: "Illegal"
+	},
+	zoruahisui: {
+		tier: "Illegal"
+	},
+	zoroark: {
+		tier: "Illegal"
+	},
+	zoroarkhisui: {
+		tier: "Illegal"
+	},
+	minccino: {
+		tier: "Illegal"
+	},
+	cinccino: {
+		tier: "Illegal"
+	},
+	gothita: {
+		tier: "Illegal"
+	},
+	gothorita: {
+		tier: "Illegal"
+	},
+	gothitelle: {
+		tier: "Illegal"
+	},
+	solosis: {
+		tier: "Illegal"
+	},
+	duosion: {
+		tier: "Illegal"
+	},
+	reuniclus: {
+		tier: "Illegal"
+	},
+	ducklett: {
+		tier: "Illegal"
+	},
+	swanna: {
+		tier: "Illegal"
+	},
+	vanillite: {
+		tier: "Illegal"
+	},
+	vanillish: {
+		tier: "Illegal"
+	},
+	vanilluxe: {
+		tier: "Illegal"
+	},
+	deerling: {
+		tier: "Illegal"
+	},
+	sawsbuck: {
+		tier: "Illegal"
+	},
+	emolga: {
+		tier: "Illegal"
+	},
+	karrablast: {
+		tier: "Illegal"
+	},
+	escavalier: {
+		tier: "Illegal"
+	},
+	foongus: {
+		tier: "Illegal"
+	},
+	amoonguss: {
+		tier: "Illegal"
+	},
+	frillish: {
+		tier: "Illegal"
+	},
+	jellicent: {
+		tier: "Illegal"
+	},
+	alomomola: {
+		tier: "Illegal"
+	},
+	joltik: {
+		tier: "Illegal"
+	},
+	galvantula: {
+		tier: "Illegal"
+	},
+	ferroseed: {
+		tier: "Illegal"
+	},
+	ferrothorn: {
+		tier: "Illegal"
+	},
+	klink: {
+		tier: "Illegal"
+	},
+	klang: {
+		tier: "Illegal"
+	},
+	klinklang: {
+		tier: "Illegal"
+	},
+	tynamo: {
+		tier: "Illegal"
+	},
+	eelektrik: {
+		tier: "Illegal"
+	},
+	eelektross: {
+		tier: "Illegal"
+	},
+	elgyem: {
+		tier: "Illegal"
+	},
+	beheeyem: {
+		tier: "Illegal"
+	},
+	litwick: {
+		tier: "Illegal"
+	},
+	lampent: {
+		tier: "Illegal"
+	},
+	chandelure: {
+		tier: "Illegal"
+	},
+	axew: {
+		tier: "Illegal"
+	},
+	fraxure: {
+		tier: "Illegal"
+	},
+	haxorus: {
+		tier: "Illegal"
+	},
+	cubchoo: {
+		tier: "Illegal"
+	},
+	beartic: {
+		tier: "Illegal"
+	},
+	cryogonal: {
+		tier: "Illegal"
+	},
+	shelmet: {
+		tier: "Illegal"
+	},
+	accelgor: {
+		tier: "Illegal"
+	},
+	stunfisk: {
+		tier: "Illegal"
+	},
+	stunfiskgalar: {
+		tier: "Illegal"
+	},
+	mienfoo: {
+		tier: "Illegal"
+	},
+	mienshao: {
+		tier: "Illegal"
+	},
+	druddigon: {
+		tier: "Illegal"
+	},
+	golett: {
+		tier: "Illegal"
+	},
+	golurk: {
+		tier: "Illegal"
+	},
+	pawniard: {
+		tier: "Illegal"
+	},
+	bisharp: {
+		tier: "Illegal"
+	},
+	bouffalant: {
+		tier: "Illegal"
+	},
+	rufflet: {
+		tier: "Illegal"
+	},
+	braviary: {
+		tier: "Illegal"
+	},
+	braviaryhisui: {
+		tier: "Illegal"
+	},
+	vullaby: {
+		tier: "Illegal"
+	},
+	mandibuzz: {
+		tier: "Illegal"
+	},
+	heatmor: {
+		tier: "Illegal"
+	},
+	durant: {
+		tier: "Illegal"
+	},
+	deino: {
+		tier: "Illegal"
+	},
+	zweilous: {
+		tier: "Illegal"
+	},
+	hydreigon: {
+		tier: "Illegal"
+	},
+	larvesta: {
+		tier: "Illegal"
+	},
+	volcarona: {
+		tier: "Illegal"
+	},
+	cobalion: {
+		tier: "Illegal"
+	},
+	terrakion: {
+		tier: "Illegal"
+	},
+	virizion: {
+		tier: "Illegal"
+	},
+	tornadus: {
+		tier: "Illegal"
+	},
+	tornadustherian: {
+		tier: "Illegal"
+	},
+	thundurus: {
+		tier: "Illegal"
+	},
+	thundurustherian: {
+		tier: "Illegal"
+	},
+	reshiram: {
+		tier: "Illegal"
+	},
+	zekrom: {
+		tier: "Illegal"
+	},
+	landorus: {
+		tier: "Illegal"
+	},
+	landorustherian: {
+		tier: "Illegal"
+	},
+	kyurem: {
+		tier: "Illegal"
+	},
+	kyuremblack: {
+		tier: "Illegal"
+	},
+	kyuremwhite: {
+		tier: "Illegal"
+	},
+	keldeo: {
+		tier: "Illegal"
+	},
+	meloetta: {
+		tier: "Illegal"
+	},
+	genesect: {
+		tier: "Illegal"
+	},
+	genesectburn: {
+		tier: "Illegal"
+	},
+	genesectchill: {
+		tier: "Illegal"
+	},
+	genesectdouse: {
+		tier: "Illegal"
+	},
+	genesectshock: {
+		tier: "Illegal"
+	},
+	chespin: {
+		tier: "Illegal"
+	},
+	quilladin: {
+		tier: "Illegal"
+	},
+	chesnaught: {
+		tier: "Illegal"
+	},
+	fennekin: {
+		tier: "Illegal"
+	},
+	braixen: {
+		tier: "Illegal"
+	},
+	delphox: {
+		tier: "Illegal"
+	},
+	froakie: {
+		tier: "Illegal"
+	},
+	frogadier: {
+		tier: "Illegal"
+	},
+	greninja: {
+		tier: "Illegal"
+	},
+	greninjaash: {
+		tier: "Illegal"
+	},
+	bunnelby: {
+		tier: "Illegal"
+	},
+	diggersby: {
+		tier: "Illegal"
+	},
+	fletchling: {
+		tier: "Illegal"
+	},
+	fletchinder: {
+		tier: "Illegal"
+	},
+	talonflame: {
+		tier: "Illegal"
+	},
+	scatterbug: {
+		tier: "Illegal"
+	},
+	spewpa: {
+		tier: "Illegal"
+	},
+	vivillon: {
+		tier: "Illegal"
+	},
+	litleo: {
+		tier: "Illegal"
+	},
+	pyroar: {
+		tier: "Illegal"
+	},
+	flabebe: {
+		tier: "Illegal"
+	},
+	floette: {
+		tier: "Illegal"
+	},
+	floetteeternal: {
+		tier: "Illegal"
+	},
+	florges: {
+		tier: "Illegal"
+	},
+	skiddo: {
+		tier: "Illegal"
+	},
+	gogoat: {
+		tier: "Illegal"
+	},
+	pancham: {
+		tier: "Illegal"
+	},
+	pangoro: {
+		tier: "Illegal"
+	},
+	furfrou: {
+		tier: "Illegal"
+	},
+	espurr: {
+		tier: "Illegal"
+	},
+	meowstic: {
+		tier: "Illegal"
+	},
+	honedge: {
+		tier: "Illegal"
+	},
+	doublade: {
+		tier: "Illegal"
+	},
+	aegislash: {
+		tier: "Illegal"
+	},
+	aegislashblade: {
+		tier: "Illegal"
+	},
+	spritzee: {
+		tier: "Illegal"
+	},
+	aromatisse: {
+		tier: "Illegal"
+	},
+	swirlix: {
+		tier: "Illegal"
+	},
+	slurpuff: {
+		tier: "Illegal"
+	},
+	inkay: {
+		tier: "Illegal"
+	},
+	malamar: {
+		tier: "Illegal"
+	},
+	binacle: {
+		tier: "Illegal"
+	},
+	barbaracle: {
+		tier: "Illegal"
+	},
+	skrelp: {
+		tier: "Illegal"
+	},
+	dragalge: {
+		tier: "Illegal"
+	},
+	clauncher: {
+		tier: "Illegal"
+	},
+	clawitzer: {
+		tier: "Illegal"
+	},
+	helioptile: {
+		tier: "Illegal"
+	},
+	heliolisk: {
+		tier: "Illegal"
+	},
+	tyrunt: {
+		tier: "Illegal"
+	},
+	tyrantrum: {
+		tier: "Illegal"
+	},
+	amaura: {
+		tier: "Illegal"
+	},
+	aurorus: {
+		tier: "Illegal"
+	},
+	hawlucha: {
+		tier: "Illegal"
+	},
+	dedenne: {
+		tier: "Illegal"
+	},
+	carbink: {
+		tier: "Illegal"
+	},
+	goomy: {
+		tier: "Illegal"
+	},
+	sliggoo: {
+		tier: "Illegal"
+	},
+	sliggoohisui: {
+		tier: "Illegal"
+	},
+	goodra: {
+		tier: "Illegal"
+	},
+	goodrahisui: {
+		tier: "Illegal"
+	},
+	klefki: {
+		tier: "Illegal"
+	},
+	phantump: {
+		tier: "Illegal"
+	},
+	trevenant: {
+		tier: "Illegal"
+	},
+	pumpkaboo: {
+		tier: "Illegal"
+	},
+	pumpkaboosmall: {
+		tier: "Illegal"
+	},
+	pumpkaboolarge: {
+		tier: "Illegal"
+	},
+	pumpkaboosuper: {
+		tier: "Illegal"
+	},
+	gourgeist: {
+		tier: "Illegal"
+	},
+	gourgeistsmall: {
+		tier: "Illegal"
+	},
+	gourgeistlarge: {
+		tier: "Illegal"
+	},
+	gourgeistsuper: {
+		tier: "Illegal"
+	},
+	bergmite: {
+		tier: "Illegal"
+	},
+	avalugg: {
+		tier: "Illegal"
+	},
+	avalugghisui: {
+		tier: "Illegal"
+	},
+	noibat: {
+		tier: "Illegal"
+	},
+	noivern: {
+		tier: "Illegal"
+	},
+	xerneas: {
+		tier: "Illegal"
+	},
+	xerneasneutral: {
+		tier: "Illegal"
+	},
+	yveltal: {
+		tier: "Illegal"
+	},
+	zygarde: {
+		tier: "Illegal"
+	},
+	zygarde10: {
+		tier: "Illegal"
+	},
+	zygardecomplete: {
+		tier: "Illegal"
+	},
+	diancie: {
+		tier: "Illegal"
+	},
+	dianciemega: {
+		tier: "Illegal"
+	},
+	hoopa: {
+		tier: "Illegal"
+	},
+	hoopaunbound: {
+		tier: "Illegal"
+	},
+	volcanion: {
+		tier: "Illegal"
+	},
+	rowlet: {
+		tier: "Illegal"
+	},
+	dartrix: {
+		tier: "Illegal"
+	},
+	decidueye: {
+		tier: "Illegal"
+	},
+	decidueyehisui: {
+		tier: "Illegal"
+	},
+	litten: {
+		tier: "Illegal"
+	},
+	torracat: {
+		tier: "Illegal"
+	},
+	incineroar: {
+		tier: "Illegal"
+	},
+	popplio: {
+		tier: "Illegal"
+	},
+	brionne: {
+		tier: "Illegal"
+	},
+	primarina: {
+		tier: "Illegal"
+	},
+	pikipek: {
+		tier: "Illegal"
+	},
+	trumbeak: {
+		tier: "Illegal"
+	},
+	toucannon: {
+		tier: "Illegal"
+	},
+	yungoos: {
+		tier: "Illegal"
+	},
+	gumshoos: {
+		tier: "Illegal"
+	},
+	gumshoostotem: {
+		tier: "Illegal"
+	},
+	grubbin: {
+		tier: "Illegal"
+	},
+	charjabug: {
+		tier: "Illegal"
+	},
+	vikavolt: {
+		tier: "Illegal"
+	},
+	vikavolttotem: {
+		tier: "Illegal"
+	},
+	crabrawler: {
+		tier: "Illegal"
+	},
+	crabominable: {
+		tier: "Illegal"
+	},
+	oricorio: {
+		tier: "Illegal"
+	},
+	oricoriopompom: {
+		tier: "Illegal"
+	},
+	oricoriopau: {
+		tier: "Illegal"
+	},
+	oricoriosensu: {
+		tier: "Illegal"
+	},
+	cutiefly: {
+		tier: "Illegal"
+	},
+	ribombee: {
+		tier: "Illegal"
+	},
+	ribombeetotem: {
+		tier: "Illegal"
+	},
+	rockruff: {
+		tier: "Illegal"
+	},
+	rockruffdusk: {
+		tier: "Illegal"
+	},
+	lycanroc: {
+		tier: "Illegal"
+	},
+	lycanrocmidnight: {
+		tier: "Illegal"
+	},
+	lycanrocdusk: {
+		tier: "Illegal"
+	},
+	wishiwashi: {
+		tier: "Illegal"
+	},
+	wishiwashischool: {
+		tier: "Illegal"
+	},
+	mareanie: {
+		tier: "Illegal"
+	},
+	toxapex: {
+		tier: "Illegal"
+	},
+	mudbray: {
+		tier: "Illegal"
+	},
+	mudsdale: {
+		tier: "Illegal"
+	},
+	dewpider: {
+		tier: "Illegal"
+	},
+	araquanid: {
+		tier: "Illegal"
+	},
+	araquanidtotem: {
+		tier: "Illegal"
+	},
+	fomantis: {
+		tier: "Illegal"
+	},
+	lurantis: {
+		tier: "Illegal"
+	},
+	lurantistotem: {
+		tier: "Illegal"
+	},
+	morelull: {
+		tier: "Illegal"
+	},
+	shiinotic: {
+		tier: "Illegal"
+	},
+	salandit: {
+		tier: "Illegal"
+	},
+	salazzle: {
+		tier: "Illegal"
+	},
+	salazzletotem: {
+		tier: "Illegal"
+	},
+	stufful: {
+		tier: "Illegal"
+	},
+	bewear: {
+		tier: "Illegal"
+	},
+	bounsweet: {
+		tier: "Illegal"
+	},
+	steenee: {
+		tier: "Illegal"
+	},
+	tsareena: {
+		tier: "Illegal"
+	},
+	comfey: {
+		tier: "Illegal"
+	},
+	oranguru: {
+		tier: "Illegal"
+	},
+	passimian: {
+		tier: "Illegal"
+	},
+	wimpod: {
+		tier: "Illegal"
+	},
+	golisopod: {
+		tier: "Illegal"
+	},
+	sandygast: {
+		tier: "Illegal"
+	},
+	palossand: {
+		tier: "Illegal"
+	},
+	pyukumuku: {
+		tier: "Illegal"
+	},
+	typenull: {
+		tier: "Illegal"
+	},
+	silvally: {
+		tier: "Illegal"
+	},
+	silvallybug: {
+		tier: "Illegal"
+	},
+	silvallydark: {
+		tier: "Illegal"
+	},
+	silvallydragon: {
+		tier: "Illegal"
+	},
+	silvallyelectric: {
+		tier: "Illegal"
+	},
+	silvallyfairy: {
+		tier: "Illegal"
+	},
+	silvallyfighting: {
+		tier: "Illegal"
+	},
+	silvallyfire: {
+		tier: "Illegal"
+	},
+	silvallyflying: {
+		tier: "Illegal"
+	},
+	silvallyghost: {
+		tier: "Illegal"
+	},
+	silvallygrass: {
+		tier: "Illegal"
+	},
+	silvallyground: {
+		tier: "Illegal"
+	},
+	silvallyice: {
+		tier: "Illegal"
+	},
+	silvallypoison: {
+		tier: "Illegal"
+	},
+	silvallypsychic: {
+		tier: "Illegal"
+	},
+	silvallyrock: {
+		tier: "Illegal"
+	},
+	silvallysteel: {
+		tier: "Illegal"
+	},
+	silvallywater: {
+		tier: "Illegal"
+	},
+	minior: {
+		tier: "Illegal"
+	},
+	komala: {
+		tier: "Illegal"
+	},
+	turtonator: {
+		tier: "Illegal"
+	},
+	togedemaru: {
+		tier: "Illegal"
+	},
+	togedemarutotem: {
+		tier: "Illegal"
+	},
+	mimikyu: {
+		tier: "Illegal"
+	},
+	mimikyutotem: {
+		tier: "Illegal"
+	},
+	mimikyubustedtotem: {
+		tier: "Illegal"
+	},
+	bruxish: {
+		tier: "Illegal"
+	},
+	drampa: {
+		tier: "Illegal"
+	},
+	dhelmise: {
+		tier: "Illegal"
+	},
+	jangmoo: {
+		tier: "Illegal"
+	},
+	hakamoo: {
+		tier: "Illegal"
+	},
+	kommoo: {
+		tier: "Illegal"
+	},
+	kommoototem: {
+		tier: "Illegal"
+	},
+	tapukoko: {
+		tier: "Illegal"
+	},
+	tapulele: {
+		tier: "Illegal"
+	},
+	tapubulu: {
+		tier: "Illegal"
+	},
+	tapufini: {
+		tier: "Illegal"
+	},
+	cosmog: {
+		tier: "Illegal"
+	},
+	cosmoem: {
+		tier: "Illegal"
+	},
+	solgaleo: {
+		tier: "Illegal"
+	},
+	lunala: {
+		tier: "Illegal"
+	},
+	nihilego: {
+		tier: "Illegal"
+	},
+	buzzwole: {
+		tier: "Illegal"
+	},
+	pheromosa: {
+		tier: "Illegal"
+	},
+	xurkitree: {
+		tier: "Illegal"
+	},
+	celesteela: {
+		tier: "Illegal"
+	},
+	kartana: {
+		tier: "Illegal"
+	},
+	guzzlord: {
+		tier: "Illegal"
+	},
+	necrozma: {
+		tier: "Illegal"
+	},
+	necrozmaduskmane: {
+		tier: "Illegal"
+	},
+	necrozmadawnwings: {
+		tier: "Illegal"
+	},
+	necrozmaultra: {
+		tier: "Illegal"
+	},
+	magearna: {
+		tier: "Illegal"
+	},
+	marshadow: {
+		tier: "Illegal"
+	},
+	poipole: {
+		tier: "Illegal"
+	},
+	naganadel: {
+		tier: "Illegal"
+	},
+	stakataka: {
+		tier: "Illegal"
+	},
+	blacephalon: {
+		tier: "Illegal"
+	},
+	zeraora: {
+		tier: "Illegal"
+	},
+	meltan: {
+		tier: "Illegal"
+	},
+	melmetal: {
+		tier: "Illegal"
+	},
+	melmetalgmax: {
+		tier: "Illegal"
+	},
+	grookey: {
+		tier: "Illegal"
+	},
+	thwackey: {
+		tier: "Illegal"
+	},
+	rillaboom: {
+		tier: "Illegal"
+	},
+	rillaboomgmax: {
+		tier: "Illegal"
+	},
+	scorbunny: {
+		tier: "Illegal"
+	},
+	raboot: {
+		tier: "Illegal"
+	},
+	cinderace: {
+		tier: "Illegal"
+	},
+	cinderacegmax: {
+		tier: "Illegal"
+	},
+	sobble: {
+		tier: "Illegal"
+	},
+	drizzile: {
+		tier: "Illegal"
+	},
+	inteleon: {
+		tier: "Illegal"
+	},
+	inteleongmax: {
+		tier: "Illegal"
+	},
+	skwovet: {
+		tier: "Illegal"
+	},
+	greedent: {
+		tier: "Illegal"
+	},
+	rookidee: {
+		tier: "Illegal"
+	},
+	corvisquire: {
+		tier: "Illegal"
+	},
+	corviknight: {
+		tier: "Illegal"
+	},
+	corviknightgmax: {
+		tier: "Illegal"
+	},
+	blipbug: {
+		tier: "Illegal"
+	},
+	dottler: {
+		tier: "Illegal"
+	},
+	orbeetle: {
+		tier: "Illegal"
+	},
+	orbeetlegmax: {
+		tier: "Illegal"
+	},
+	nickit: {
+		tier: "Illegal"
+	},
+	thievul: {
+		tier: "Illegal"
+	},
+	gossifleur: {
+		tier: "Illegal"
+	},
+	eldegoss: {
+		tier: "Illegal"
+	},
+	wooloo: {
+		tier: "Illegal"
+	},
+	dubwool: {
+		tier: "Illegal"
+	},
+	chewtle: {
+		tier: "Illegal"
+	},
+	drednaw: {
+		tier: "Illegal"
+	},
+	drednawgmax: {
+		tier: "Illegal"
+	},
+	yamper: {
+		tier: "Illegal"
+	},
+	boltund: {
+		tier: "Illegal"
+	},
+	rolycoly: {
+		tier: "Illegal"
+	},
+	carkol: {
+		tier: "Illegal"
+	},
+	coalossal: {
+		tier: "Illegal"
+	},
+	coalossalgmax: {
+		tier: "Illegal"
+	},
+	applin: {
+		tier: "Illegal"
+	},
+	flapple: {
+		tier: "Illegal"
+	},
+	flapplegmax: {
+		tier: "Illegal"
+	},
+	appletun: {
+		tier: "Illegal"
+	},
+	appletungmax: {
+		tier: "Illegal"
+	},
+	dipplin: {
+		tier: "Illegal"
+	},
+	silicobra: {
+		tier: "Illegal"
+	},
+	sandaconda: {
+		tier: "Illegal"
+	},
+	sandacondagmax: {
+		tier: "Illegal"
+	},
+	cramorant: {
+		tier: "Illegal"
+	},
+	arrokuda: {
+		tier: "Illegal"
+	},
+	barraskewda: {
+		tier: "Illegal"
+	},
+	toxel: {
+		tier: "Illegal"
+	},
+	toxtricity: {
+		tier: "Illegal"
+	},
+	toxtricitygmax: {
+		tier: "Illegal"
+	},
+	toxtricitylowkeygmax: {
+		tier: "Illegal"
+	},
+	sizzlipede: {
+		tier: "Illegal"
+	},
+	centiskorch: {
+		tier: "Illegal"
+	},
+	centiskorchgmax: {
+		tier: "Illegal"
+	},
+	clobbopus: {
+		tier: "Illegal"
+	},
+	grapploct: {
+		tier: "Illegal"
+	},
+	sinistea: {
+		tier: "Illegal"
+	},
+	polteageist: {
+		tier: "Illegal"
+	},
+	hatenna: {
+		tier: "Illegal"
+	},
+	hattrem: {
+		tier: "Illegal"
+	},
+	hatterene: {
+		tier: "Illegal"
+	},
+	hatterenegmax: {
+		tier: "Illegal"
+	},
+	impidimp: {
+		tier: "Illegal"
+	},
+	morgrem: {
+		tier: "Illegal"
+	},
+	grimmsnarl: {
+		tier: "Illegal"
+	},
+	grimmsnarlgmax: {
+		tier: "Illegal"
+	},
+	milcery: {
+		tier: "Illegal"
+	},
+	alcremie: {
+		tier: "Illegal"
+	},
+	alcremiegmax: {
+		tier: "Illegal"
+	},
+	falinks: {
+		tier: "Illegal"
+	},
+	pincurchin: {
+		tier: "Illegal"
+	},
+	snom: {
+		tier: "Illegal"
+	},
+	frosmoth: {
+		tier: "Illegal"
+	},
+	stonjourner: {
+		tier: "Illegal"
+	},
+	eiscue: {
+		tier: "Illegal"
+	},
+	indeedee: {
+		tier: "Illegal"
+	},
+	indeedeef: {
+		tier: "Illegal"
+	},
+	morpeko: {
+		tier: "Illegal"
+	},
+	cufant: {
+		tier: "Illegal"
+	},
+	copperajah: {
+		tier: "Illegal"
+	},
+	copperajahgmax: {
+		tier: "Illegal"
+	},
+	dracozolt: {
+		tier: "Illegal"
+	},
+	arctozolt: {
+		tier: "Illegal"
+	},
+	dracovish: {
+		tier: "Illegal"
+	},
+	arctovish: {
+		tier: "Illegal"
+	},
+	duraludon: {
+		tier: "Illegal"
+	},
+	duraludongmax: {
+		tier: "Illegal"
+	},
+	dreepy: {
+		tier: "Illegal"
+	},
+	drakloak: {
+		tier: "Illegal"
+	},
+	dragapult: {
+		tier: "Illegal"
+	},
+	zacian: {
+		tier: "Illegal"
+	},
+	zaciancrowned: {
+		tier: "Illegal"
+	},
+	zamazenta: {
+		tier: "Illegal"
+	},
+	zamazentacrowned: {
+		tier: "Illegal"
+	},
+	eternatus: {
+		tier: "Illegal"
+	},
+	eternatuseternamax: {
+		tier: "Illegal"
+	},
+	kubfu: {
+		tier: "Illegal"
+	},
+	urshifu: {
+		tier: "Illegal"
+	},
+	urshifurapidstrike: {
+		tier: "Illegal"
+	},
+	urshifugmax: {
+		tier: "Illegal"
+	},
+	urshifurapidstrikegmax: {
+		tier: "Illegal"
+	},
+	zarude: {
+		tier: "Illegal"
+	},
+	regieleki: {
+		tier: "Illegal"
+	},
+	regidrago: {
+		tier: "Illegal"
+	},
+	glastrier: {
+		tier: "Illegal"
+	},
+	spectrier: {
+		tier: "Illegal"
+	},
+	calyrex: {
+		tier: "Illegal"
+	},
+	calyrexice: {
+		tier: "Illegal"
+	},
+	calyrexshadow: {
+		tier: "Illegal"
+	},
+	enamorus: {
+		tier: "Illegal"
+	},
+	enamorustherian: {
+		tier: "Illegal"
+	},
+	sprigatito: {
+		tier: "Illegal"
+	},
+	floragato: {
+		tier: "Illegal"
+	},
+	meowscarada: {
+		tier: "Illegal"
+	},
+	fuecoco: {
+		tier: "Illegal"
+	},
+	crocalor: {
+		tier: "Illegal"
+	},
+	skeledirge: {
+		tier: "Illegal"
+	},
+	quaxly: {
+		tier: "Illegal"
+	},
+	quaxwell: {
+		tier: "Illegal"
+	},
+	quaquaval: {
+		tier: "Illegal"
+	},
+	lechonk: {
+		tier: "Illegal"
+	},
+	oinkologne: {
+		tier: "Illegal"
+	},
+	oinkolognef: {
+		tier: "Illegal"
+	},
+	tarountula: {
+		tier: "Illegal"
+	},
+	spidops: {
+		tier: "Illegal"
+	},
+	nymble: {
+		tier: "Illegal"
+	},
+	lokix: {
+		tier: "Illegal"
+	},
+	rellor: {
+		tier: "Illegal"
+	},
+	rabsca: {
+		tier: "Illegal"
+	},
+	greavard: {
+		tier: "Illegal"
+	},
+	houndstone: {
+		tier: "Illegal"
+	},
+	flittle: {
+		tier: "Illegal"
+	},
+	espathra: {
+		tier: "Illegal"
+	},
+	wiglett: {
+		tier: "Illegal"
+	},
+	wugtrio: {
+		tier: "Illegal"
+	},
+	dondozo: {
+		tier: "Illegal"
+	},
+	veluza: {
+		tier: "Illegal"
+	},
+	finizen: {
+		tier: "Illegal"
+	},
+	palafin: {
+		tier: "Illegal"
+	},
+	smoliv: {
+		tier: "Illegal"
+	},
+	dolliv: {
+		tier: "Illegal"
+	},
+	arboliva: {
+		tier: "Illegal"
+	},
+	capsakid: {
+		tier: "Illegal"
+	},
+	scovillain: {
+		tier: "Illegal"
+	},
+	tadbulb: {
+		tier: "Illegal"
+	},
+	bellibolt: {
+		tier: "Illegal"
+	},
+	varoom: {
+		tier: "Illegal"
+	},
+	revavroom: {
+		tier: "Illegal"
+	},
+	orthworm: {
+		tier: "Illegal"
+	},
+	tandemaus: {
+		tier: "Illegal"
+	},
+	maushold: {
+		tier: "Illegal"
+	},
+	cetoddle: {
+		tier: "Illegal"
+	},
+	cetitan: {
+		tier: "Illegal"
+	},
+	frigibax: {
+		tier: "Illegal"
+	},
+	arctibax: {
+		tier: "Illegal"
+	},
+	baxcalibur: {
+		tier: "Illegal"
+	},
+	tatsugiri: {
+		tier: "Illegal"
+	},
+	cyclizar: {
+		tier: "Illegal"
+	},
+	pawmi: {
+		tier: "Illegal"
+	},
+	pawmo: {
+		tier: "Illegal"
+	},
+	pawmot: {
+		tier: "Illegal"
+	},
+	wattrel: {
+		tier: "Illegal"
+	},
+	kilowattrel: {
+		tier: "Illegal"
+	},
+	bombirdier: {
+		tier: "Illegal"
+	},
+	squawkabilly: {
+		tier: "Illegal"
+	},
+	flamigo: {
+		tier: "Illegal"
+	},
+	klawf: {
+		tier: "Illegal"
+	},
+	nacli: {
+		tier: "Illegal"
+	},
+	naclstack: {
+		tier: "Illegal"
+	},
+	garganacl: {
+		tier: "Illegal"
+	},
+	glimmet: {
+		tier: "Illegal"
+	},
+	glimmora: {
+		tier: "Illegal"
+	},
+	shroodle: {
+		tier: "Illegal"
+	},
+	grafaiai: {
+		tier: "Illegal"
+	},
+	fidough: {
+		tier: "Illegal"
+	},
+	dachsbun: {
+		tier: "Illegal"
+	},
+	maschiff: {
+		tier: "Illegal"
+	},
+	mabosstiff: {
+		tier: "Illegal"
+	},
+	bramblin: {
+		tier: "Illegal"
+	},
+	brambleghast: {
+		tier: "Illegal"
+	},
+	gimmighoul: {
+		tier: "Illegal"
+	},
+	gimmighoulroaming: {
+		tier: "Illegal"
+	},
+	gholdengo: {
+		tier: "Illegal"
+	},
+	greattusk: {
+		tier: "Illegal"
+	},
+	brutebonnet: {
+		tier: "Illegal"
+	},
+	sandyshocks: {
+		tier: "Illegal"
+	},
+	screamtail: {
+		tier: "Illegal"
+	},
+	fluttermane: {
+		tier: "Illegal"
+	},
+	slitherwing: {
+		tier: "Illegal"
+	},
+	roaringmoon: {
+		tier: "Illegal"
+	},
+	irontreads: {
+		tier: "Illegal"
+	},
+	ironmoth: {
+		tier: "Illegal"
+	},
+	ironhands: {
+		tier: "Illegal"
+	},
+	ironjugulis: {
+		tier: "Illegal"
+	},
+	ironthorns: {
+		tier: "Illegal"
+	},
+	ironbundle: {
+		tier: "Illegal"
+	},
+	ironvaliant: {
+		tier: "Illegal"
+	},
+	tinglu: {
+		tier: "Illegal"
+	},
+	chienpao: {
+		tier: "Illegal"
+	},
+	wochien: {
+		tier: "Illegal"
+	},
+	chiyu: {
+		tier: "Illegal"
+	},
+	koraidon: {
+		tier: "Illegal"
+	},
+	miraidon: {
+		tier: "Illegal"
+	},
+	tinkatink: {
+		tier: "Illegal"
+	},
+	tinkatuff: {
+		tier: "Illegal"
+	},
+	tinkaton: {
+		tier: "Illegal"
+	},
+	charcadet: {
+		tier: "Illegal"
+	},
+	armarouge: {
+		tier: "Illegal"
+	},
+	ceruledge: {
+		tier: "Illegal"
+	},
+	toedscool: {
+		tier: "Illegal"
+	},
+	toedscruel: {
+		tier: "Illegal"
+	},
+	kingambit: {
+		tier: "Illegal"
+	},
+	clodsire: {
+		tier: "Illegal"
+	},
+	annihilape: {
+		tier: "Illegal"
+	},
+	walkingwake: {
+		tier: "Illegal"
+	},
+	ironleaves: {
+		tier: "Illegal"
+	},
+	poltchageist: {
+		tier: "Illegal"
+	},
+	sinistcha: {
+		tier: "Illegal"
+	},
+	okidogi: {
+		tier: "Illegal"
+	},
+	munkidori: {
+		tier: "Illegal"
+	},
+	fezandipiti: {
+		tier: "Illegal"
+	},
+	ogerpon: {
+		tier: "Illegal"
+	},
+	ogerponwellspring: {
+		tier: "Illegal"
+	},
+	ogerponhearthflame: {
+		tier: "Illegal"
+	},
+	ogerponcornerstone: {
+		tier: "Illegal"
+	},
+	archaludon: {
+		tier: "Illegal"
+	},
+	hydrapple: {
+		tier: "Illegal"
+	},
+	gougingfire: {
+		tier: "Illegal"
+	},
+	ragingbolt: {
+		tier: "Illegal"
+	},
+	ironboulder: {
+		tier: "Illegal"
+	},
+	ironcrown: {
+		tier: "Illegal"
+	},
+	terapagos: {
+		tier: "Illegal"
+	},
+	terapagosstellar: {
+		tier: "Illegal"
+	},
+	pecharunt: {
+		tier: "Illegal"
+	},
+	missingno: {
+		tier: "Illegal"
+	},
+	syclar: {
+		tier: "Illegal"
+	},
+	syclant: {
+		tier: "Illegal"
+	},
+	revenankh: {
+		tier: "Illegal"
+	},
+	embirch: {
+		tier: "Illegal"
+	},
+	flarelm: {
+		tier: "Illegal"
+	},
+	pyroak: {
+		tier: "Illegal"
+	},
+	breezi: {
+		tier: "Illegal"
+	},
+	fidgit: {
+		tier: "Illegal"
+	},
+	rebble: {
+		tier: "Illegal"
+	},
+	tactite: {
+		tier: "Illegal"
+	},
+	stratagem: {
+		tier: "Illegal"
+	},
+	privatyke: {
+		tier: "Illegal"
+	},
+	arghonaut: {
+		tier: "Illegal"
+	},
+	nohface: {
+		tier: "Illegal"
+	},
+	kitsunoh: {
+		tier: "Illegal"
+	},
+	monohm: {
+		tier: "Illegal"
+	},
+	duohm: {
+		tier: "Illegal"
+	},
+	cyclohm: {
+		tier: "Illegal"
+	},
+	dorsoil: {
+		tier: "Illegal"
+	},
+	colossoil: {
+		tier: "Illegal"
+	},
+	protowatt: {
+		tier: "Illegal"
+	},
+	krilowatt: {
+		tier: "Illegal"
+	},
+	voodoll: {
+		tier: "Illegal"
+	},
+	voodoom: {
+		tier: "Illegal"
+	},
+	scratchet: {
+		tier: "Illegal"
+	},
+	tomohawk: {
+		tier: "Illegal"
+	},
+	necturine: {
+		tier: "Illegal"
+	},
+	necturna: {
+		tier: "Illegal"
+	},
+	mollux: {
+		tier: "Illegal"
+	},
+	cupra: {
+		tier: "Illegal"
+	},
+	argalis: {
+		tier: "Illegal"
+	},
+	aurumoth: {
+		tier: "Illegal"
+	},
+	brattler: {
+		tier: "Illegal"
+	},
+	malaconda: {
+		tier: "Illegal"
+	},
+	cawdet: {
+		tier: "Illegal"
+	},
+	cawmodore: {
+		tier: "Illegal"
+	},
+	volkritter: {
+		tier: "Illegal"
+	},
+	volkraken: {
+		tier: "Illegal"
+	},
+	snugglow: {
+		tier: "Illegal"
+	},
+	plasmanta: {
+		tier: "Illegal"
+	},
+	floatoy: {
+		tier: "Illegal"
+	},
+	caimanoe: {
+		tier: "Illegal"
+	},
+	naviathan: {
+		tier: "Illegal"
+	},
+	crucibelle: {
+		tier: "Illegal"
+	},
+	crucibellemega: {
+		tier: "Illegal"
+	},
+	pluffle: {
+		tier: "Illegal"
+	},
+	kerfluffle: {
+		tier: "Illegal"
+	},
+	pajantom: {
+		tier: "Illegal"
+	},
+	mumbao: {
+		tier: "Illegal"
+	},
+	jumbao: {
+		tier: "Illegal"
+	},
+	fawnifer: {
+		tier: "Illegal"
+	},
+	electrelk: {
+		tier: "Illegal"
+	},
+	caribolt: {
+		tier: "Illegal"
+	},
+	smogecko: {
+		tier: "Illegal"
+	},
+	smoguana: {
+		tier: "Illegal"
+	},
+	smokomodo: {
+		tier: "Illegal"
+	},
+	swirlpool: {
+		tier: "Illegal"
+	},
+	coribalis: {
+		tier: "Illegal"
+	},
+	snaelstrom: {
+		tier: "Illegal"
+	},
+	justyke: {
+		tier: "Illegal"
+	},
+	equilibra: {
+		tier: "Illegal"
+	},
+	solotl: {
+		tier: "Illegal"
+	},
+	astrolotl: {
+		tier: "Illegal"
+	},
+	miasmite: {
+		tier: "Illegal"
+	},
+	miasmaw: {
+		tier: "Illegal"
+	},
+	chromera: {
+		tier: "Illegal"
+	},
+	venomicon: {
+		tier: "Illegal"
+	},
+	venomiconepilogue: {
+		tier: "Illegal"
+	},
+	saharascal: {
+		tier: "Illegal"
+	},
+	saharaja: {
+		tier: "Illegal"
+	},
+	ababo: {
+		tier: "Illegal"
+	},
+	scattervein: {
+		tier: "Illegal"
+	},
+	hemogoblin: {
+		tier: "Illegal"
+	},
+	cresceidon: {
+		tier: "Illegal"
+	},
+	chuggon: {
+		tier: "Illegal"
+	},
+	draggalong: {
+		tier: "Illegal"
+	},
+	chuggalong: {
+		tier: "Illegal"
+	},
+	shox: {
+		tier: "Illegal"
+	},
+	pokestarsmeargle: {
+		tier: "Illegal"
+	},
+	pokestarufo: {
+		tier: "Illegal"
+	},
+	pokestarufo2: {
+		tier: "Illegal"
+	},
+	pokestarbrycenman: {
+		tier: "Illegal"
+	},
+	pokestarmt: {
+		tier: "Illegal"
+	},
+	pokestarmt2: {
+		tier: "Illegal"
+	},
+	pokestartransport: {
+		tier: "Illegal"
+	},
+	pokestargiant: {
+		tier: "Illegal"
+	},
+	pokestarhumanoid: {
+		tier: "Illegal"
+	},
+	pokestarmonster: {
+		tier: "Illegal"
+	},
+	pokestarf00: {
+		tier: "Illegal"
+	},
+	pokestarf002: {
+		tier: "Illegal"
+	},
+	pokestarspirit: {
+		tier: "Illegal"
+	},
+	pokestarblackdoor: {
+		tier: "Illegal"
+	},
+	pokestarwhitedoor: {
+		tier: "Illegal"
+	},
+	pokestarblackbelt: {
+		tier: "Illegal"
+	},
+	pokestarufopropu2: {
+		tier: "Illegal"
+	},
 };

--- a/data/mods/ccapm2024/formats-data.ts
+++ b/data/mods/ccapm2024/formats-data.ts
@@ -1,0 +1,191 @@
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
+	aesap: {
+		tier: "OU",
+	},
+	anxiousoil: {
+		tier: "OU",
+	},
+	araquisis: {
+		tier: "OU",
+	},
+	arthrostrike: {
+		tier: "OU",
+	},
+	bleyabat: {
+		tier: "OU",
+	},
+	boillusk: {
+		tier: "OU",
+	},
+	boogeymancer: {
+		tier: "OU",
+	},
+	buffball: {
+		tier: "OU",
+	},
+	bugsome: {
+		tier: "OU",
+	},
+	cliffilisk: {
+		tier: "OU",
+	},
+	cogwyld: {
+		tier: "OU",
+	},
+	contradox: {
+		tier: "OU",
+	},
+	cosmole: {
+		tier: "OU",
+	},
+	crashtank: {
+		tier: "OU",
+	},
+	cryobser: {
+		tier: "OU",
+	},
+	delirirak: {
+		tier: "OU",
+	},
+	depresloth: {
+		tier: "OU",
+	},
+	faellen: {
+		tier: "OU",
+	},
+	fightinfly: {
+		tier: "OU",
+	},
+	folibower: {
+		tier: "OU",
+	},
+	frenzaiai: {
+		tier: "OU",
+	},
+	fungemory: {
+		tier: "OU",
+	},
+	guarden: {
+		tier: "OU",
+	},
+	hawksectiff: {
+		tier: "OU",
+	},
+	ichthyocorn: {
+		tier: "OU",
+	},
+	lampyre: {
+		tier: "OU",
+	},
+	lazahrusk: {
+		tier: "OU",
+	},
+	leviadon: {
+		tier: "OU",
+	},
+	liwyzard: {
+		tier: "OU",
+	},
+	magmouth: {
+		tier: "OU",
+	},
+	manticrash: {
+		tier: "OU",
+	},
+	marlord: {
+		tier: "OU",
+	},
+	marsonmallow: {
+		tier: "OU",
+	},
+	mindwyrm: {
+		tier: "OU",
+	},
+	minkai: {
+		tier: "OU",
+	},
+	mosstrosity: {
+		tier: "OU",
+	},
+	nectaregal: {
+		tier: "OU",
+	},
+	nharboard: {
+		tier: "OU",
+	},
+	noyew: {
+		tier: "OU",
+	},
+	nucleophage: {
+		tier: "OU",
+	},
+	nummanutts: {
+		tier: "OU",
+	},
+	obsallas: {
+		tier: "OU",
+	},
+	oonoonsi: {
+		tier: "OU",
+	},
+	orchidauntless: {
+		tier: "OU",
+	},
+	pestifer: {
+		tier: "OU",
+	},
+	pomegrenade: {
+		tier: "OU",
+	},
+	raintoad: {
+		tier: "OU",
+	},
+	remnant: {
+		tier: "OU",
+	},
+	rizzquaza: {
+		tier: "OU",
+	},
+	roddammit: {
+		tier: "OU",
+	},
+	roolette: {
+		tier: "OU",
+	},
+	rootfraction: {
+		tier: "OU",
+	},
+	shail: {
+		tier: "OU",
+	},
+	shufflux: {
+		tier: "OU",
+	},
+	shurifluri: {
+		tier: "OU",
+	},
+	skibidragon: {
+		tier: "OU",
+	},
+	spreetah: {
+		tier: "OU",
+	},
+	suragon: {
+		tier: "OU",
+	},
+	surfsurge: {
+		tier: "OU",
+	},
+	tardeblade: {
+		tier: "OU",
+	},
+	trawlutre: {
+		tier: "OU",
+	},
+	tuxquito: {
+		tier: "OU",
+	},
+	underhazard: {
+		tier: "OU",
+	},
+};

--- a/data/mods/ccapm2024/pokedex.ts
+++ b/data/mods/ccapm2024/pokedex.ts
@@ -375,6 +375,8 @@ export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable 
 		baseStats: { hp: 83, atk: 95, def: 85, spa: 80, spd: 92, spe: 110 },
 		abilities: { 0: "Asymmetry" },
 		weightkg: 50,
+		prevo: "Grafaiai",
+		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 	},
 	buffball: {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2970,11 +2970,10 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 		name: 'Data Preview',
 		desc: 'When a new Pokémon switches in for the first time, information about its types, stats and Abilities is displayed to both players.',
 		onSwitchIn(pokemon) {
-			let species = this.dex.species.get(pokemon.species.name);
+			const species = pokemon.illusion?.species || pokemon.species;
 			const gen = this.gen;
 
 			if (pokemon.illusion) {
-				species = this.dex.species.get(pokemon.illusion.species.name);
 				pokemon.m.revealed = false;
 			}
 

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1,7 +1,6 @@
 // Note: These are the rules that formats use
 
 import type { Learnset } from "../sim/dex-species";
-import { Chat } from "../server/chat";
 
 // The list of formats is stored in config/formats.js
 export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
@@ -2972,21 +2971,167 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 		desc: 'When a new Pokémon switches in for the first time, information about its types, stats and Abilities is displayed to both players.',
 		onSwitchIn(pokemon) {
 			let species = this.dex.species.get(pokemon.species.name);
+			const gen = this.gen;
+
 			if (pokemon.illusion) {
 				species = this.dex.species.get(pokemon.illusion.species.name);
+
+				// Recreation of Chat.getDataPokemonHTML
+				let buf = '<li class="result">';
+				buf += `<span class="col numcol">${species.tier}</span> `;
+				buf += `<span class="col iconcol"><psicon pokemon="${species.id}"/></span> `;
+				buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/pokemon/${species.id}" target="_blank">${species.name}</a></span> `;
+				buf += '<span class="col typecol">';
+				if (species.types) {
+					for (const type of species.types) {
+						buf += `<img src="https://${Config.routes.client}/sprites/types/${type}.png" alt="${type}" height="14" width="32">`;
+					}
+				}
+				buf += '</span> ';
+				if (gen >= 3) {
+					buf += '<span style="float:left;min-height:26px">';
+					if (species.abilities['1'] && (gen >= 4 || Dex.abilities.get(species.abilities['1']).gen === 3)) {
+						buf += `<span class="col twoabilitycol">${species.abilities['0']}<br />${species.abilities['1']}</span>`;
+					} else {
+						buf += `<span class="col abilitycol">${species.abilities['0']}</span>`;
+					}
+					if (species.abilities['H'] && species.abilities['S']) {
+						buf += `<span class="col twoabilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}<br />(${species.abilities['S']})</em></span>`;
+					} else if (species.abilities['H']) {
+						buf += `<span class="col abilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}</em></span>`;
+					} else if (species.abilities['S']) {
+						// special case for Zygarde
+						buf += `<span class="col abilitycol"><em>(${species.abilities['S']})</em></span>`;
+					} else {
+						buf += '<span class="col abilitycol"></span>';
+					}
+					buf += '</span>';
+				}
+				buf += '<span style="float:left;min-height:26px">';
+				buf += `<span class="col statcol"><em>HP</em><br />${species.baseStats.hp}</span> `;
+				buf += `<span class="col statcol"><em>Atk</em><br />${species.baseStats.atk}</span> `;
+				buf += `<span class="col statcol"><em>Def</em><br />${species.baseStats.def}</span> `;
+				if (gen <= 1) {
+					buf += `<span class="col statcol"><em>Spc</em><br />${species.baseStats.spa}</span> `;
+				} else {
+					buf += `<span class="col statcol"><em>SpA</em><br />${species.baseStats.spa}</span> `;
+					buf += `<span class="col statcol"><em>SpD</em><br />${species.baseStats.spd}</span> `;
+				}
+				buf += `<span class="col statcol"><em>Spe</em><br />${species.baseStats.spe}</span> `;
+				buf += `<span class="col bstcol"><em>BST<br />${species.bst}</em></span> `;
+				buf += '</span>';
+				buf += '</li>';
+				buf = `<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`;
+
 				this.add('-start', pokemon, 'typechange', pokemon.illusion.getTypes(true).join('/'), '[silent]');
-				this.add(`raw|${Chat.getDataPokemonHTML(species, this.gen)}`);
+				this.add(`raw|${buf}`);
 				pokemon.m.revealed = false;
 			} else {
+				// Recreation of Chat.getDataPokemonHTML
+				let buf = '<li class="result">';
+				buf += `<span class="col numcol">${species.tier}</span> `;
+				buf += `<span class="col iconcol"><psicon pokemon="${species.id}"/></span> `;
+				buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/pokemon/${species.id}" target="_blank">${species.name}</a></span> `;
+				buf += '<span class="col typecol">';
+				if (species.types) {
+					for (const type of species.types) {
+						buf += `<img src="https://${Config.routes.client}/sprites/types/${type}.png" alt="${type}" height="14" width="32">`;
+					}
+				}
+				buf += '</span> ';
+				if (gen >= 3) {
+					buf += '<span style="float:left;min-height:26px">';
+					if (species.abilities['1'] && (gen >= 4 || Dex.abilities.get(species.abilities['1']).gen === 3)) {
+						buf += `<span class="col twoabilitycol">${species.abilities['0']}<br />${species.abilities['1']}</span>`;
+					} else {
+						buf += `<span class="col abilitycol">${species.abilities['0']}</span>`;
+					}
+					if (species.abilities['H'] && species.abilities['S']) {
+						buf += `<span class="col twoabilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}<br />(${species.abilities['S']})</em></span>`;
+					} else if (species.abilities['H']) {
+						buf += `<span class="col abilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}</em></span>`;
+					} else if (species.abilities['S']) {
+						// special case for Zygarde
+						buf += `<span class="col abilitycol"><em>(${species.abilities['S']})</em></span>`;
+					} else {
+						buf += '<span class="col abilitycol"></span>';
+					}
+					buf += '</span>';
+				}
+				buf += '<span style="float:left;min-height:26px">';
+				buf += `<span class="col statcol"><em>HP</em><br />${species.baseStats.hp}</span> `;
+				buf += `<span class="col statcol"><em>Atk</em><br />${species.baseStats.atk}</span> `;
+				buf += `<span class="col statcol"><em>Def</em><br />${species.baseStats.def}</span> `;
+				if (gen <= 1) {
+					buf += `<span class="col statcol"><em>Spc</em><br />${species.baseStats.spa}</span> `;
+				} else {
+					buf += `<span class="col statcol"><em>SpA</em><br />${species.baseStats.spa}</span> `;
+					buf += `<span class="col statcol"><em>SpD</em><br />${species.baseStats.spd}</span> `;
+				}
+				buf += `<span class="col statcol"><em>Spe</em><br />${species.baseStats.spe}</span> `;
+				buf += `<span class="col bstcol"><em>BST<br />${species.bst}</em></span> `;
+				buf += '</span>';
+				buf += '</li>';
+				buf = `<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`;
+
 				this.add('-start', pokemon, 'typechange', pokemon.getTypes(true).join('/'), '[silent]');
-				this.add(`raw|${Chat.getDataPokemonHTML(species, this.gen)}`);
+				this.add(`raw|${buf}`);
 			}
 		},
 		onDamagingHit(damage, target, source, move) {
 			if (target.hasAbility('illusion') && !target.m.revealed) {
-				this.add('-start', target, 'typechange', target.getTypes(true).join('/'), '[silent]');
 				const species = this.dex.species.get(target.species.name);
-				this.add(`raw|${Chat.getDataPokemonHTML(species, this.gen)}`);
+				const gen = this.gen;
+
+				// Recreation of Chat.getDataPokemonHTML
+				let buf = '<li class="result">';
+				buf += `<span class="col numcol">${species.tier}</span> `;
+				buf += `<span class="col iconcol"><psicon pokemon="${species.id}"/></span> `;
+				buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/pokemon/${species.id}" target="_blank">${species.name}</a></span> `;
+				buf += '<span class="col typecol">';
+				if (species.types) {
+					for (const type of species.types) {
+						buf += `<img src="https://${Config.routes.client}/sprites/types/${type}.png" alt="${type}" height="14" width="32">`;
+					}
+				}
+				buf += '</span> ';
+				if (gen >= 3) {
+					buf += '<span style="float:left;min-height:26px">';
+					if (species.abilities['1'] && (gen >= 4 || Dex.abilities.get(species.abilities['1']).gen === 3)) {
+						buf += `<span class="col twoabilitycol">${species.abilities['0']}<br />${species.abilities['1']}</span>`;
+					} else {
+						buf += `<span class="col abilitycol">${species.abilities['0']}</span>`;
+					}
+					if (species.abilities['H'] && species.abilities['S']) {
+						buf += `<span class="col twoabilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}<br />(${species.abilities['S']})</em></span>`;
+					} else if (species.abilities['H']) {
+						buf += `<span class="col abilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}</em></span>`;
+					} else if (species.abilities['S']) {
+						// special case for Zygarde
+						buf += `<span class="col abilitycol"><em>(${species.abilities['S']})</em></span>`;
+					} else {
+						buf += '<span class="col abilitycol"></span>';
+					}
+					buf += '</span>';
+				}
+				buf += '<span style="float:left;min-height:26px">';
+				buf += `<span class="col statcol"><em>HP</em><br />${species.baseStats.hp}</span> `;
+				buf += `<span class="col statcol"><em>Atk</em><br />${species.baseStats.atk}</span> `;
+				buf += `<span class="col statcol"><em>Def</em><br />${species.baseStats.def}</span> `;
+				if (gen <= 1) {
+					buf += `<span class="col statcol"><em>Spc</em><br />${species.baseStats.spa}</span> `;
+				} else {
+					buf += `<span class="col statcol"><em>SpA</em><br />${species.baseStats.spa}</span> `;
+					buf += `<span class="col statcol"><em>SpD</em><br />${species.baseStats.spd}</span> `;
+				}
+				buf += `<span class="col statcol"><em>Spe</em><br />${species.baseStats.spe}</span> `;
+				buf += `<span class="col bstcol"><em>BST<br />${species.bst}</em></span> `;
+				buf += '</span>';
+				buf += '</li>';
+				buf = `<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`;
+
+				this.add('-start', target, 'typechange', target.getTypes(true).join('/'), '[silent]');
+				this.add(`raw|${buf}`);
 				target.m.revealed = true;
 			}
 		},

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -3028,7 +3028,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 		},
 		onDamagingHit(damage, target, source, move) {
 			if (target.hasAbility('illusion') && !target.m.revealed) {
-				const species = this.dex.species.get(target.species.name);
+				const species = target.species;
 				const gen = this.gen;
 
 				// Recreation of Chat.getDataPokemonHTML

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2966,9 +2966,9 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 			return newSpecies;
 		},
 	},
-	datamod: {
+	datapreview: {
 		effectType: 'Rule',
-		name: 'Data Mod',
+		name: 'Data Preview',
 		desc: 'When a new Pokémon switches in for the first time, information about its types, stats and Abilities is displayed to both players.',
 		onSwitchIn(pokemon) {
 			let species = this.dex.species.get(pokemon.species.name);

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1,6 +1,7 @@
 // Note: These are the rules that formats use
 
 import type { Learnset } from "../sim/dex-species";
+import { Chat } from "../server/chat";
 
 // The list of formats is stored in config/formats.js
 export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
@@ -2963,6 +2964,31 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 				newSpecies.bst += newSpecies.baseStats[stat];
 			}
 			return newSpecies;
+		},
+	},
+	datamod: {
+		effectType: 'Rule',
+		name: 'Data Mod',
+		desc: 'When a new Pokémon switches in for the first time, information about its types, stats and Abilities is displayed to both players.',
+		onSwitchIn(pokemon) {
+			let species = this.dex.species.get(pokemon.species.name);
+			if (pokemon.illusion) {
+				species = this.dex.species.get(pokemon.illusion.species.name);
+				this.add('-start', pokemon, 'typechange', pokemon.illusion.getTypes(true).join('/'), '[silent]');
+				this.add(`raw|${Chat.getDataPokemonHTML(species, this.gen)}`);
+				pokemon.m.revealed = false;
+			} else {
+				this.add('-start', pokemon, 'typechange', pokemon.getTypes(true).join('/'), '[silent]');
+				this.add(`raw|${Chat.getDataPokemonHTML(species, this.gen)}`);
+			}
+		},
+		onDamagingHit(damage, target, source, move) {
+			if (target.hasAbility('illusion') && !target.m.revealed) {
+				this.add('-start', target, 'typechange', target.getTypes(true).join('/'), '[silent]');
+				const species = this.dex.species.get(target.species.name);
+				this.add(`raw|${Chat.getDataPokemonHTML(species, this.gen)}`);
+				target.m.revealed = true;
+			}
 		},
 	},
 };

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2975,108 +2975,57 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 
 			if (pokemon.illusion) {
 				species = this.dex.species.get(pokemon.illusion.species.name);
-
-				// Recreation of Chat.getDataPokemonHTML
-				let buf = '<li class="result">';
-				buf += `<span class="col numcol">${species.tier}</span> `;
-				buf += `<span class="col iconcol"><psicon pokemon="${species.id}"/></span> `;
-				buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/pokemon/${species.id}" target="_blank">${species.name}</a></span> `;
-				buf += '<span class="col typecol">';
-				if (species.types) {
-					for (const type of species.types) {
-						buf += `<img src="https://${Config.routes.client}/sprites/types/${type}.png" alt="${type}" height="14" width="32">`;
-					}
-				}
-				buf += '</span> ';
-				if (gen >= 3) {
-					buf += '<span style="float:left;min-height:26px">';
-					if (species.abilities['1'] && (gen >= 4 || Dex.abilities.get(species.abilities['1']).gen === 3)) {
-						buf += `<span class="col twoabilitycol">${species.abilities['0']}<br />${species.abilities['1']}</span>`;
-					} else {
-						buf += `<span class="col abilitycol">${species.abilities['0']}</span>`;
-					}
-					if (species.abilities['H'] && species.abilities['S']) {
-						buf += `<span class="col twoabilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}<br />(${species.abilities['S']})</em></span>`;
-					} else if (species.abilities['H']) {
-						buf += `<span class="col abilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}</em></span>`;
-					} else if (species.abilities['S']) {
-						// special case for Zygarde
-						buf += `<span class="col abilitycol"><em>(${species.abilities['S']})</em></span>`;
-					} else {
-						buf += '<span class="col abilitycol"></span>';
-					}
-					buf += '</span>';
-				}
-				buf += '<span style="float:left;min-height:26px">';
-				buf += `<span class="col statcol"><em>HP</em><br />${species.baseStats.hp}</span> `;
-				buf += `<span class="col statcol"><em>Atk</em><br />${species.baseStats.atk}</span> `;
-				buf += `<span class="col statcol"><em>Def</em><br />${species.baseStats.def}</span> `;
-				if (gen <= 1) {
-					buf += `<span class="col statcol"><em>Spc</em><br />${species.baseStats.spa}</span> `;
-				} else {
-					buf += `<span class="col statcol"><em>SpA</em><br />${species.baseStats.spa}</span> `;
-					buf += `<span class="col statcol"><em>SpD</em><br />${species.baseStats.spd}</span> `;
-				}
-				buf += `<span class="col statcol"><em>Spe</em><br />${species.baseStats.spe}</span> `;
-				buf += `<span class="col bstcol"><em>BST<br />${species.bst}</em></span> `;
-				buf += '</span>';
-				buf += '</li>';
-				buf = `<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`;
-
-				this.add('-start', pokemon, 'typechange', pokemon.illusion.getTypes(true).join('/'), '[silent]');
-				this.add(`raw|${buf}`);
 				pokemon.m.revealed = false;
-			} else {
-				// Recreation of Chat.getDataPokemonHTML
-				let buf = '<li class="result">';
-				buf += `<span class="col numcol">${species.tier}</span> `;
-				buf += `<span class="col iconcol"><psicon pokemon="${species.id}"/></span> `;
-				buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/pokemon/${species.id}" target="_blank">${species.name}</a></span> `;
-				buf += '<span class="col typecol">';
-				if (species.types) {
-					for (const type of species.types) {
-						buf += `<img src="https://${Config.routes.client}/sprites/types/${type}.png" alt="${type}" height="14" width="32">`;
-					}
-				}
-				buf += '</span> ';
-				if (gen >= 3) {
-					buf += '<span style="float:left;min-height:26px">';
-					if (species.abilities['1'] && (gen >= 4 || Dex.abilities.get(species.abilities['1']).gen === 3)) {
-						buf += `<span class="col twoabilitycol">${species.abilities['0']}<br />${species.abilities['1']}</span>`;
-					} else {
-						buf += `<span class="col abilitycol">${species.abilities['0']}</span>`;
-					}
-					if (species.abilities['H'] && species.abilities['S']) {
-						buf += `<span class="col twoabilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}<br />(${species.abilities['S']})</em></span>`;
-					} else if (species.abilities['H']) {
-						buf += `<span class="col abilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}</em></span>`;
-					} else if (species.abilities['S']) {
-						// special case for Zygarde
-						buf += `<span class="col abilitycol"><em>(${species.abilities['S']})</em></span>`;
-					} else {
-						buf += '<span class="col abilitycol"></span>';
-					}
-					buf += '</span>';
-				}
-				buf += '<span style="float:left;min-height:26px">';
-				buf += `<span class="col statcol"><em>HP</em><br />${species.baseStats.hp}</span> `;
-				buf += `<span class="col statcol"><em>Atk</em><br />${species.baseStats.atk}</span> `;
-				buf += `<span class="col statcol"><em>Def</em><br />${species.baseStats.def}</span> `;
-				if (gen <= 1) {
-					buf += `<span class="col statcol"><em>Spc</em><br />${species.baseStats.spa}</span> `;
-				} else {
-					buf += `<span class="col statcol"><em>SpA</em><br />${species.baseStats.spa}</span> `;
-					buf += `<span class="col statcol"><em>SpD</em><br />${species.baseStats.spd}</span> `;
-				}
-				buf += `<span class="col statcol"><em>Spe</em><br />${species.baseStats.spe}</span> `;
-				buf += `<span class="col bstcol"><em>BST<br />${species.bst}</em></span> `;
-				buf += '</span>';
-				buf += '</li>';
-				buf = `<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`;
-
-				this.add('-start', pokemon, 'typechange', pokemon.getTypes(true).join('/'), '[silent]');
-				this.add(`raw|${buf}`);
 			}
+
+			// Recreation of Chat.getDataPokemonHTML
+			let buf = '<li class="result">';
+			buf += `<span class="col numcol">${species.tier}</span> `;
+			buf += `<span class="col iconcol"><psicon pokemon="${species.id}"/></span> `;
+			buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/pokemon/${species.id}" target="_blank">${species.name}</a></span> `;
+			buf += '<span class="col typecol">';
+			if (species.types) {
+				for (const type of species.types) {
+					buf += `<img src="https://${Config.routes.client}/sprites/types/${type}.png" alt="${type}" height="14" width="32">`;
+				}
+			}
+			buf += '</span> ';
+			if (gen >= 3) {
+				buf += '<span style="float:left;min-height:26px">';
+				if (species.abilities['1'] && (gen >= 4 || Dex.abilities.get(species.abilities['1']).gen === 3)) {
+					buf += `<span class="col twoabilitycol">${species.abilities['0']}<br />${species.abilities['1']}</span>`;
+				} else {
+					buf += `<span class="col abilitycol">${species.abilities['0']}</span>`;
+				}
+				if (species.abilities['H'] && species.abilities['S']) {
+					buf += `<span class="col twoabilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}<br />(${species.abilities['S']})</em></span>`;
+				} else if (species.abilities['H']) {
+					buf += `<span class="col abilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}</em></span>`;
+				} else if (species.abilities['S']) {
+					// special case for Zygarde
+					buf += `<span class="col abilitycol"><em>(${species.abilities['S']})</em></span>`;
+				} else {
+					buf += '<span class="col abilitycol"></span>';
+				}
+				buf += '</span>';
+			}
+			buf += '<span style="float:left;min-height:26px">';
+			buf += `<span class="col statcol"><em>HP</em><br />${species.baseStats.hp}</span> `;
+			buf += `<span class="col statcol"><em>Atk</em><br />${species.baseStats.atk}</span> `;
+			buf += `<span class="col statcol"><em>Def</em><br />${species.baseStats.def}</span> `;
+			if (gen <= 1) {
+				buf += `<span class="col statcol"><em>Spc</em><br />${species.baseStats.spa}</span> `;
+			} else {
+				buf += `<span class="col statcol"><em>SpA</em><br />${species.baseStats.spa}</span> `;
+				buf += `<span class="col statcol"><em>SpD</em><br />${species.baseStats.spd}</span> `;
+			}
+			buf += `<span class="col statcol"><em>Spe</em><br />${species.baseStats.spe}</span> `;
+			buf += `<span class="col bstcol"><em>BST<br />${species.bst}</em></span> `;
+			buf += '</span>';
+			buf += '</li>';
+			buf = `<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`;
+			this.add('-start', pokemon, 'typechange', pokemon.getTypes(true).join('/'), '[silent]');
+			this.add(`raw|${buf}`);
 		},
 		onDamagingHit(damage, target, source, move) {
 			if (target.hasAbility('illusion') && !target.m.revealed) {


### PR DESCRIPTION
As previously merged (but reverted). Now avoids importing Chat by reusing the same code within the ruleset.

See: https://github.com/smogon/pokemon-showdown/pull/11097

Requested by Pet Mods