### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -449,7 +449,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "earthquake", "explosion", "hiddenpowerbug", "rockslide", "toxic"],
+                "movepool": ["doubleedge", "earthquake", "explosion", "rockslide", "toxic"],
                 "abilities": ["Rock Head"]
             }
         ]
@@ -1313,9 +1313,14 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["brickbreak", "doubleedge", "earthquake", "explosion", "rockslide", "toxic"],
+                "movepool": ["doubleedge", "earthquake", "explosion", "rockslide", "toxic"],
                 "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Generalist",
+                "movepool": ["explosion", "focuspunch", "rockslide", "substitute", "toxic"],
+                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -2383,7 +2388,7 @@
             },
             {
                 "role": "Generalist",
-                "movepool": ["doubleedge", "earthquake", "focuspunch", "irontail", "rockslide", "substitute"],
+                "movepool": ["focuspunch", "irontail", "rockslide", "substitute"],
                 "abilities": ["Rock Head"]
             }
         ]

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -844,7 +844,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["aerialace", "aquatail", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "movepool": ["aerialace", "aquatail", "earthquake", "roost", "stealthrock", "stoneedge"],
                 "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -886,7 +886,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["aerialace", "aquatail", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "movepool": ["aerialace", "aquatail", "earthquake", "roost", "stealthrock", "stoneedge"],
                 "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             }
@@ -2172,7 +2172,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "lavaplume", "rapidspin", "stealthrock", "yawn"],
-                "abilities": ["White Smoke"]
+                "abilities": ["Shell Armor"]
             }
         ]
     },

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -585,6 +585,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (ability === 'Harvest') return 'Sitrus Berry';
 		if (species.id === 'ditto') return 'Choice Scarf';
+		if (species.id === 'honchkrow') return 'Life Orb';
 		if (species.id === 'exploud' && role === 'Bulky Attacker') return 'Choice Band';
 		if (ability === 'Poison Heal' || moves.has('facade')) return 'Toxic Orb';
 		if (ability === 'Speed Boost' && species.id !== 'ninjask') return 'Life Orb';

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -978,7 +978,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["aerialace", "aquatail", "defog", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "movepool": ["aerialace", "aquatail", "defog", "earthquake", "roost", "stealthrock", "stoneedge"],
                 "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             }
@@ -2434,7 +2434,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "lavaplume", "rapidspin", "stealthrock", "yawn"],
-                "abilities": ["White Smoke"]
+                "abilities": ["Shell Armor"]
             }
         ]
     },
@@ -4490,11 +4490,6 @@
                 "role": "Fast Support",
                 "movepool": ["copycat", "encore", "knockoff", "substitute", "thunderwave", "uturn"],
                 "abilities": ["Prankster"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["gunkshot", "knockoff", "playrough", "thunderwave"],
-                "abilities": ["Prankster"]
             }
         ]
     },
@@ -4979,7 +4974,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"],
+                "movepool": ["drillrun", "ironhead", "knockoff", "megahorn", "swordsdance"],
                 "abilities": ["Overcoat", "Swarm"]
             }
         ]
@@ -5795,7 +5790,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "focusblast", "sludgewave", "toxicspikes"],
+                "movepool": ["dracometeor", "dragontail", "focusblast", "sludgewave", "toxicspikes"],
                 "abilities": ["Adaptability"]
             },
             {

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -636,6 +636,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (species.name === 'Shuckle') return 'Mental Herb';
+		if (species.name === 'Honchkrow') return 'Life Orb';
 		if (ability === 'Harvest' || ability === 'Cheek Pouch') return 'Sitrus Berry';
 		if (species.name === 'Ditto') return 'Choice Scarf';
 		if (ability === 'Poison Heal') return 'Toxic Orb';

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1174,7 +1174,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["aerialace", "aquatail", "defog", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "movepool": ["aerialace", "aquatail", "defog", "earthquake", "roost", "stealthrock", "stoneedge"],
                 "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             },
@@ -2566,12 +2566,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "encore", "roost", "thunderwave", "uturn"],
+                "movepool": ["encore", "roost", "thunderwave", "uturn"],
                 "abilities": ["Prankster"]
             },
             {
                 "role": "Staller",
-                "movepool": ["defog", "encore", "lunge", "roost", "thunderwave"],
+                "movepool": ["encore", "lunge", "roost", "thunderwave"],
                 "abilities": ["Prankster"]
             }
         ]
