### PR TITLE
Fix [Gen 8 DLC 1] National Dex AG Legalities

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2704,9 +2704,18 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 	},
 	{
 		name: "[Gen 8 DLC 1] National Dex AG",
-		mod: 'gen8',
+		mod: 'gen8dlc1',
 		searchShow: false,
-		ruleset: ['Standard AG', 'NatDex Mod'],
+		ruleset: ['Standard AG','NatDex Mod'],
+		unbanlist: [
+			'Absol', 'Aerodactyl', 'Aggron', 'Altaria', 'Amaura', 'Anorith', 'Archen', 'Archeops', 'Armaldo', 'Aron', 'Articuno', 'Audino', 'Aurorus', 'Azelf', 'Bagon', 'Beldum', 'Blacephalon', 'Blaziken', 'Buzzwole', 'Carbink',
+			'Carracosta', 'Celesteela', 'Combusken', 'Cradily', 'Cresselia', 'Crobat', 'Cryogonal', 'Dialga', 'Diancie', 'Dragonair', 'Dragonite', 'Dratini', 'Electabuzz', 'Electivire', 'Elekid', 'Entei', 'Gabite', 'Garchomp',
+			'Genesect', 'Gible', 'Giratina', 'Golbat', 'Groudon', 'Grovyle', 'Guzzlord', 'Heatran', 'Hooh', 'Jynx', 'Kabuto', 'Kabutops', 'Kartana', 'Kyogre', 'Lairon', 'Landorus', 'Landorus-Therian', 'Latias', 'Latios', 'Lileep',
+			'Lugia', 'Magby', 'Magmar', 'Magmortar', 'Marshtomp', 'Mesprit', 'Metagross', 'Metang', 'Moltres', 'Mudkip', 'Naganadel', 'Nidoking', 'Nidoqueen', 'Nidoran-F', 'Nidoran-M', 'Nidorina', 'Nidorino', 'Nihilego', 'Omanyte',
+			'Omastar', 'Palkia', 'Pheromosa', 'Poipole', 'Raikou', 'Rayquaza', 'Regice', 'Regigigas', 'Regirock', 'Registeel', 'Salamence', 'Sceptile', 'Sealeo', 'Shelgon', 'Smoochum', 'Spheal', 'Spiritomb', 'Stakataka', 'Suicune',
+			'Swablu', 'Swampert', 'Tapu Bulu', 'Tapu Fini', 'Tapu Koko', 'Tapu Lele', 'Thundurus', 'Thundurus-Therian', 'Tirtouga', 'Torchic', 'Tornadus', 'Tornadus-Therian', 'Treecko', 'Tyrantrum', 'Tyrunt', 'Uxie', 'Victini',
+			'Volcanion', 'Walrein', 'Xerneas', 'Xurkitree', 'Yveltal', 'Zapdos', 'Zubat', 'Zygarde', 'Zygarde-10%',
+		],
 	},
 
 	// Randomized Format Spotlight

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2706,7 +2706,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		name: "[Gen 8 DLC 1] National Dex AG",
 		mod: 'gen8dlc1',
 		searchShow: false,
-		ruleset: ['Standard AG','NatDex Mod'],
+		ruleset: ['Standard AG', 'NatDex Mod'],
 		unbanlist: [
 			'Absol', 'Aerodactyl', 'Aggron', 'Altaria', 'Amaura', 'Anorith', 'Archen', 'Archeops', 'Armaldo', 'Aron', 'Articuno', 'Audino', 'Aurorus', 'Azelf', 'Bagon', 'Beldum', 'Blacephalon', 'Blaziken', 'Buzzwole', 'Carbink',
 			'Carracosta', 'Celesteela', 'Combusken', 'Cradily', 'Cresselia', 'Crobat', 'Cryogonal', 'Dialga', 'Diancie', 'Dragonair', 'Dragonite', 'Dratini', 'Electabuzz', 'Electivire', 'Elekid', 'Entei', 'Gabite', 'Garchomp',

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2707,15 +2707,6 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen8dlc1',
 		searchShow: false,
 		ruleset: ['Standard AG', 'NatDex Mod'],
-		unbanlist: [
-			'Absol', 'Aerodactyl', 'Aggron', 'Altaria', 'Amaura', 'Anorith', 'Archen', 'Archeops', 'Armaldo', 'Aron', 'Articuno', 'Audino', 'Aurorus', 'Azelf', 'Bagon', 'Beldum', 'Blacephalon', 'Blaziken', 'Buzzwole', 'Carbink',
-			'Carracosta', 'Celesteela', 'Combusken', 'Cradily', 'Cresselia', 'Crobat', 'Cryogonal', 'Dialga', 'Diancie', 'Dragonair', 'Dragonite', 'Dratini', 'Electabuzz', 'Electivire', 'Elekid', 'Entei', 'Gabite', 'Garchomp',
-			'Genesect', 'Gible', 'Giratina', 'Golbat', 'Groudon', 'Grovyle', 'Guzzlord', 'Heatran', 'Hooh', 'Jynx', 'Kabuto', 'Kabutops', 'Kartana', 'Kyogre', 'Lairon', 'Landorus', 'Landorus-Therian', 'Latias', 'Latios', 'Lileep',
-			'Lugia', 'Magby', 'Magmar', 'Magmortar', 'Marshtomp', 'Mesprit', 'Metagross', 'Metang', 'Moltres', 'Mudkip', 'Naganadel', 'Nidoking', 'Nidoqueen', 'Nidoran-F', 'Nidoran-M', 'Nidorina', 'Nidorino', 'Nihilego', 'Omanyte',
-			'Omastar', 'Palkia', 'Pheromosa', 'Poipole', 'Raikou', 'Rayquaza', 'Regice', 'Regigigas', 'Regirock', 'Registeel', 'Salamence', 'Sceptile', 'Sealeo', 'Shelgon', 'Smoochum', 'Spheal', 'Spiritomb', 'Stakataka', 'Suicune',
-			'Swablu', 'Swampert', 'Tapu Bulu', 'Tapu Fini', 'Tapu Koko', 'Tapu Lele', 'Thundurus', 'Thundurus-Therian', 'Tirtouga', 'Torchic', 'Tornadus', 'Tornadus-Therian', 'Treecko', 'Tyrantrum', 'Tyrunt', 'Uxie', 'Victini',
-			'Volcanion', 'Walrein', 'Xerneas', 'Xurkitree', 'Yveltal', 'Zapdos', 'Zubat', 'Zygarde', 'Zygarde-10%',
-		],
 	},
 
 	// Randomized Format Spotlight

