### PR TITLE
Pages: Notify bots when a user leaves a bot page

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -514,6 +514,11 @@ export const commands: Chat.ChatCommands = {
 			if (target.startsWith('view-')) {
 				connection.openPages?.delete(target.slice(5));
 				if (!connection.openPages?.size) connection.openPages = null;
+				if (target.startsWith('view-bot-')) {
+					const [botId, pageId] = target.slice('view-bot-'.length).split('-');
+					const bot = Users.get(botId);
+					if (bot) bot.sendTo(null, `|pm|${user.getIdentity()}|${botId}||closepage|${user.name}|${pageId}`);
+				}
 				Chat.handleRoomClose(target as RoomID, user, connection);
 				return;
 			}


### PR DESCRIPTION
Sends an event to the bot of a bot HTML page when a user closes it. Follows the same syntax as `|requestpage|`, which is run when reconnecting to one.

Smogon Suggestion (Approved): https://www.smogon.com/forums/threads/send-an-event-on-bot-created-htmlroom-close.3694884/