@@ -2581,7 +2581,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bugbuzz", "defog", "encore", "roost", "thunderwave"],
+                "movepool": ["bugbuzz", "encore", "roost", "thunderwave"],
                 "abilities": ["Prankster"]
             }
         ]
@@ -2965,8 +2965,14 @@
         "level": 82,
         "sets": [
             {
+                "role": "Setup Sweeper",
+                "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"],
+                "abilities": ["Justified"],
+                "preferredTypes": ["Fairy"]
+            },
+            {
                 "role": "Fast Attacker",
-                "movepool": ["irontail", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+                "movepool": ["irontail", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower"],
                 "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
             }
@@ -4240,7 +4246,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+                "movepool": ["defog", "hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -4260,7 +4266,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+                "movepool": ["blizzard", "defog", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
                 "abilities": ["Levitate"]
             },
             {
@@ -5346,7 +5352,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"],
+                "movepool": ["drillrun", "ironhead", "knockoff", "megahorn", "swordsdance"],
                 "abilities": ["Overcoat", "Swarm"]
             }
         ]
@@ -6250,7 +6256,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "focusblast", "sludgewave", "toxicspikes"],
+                "movepool": ["dracometeor", "dragontail", "focusblast", "sludgewave", "toxicspikes"],
                 "abilities": ["Adaptability"]
             },
             {

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -851,6 +851,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (species.name === 'Shuckle') return 'Mental Herb';
+		if (species.name === 'Honchkrow') return 'Life Orb';
 		if (
 			ability === 'Harvest' || ability === 'Cheek Pouch' || (ability === 'Emergency Exit' && !!counter.get('Status'))
 		) return 'Sitrus Berry';

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -1613,17 +1613,32 @@
           },
           {
               "species": "Dragapult",
-              "weight": 20,
+              "weight": 10,
               "moves": [
                   ["Shadow Ball"],
                   ["Draco Meteor"],
                   ["Thunderbolt"],
-                  ["Flamethrower", "U-turn"]
+                  ["Flamethrower"]
               ],
               "item": ["Choice Specs"],
               "nature": "Timid",
               "evs": {"spa": 252, "spd": 4, "spe": 252},
               "teraType": ["Electric", "Fighting", "Fire", "Ghost"],
+              "ability": ["Infiltrator"]
+          },
+          {
+              "species": "Dragapult",
+              "weight": 10,
+              "moves": [
+                  ["Shadow Ball"],
+                  ["Draco Meteor"],
+                  ["Thunderbolt"],
+                  ["U-turn"]
+              ],
+              "item": ["Choice Specs"],
+              "nature": "Timid",
+              "evs": {"spa": 252, "spd": 4, "spe": 252},
+              "teraType": ["Electric", "Fighting", "Ghost"],
               "ability": ["Infiltrator"]
           }
       ]

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -88,13 +88,13 @@
         "sets": [
             {
                 "role": "Choice Item user",
-                "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Psychic", "Psyshock", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Psychic", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Surge Surfer"],
                 "teraTypes": ["Electric", "Fairy", "Fighting", "Grass"]
             },
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Nasty Plot", "Protect", "Psychic", "Psyshock", "Thunderbolt"],
+                "movepool": ["Nasty Plot", "Protect", "Psychic", "Thunderbolt"],
                 "abilities": ["Surge Surfer"],
                 "teraTypes": ["Dark", "Electric", "Flying"]
             }
@@ -383,13 +383,13 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psyshock", "Scald", "Trick Room"],
+                "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psychic", "Scald", "Trick Room"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psyshock", "Scald", "Trick Room"],
+                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Scald", "Trick Room"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Fire", "Water"]
             }
@@ -1204,13 +1204,13 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psyshock", "Scald", "Trick Room"],
+                "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psychic", "Scald", "Trick Room"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Grass", "Steel"]
             },
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psyshock", "Scald", "Trick Room"],
+                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Scald", "Trick Room"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Fire", "Water"]
             }
@@ -1221,7 +1221,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Fire Blast", "Protect", "Psyshock", "Sludge Bomb", "Trick Room"],
+                "movepool": ["Fire Blast", "Protect", "Psychic", "Sludge Bomb", "Trick Room"],
                 "abilities": ["Regenerator"],
                 "teraTypes": ["Dark", "Poison"]
             }
