### PR TITLE
Refactor White Herb activation

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -7209,37 +7209,28 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 				}
 			},
 		},
-		onAfterBoost(boost, pokemon) {
-			delete this.effectState.ready;
+		onStart(pokemon) {
 			this.effectState.boosts = {} as SparseBoostsTable;
+			let ready = false;
 			let i: BoostID;
 			for (i in pokemon.boosts) {
 				if (pokemon.boosts[i] < 0) {
-					this.effectState.ready = true;
+					ready = true;
 					this.effectState.boosts[i] = 0;
 				}
 			}
-		},
-		onStart(pokemon) {
-			((this.effect as any).onAfterBoost as (b: SparseBoostsTable, p: Pokemon) => void).call(this, pokemon.boosts, pokemon);
-			if (!this.effectState.ready) return;
-			(this.effectState.target as Pokemon).useItem();
+			if (ready) (this.effectState.target as Pokemon).useItem();
 		},
 		onAnySwitchInPriority: -2,
 		onAnySwitchIn() {
-			const pokemon = this.effectState.target;
-			((this.effect as any).onAfterBoost as (b: SparseBoostsTable, p: Pokemon) => void).call(this, pokemon.boosts, pokemon);
-			if (!this.effectState.ready) return;
-			(this.effectState.target as Pokemon).useItem();
+			((this.effect as any).onStart as (p: Pokemon) => void).call(this, this.effectState.target);
 		},
 		onAnyAfterMove() {
-			if (!this.effectState.ready) return;
-			(this.effectState.target as Pokemon).useItem();
+			((this.effect as any).onStart as (p: Pokemon) => void).call(this, this.effectState.target);
 		},
 		onResidualOrder: 29,
 		onResidual(pokemon) {
-			if (!this.effectState.ready) return;
-			(this.effectState.target as Pokemon).useItem();
+			((this.effect as any).onStart as (p: Pokemon) => void).call(this, pokemon);
 		},
 		onUse(pokemon) {
 			pokemon.setBoost(this.effectState.boosts);
@@ -7247,7 +7238,6 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		},
 		onEnd() {
 			delete this.effectState.boosts;
-			delete this.effectState.ready;
 		},
 		num: 214,
 		gen: 3,

--- a/data/items.ts
+++ b/data/items.ts
@@ -7227,6 +7227,8 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		},
 		onAnySwitchInPriority: -2,
 		onAnySwitchIn() {
+			const pokemon = this.effectState.target;
+			((this.effect as any).onAfterBoost as (b: SparseBoostsTable, p: Pokemon) => void).call(this, pokemon.boosts, pokemon);
 			if (!this.effectState.ready) return;
 			(this.effectState.target as Pokemon).useItem();
 		},

--- a/data/items.ts
+++ b/data/items.ts
@@ -7220,6 +7220,7 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 				}
 			}
 			if (ready) (this.effectState.target as Pokemon).useItem();
+			delete this.effectState.boosts;
 		},
 		onAnySwitchInPriority: -2,
 		onAnySwitchIn() {
@@ -7235,9 +7236,6 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		onUse(pokemon) {
 			pokemon.setBoost(this.effectState.boosts);
 			this.add('-clearnegativeboost', pokemon, '[silent]');
-		},
-		onEnd() {
-			delete this.effectState.boosts;
 		},
 		num: 214,
 		gen: 3,

--- a/data/items.ts
+++ b/data/items.ts
@@ -1586,6 +1586,10 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			if (!this.effectState.eject) return;
 			(this.effectState.target as Pokemon).useItem();
 		},
+		onAnyAfterMega() {
+			if (!this.effectState.eject) return;
+			(this.effectState.target as Pokemon).useItem();
+		},
 		onAnyAfterMove() {
 			if (!this.effectState.eject) return;
 			(this.effectState.target as Pokemon).useItem();
@@ -3834,6 +3838,14 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		},
 		onAnySwitchInPriority: -3,
 		onAnySwitchIn() {
+			if (!this.effectState.ready) return;
+			(this.effectState.target as Pokemon).useItem();
+		},
+		onAnyAfterMega() {
+			if (!this.effectState.ready) return;
+			(this.effectState.target as Pokemon).useItem();
+		},
+		onAnyAfterTerastallization() {
 			if (!this.effectState.ready) return;
 			(this.effectState.target as Pokemon).useItem();
 		},
@@ -7224,6 +7236,9 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		},
 		onAnySwitchInPriority: -2,
 		onAnySwitchIn() {
+			((this.effect as any).onStart as (p: Pokemon) => void).call(this, this.effectState.target);
+		},
+		onAnyAfterMega() {
 			((this.effect as any).onStart as (p: Pokemon) => void).call(this, this.effectState.target);
 		},
 		onAnyAfterMove() {

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -328,10 +328,12 @@ export interface EventMethods {
 	onAnyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAnyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAnyAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onAnyAfterMega?: (this: Battle, pokemon: Pokemon) => void;
 	onAnyAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAnyAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onAnyAfterMove?: MoveEventMethods['onAfterMove'];
 	onAnyAfterMoveSelf?: CommonHandlers['VoidSourceMove'];
+	onAnyAfterTerastallization?: (this: Battle, pokemon: Pokemon) => void;
 	onAnyAttract?: (this: Battle, target: Pokemon, source: Pokemon) => void;
 	onAnyAccuracy?: (
 		this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: ActiveMove

--- a/test/sim/items/whiteherb.js
+++ b/test/sim/items/whiteherb.js
@@ -24,6 +24,26 @@ describe("White Herb", () => {
 		assert.statStage(wynaut, 'spa', 0);
 	});
 
+	it('should activate after Costar', () => {
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: 'litten', moves: ['sleeptalk'] },
+			{ species: 'blastoise', moves: ['shellsmash', 'sleeptalk'] },
+			{ species: 'flamigo', item: 'whiteherb', ability: 'costar', moves: ['sleeptalk'] },
+		], [
+			{ species: 'wynaut', moves: ['sleeptalk'] },
+			{ species: 'torracat', moves: ['sleeptalk'] },
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('switch 3, move sleeptalk', 'auto');
+		const flamigo = battle.p1.active[0];
+		assert.false.holdsItem(flamigo);
+		assert.statStage(flamigo, 'atk', 2);
+		assert.statStage(flamigo, 'spa', 2);
+		assert.statStage(flamigo, 'spe', 2);
+		assert.statStage(flamigo, 'def', 0);
+		assert.statStage(flamigo, 'spd', 0);
+	});
+
 	it('should activate after Abilities that boost stats on KOs', () => {
 		battle = common.createBattle([[
 			{ species: 'litten', level: 1, ability: 'noguard', moves: ['sleeptalk'] },


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/bug-report-ladder.3765412/

White Herb shouldn't activate on boost changes; it should activate based on negative boosts. This fixes issues with effects like Costar, Topsy-Turvy and Psych Up. I'll just check whether Eject Pack activates with Coaster or not.

Edit: Eject Pack does **_NOT_** activate after Costar copies negative boosts. This is ready for review.