### PR TITLE
/ds: add sorting by (doubles) tier

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -726,7 +726,7 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 		water3: 'Water 3',
 	});
 	const allFormes = ['alola', 'galar', 'hisui', 'paldea', 'primal', 'therian', 'totem'];
-	const allStats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'bst', 'weight', 'height', 'gen', 'num'];
+	const allStats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'bst', 'weight', 'height', 'gen', 'num', 'tier'];
 	const allStatAliases: { [k: string]: string } = {
 		attack: 'atk', defense: 'def', specialattack: 'spa', spc: 'spa', special: 'spa', spatk: 'spa',
 		specialdefense: 'spd', spdef: 'spd', speed: 'spe', wt: 'weight', ht: 'height', generation: 'gen',
@@ -837,6 +837,17 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 			if (target.startsWith('!')) {
 				isNotSearch = true;
 				target = target.substr(1);
+			}
+
+			if (target.endsWith(' asc') || target.endsWith(' desc')) {
+				if (parameters.length > 1) {
+					return { error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.` };
+				}
+				const stat = allStatAliases[toID(target.split(' ')[0])] || toID(target.split(' ')[0]);
+				if (!allStats.includes(stat)) return { error: `'${target}' did not contain a valid stat.` };
+				sort = `${stat}${target.endsWith(' asc') ? '+' : '-'}`;
+				orGroup.skip = true;
+				break;
 			}
 
 			let isTierInequalityParam = false;
@@ -998,17 +1009,6 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 				if (invalid) return { error: invalid };
 				orGroup.gens[targetInt] = !isNotSearch;
 				continue;
-			}
-
-			if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				if (parameters.length > 1) {
-					return { error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.` };
-				}
-				const stat = allStatAliases[toID(target.split(' ')[0])] || toID(target.split(' ')[0]);
-				if (!allStats.includes(stat)) return { error: `'${target}' did not contain a valid stat.` };
-				sort = `${stat}${target.endsWith(' asc') ? '+' : '-'}`;
-				orGroup.skip = true;
-				break;
 			}
 
 			if (target === 'all') {
@@ -1539,6 +1539,8 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 			return species.gen;
 		case 'num':
 			return species.num;
+		case 'tier':
+			return singlesTiersValues[species.tier];
 		default:
 			return species.baseStats[stat as StatID];
 		}

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -741,7 +741,7 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 	let gmaxSearch = null;
 	let tierSearch = null;
 	let capSearch: boolean | null = null;
-	let nationalSearch = null;
+	let nationalSearch: boolean | null = null;
 	let unreleasedSearch = null;
 	let fullyEvolvedSearch = null;
 	let restrictedSearch = null;
@@ -1530,7 +1530,7 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 
 	const stat = sort?.slice(0, -1);
 
-	function getSortValue(species: Species, nationalSearch = false) {
+	function getSortValue(species: Species) {
 		if (!stat) return 0;
 		switch (stat) {
 		case 'bst':
@@ -1560,11 +1560,11 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 		const maskForm = mon.baseSpecies === "Ogerpon" && !mon.forme.endsWith("Tera");
 		const allowGmax = (gmaxSearch || tierSearch);
 		if (!isRegionalForm && !maskForm && mon.baseSpecies && results.includes(mod.species.get(mon.baseSpecies)) &&
-			getSortValue(mon, nationalSearch) === getSortValue(mod.species.get(mon.baseSpecies), nationalSearch)) continue;
+			getSortValue(mon) === getSortValue(mod.species.get(mon.baseSpecies))) continue;
 		const teraFormeChangesFrom = mon.forme.endsWith("Tera") ? !Array.isArray(mon.battleOnly) ?
 			mon.battleOnly! : null : null;
 		if (teraFormeChangesFrom && results.includes(mod.species.get(teraFormeChangesFrom)) &&
-			getSortValue(mon, nationalSearch) === getSortValue(mod.species.get(teraFormeChangesFrom), nationalSearch)) continue;
+			getSortValue(mon) === getSortValue(mod.species.get(teraFormeChangesFrom))) continue;
 		if (mon.isNonstandard === 'Gigantamax' && !allowGmax) continue;
 		results.push(mon);
 	}
@@ -1595,7 +1595,7 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 		results.sort();
 		if (sort) {
 			const direction = sort.slice(-1);
-			Utils.sortBy(results, species => getSortValue(species, nationalSearch) * (direction === '+' ? 1 : -1));
+			Utils.sortBy(results, species => getSortValue(species) * (direction === '+' ? 1 : -1));
 		}
 
 		function mapPokemonResults(inputArr: Species[]) {


### PR DESCRIPTION
Adds an option to sort by (doubles) tier in `/ds`.
Adds tiers for LC/NFE in doubles and Illegal as a whole so those Pokemon can be sorted.

Change approved from suggestions forum: https://www.smogon.com/forums/threads/sorting-by-tier-in-ds.3765667/