### PR TITLE
Fix Magic Bounce in Free-For-All battles

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2403,6 +2403,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			newMove.hasBounced = true;
 			newMove.pranksterBoosted = false;
 			this.actions.useMove(newMove, this.effectState.target, { target: source });
+			move.hasBounced = true; // only bounce once in free-for-all battles
 			return null;
 		},
 		condition: {

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -43,6 +43,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			newMove.hasBounced = true;
 			newMove.pranksterBoosted = false;
 			this.actions.useMove(newMove, this.effectState.target, { target: source });
+			move.hasBounced = true; // only bounce once in free-for-all battles
 			return null;
 		},
 	},

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1001,6 +1001,10 @@ export class Battle {
 		if (handler.effectHolder && (handler.effectHolder as Pokemon).getStat) {
 			const pokemon = handler.effectHolder as Pokemon;
 			handler.speed = pokemon.speed;
+			if (handler.effect.effectType === 'Ability' && handler.effect.name === 'Magic Bounce' &&
+				callbackName === 'onAllyTryHitSide') {
+				handler.speed = pokemon.getStat('spe', true, true);
+			}
 			if (callbackName.endsWith('SwitchIn')) {
 				// Pokemon speeds including ties are resolved before all onSwitchIn handlers and aren't re-sorted in-between
 				// so we subtract a fractional speed from each Pokemon's respective event handlers by using the index of their

--- a/test/sim/abilities/magicbounce.js
+++ b/test/sim/abilities/magicbounce.js
@@ -68,6 +68,35 @@ describe('Magic Bounce', () => {
 		assert(battle.p2.sideConditions['stealthrock']);
 	});
 
+	it(`should should only activate for the fastest Pokemon in a Free-for-all battle`, () => {
+		battle = common.createBattle({ gameType: 'freeforall' }, [[
+			{ species: 'Deoxys-Speed', moves: ['stealthrock'] },
+		], [
+			{ species: 'Espeon', ability: 'magicbounce', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Hatterene', ability: 'magicbounce', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Hattrem', ability: 'magicbounce', moves: ['sleeptalk'] },
+		]]);
+		battle.makeChoices();
+		assert.deepEqual(battle.sides.map(side => !!side.sideConditions.stealthrock), [true, false, true, true]);
+	});
+
+	it.skip(`should should only activate for the fastest (unmodified speed) Pokemon in a Free-for-all battle`, () => {
+		battle = common.createBattle({ gameType: 'freeforall' }, [[
+			{ species: 'Deoxys-Speed', moves: ['trickroom', 'stealthrock'] },
+		], [
+			{ species: 'Espeon', ability: 'magicbounce', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Hatterene', ability: 'magicbounce', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Hattrem', ability: 'magicbounce', moves: ['sleeptalk'] },
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('move stealthrock', 'auto', 'auto', 'auto');
+		assert.deepEqual(battle.sides.map(side => !!side.sideConditions.stealthrock), [true, false, true, true]);
+	});
+
 	it(`[Gen 5] should bounce moves that target the foe's side while semi-invulnerable`, () => {
 		battle = common.gen(5).createBattle({ gameType: 'doubles' });
 		battle.setPlayer('p1', { team: [

--- a/test/sim/abilities/magicbounce.js
+++ b/test/sim/abilities/magicbounce.js
@@ -82,7 +82,7 @@ describe('Magic Bounce', () => {
 		assert.deepEqual(battle.sides.map(side => !!side.sideConditions.stealthrock), [true, false, true, true]);
 	});
 
-	it.skip(`should should only activate for the fastest (unmodified speed) Pokemon in a Free-for-all battle`, () => {
+	it(`should should only activate for the fastest (unmodified speed) Pokemon in a Free-for-all battle`, () => {
 		battle = common.createBattle({ gameType: 'freeforall' }, [[
 			{ species: 'Deoxys-Speed', moves: ['trickroom', 'stealthrock'] },
 		], [

--- a/test/sim/abilities/magicbounce.js
+++ b/test/sim/abilities/magicbounce.js
@@ -82,7 +82,7 @@ describe('Magic Bounce', () => {
 		assert.deepEqual(battle.sides.map(side => !!side.sideConditions.stealthrock), [true, false, true, true]);
 	});
 
-	it(`should should only activate for the fastest (unmodified speed) Pokemon in a Free-for-all battle`, () => {
+	it(`should activate from fastest to slowest based on unmodified speed`, () => {
 		battle = common.createBattle({ gameType: 'freeforall' }, [[
 			{ species: 'Deoxys-Speed', moves: ['trickroom', 'stealthrock'] },
 		], [

--- a/test/sim/abilities/magicbounce.js
+++ b/test/sim/abilities/magicbounce.js
@@ -92,7 +92,7 @@ describe('Magic Bounce', () => {
 		], [
 			{ species: 'Hattrem', ability: 'magicbounce', moves: ['sleeptalk'] },
 		]]);
-		battle.makeChoices('move trickroom');
+		battle.makeChoices('move trickroom', 'auto', 'auto', 'auto');
 		battle.makeChoices();
 		assert.deepEqual(battle.sides.map(side => !!side.sideConditions.stealthrock), [true, false, true, true]);
 	});

--- a/test/sim/abilities/magicbounce.js
+++ b/test/sim/abilities/magicbounce.js
@@ -68,7 +68,7 @@ describe('Magic Bounce', () => {
 		assert(battle.p2.sideConditions['stealthrock']);
 	});
 
-	it(`should should only activate for the fastest Pokemon in a Free-for-all battle`, () => {
+	it(`should only activate for the fastest Pokemon in a Free-for-all battle`, () => {
 		battle = common.createBattle({ gameType: 'freeforall' }, [[
 			{ species: 'Deoxys-Speed', moves: ['stealthrock'] },
 		], [
@@ -84,7 +84,7 @@ describe('Magic Bounce', () => {
 
 	it(`should activate from fastest to slowest based on unmodified speed`, () => {
 		battle = common.createBattle({ gameType: 'freeforall' }, [[
-			{ species: 'Deoxys-Speed', moves: ['trickroom', 'stealthrock'] },
+			{ species: 'Deoxys-Speed', moves: ['stealthrock', 'trickroom'] },
 		], [
 			{ species: 'Espeon', ability: 'magicbounce', moves: ['sleeptalk'] },
 		], [
@@ -92,8 +92,8 @@ describe('Magic Bounce', () => {
 		], [
 			{ species: 'Hattrem', ability: 'magicbounce', moves: ['sleeptalk'] },
 		]]);
+		battle.makeChoices('move trickroom');
 		battle.makeChoices();
-		battle.makeChoices('move stealthrock', 'auto', 'auto', 'auto');
 		assert.deepEqual(battle.sides.map(side => !!side.sideConditions.stealthrock), [true, false, true, true]);
 	});
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/multiple-magic-bounce-with-hazards-in-ffa.3751449/
~Activation based on unmodified speed is still not implemented, but I've left a skipped test for it. This will require an overhaul of the events that use unmodified speed.~