--- a/data/mods/gen8dlc1/formats-data.ts
+++ b/data/mods/gen8dlc1/formats-data.ts
@@ -6,38 +6,47 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	nidoranf: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	nidorina: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	nidoqueen: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	nidoranm: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	nidorino: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	nidoking: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	zubat: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	golbat: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	crobat: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	slowkinggalar: {
 		isNonstandard: "Unobtainable",
@@ -46,58 +55,72 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	smoochum: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	jynx: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	elekid: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	electabuzz: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	electivire: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	magby: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	magmar: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	magmortar: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	omanyte: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	omastar: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	kabuto: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	kabutops: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	aerodactyl: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	articuno: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	articunogalar: {
 		isNonstandard: "Unobtainable",
@@ -106,6 +129,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	zapdos: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	zapdosgalar: {
 		isNonstandard: "Unobtainable",
@@ -114,6 +138,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	moltres: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UU",
 	},
 	moltresgalar: {
 		isNonstandard: "Unobtainable",
@@ -122,413 +147,516 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	dratini: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	dragonair: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	dragonite: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UUBL",
 	},
 	raikou: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	entei: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	suicune: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	lugia: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	hooh: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	treecko: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	grovyle: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	sceptile: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	torchic: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	combusken: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	blaziken: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	mudkip: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	marshtomp: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	swampert: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	aron: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	lairon: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	aggron: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	swablu: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	altaria: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	lileep: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	cradily: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	anorith: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	armaldo: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	absol: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	spheal: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	sealeo: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	walrein: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	bagon: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	shelgon: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	salamence: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UU",
 	},
 	beldum: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	metang: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	metagross: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	regirock: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	regice: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	registeel: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	latias: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UU",
 	},
 	latios: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UUBL",
 	},
 	kyogre: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	groudon: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	rayquaza: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	spiritomb: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	gible: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	gabite: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "NFE",
 	},
 	garchomp: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	uxie: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	mesprit: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	azelf: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	dialga: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	palkia: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	heatran: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	regigigas: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	giratina: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	giratinaorigin: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	cresselia: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	victini: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	audino: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	tirtouga: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	carracosta: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	archen: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	archeops: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	cryogonal: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	tornadus: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RUBL",
 	},
 	tornadustherian: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	thundurus: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UUBL",
 	},
 	thundurustherian: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	landorus: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	landorustherian: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	genesect: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	genesectburn: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	genesectchill: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	genesectdouse: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	genesectshock: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	tyrunt: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	tyrantrum: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	amaura: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	aurorus: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	carbink: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	xerneas: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	yveltal: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	zygarde: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	zygarde10: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	diancie: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	volcanion: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	tapukoko: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	tapulele: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	tapubulu: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	tapufini: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	nihilego: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	buzzwole: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UU",
 	},
 	pheromosa: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	xurkitree: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UUBL",
 	},
 	celesteela: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "UU",
 	},
 	kartana: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	guzzlord: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	poipole: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "LC",
 	},
 	naganadel: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "Uber",
 	},
 	stakataka: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "RU",
 	},
 	blacephalon: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
+		natDexTier: "OU",
 	},
 	melmetal: {
-		gmaxUnreleased: true,
+		gmaxUnreleased: "True",
+		natDexTier: "OU",
 	},
 	melmetalgmax: {
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen8dlc1/formats-data.ts
+++ b/data/mods/gen8dlc1/formats-data.ts
@@ -655,7 +655,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		natDexTier: "OU",
 	},
 	melmetal: {
-		gmaxUnreleased: "True",
+		gmaxUnreleased: true,
 		natDexTier: "OU",
 	},
 	melmetalgmax: {


### PR DESCRIPTION
Current implementation of the format is just DLC 2 NDAG, this PR removes the DLC 2 changes:

![image](https://github.com/user-attachments/assets/e7f5c86f-5eb9-49a5-bc8d-3f4ca98ef252)