@@ -1658,7 +1658,7 @@
         "sets": [
             {
                 "role": "Choice Item user",
-                "movepool": ["Dazzling Gleam", "Moonblast", "Mystical Fire", "Psychic", "Psyshock", "Trick"],
+                "movepool": ["Dazzling Gleam", "Moonblast", "Mystical Fire", "Psychic", "Trick"],
                 "abilities": ["Trace"],
                 "teraTypes": ["Fairy", "Fire", "Steel"]
             }
@@ -1859,7 +1859,7 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Dazzling Gleam", "Earth Power", "Nasty Plot", "Psychic", "Psyshock"],
+                "movepool": ["Dazzling Gleam", "Earth Power", "Nasty Plot", "Psychic"],
                 "abilities": ["Thick Fat"],
                 "teraTypes": ["Fairy", "Ground"]
             }
@@ -2891,13 +2891,13 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Dazzling Gleam", "Energy Ball", "Fire Blast", "Nasty Plot", "Psychic", "Psyshock", "U-turn"],
+                "movepool": ["Dazzling Gleam", "Energy Ball", "Fire Blast", "Nasty Plot", "Psychic", "U-turn"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Fairy", "Fire"]
             },
             {
                 "role": "Offensive Protect",
-                "movepool": ["Dazzling Gleam", "Fire Blast", "Nasty Plot", "Protect", "Psychic", "Psyshock", "Thunderbolt"],
+                "movepool": ["Dazzling Gleam", "Fire Blast", "Nasty Plot", "Protect", "Psychic", "Thunderbolt"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Fire"]
             }
@@ -4123,7 +4123,7 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Fire Blast", "Heat Wave", "Nasty Plot", "Protect", "Psyshock"],
+                "movepool": ["Fire Blast", "Heat Wave", "Nasty Plot", "Protect", "Psychic"],
                 "abilities": ["Blaze"],
                 "teraTypes": ["Fire"]
             }
@@ -4757,7 +4757,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Hyper Voice", "Instruct", "Psyshock", "Trick Room"],
+                "movepool": ["Hyper Voice", "Instruct", "Psychic", "Trick Room"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Fairy"]
             }
@@ -5605,7 +5605,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Astral Barrage", "Encore", "Nasty Plot", "Pollen Puff", "Protect", "Psyshock"],
+                "movepool": ["Astral Barrage", "Encore", "Nasty Plot", "Pollen Puff", "Protect", "Psychic"],
                 "abilities": ["As One (Spectrier)"],
                 "teraTypes": ["Dark", "Ghost"]
             }
@@ -5912,7 +5912,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Heat Wave", "Psyshock"],
+                "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Heat Wave", "Psychic"],
                 "abilities": ["Flash Fire"],
                 "teraTypes": ["Fighting", "Fire", "Grass"]
             },
@@ -5924,7 +5924,7 @@
             },
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Heat Wave", "Meteor Beam", "Protect", "Psychic", "Psyshock"],
+                "movepool": ["Heat Wave", "Meteor Beam", "Protect", "Psychic"],
                 "abilities": ["Weak Armor"],
                 "teraTypes": ["Dark", "Grass"]
             }
@@ -6288,7 +6288,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Hyper Voice", "Nasty Plot", "Protect", "Psychic", "Psyshock", "Trick Room"],
+                "movepool": ["Hyper Voice", "Nasty Plot", "Protect", "Psychic", "Trick Room"],
                 "abilities": ["Armor Tail"],
                 "teraTypes": ["Fairy"]
             }
@@ -6726,13 +6726,13 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Focus Blast", "Protect", "Psyshock", "Sludge Bomb", "U-turn"],
+                "movepool": ["Focus Blast", "Protect", "Psychic", "Sludge Bomb", "U-turn"],
                 "abilities": ["Toxic Chain"],
                 "teraTypes": ["Fighting", "Poison"]
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Fake Out", "Focus Blast", "Psyshock", "Sludge Bomb", "U-turn"],
+                "movepool": ["Fake Out", "Focus Blast", "Psychic", "Sludge Bomb", "U-turn"],
                 "abilities": ["Toxic Chain"],
                 "teraTypes": ["Fighting", "Poison"]
             }
@@ -6925,19 +6925,19 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Focus Blast", "Protect", "Psychic", "Psyshock", "Tachyon Cutter"],
+                "movepool": ["Focus Blast", "Protect", "Psychic", "Tachyon Cutter"],
                 "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Focus Blast", "Psychic", "Psyshock", "Tachyon Cutter", "Volt Switch"],
+                "movepool": ["Focus Blast", "Psychic", "Tachyon Cutter", "Volt Switch"],
                 "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
