### PR TITLE
Fix Healing Wish and Lunar Dance switch in priority in Gen 7

### DIFF
--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -386,7 +386,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		condition: {
 			duration: 2,
-			onSwitchInPriority: 1,
 			onSwitchIn(target) {
 				if (!target.fainted) {
 					target.heal(target.maxhp);
@@ -613,7 +612,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		condition: {
 			duration: 2,
-			onSwitchInPriority: 1,
 			onSwitchIn(target) {
 				if (!target.fainted) {
 					target.heal(target.maxhp);


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/pull/10766#issuecomment-2606193048

> Healing Wish and Lunar Dance need their onSwitchInPriority updated in the Gen 7 mod to match Gen 9