### PR TITLE
Fix Chatter's old gen mechanics

### DIFF
--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -390,7 +390,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	serenegrace: {
 		inherit: true,
 		onModifyMove(move) {
-			if (move.secondaries) {
+			if (move.secondaries && move.id !== 'chatter') {
 				this.debug('doubling secondary chance');
 				for (const secondary of move.secondaries) {
 					if (secondary.chance) secondary.chance *= 2;

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -107,7 +107,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		onModifyMove(move, pokemon) {
 			if (pokemon.species.name !== 'Chatot') {
 				const confusion = move.secondaries?.find(secondary => secondary.volatileStatus === 'confusion');
-				if (confusion) confusion.chance = 0;
+				if (confusion) confusion.chance = 0; // boosted by Sheer Force
 			}
 		},
 		secondary: {

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -105,7 +105,10 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		basePower: 60,
 		onModifyMove(move, pokemon) {
-			if (pokemon.species.name !== 'Chatot') delete move.secondaries;
+			if (pokemon.species.name !== 'Chatot') {
+				const confusion = move.secondaries?.find(secondary => secondary.volatileStatus === 'confusion');
+				if (confusion) confusion.chance = 0;
+			}
 		},
 		secondary: {
 			chance: 10,

--- a/test/sim/moves/chatter.js
+++ b/test/sim/moves/chatter.js
@@ -34,4 +34,14 @@ describe('Chatter [Gen 5]', () => {
 		battle.makeChoices('move chatter', 'move rest');
 		assert.equal(battle.p2.active[0].item, 'focussash');
 	});
+
+	it('should be boosted by Sheer Force', () => {
+		battle = common.gen(5).createBattle([
+			[{ species: "Rayquaza", ability: 'sheerforce', moves: ['chatter'] }],
+			[{ species: "Carnivine", moves: ['sleeptalk'] }],
+		]);
+		battle.makeChoices();
+		console.log(battle.log);
+		assert.fainted(battle.p2.active[0]);
+	});
 });

--- a/test/sim/moves/chatter.js
+++ b/test/sim/moves/chatter.js
@@ -38,10 +38,9 @@ describe('Chatter [Gen 5]', () => {
 	it('should be boosted by Sheer Force', () => {
 		battle = common.gen(5).createBattle([
 			[{ species: "Rayquaza", ability: 'sheerforce', moves: ['chatter'] }],
-			[{ species: "Carnivine", moves: ['sleeptalk'] }],
+			[{ species: "Carnivine", ability: 'battlearmor', moves: ['sleeptalk'] }],
 		]);
 		battle.makeChoices();
-		console.log(battle.log);
 		assert.fainted(battle.p2.active[0]);
 	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/old-gen-chatter-secondary-effect-weirdness.3753441/

> - [Gen 4] Chatter's confusion chance should not be boosted by Serene Grace
> - [Gen 5] Chatter should still be boosted by Sheer Force when used by a Pokemon other than Chatot, even though there is a 0% confusion chance