-                "movepool": ["Agility", "Focus Blast", "Protect", "Psychic", "Psyshock", "Tachyon Cutter"],
+                "movepool": ["Agility", "Focus Blast", "Protect", "Psychic", "Tachyon Cutter"],
                 "abilities": ["Quark Drive"],
                 "teraTypes": ["Fighting", "Psychic", "Steel"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -745,12 +745,6 @@
         "level": 97,
         "sets": [
             {
-                "role": "Choice Item user",
-                "movepool": ["Transform"],
-                "abilities": ["Imposter"],
-                "teraTypes": ["Bug", "Dark", "Dragon", "Electric", "Fairy", "Fighting", "Fire", "Flying", "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic", "Rock", "Steel", "Water"]
-            },
-            {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Transform"],
                 "abilities": ["Imposter"],
@@ -1879,6 +1873,12 @@
                 "movepool": ["Breaking Swipe", "Earth Power", "Protect", "Tailwind"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Earth Power", "Protect", "Scale Shot", "Tailwind"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -1915,7 +1915,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Close Combat", "Facade", "Knock Off", "Protect", "Quick Attack"],
+                "movepool": ["Close Combat", "Facade", "Feint", "Knock Off", "Protect"],
                 "abilities": ["Toxic Boost"],
                 "teraTypes": ["Normal"]
             }
@@ -2048,7 +2048,7 @@
             },
             {
                 "role": "Doubles Bulky Setup",
-                "movepool": ["Agility", "Brick Break", "Heavy Slam", "Knock Off", "Protect", "Psychic Fangs"],
+                "movepool": ["Agility", "Heavy Slam", "Protect", "Psychic Fangs", "Stomping Tantrum"],
                 "abilities": ["Clear Body"],
                 "teraTypes": ["Dragon"]
             }
@@ -2993,13 +2993,13 @@
             {
                 "role": "Bulky Protect",
                 "movepool": ["Aura Sphere", "Calm Mind", "Protect", "Shadow Ball"],
-                "abilities": ["Telepathy"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fairy", "Fighting"]
             },
             {
                 "role": "Doubles Support",
                 "movepool": ["Breaking Swipe", "Icy Wind", "Rest", "Shadow Ball", "Thunder Wave", "Will-O-Wisp"],
-                "abilities": ["Telepathy"],
+                "abilities": ["Pressure"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -5002,7 +5002,7 @@
                 "role": "Offensive Protect",
                 "movepool": ["Court Change", "Gunk Shot", "High Jump Kick", "Protect", "Pyro Ball", "Sucker Punch", "U-turn"],
                 "abilities": ["Blaze"],
-                "teraTypes": ["Fighting", "Fire", "Poison"]
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -5061,7 +5061,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Fire Blast", "Heat Wave", "Incinerate", "Protect", "Rapid Spin", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
+                "movepool": ["Fire Blast", "Heat Wave", "Incinerate", "Protect", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
                 "abilities": ["Flame Body"],
                 "teraTypes": ["Water"]
             }
@@ -6492,7 +6492,7 @@
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Dragon Dance", "High Horsepower", "Ice Punch", "Protect", "Rock Slide", "Wild Charge"],
                 "abilities": ["Quark Drive"],
-                "teraTypes": ["Grass", "Rock"]
+                "teraTypes": ["Grass"]
             }
         ]
     },
@@ -6563,9 +6563,15 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Body Press", "Protect", "Ruination", "Spikes", "Stealth Rock", "Stomping Tantrum", "Throat Chop"],
+                "movepool": ["Protect", "Ruination", "Stomping Tantrum", "Throat Chop"],
                 "abilities": ["Vessel of Ruin"],
-                "teraTypes": ["Fairy", "Water"]
+                "teraTypes": ["Poison"]
+            },
+            {
+                "role": "Doubles Support",
+                "movepool": ["Spikes", "Stealth Rock", "Stomping Tantrum", "Throat Chop", "Whirlwind"],
+                "abilities": ["Vessel of Ruin"],
+                "teraTypes": ["Poison"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -257,9 +257,9 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Double-Edge", "Gunk Shot", "Knock Off", "Switcheroo", "U-turn"],
+                "movepool": ["Double-Edge", "Knock Off", "Switcheroo", "U-turn"],
                 "abilities": ["Limber"],
-                "teraTypes": ["Normal", "Poison"]
+                "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Fast Attacker",
@@ -485,6 +485,12 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Brave Bird", "Double-Edge", "Drill Run", "Knock Off", "Swords Dance"],
+                "abilities": ["Early Bird"],
+                "teraTypes": ["Flying", "Ground", "Normal"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Brave Bird", "Double-Edge", "Drill Run", "Knock Off", "Quick Attack"],
                 "abilities": ["Early Bird"],
                 "teraTypes": ["Flying", "Ground", "Normal"]
             }
@@ -1070,7 +1076,7 @@
                 "teraTypes": ["Poison", "Steel", "Water"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Knock Off", "Petal Blizzard", "Swords Dance"],
                 "abilities": ["Overgrow"],
                 "teraTypes": ["Ground", "Steel", "Water"]
@@ -2020,7 +2026,13 @@
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Earthquake", "Giga Impact", "Knock Off"],
                 "abilities": ["Truant"],
-                "teraTypes": ["Ghost", "Ground", "Normal"]
+                "teraTypes": ["Normal"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Double-Edge", "Earthquake", "Giga Impact", "Knock Off"],
+                "abilities": ["Truant"],
+                "teraTypes": ["Ghost", "Ground"]
             }
         ]
     },
@@ -2186,9 +2198,15 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dragon Dance", "Earthquake", "Outrage", "Stone Edge", "U-turn"],
+                "movepool": ["Earthquake", "Outrage", "Stone Edge", "U-turn"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Ground", "Rock", "Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Earthquake", "Scale Shot", "Stone Edge"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Dragon", "Ground", "Rock", "Steel"]  
             }
         ]
     },
