### PR TITLE
Fix interaction between Max Weather Ball and -ate Abilities

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -60,7 +60,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const noModifyType = [
 				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
 			];
-			if (move.type === 'Normal' && !noModifyType.includes(move.id) &&
+			if (move.type === 'Normal' && (!noModifyType.includes(move.id) ||
+				(['terrainpulse', 'weatherball'].includes(move.id) && this.activeMove?.isMax)) &&
 				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
 				move.type = 'Flying';
 				move.typeChangerBoosted = this.effect;
@@ -1547,7 +1548,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const noModifyType = [
 				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
 			];
-			if (move.type === 'Normal' && !noModifyType.includes(move.id) &&
+			if (move.type === 'Normal' && (!noModifyType.includes(move.id) ||
+				(['terrainpulse', 'weatherball'].includes(move.id) && this.activeMove?.isMax)) &&
 				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
 				move.type = 'Electric';
 				move.typeChangerBoosted = this.effect;
@@ -3225,7 +3227,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const noModifyType = [
 				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
 			];
-			if (move.type === 'Normal' && !noModifyType.includes(move.id) &&
+			if (move.type === 'Normal' && (!noModifyType.includes(move.id) ||
+				(['terrainpulse', 'weatherball'].includes(move.id) && this.activeMove?.isMax)) &&
 				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
 				move.type = 'Fairy';
 				move.typeChangerBoosted = this.effect;
@@ -3751,7 +3754,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const noModifyType = [
 				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
 			];
-			if (move.type === 'Normal' && !noModifyType.includes(move.id) &&
+			if (move.type === 'Normal' && (!noModifyType.includes(move.id) ||
+				(['terrainpulse', 'weatherball'].includes(move.id) && this.activeMove?.isMax)) &&
 				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
 				move.type = 'Ice';
 				move.typeChangerBoosted = this.effect;

--- a/test/sim/abilities/download.js
+++ b/test/sim/abilities/download.js
@@ -56,7 +56,7 @@ describe('Download', () => {
 		assert.statStage(battle.p1.active[0], 'atk', 1);
 	});
 
-	describe('Gen 4', () => {
+	describe('[Gen 4]', () => {
 		it('should not trigger if the foe is behind a Substitute', () => {
 			battle = common.gen(4).createBattle([[
 				{ species: 'furret', moves: ['sleeptalk'] },

--- a/test/sim/abilities/protean.js
+++ b/test/sim/abilities/protean.js
@@ -180,7 +180,7 @@ describe('Protean', () => {
 		assert(cinder.hasType('Normal'));
 	});
 
-	describe('Gen 6-8', () => {
+	describe('[Gen 6-8]', () => {
 		it(`should activate on both turns of a charge move`, () => {
 			battle = common.gen(8).createBattle([[
 				{ species: 'Wynaut', ability: 'protean', moves: ['bounce'] },

--- a/test/sim/moves/weatherball.js
+++ b/test/sim/moves/weatherball.js
@@ -36,35 +36,47 @@ describe('Weather Ball', () => {
 		assert(!battle.p2.active[0].fainted);
 	});
 
-	it('should not trigger counter when it is special during gen 3', () => {
-		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'drizzle', moves: ['weatherball'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['counter'] }] });
-		battle.makeChoices();
-		assert.fullHP(battle.p1.active[0]);
+	it('should change max moves if it has an -ate ability', () => {
+		battle = common.gen(8).createBattle([[
+			{ species: 'Aurorus', ability: 'refrigerate', moves: ['weatherball'] },
+		], [
+			{ species: 'Cofagrigus', ability: 'shellarmor', moves: ['sleeptalk'] },
+		]]);
+		assert.hurts(battle.p2.active[0], () => battle.makeChoices('move weatherball dynamax', 'move sleeptalk'));
+		assert(battle.getDebugLog().includes('Max Hailstorm'));
 	});
 
-	it('should trigger mirror coat when it is special during gen 3', () => {
-		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'drought', moves: ['weatherball'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['mirrorcoat'] }] });
-		battle.makeChoices();
-		assert.false.fullHP(battle.p1.active[0]);
-	});
+	describe('[Gen 3]', () => {
+		it('should not trigger counter when it is special', () => {
+			battle = common.gen(3).createBattle();
+			battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'drizzle', moves: ['weatherball'] }] });
+			battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['counter'] }] });
+			battle.makeChoices();
+			assert.fullHP(battle.p1.active[0]);
+		});
 
-	it('should not trigger mirror coat when it is physical during gen 3', () => {
-		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shuckle', moves: ['weatherball'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['mirrorcoat'] }] });
-		battle.makeChoices();
-		assert.fullHP(battle.p1.active[0]);
-	});
+		it('should trigger mirror coat when it is special', () => {
+			battle = common.gen(3).createBattle();
+			battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'drought', moves: ['weatherball'] }] });
+			battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['mirrorcoat'] }] });
+			battle.makeChoices();
+			assert.false.fullHP(battle.p1.active[0]);
+		});
 
-	it('should trigger counter when it is physical during gen 3', () => {
-		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'sandstream', moves: ['weatherball'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['counter'] }] });
-		battle.makeChoices();
-		assert.false.fullHP(battle.p1.active[0]);
+		it('should not trigger mirror coat when it is physical', () => {
+			battle = common.gen(3).createBattle();
+			battle.setPlayer('p1', { team: [{ species: 'Shuckle', moves: ['weatherball'] }] });
+			battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['mirrorcoat'] }] });
+			battle.makeChoices();
+			assert.fullHP(battle.p1.active[0]);
+		});
+
+		it('should trigger counter when it is physical', () => {
+			battle = common.gen(3).createBattle();
+			battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'sandstream', moves: ['weatherball'] }] });
+			battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['counter'] }] });
+			battle.makeChoices();
+			assert.false.fullHP(battle.p1.active[0]);
+		});
 	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/max-weather-ball-ate-ability.3757911/
@DaWoblefet mentioned that 
```
the effects use this Max Move type change event:

Weather Ball
Terrain Pulse
Multi Attack
Techno Blast
Aura Wheel

Ion Deluge / Plasma Fists effect

Normalize
Aerilate
Pixilate
Refrigerate
Galvanize
```
I think the only moves that have this specific interaction are Terrain Pulse and Weather Ball.