### PR TITLE
Support fuzzy searching /dt etc

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -603,7 +603,7 @@ export const commands: Chat.ChatCommands = {
 		const newTargets = dex.dataSearch(target);
 		const showDetails = (cmd.startsWith('dt') || cmd === 'details');
 		if (!newTargets?.length) {
-			throw new Chat.ErrorMessage(`No Pok\u00e9mon, item, move, ability or nature named '${target}' was found${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. (Check your spelling?)`);
+			throw new Chat.ErrorMessage(`'${target}' doesn't match any Pok\u00e9mon, item, move, ability or nature${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. (Check your spelling?)`);
 		}
 		if (newTargets.length > 2) {
 			throw new Chat.ErrorMessage(`'${target}' has no exact match. Too many approximate matches: ${newTargets.map(t => t.name).join(', ')}`);

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -605,6 +605,9 @@ export const commands: Chat.ChatCommands = {
 		if (!newTargets?.length) {
 			throw new Chat.ErrorMessage(`No Pok\u00e9mon, item, move, ability or nature named '${target}' was found${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. (Check your spelling?)`);
 		}
+		if (newTargets.length > 2) {
+			throw new Chat.ErrorMessage(`Too many results for '${target}': ${newTargets.map(t => t.name).join(', ')}`);
+		}
 
 		for (const [i, newTarget] of newTargets.entries()) {
 			if (newTarget.isInexact && !i) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -606,12 +606,12 @@ export const commands: Chat.ChatCommands = {
 			throw new Chat.ErrorMessage(`No Pok\u00e9mon, item, move, ability or nature named '${target}' was found${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. (Check your spelling?)`);
 		}
 		if (newTargets.length > 2) {
-			throw new Chat.ErrorMessage(`Too many results for '${target}': ${newTargets.map(t => t.name).join(', ')}`);
+			throw new Chat.ErrorMessage(`'${target}' doesn't match anything exactly. Too many approximate matches: ${newTargets.map(t => t.name).join(', ')}`);
 		}
 
 		for (const [i, newTarget] of newTargets.entries()) {
 			if (newTarget.isInexact && !i) {
-				buffer = `No Pok\u00e9mon, item, move, ability or nature named '${target}' was found${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. Showing the data of '${newTargets[0].name}' instead.\n`;
+				buffer = `'${target}' doesn't match anything exactly${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. Approximate match${newTarget.length === 1 ? '' : 'es'}:\n`;
 			}
 			let details: { [k: string]: string } = {};
 			switch (newTarget.searchType) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -606,12 +606,12 @@ export const commands: Chat.ChatCommands = {
 			throw new Chat.ErrorMessage(`No Pok\u00e9mon, item, move, ability or nature named '${target}' was found${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. (Check your spelling?)`);
 		}
 		if (newTargets.length > 2) {
-			throw new Chat.ErrorMessage(`'${target}' doesn't match anything exactly. Too many approximate matches: ${newTargets.map(t => t.name).join(', ')}`);
+			throw new Chat.ErrorMessage(`'${target}' has no exact match. Too many approximate matches: ${newTargets.map(t => t.name).join(', ')}`);
 		}
 
 		for (const [i, newTarget] of newTargets.entries()) {
 			if (newTarget.isInexact && !i) {
-				buffer = `'${target}' doesn't match anything exactly${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. Approximate match${newTarget.length === 1 ? '' : 'es'}:\n`;
+				buffer = `'${target}' has no exact match${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. Approximate match${newTargets.length === 1 ? '' : 'es'}:\n`;
 			}
 			let details: { [k: string]: string } = {};
 			switch (newTarget.searchType) {

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -89,8 +89,8 @@ export class DexAbilities {
 		let ability = this.abilityCache.get(id);
 		if (ability) return ability;
 
-		if (this.dex.data.Aliases.hasOwnProperty(id)) {
-			ability = this.get(this.dex.data.Aliases[id]);
+		if (this.dex.getAlias(id)) {
+			ability = this.get(this.dex.getAlias(id));
 		} else if (id && this.dex.data.Abilities.hasOwnProperty(id)) {
 			const abilityData = this.dex.data.Abilities[id] as any;
 			const abilityTextData = this.dex.getDescs('Abilities', id, abilityData);

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -176,8 +176,9 @@ export class DexNatures {
 		let nature = this.natureCache.get(id);
 		if (nature) return nature;
 
-		if (this.dex.data.Aliases.hasOwnProperty(id)) {
-			nature = this.get(this.dex.data.Aliases[id]);
+		const alias = this.dex.getAlias(id);
+		if (alias) {
+			nature = this.get(alias);
 			if (nature.exists) {
 				this.natureCache.set(id, nature);
 			}

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -676,9 +676,9 @@ export class DexFormats {
 			if (ruleset) return ruleset;
 		}
 
-		if (this.dex.data.Aliases.hasOwnProperty(id)) {
-			name = this.dex.data.Aliases[id];
-			id = toID(name);
+		if (this.dex.getAlias(id)) {
+			id = this.dex.getAlias(id)!;
+			name = id;
 		}
 		if (this.dex.data.Rulesets.hasOwnProperty(DEFAULT_MOD + id)) {
 			id = (DEFAULT_MOD + id) as ID;
@@ -1030,7 +1030,7 @@ export class DexFormats {
 			}
 		}
 		const ruleid = id;
-		if (this.dex.data.Aliases.hasOwnProperty(id)) id = toID(this.dex.data.Aliases[id]);
+		id = this.dex.getAlias(id) || id;
 		for (const matchType of matchTypes) {
 			if (matchType === 'item' && ruleid === 'noitem') return 'item:noitem';
 			let table;

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -179,8 +179,8 @@ export class DexItems {
 		if (id === '') return EMPTY_ITEM;
 		let item = this.itemCache.get(id);
 		if (item) return item;
-		if (this.dex.data.Aliases.hasOwnProperty(id)) {
-			item = this.get(this.dex.data.Aliases[id]);
+		if (this.dex.getAlias(id)) {
+			item = this.get(this.dex.getAlias(id));
 			if (item.exists) {
 				this.itemCache.set(id, item);
 			}

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -629,8 +629,8 @@ export class DexMoves {
 		if (id === '') return EMPTY_MOVE;
 		let move = this.moveCache.get(id);
 		if (move) return move;
-		if (this.dex.data.Aliases.hasOwnProperty(id)) {
-			move = this.get(this.dex.data.Aliases[id]);
+		if (this.dex.getAlias(id)) {
+			move = this.get(this.dex.getAlias(id));
 			if (move.exists) {
 				this.moveCache.set(id, move);
 			}

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -419,18 +419,18 @@ export class DexSpecies {
 		let species: Mutable<Species> | undefined = this.speciesCache.get(id);
 		if (species) return species;
 
-		if (this.dex.data.Aliases.hasOwnProperty(id)) {
+		const alias = this.dex.getAlias(id);
+		if (alias) {
 			if (this.dex.data.FormatsData.hasOwnProperty(id)) {
 				// special event ID
-				const baseId = toID(this.dex.data.Aliases[id]);
 				species = new Species({
-					...this.dex.data.Pokedex[baseId],
+					...this.dex.data.Pokedex[alias],
 					...this.dex.data.FormatsData[id],
 					name: id,
 				});
 				species.abilities = { 0: species.abilities['S']! };
 			} else {
-				species = this.get(this.dex.data.Aliases[id]);
+				species = this.get(alias);
 				if (species.cosmeticFormes) {
 					for (const forme of species.cosmeticFormes) {
 						if (toID(forme) === id) {
@@ -471,7 +471,7 @@ export class DexSpecies {
 						pokeName = id.slice(0, -i.length);
 					}
 				}
-				if (this.dex.data.Aliases.hasOwnProperty(pokeName)) pokeName = toID(this.dex.data.Aliases[pokeName]);
+				pokeName = this.dex.getAlias(pokeName as ID) || pokeName;
 				if (this.dex.data.Pokedex[pokeName + forme]) {
 					aliasTo = pokeName + forme;
 					break;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -47,14 +47,13 @@ const dexes: { [mod: string]: ModdedDex } = Object.create(null);
 type DataType =
 	'Abilities' | 'Rulesets' | 'FormatsData' | 'Items' | 'Learnsets' | 'Moves' |
 	'Natures' | 'Pokedex' | 'Scripts' | 'Conditions' | 'TypeChart' | 'PokemonGoData';
-const DATA_TYPES: (DataType | 'Aliases')[] = [
+const DATA_TYPES: DataType[] = [
 	'Abilities', 'Rulesets', 'FormatsData', 'Items', 'Learnsets', 'Moves',
 	'Natures', 'Pokedex', 'Scripts', 'Conditions', 'TypeChart', 'PokemonGoData',
 ];
 
 const DATA_FILES = {
 	Abilities: 'abilities',
-	Aliases: 'aliases',
 	Rulesets: 'rulesets',
 	FormatsData: 'formats-data',
 	Items: 'items',
@@ -74,7 +73,6 @@ export interface AliasesTable { [id: IDEntry]: string }
 
 interface DexTableData {
 	Abilities: DexTable<import('./dex-abilities').AbilityData>;
-	Aliases: DexTable<string>;
 	Rulesets: DexTable<import('./dex-formats').FormatData>;
 	Items: DexTable<import('./dex-items').ItemData>;
 	Learnsets: DexTable<import('./dex-species').LearnsetData>;
@@ -134,6 +132,8 @@ export class ModdedDex {
 	readonly natures: Data.DexNatures;
 	readonly types: Data.DexTypes;
 	readonly stats: Data.DexStats;
+	readonly aliases: Map<ID, ID> | null = null;
+	readonly fuzzyAliases: Map<ID, ID[]> | null = null;
 
 	constructor(mod = 'base') {
 		this.isBase = (mod === 'base');
@@ -392,6 +392,24 @@ export class ModdedDex {
 		if (searchResults.length) return searchResults;
 		if (isInexact) return null; // prevent infinite loop
 
+		this.loadAliases();
+		const fuzzyAliases = Dex.fuzzyAliases!.get(toID(target));
+		if (fuzzyAliases) {
+			for (const table of searchIn) {
+				for (const alias of fuzzyAliases) {
+					const res = this[searchObjects[table]].get(alias);
+					if (res.exists && res.gen <= this.gen) {
+						searchResults.push({
+							isInexact: true,
+							searchType: searchTypes[table],
+							name: res.name,
+						});
+					}
+				}
+			}
+		}
+		if (searchResults.length) return searchResults;
+
 		const cmpTarget = toID(target);
 		let maxLd = 3;
 		if (cmpTarget.length <= 1) {
@@ -402,7 +420,7 @@ export class ModdedDex {
 			maxLd = 2;
 		}
 		searchResults = null;
-		for (const table of [...searchIn, 'Aliases'] as const) {
+		for (const table of searchIn) {
 			const searchObj = this.data[table] as DexTable<any>;
 			if (!searchObj) continue;
 
@@ -422,7 +440,7 @@ export class ModdedDex {
 		return searchResults;
 	}
 
-	loadDataFile(basePath: string, dataType: DataType | 'Aliases'): AnyObject | void {
+	loadDataFile(basePath: string, dataType: DataType): AnyObject | void {
 		try {
 			const filePath = basePath + DATA_FILES[dataType];
 			const dataObject = require(filePath);
@@ -482,6 +500,86 @@ export class ModdedDex {
 		return dexes['base'].textCache;
 	}
 
+	getAlias(id: ID): ID | undefined {
+		return this.loadAliases().get(id);
+	}
+
+	loadAliases(): NonNullable<ModdedDex['aliases']> {
+		if (!this.isBase) return Dex.loadAliases();
+		if (this.aliases) return this.aliases;
+		const exported = require(path.resolve(DATA_DIR, 'aliases'));
+		const aliases = new Map<ID, ID>();
+		for (const [alias, target] of Object.entries(exported.Aliases)) {
+			aliases.set(alias as ID, toID(target));
+		}
+		const compoundNames = new Map<ID, string>();
+		for (const name of exported.CompoundWordNames) {
+			compoundNames.set(toID(name), name);
+		}
+
+		const fuzzyAliases = new Map<ID, ID[]>();
+		const addFuzzy = (alias: ID, target: ID) => {
+			if (alias === target) return;
+			if (alias.length < 2) return;
+			const prev = fuzzyAliases.get(alias) || [];
+			if (!prev.includes(target)) prev.push(target);
+			fuzzyAliases.set(alias, prev);
+		};
+		const addFuzzyForme = (alias: ID, target: ID, forme: ID) => {
+			addFuzzy(`${alias}${forme}` as ID, target);
+			if (!forme) return;
+			const formeLetter = forme === 'fan' ? 's' : forme === 'bloodmoon' ? 'bm' : forme.charAt(0);
+			addFuzzy(`${alias}${formeLetter}` as ID, target);
+			addFuzzy(`${formeLetter}${alias}` as ID, target);
+			if (forme === 'alola') addFuzzy(`alolan${alias}` as ID, target);
+			else if (forme === 'galar') addFuzzy(`galarian${alias}` as ID, target);
+			else if (forme === 'hisui') addFuzzy(`hisuian${alias}` as ID, target);
+			else if (forme === 'paldea') addFuzzy(`paldean${alias}` as ID, target);
+			else if (forme === 'megax') addFuzzy(`mega${alias}x` as ID, target);
+			else if (forme === 'megay') addFuzzy(`mega${alias}y` as ID, target);
+			else addFuzzy(`${forme}${alias}` as ID, target);
+		};
+		for (const table of ['Items', 'Abilities', 'Moves', 'Pokedex'] as const) {
+			const data = this.data[table];
+			for (const [id, entry] of Object.entries(data) as [ID, DexTableData[typeof table][string]][]) {
+				let name = compoundNames.get(id) || entry.name;
+				let forme = '' as ID;
+				if (table === 'Pokedex') {
+					// can't Dex.species.get; aliases isn't loaded
+					const species = entry as DexTableData['Pokedex'][string];
+					const baseid = toID(species.baseSpecies);
+					if (baseid && baseid !== id) {
+						name = compoundNames.get(baseid) || baseid;
+					}
+					forme = toID(species.forme || species.baseForme);
+				}
+
+				addFuzzyForme(toID(name), id, forme);
+				const fullSplit = name.split(/ |-/).map(toID);
+				if (fullSplit.length < 2) continue;
+				const fullAcronym = fullSplit.map(x => x.charAt(0)).join('');
+				addFuzzyForme(fullAcronym as ID, id, forme);
+				const fullAcronymWord = fullAcronym + fullSplit[fullSplit.length - 1].slice(1);
+				addFuzzyForme(fullAcronymWord as ID, id, forme);
+				for (const wordPart of fullSplit) addFuzzyForme(wordPart, id, forme);
+
+				const spaceSplit = name.split(' ').map(toID);
+				if (spaceSplit.length !== fullSplit.length) {
+					const spaceAcronym = spaceSplit.map(x => x.charAt(0)).join('');
+					addFuzzyForme(spaceAcronym as ID, id, forme);
+					const spaceAcronymWord = spaceAcronym + spaceSplit[spaceSplit.length - 1].slice(1);
+					if (fullAcronymWord !== spaceAcronymWord) {
+						addFuzzyForme(spaceAcronymWord as ID, id, forme);
+					}
+					for (const word of fullSplit) addFuzzyForme(word, id, forme);
+				}
+			}
+		}
+
+		(this as any).aliases = aliases satisfies this['aliases'];
+		(this as any).fuzzyAliases = fuzzyAliases satisfies this['fuzzyAliases'];
+		return this.aliases!;
+	}
 	loadData(): DexTableData {
 		if (this.dataCache) return this.dataCache;
 		dexes['base'].includeMods();
@@ -508,7 +606,7 @@ export class ModdedDex {
 			// Formats are inherited by mods and used by Rulesets
 			this.includeFormats();
 		}
-		for (const dataType of DATA_TYPES.concat('Aliases')) {
+		for (const dataType of DATA_TYPES) {
 			dataCache[dataType] = this.loadDataFile(basePath, dataType);
 			if (dataType === 'Rulesets' && !parentDex) {
 				for (const format of this.formats.all()) {
@@ -541,7 +639,6 @@ export class ModdedDex {
 					}
 				}
 			}
-			dataCache['Aliases'] = parentDex.data['Aliases'];
 		}
 
 		// Flag the generation. Required for team validator.

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -551,6 +551,9 @@ export class ModdedDex {
 				let name = compoundNames.get(id) || entry.name;
 				let forme = '' as ID;
 				let formeLetter = '' as ID;
+				if (name.includes('(')) {
+					addFuzzy(toID(name.split('(')[0]), id);
+				}
 				if (table === 'Pokedex') {
 					// can't Dex.species.get; aliases isn't loaded
 					const species = entry as DexTableData['Pokedex'][string];
@@ -588,12 +591,6 @@ export class ModdedDex {
 				}
 			}
 		}
-		addFuzzy('asone' as ID, 'asonespectrier' as ID);
-		addFuzzy('asone' as ID, 'asoneglastrier' as ID);
-		addFuzzy('embodyaspect' as ID, 'embodyaspectteal' as ID);
-		addFuzzy('embodyaspect' as ID, 'embodyaspectwellspring' as ID);
-		addFuzzy('embodyaspect' as ID, 'embodyaspecthearthflame' as ID);
-		addFuzzy('embodyaspect' as ID, 'embodyaspectcornerstone ' as ID);
 
 		(this as any).aliases = aliases satisfies this['aliases'];
 		(this as any).fuzzyAliases = fuzzyAliases satisfies this['fuzzyAliases'];

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -590,6 +590,10 @@ export class ModdedDex {
 		}
 		addFuzzy('asone' as ID, 'asonespectrier' as ID);
 		addFuzzy('asone' as ID, 'asoneglastrier' as ID);
+		addFuzzy('embodyaspect' as ID, 'embodyaspectteal' as ID);
+		addFuzzy('embodyaspect' as ID, 'embodyaspectwellspring' as ID);
+		addFuzzy('embodyaspect' as ID, 'embodyaspecthearthflame' as ID);
+		addFuzzy('embodyaspect' as ID, 'embodyaspectcornerstone ' as ID);
 
 		(this as any).aliases = aliases satisfies this['aliases'];
 		(this as any).fuzzyAliases = fuzzyAliases satisfies this['fuzzyAliases'];

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -538,6 +538,13 @@ export class ModdedDex {
 			else if (forme === 'megax') addFuzzy(`mega${alias}x` as ID, target);
 			else if (forme === 'megay') addFuzzy(`mega${alias}y` as ID, target);
 			else addFuzzy(`${forme}${alias}` as ID, target);
+
+			if (forme === 'megax' || forme === 'megay') {
+				addFuzzy(`mega${alias}` as ID, target);
+				addFuzzy(`${alias}mega` as ID, target);
+				addFuzzy(`m${alias}` as ID, target);
+				addFuzzy(`${alias}m` as ID, target);
+			}
 		};
 		for (const table of ['Items', 'Abilities', 'Moves', 'Pokedex'] as const) {
 			const data = this.data[table];
@@ -575,6 +582,8 @@ export class ModdedDex {
 				}
 			}
 		}
+		addFuzzy('asone' as ID, 'asonespectrier' as ID);
+		addFuzzy('asone' as ID, 'asoneglastrier' as ID);
 
 		(this as any).aliases = aliases satisfies this['aliases'];
 		(this as any).fuzzyAliases = fuzzyAliases satisfies this['fuzzyAliases'];

--- a/test/sim/data.js
+++ b/test/sim/data.js
@@ -21,15 +21,17 @@ describe('Dex data', () => {
 				assert(baseEntry && !baseEntry.forme, `Forme ${entry.name} should have a valid baseSpecies`);
 				// Gmax formes are not actually formes, they are only included in pokedex.ts for convenience
 				if (!entry.name.includes('Gmax')) assert((baseEntry.otherFormes || []).includes(entry.name), `Base species ${entry.baseSpecies} should have ${entry.name} listed as an otherForme`);
-				assert(!entry.otherFormes, `Forme ${entry.baseSpecies} should not have a forme list (the list goes in baseSpecies).`);
-				assert(!entry.cosmeticFormes, `Forme ${entry.baseSpecies} should not have a cosmetic forme list (the list goes in baseSpecies).`);
-				assert(!entry.baseForme, `Forme ${entry.baseSpecies} should not have a baseForme (its forme name goes in forme) (did you mean baseSpecies?).`);
+				assert.false(entry.otherFormes, `Forme ${entry.baseSpecies} should not have a forme list (the list goes in baseSpecies).`);
+				assert.false(entry.cosmeticFormes, `Forme ${entry.baseSpecies} should not have a cosmetic forme list (the list goes in baseSpecies).`);
+				assert.false(entry.baseForme, `Forme ${entry.baseSpecies} should not have a baseForme (its forme name goes in forme) (did you mean baseSpecies?).`);
 			} else {
 				// entry should be a base species
-				assert(!entry.baseSpecies, `Base species ${entry.name} should not have its own baseSpecies.`);
-				assert(!entry.changesFrom, `Base species ${entry.name} should not change from anything (its changesFrom forme should be base).`);
-				assert(!entry.battleOnly, `Base species ${entry.name} should not be battle-only (its out-of-battle forme should be base).`);
-				assert(!entry.baseForme || Dex.data.Aliases[pokemonid + toID(entry.baseForme)] === entry.name, `Base species ${entry.name}-${entry.baseForme} should be aliased to ${entry.name}`);
+				assert.false(entry.baseSpecies, `Base species ${entry.name} should not have its own baseSpecies.`);
+				assert.false(entry.changesFrom, `Base species ${entry.name} should not change from anything (its changesFrom forme should be base).`);
+				assert.false(entry.battleOnly, `Base species ${entry.name} should not be battle-only (its out-of-battle forme should be base).`);
+				if (entry.baseForme) {
+					assert.equal(Dex.getAlias(pokemonid + toID(entry.baseForme)), pokemonid, `Base species ${entry.name}-${entry.baseForme} should be aliased to ${entry.name}`);
+				}
 			}
 
 			if (entry.prevo) {
@@ -59,7 +61,7 @@ describe('Dex data', () => {
 			}
 			if (entry.cosmeticFormes) {
 				for (const forme of entry.cosmeticFormes) {
-					assert.equal(Dex.data.Aliases[toID(forme)], entry.name, `Misspelled/nonexistent alias "${forme}" of ${entry.name}`);
+					assert.equal(Dex.getAlias(toID(forme)), pokemonid, `Misspelled/nonexistent alias "${forme}" of ${entry.name}`);
 					assert.equal(Dex.data.FormatsData[toID(forme)], undefined, `Cosmetic forme "${forme}" should not have its own tier`);
 				}
 			}
@@ -148,7 +150,7 @@ describe('Dex data', () => {
 	});
 
 	it('should have valid Aliases entries', () => {
-		const Aliases = Dex.data.Aliases;
+		const Aliases = require('../../dist/data/aliases').Aliases;
 		for (const aliasid in Aliases) {
 			const targetid = toID(Aliases[aliasid]);
 			if (targetid in Dex.data.Pokedex) {


### PR DESCRIPTION
The teambuilder is already good at fuzzy matching, but a lot of users are requesting aliases that the teambuilder's fuzzy matches already support. I assume this is for `/dt` and similar commands, so I'm just going to bring the teambuilder's fuzzy matching into `/dt`.

Note that this is still stricter than teambuilder, because teambuilder is a prefix search, while this is a full match. This can match `tt`, `ttar`, and `tar`, but teambuilder will also match `ty`, `tyr`, `tyra` etc.