@@ -2969,7 +2987,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Alluring Voice", "Encore", "Hydro Pump", "Ice Beam", "U-turn"],
+                "movepool": ["Encore", "Hydro Pump", "Ice Beam", "U-turn"],
+                "abilities": ["Storm Drain"],
+                "teraTypes": ["Dragon", "Fire", "Ground", "Steel"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Alluring Voice", "Encore", "Hydro Pump", "Ice Beam"],
                 "abilities": ["Storm Drain"],
                 "teraTypes": ["Fairy", "Water"]
             }
@@ -4161,7 +4185,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Focus Blast", "Psychic", "Psyshock", "Recover", "Shadow Ball"],
+                "movepool": ["Calm Mind", "Focus Blast", "Psychic", "Psyshock", "Recover"],
                 "abilities": ["Magic Guard"],
                 "teraTypes": ["Fighting", "Steel"]
             }
@@ -5323,7 +5347,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Heavy Slam", "Roar", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Earthquake", "Heavy Slam", "Rest", "Roar", "Sleep Talk", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Stamina"],
                 "teraTypes": ["Steel"]
             }
@@ -5531,7 +5555,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Close Combat", "Earthquake", "Flare Blitz", "Knock Off", "Morning Sun", "Psychic Fangs", "Sunsteel Strike"],
+                "movepool": ["Close Combat", "Earthquake", "Knock Off", "Morning Sun", "Psychic Fangs", "Roar", "Sunsteel Strike", "Teleport"],
                 "abilities": ["Full Metal Body"],
                 "teraTypes": ["Water"]
             }
@@ -5542,9 +5566,9 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Moonblast", "Moongeist Beam", "Moonlight"],
+                "movepool": ["Calm Mind", "Focus Blast", "Moonblast", "Moongeist Beam", "Moonlight"],
                 "abilities": ["Shadow Shield"],
