### PR TITLE
Add Gen 8 Formats: National Dex RU, National Dex Doubles OU, DLC 1 National Dex AG

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2670,6 +2670,13 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		banlist: ['ND OU', 'ND UUBL', 'Drizzle', 'Drought', 'Light Clay', 'Slowbronite'],
 	},
 	{
+		name: "[Gen 8] National Dex RU",
+		mod: 'gen8',
+		searchShow: false,
+		ruleset: ['[Gen 8] National Dex UU'],
+		banlist: ['ND UU', 'ND RUBL'],
+	},
+	{
 		name: "[Gen 8] National Dex Monotype",
 		mod: 'gen8',
 		searchShow: false,
@@ -2683,7 +2690,33 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'Power Construct', 'Moody', 'Shadow Tag', 'Damp Rock', 'Focus Band', 'King\'s Rock', 'Quick Claw', 'Razor Fang', 'Smooth Rock', 'Terrain Extender', 'Baton Pass',
 		],
 	},
-
+	{
+		name: "[Gen 8] National Dex Doubles OU",
+		mod: 'gen8',
+		searchShow: false,
+		gameType: 'doubles',
+		ruleset: ['Standard Doubles', 'NatDex Mod', 'Evasion Abilities Clause'],
+		banlist: [
+			'Arceus', 'Calyrex-Ice', 'Calyrex-Shadow', 'Dialga', 'Eternatus', 'Gengar-Mega', 'Giratina', 'Giratina-Origin','Groudon', 'Ho-Oh', 'Kyogre', 'Kyurem-White', 'Lugia', 'Lunala', 'Magearna', 'Melmetal', 'Mewtwo', 
+			'Necrozma-Dawn-Wings','Necrozma-Dusk-Mane', 'Necrozma-Ultra', 'Palkia', 'Rayquaza', 'Reshiram', 'Solgaleo', 'Venusaur', 'Xerneas', 'Yveltal', 'Zacian', 'Zacian-Crowned', 'Zamazenta', 'Zamazenta-Crowned', 'Zekrom', 
+			'Zygarde-50%', 'Zygarde-Complete','Commander', 'Power Construct', 'Shadow Tag', 'Coaching', 'Dark Void', 'Swagger',
+		],
+	}, 
+	{
+		name: "[Gen 8] DLC 1 National Dex AG",
+		mod: 'gen8dlc1',
+		searchShow: false,
+		ruleset: ['Standard AG','NatDex Mod'],
+		unbanlist: [
+		'Absol', 'Aerodactyl', 'Aggron', 'Altaria', 'Amaura', 'Anorith', 'Archen', 'Archeops', 'Armaldo', 'Aron', 'Articuno', 'Audino', 'Aurorus', 'Azelf', 'Bagon', 'Beldum', 'Blacephalon', 'Blaziken', 'Buzzwole', 'Carbink', 
+		'Carracosta', 'Celesteela', 'Combusken', 'Cradily', 'Cresselia', 'Crobat', 'Cryogonal', 'Dialga', 'Diancie', 'Dragonair', 'Dragonite', 'Dratini', 'Electabuzz', 'Electivire', 'Elekid', 'Entei', 'Gabite', 'Garchomp', 
+		'Genesect', 'Gible', 'Giratina', 'Golbat', 'Groudon', 'Grovyle', 'Guzzlord', 'Heatran', 'Hooh', 'Jynx', 'Kabuto', 'Kabutops', 'Kartana', 'Kyogre', 'Lairon', 'Landorus', 'Landorus-Therian', 'Latias', 'Latios', 'Lileep', 
+		'Lugia', 'Magby', 'Magmar', 'Magmortar', 'Marshtomp', 'Mesprit', 'Metagross', 'Metang', 'Moltres', 'Mudkip', 'Naganadel', 'Nidoking', 'Nidoqueen', 'Nidoran-F', 'Nidoran-M', 'Nidorina', 'Nidorino', 'Nihilego', 'Omanyte', 
+		'Omastar', 'Palkia', 'Pheromosa', 'Poipole', 'Raikou', 'Rayquaza', 'Regice', 'Regigigas', 'Regirock', 'Registeel', 'Salamence', 'Sceptile', 'Sealeo', 'Shelgon', 'Smoochum', 'Spheal', 'Spiritomb', 'Stakataka', 'Suicune', 
+		'Swablu', 'Swampert', 'Tapu Bulu', 'Tapu Fini', 'Tapu Koko', 'Tapu Lele', 'Thundurus', 'Thundurus-Therian', 'Tirtouga', 'Torchic', 'Tornadus', 'Tornadus-Therian', 'Treecko', 'Tyrantrum', 'Tyrunt', 'Uxie', 'Victini', 
+		'Volcanion', 'Walrein', 'Xerneas', 'Xurkitree', 'Yveltal', 'Zapdos', 'Zubat', 'Zygarde', 'Zygarde-10%'
+		],
+	},
 	// Randomized Format Spotlight
 	///////////////////////////////////////////////////////////////////
 

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2708,13 +2708,13 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		searchShow: false,
 		ruleset: ['Standard AG','NatDex Mod'],
 		unbanlist: [
-		'Absol', 'Aerodactyl', 'Aggron', 'Altaria', 'Amaura', 'Anorith', 'Archen', 'Archeops', 'Armaldo', 'Aron', 'Articuno', 'Audino', 'Aurorus', 'Azelf', 'Bagon', 'Beldum', 'Blacephalon', 'Blaziken', 'Buzzwole', 'Carbink', 
-		'Carracosta', 'Celesteela', 'Combusken', 'Cradily', 'Cresselia', 'Crobat', 'Cryogonal', 'Dialga', 'Diancie', 'Dragonair', 'Dragonite', 'Dratini', 'Electabuzz', 'Electivire', 'Elekid', 'Entei', 'Gabite', 'Garchomp', 
-		'Genesect', 'Gible', 'Giratina', 'Golbat', 'Groudon', 'Grovyle', 'Guzzlord', 'Heatran', 'Hooh', 'Jynx', 'Kabuto', 'Kabutops', 'Kartana', 'Kyogre', 'Lairon', 'Landorus', 'Landorus-Therian', 'Latias', 'Latios', 'Lileep', 
-		'Lugia', 'Magby', 'Magmar', 'Magmortar', 'Marshtomp', 'Mesprit', 'Metagross', 'Metang', 'Moltres', 'Mudkip', 'Naganadel', 'Nidoking', 'Nidoqueen', 'Nidoran-F', 'Nidoran-M', 'Nidorina', 'Nidorino', 'Nihilego', 'Omanyte', 
-		'Omastar', 'Palkia', 'Pheromosa', 'Poipole', 'Raikou', 'Rayquaza', 'Regice', 'Regigigas', 'Regirock', 'Registeel', 'Salamence', 'Sceptile', 'Sealeo', 'Shelgon', 'Smoochum', 'Spheal', 'Spiritomb', 'Stakataka', 'Suicune', 
-		'Swablu', 'Swampert', 'Tapu Bulu', 'Tapu Fini', 'Tapu Koko', 'Tapu Lele', 'Thundurus', 'Thundurus-Therian', 'Tirtouga', 'Torchic', 'Tornadus', 'Tornadus-Therian', 'Treecko', 'Tyrantrum', 'Tyrunt', 'Uxie', 'Victini', 
-		'Volcanion', 'Walrein', 'Xerneas', 'Xurkitree', 'Yveltal', 'Zapdos', 'Zubat', 'Zygarde', 'Zygarde-10%'
+			'Absol', 'Aerodactyl', 'Aggron', 'Altaria', 'Amaura', 'Anorith', 'Archen', 'Archeops', 'Armaldo', 'Aron', 'Articuno', 'Audino', 'Aurorus', 'Azelf', 'Bagon', 'Beldum', 'Blacephalon', 'Blaziken', 'Buzzwole', 'Carbink', 
+			'Carracosta', 'Celesteela', 'Combusken', 'Cradily', 'Cresselia', 'Crobat', 'Cryogonal', 'Dialga', 'Diancie', 'Dragonair', 'Dragonite', 'Dratini', 'Electabuzz', 'Electivire', 'Elekid', 'Entei', 'Gabite', 'Garchomp', 
+			'Genesect', 'Gible', 'Giratina', 'Golbat', 'Groudon', 'Grovyle', 'Guzzlord', 'Heatran', 'Hooh', 'Jynx', 'Kabuto', 'Kabutops', 'Kartana', 'Kyogre', 'Lairon', 'Landorus', 'Landorus-Therian', 'Latias', 'Latios', 'Lileep', 
+			'Lugia', 'Magby', 'Magmar', 'Magmortar', 'Marshtomp', 'Mesprit', 'Metagross', 'Metang', 'Moltres', 'Mudkip', 'Naganadel', 'Nidoking', 'Nidoqueen', 'Nidoran-F', 'Nidoran-M', 'Nidorina', 'Nidorino', 'Nihilego', 'Omanyte', 
+			'Omastar', 'Palkia', 'Pheromosa', 'Poipole', 'Raikou', 'Rayquaza', 'Regice', 'Regigigas', 'Regirock', 'Registeel', 'Salamence', 'Sceptile', 'Sealeo', 'Shelgon', 'Smoochum', 'Spheal', 'Spiritomb', 'Stakataka', 'Suicune', 
+			'Swablu', 'Swampert', 'Tapu Bulu', 'Tapu Fini', 'Tapu Koko', 'Tapu Lele', 'Thundurus', 'Thundurus-Therian', 'Tirtouga', 'Torchic', 'Tornadus', 'Tornadus-Therian', 'Treecko', 'Tyrantrum', 'Tyrunt', 'Uxie', 'Victini', 
+			'Volcanion', 'Walrein', 'Xerneas', 'Xurkitree', 'Yveltal', 'Zapdos', 'Zubat', 'Zygarde', 'Zygarde-10%'
 		],
 	},
 	// Randomized Format Spotlight


### PR DESCRIPTION
> dhelmise — 5/10/2025 12:30 PM
> Make format request in admin requests
> runoisch — 5/10/2025 1:11 PM
> https://www.smogon.com/forums/threads/teambuilder-support-gen-8-national-dex-ru-gen-8-national-dex-doubles-gen-8-dlc-1-national-dex-ag.3764672/

> runoisch — 5/19/2025 6:56 PM
> hey dhelmise any update on this? as the post said this is for a team tour with money as a prize so it would be helpful to know the status before this weekend's auction / week 1 next monday so managers and hosts can work around this.
> dhelmise — 5/19/2025 6:57 PM
> havent really done much code work since getting back
> ill try to do it tonight/tomorrow
> runoisch — 5/19/2025 6:58 PM
> i'm perfectly fine with making the PRs and coding it myself if that saves time as per the request

I'm treating dhelmise's last message to mean these formats were in fact approved. If they weren't then feel free to say otherwise.