-                "teraTypes": ["Fairy"]
+                "teraTypes": ["Fairy", "Fighting"]
             },
             {
                 "role": "Fast Bulky Setup",
@@ -5742,7 +5766,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Dance", "Grav Apple", "Outrage", "Sucker Punch", "U-turn"],
                 "abilities": ["Hustle"],
-                "teraTypes": ["Dragon", "Grass"]
+                "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Tera Blast user",
@@ -5897,12 +5921,6 @@
         "level": 89,
         "sets": [
             {
-                "role": "Tera Blast user",
-                "movepool": ["Alluring Voice", "Calm Mind", "Recover", "Tera Blast"],
-                "abilities": ["Aroma Veil"],
-                "teraTypes": ["Ground"]
-            },
-            {
                 "role": "Bulky Setup",
                 "movepool": ["Acid Armor", "Alluring Voice", "Calm Mind", "Dazzling Gleam", "Recover"],
                 "abilities": ["Aroma Veil"],
@@ -5971,13 +5989,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Belly Drum", "Ice Spinner", "Iron Head", "Liquidation", "Substitute", "Zen Headbutt"],
+                "movepool": ["Belly Drum", "Ice Spinner", "Iron Head", "Liquidation", "Zen Headbutt"],
                 "abilities": ["Ice Face"],
                 "teraTypes": ["Water"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute", "Tera Blast"],
+                "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Tera Blast"],
                 "abilities": ["Ice Face"],
                 "teraTypes": ["Electric", "Ground"]
             }

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1197,7 +1197,6 @@ export class RandomTeams {
 			moves.has('courtchange') ||
 			!isDoubles && (species.id === 'luvdisc' || (species.id === 'terapagos' && !moves.has('rest')))
 		) return 'Heavy-Duty Boots';
-		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 		if (
 			['Cheek Pouch', 'Cud Chew', 'Harvest', 'Ripen'].some(m => ability === m) ||
 			moves.has('bellydrum') || moves.has('filletaway')
@@ -1278,7 +1277,7 @@ export class RandomTeams {
 		if (moves.has('blizzard') && ability !== 'Snow Warning' && !teamDetails.snow) return 'Blunder Policy';
 
 		if (role === 'Choice Item user') {
-			if (scarfReqs || moves.has('finalgambit') || species.id === 'ditto' || species.id === 'jirachi') return 'Choice Scarf';
+			if (scarfReqs || moves.has('finalgambit') || species.id === 'jirachi') return 'Choice Scarf';
 			return (counter.get('Physical') > counter.get('Special')) ? 'Choice Band' : 'Choice Specs';
 		}
 		if (counter.get('Physical') >= moves.size &&
@@ -1538,7 +1537,7 @@ export class RandomTeams {
 		if (['axekick', 'highjumpkick', 'jumpkick', 'supercellslam'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			if ((moves.has('substitute') && ['Sitrus Berry', 'Salac Berry'].includes(item)) || species.id === 'minior') {
+			if ((moves.has('substitute') && ['Sitrus Berry'].includes(item)) || species.id === 'minior') {
 				// Two Substitutes should activate Sitrus Berry. Two switch-ins to Stealth Rock should activate Shields Down on Minior.
 				if (hp % 4 === 0) break;
 			} else if (

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -4,7 +4,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Brick Break", "Double-Edge", "Fake Out", "Fire Punch", "Gunk Shot", "Knock Off", "U-turn"],
+                "movepool": ["Brick Break", "Double-Edge", "Fake Out", "Knock Off", "U-turn"],
                 "abilities": ["Pickup"],
                 "teraTypes": ["Normal"]
             }
@@ -256,9 +256,9 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Ice Shard", "Icicle Spear", "Knock Off", "Liquidation", "Yawn"],
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Spear", "Knock Off", "Yawn"],
                 "abilities": ["Thick Fat"],
-                "teraTypes": ["Ground", "Water"]
+                "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
@@ -354,12 +354,6 @@
                 "movepool": ["Discharge", "Ice Beam", "Scald", "Thunder Wave", "Volt Switch"],
                 "abilities": ["Volt Absorb"],
                 "teraTypes": ["Flying", "Water"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Discharge", "Flip Turn", "Scald", "Volt Switch"],
-                "abilities": ["Volt Absorb"],
-                "teraTypes": ["Flying"]
             }
         ]
     },
@@ -370,7 +364,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Knock Off", "Psychic", "Recover", "Thunder Wave"],
                 "abilities": ["Levitate"],
-                "teraTypes": ["Fairy", "Steel"]
+                "teraTypes": ["Dark", "Fairy", "Steel"]
             },
             {
                 "role": "Bulky Setup",
@@ -689,19 +683,19 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Coil", "Earthquake", "Roost"],
                 "abilities": ["Serene Grace"],
-                "teraTypes": ["Ground", "Poison"]
+                "teraTypes": ["Ghost", "Ground", "Poison"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
                 "abilities": ["Serene Grace"],
-                "teraTypes": ["Ghost", "Ground"]
+                "teraTypes": ["Ghost", "Ground", "Poison"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Hyper Voice", "Roost", "Shadow Ball"],
                 "abilities": ["Rattled"],
-                "teraTypes": ["Fairy", "Ghost"]
+                "teraTypes": ["Ghost", "Ground", "Poison"]
             }
         ]
     },
@@ -752,7 +746,7 @@
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Protect", "Tera Blast", "Wish"],
                 "abilities": ["Adaptability"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -769,7 +763,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Coil", "Earthquake", "Gunk Shot", "Trailblaze"],
                 "abilities": ["Intimidate"],
-                "teraTypes": ["Dark", "Grass", "Ground"]
+                "teraTypes": ["Grass", "Ground"]
             }
         ]
     },
@@ -795,9 +789,15 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Dark Pulse", "Nasty Plot", "Psychic", "Thunder Wave", "Thunderbolt", "Trick"],
+                "movepool": ["Dark Pulse", "Play Rough", "Psychic", "Thunder Wave", "Thunderbolt", "Trick"],
                 "abilities": ["Infiltrator"],
-                "teraTypes": ["Dark", "Electric", "Psychic"]
+                "teraTypes": ["Fairy"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dark Pulse", "Nasty Plot", "Psychic", "Tera Blast"],
+                "abilities": ["Infiltrator"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -1204,7 +1204,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Flamethrower", "Morning Sun", "Roar", "Wild Charge", "Will-O-Wisp"],
                 "abilities": ["Intimidate"],
-                "teraTypes": ["Dragon", "Fairy", "Fighting"]
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -1697,7 +1697,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Double-Edge", "Fake Out", "Knock Off", "Play Rough", "Thunder Wave", "U-turn"],
+                "movepool": ["Double-Edge", "Fake Out", "Knock Off", "Thunder Wave", "U-turn"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Normal"]
             }
@@ -1951,7 +1951,7 @@
                 "role": "Fast Support",
                 "movepool": ["Discharge", "Encore", "Nuzzle", "Play Rough", "Super Fang", "Thief", "Volt Switch"],
                 "abilities": ["Natural Cure", "Static"],
-                "teraTypes": ["Electric", "Fairy", "Grass"]
+                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -2364,7 +2364,7 @@
                 "role": "Wallbreaker",
                 "movepool": ["Flare Blitz", "Gunk Shot", "High Jump Kick", "Sucker Punch", "U-turn"],
                 "abilities": ["Libero"],
-                "teraTypes": ["Fighting", "Fire"]
+                "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Attacker",
@@ -2491,7 +2491,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earth Power", "Flash Cannon", "Ice Beam", "Rock Blast", "Stealth Rock"],
+                "movepool": ["Earth Power", "Flamethrower", "Flash Cannon", "Rock Blast", "Stealth Rock"],
                 "abilities": ["Sturdy"],
                 "teraTypes": ["Fairy", "Flying", "Ground"]
             }
@@ -2867,7 +2867,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Double-Edge", "Earthquake", "Hypnosis", "Megahorn", "Shadow Ball", "Thunder Wave", "Trick"],
                 "abilities": ["Intimidate"],
-                "teraTypes": ["Bug", "Ghost", "Ground"]
+                "teraTypes": ["Ground"]
             },
             {
                 "role": "Tera Blast user",
@@ -3305,15 +3305,9 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Earthquake", "Liquidation", "Recover", "Spikes", "Stealth Rock"],
+                "role": "Bulky Attacker",
+                "movepool": ["Curse", "Earthquake", "Recover", "Spikes", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Unaware", "Water Absorb"],
-                "teraTypes": ["Poison", "Steel"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Curse", "Earthquake", "Liquidation", "Recover"],
-                "abilities": ["Unaware"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -3322,14 +3316,8 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover"],
-                "abilities": ["Unaware", "Water Absorb"],
-                "teraTypes": ["Flying", "Steel"]
-            },
-            {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Spikes", "Stealth Rock", "Toxic Spikes"],
+                "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Spikes", "Stealth Rock", "Toxic Spikes"],
                 "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Flying", "Steel"]
             }

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -146,7 +146,10 @@ export class RandomBabyTeams extends RandomTeams {
 				['alluringvoice', 'dazzlinggleam', 'drainingkiss', 'moonblast'],
 				['alluringvoice', 'dazzlinggleam', 'drainingkiss', 'moonblast'],
 			],
-			[['bulletseed', 'gigadrain', 'leafstorm', 'seedbomb'], ['bulletseed', 'gigadrain', 'leafstorm', 'seedbomb']],
+			[
+				['bulletseed', 'gigadrain', 'leafstorm', 'powerwhip', 'seedbomb'],
+				['bulletseed', 'gigadrain', 'leafstorm', 'seedbomb'],
+			],
 			[['hypnosis', 'thunderwave', 'toxic', 'willowisp', 'yawn'], ['hypnosis', 'thunderwave', 'toxic', 'willowisp', 'yawn']],
 			['roar', 'yawn'],
 			['dragonclaw', 'outrage'],


### PR DESCRIPTION
**Gen 9 Random Battle:**
-Substitute and Salac Berry have been removed from all Eiscue sets entirely.
-Tera Blast Alcremie has been removed. It is now entirely Acid Armor. I'm sorry.
-Flygon's set has been split between Dragon Dance and Choice items. Dragon Dance now runs Loaded Dice + Scale Shot instead of Lum Berry + Outrage. Tera Dragon now also exists on Dragon Dance.
-Dodrio now has a second set with Choice Band and the chance for Quick Attack.
-Lumineon's set has been split such that Boots runs various defensive teras, Life Orb runs Water/Fairy teras, and Choice Specs no longer exists.
-Slaking's set has been split so that Choice Band is more common than Choice Scarf and Choice Scarf will only be Tera Normal.
-Swords Dance Meganium's role has been changed to Bulky Setup to give it Leftovers instead of Life Orb
-Bulky Attacker Solgaleo: -Flare Blitz, +Roar, +Teleport
-Mudsdale: +Rest, +Sleep Talk
-Bulky Setup Lunala: +Focus Blast, +Tera Fighting
-Persian: -Tera Poison, -Gunk Shot, +Tera Ghost
-Reuniclus: -Shadow Ball
-Flapple: -Tera Grass, +Tera Steel

**Gen 9 Random Doubles**:
-Psyshock has been obliterated from the format and replaced with Psychic when needed to better combat IronPress mons. Choice Indeedee-M still has Psyshock, since it's also got Expanding Force.
-Choice Scarf Ditto has been removed.
-Flygon now has a second set with Scale Shot over Breaking Swipe. That set runs Loaded Dice.
-Ting-Lu now has two sets: one with Ruination and Protect, and one with an entry hazard and Whirlwind. Body Press no longer exists on it, and it always runs Tera Poison.
-Coalossal: -Rapid Spin (and Boots)
-Zangoose: -Quick Attack, +Feint
-Giratina: -Telepathy, +Pressure
-Agility Metagross: -Brick Break, -Knock Off, +Stomping Tantrum
-Iron Thorns: -Tera Rock
-Cinderace: -Tera Fire, -Tera Poison

**Gen 9 Baby Random Battle**:
-Espurr now has a third set of Tera Blast Fighting Nasty Plot, and its Fast Support set no longer runs Nasty Plot and now runs Play Rough with only Tera Fairy.
-Wooper's sets have been merged together. Liquidation has been replaced with Stone Edge.
-Paldean Wooper's sets have been merged together.
-Fast Support Chinchou no longer exists.
-Power Whip will no longer generate with Giga Drain on anything with both.
-All of Dunsparce's sets are now a roll between Tera Ghost/Ground/Poison.
-Aipom: -Fire Punch, -Gunk Shot
-Meowth: -Play Rough
-Cetoddle: -Liquidation, -Tera Water
-Shieldon: -Ice Beam, +Flamethrower
-Bulky Support Chingling: +Tera Dark
-Growlithe: -all teras other than Fighting (forces Close Combat)
-Tera Blast Eevee: -Tera Ghost, +Tera Fairy
-Wallbreaker Scorbunny: -Tera Fire
-Trailblaze Ekans: -Tera Dark
-Pawmi: -all teras other than Fairy (forces Play Rough)
-Stantler: -all teras other than Ground (forces Earthquake)

**Gen 9 BSS Factory**:
-Dragapult no longer runs Tera Fire without a fire move.
-Cloyster no longer runs Tera Blast Ghost.

**Old Gens**:
-In Gens 4-7, Aerodactyl no longer runs Pursuit.
-In Gens 4-7, Honchkrow now runs Life Orb always instead of having a chance to get Choice Band.
-In Gens 6-7, Escavalier no longer runs Pursuit.
-In Gens 6-7, Bulky Attacker Dragalge can now run Dragon Tail and Assault Vest.
-In Gen 7, Volbeat and Illumise no longer run Defog.
-In Gen 7, Rotom-Heat and Rotom-Frost can now run Defog.
-In Gen 7, Mega Absol no longer gets Iron Tail with Swords Dance.
-In Gens 5-6, Torkoal now runs Shell Armor instead of White Smoke.
-In Gen 6, offensive Liepard no longer exists.
-In Gen 3, the SubPunch Aggron set no longer runs Double-Edge or Earthquake
-In Gen 3, Golem no longer runs HP Bug.
-In Gen 3, Sudowoodo now has a second set with SubPunch and no longer runs Brick Break on its other set.