### PR TITLE
Gen 1 Random Battle updates

### DIFF
--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -106,7 +106,7 @@
     "pikachu": {
         "level": 87,
         "moves": ["surf", "thunderbolt", "thunderwave"],
-        "exclusiveMoves": ["agility", "bodyslam", "seismictoss", "seismictoss", "thunder"]
+        "exclusiveMoves": ["agility", "bodyslam", "seismictoss", "seismictoss"]
     },
     "raichu": {
         "level": 74,
@@ -148,9 +148,8 @@
     },
     "nidoking": {
         "level": 74,
-        "moves": ["rockslide", "thunderbolt", "thunderbolt"],
-        "essentialMoves": ["blizzard", "earthquake"],
-        "exclusiveMoves": ["bodyslam", "bodyslam", "substitute"]
+        "moves": ["blizzard", "earthquake", "thunderbolt"],
+        "exclusiveMoves": ["bodyslam", "rockslide", "substitute"]
     },
     "clefairy": {
         "level": 88,
@@ -341,7 +340,7 @@
     "tentacool": {
         "level": 86,
         "moves": ["blizzard", "megadrain", "surf"],
-        "exclusiveMoves": ["barrier", "hydropump", "hydropump"]
+        "exclusiveMoves": ["hydropump", "hydropump", "substitute"]
     },
     "tentacruel": {
         "level": 73,
@@ -433,18 +432,18 @@
     },
     "gastly": {
         "level": 83,
-        "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
-        "essentialMoves": ["thunderbolt", "hypnosis"]
+        "moves": ["hypnosis", "psychic", "thunderbolt"],
+        "exclusiveMoves": ["explosion", "explosion", "megadrain", "nightshade"]
     },
     "haunter": {
         "level": 74,
-        "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
-        "essentialMoves": ["thunderbolt", "hypnosis"]
+        "moves": ["hypnosis", "psychic", "thunderbolt"],
+        "exclusiveMoves": ["explosion", "explosion", "megadrain", "nightshade"]
     },
     "gengar": {
         "level": 68,
-        "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
-        "essentialMoves": ["thunderbolt", "hypnosis"]
+        "moves": ["hypnosis", "psychic", "thunderbolt"],
+        "exclusiveMoves": ["explosion", "explosion", "megadrain", "nightshade"]
     },
     "onix": {
         "level": 80,
@@ -535,7 +534,7 @@
     "tangela": {
         "level": 74,
         "moves": ["bodyslam", "megadrain", "sleeppowder"],
-        "exclusiveMoves": ["growth", "stunspore", "stunspore", "stunspore", "swordsdance", "swordsdance"]
+        "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "kangaskhan": {
         "level": 73,
@@ -550,7 +549,7 @@
     "seadra": {
         "level": 77,
         "moves": ["agility", "blizzard", "surf"],
-        "exclusiveMoves": ["doubleedge", "hydropump", "hyperbeam", "smokescreen"]
+        "exclusiveMoves": ["doubleedge", "hydropump", "hyperbeam", "rest", "smokescreen"]
     },
     "goldeen": {
         "level": 88,
@@ -569,8 +568,8 @@
     },
     "starmie": {
         "level": 68,
-        "moves": ["blizzard", "psychic", "thunderbolt", "thunderwave", "thunderwave"],
-        "essentialMoves": ["recover"],
+        "moves": ["blizzard", "psychic", "thunderbolt"],
+        "essentialMoves": ["recover", "thunderwave"],
         "exclusiveMoves": ["hydropump", "psychic", "surf", "surf"]
     },
     "mrmime": {

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -553,6 +553,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (species.id === 'ditto' || (species.id === 'rampardos' && role === 'Fast Attacker')) return 'Choice Scarf';
+		if (species.id === 'honchkrow') return 'Life Orb';
 		if (ability === 'Poison Heal' || moves.has('facade')) return 'Toxic Orb';
 		if (ability === 'Speed Boost' && species.id === 'yanmega') return 'Life Orb';
 		if (['healingwish', 'switcheroo', 'trick'].some(m => moves.has(m))) {

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -3316,7 +3316,7 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Spikes", "Stealth Rock", "Toxic Spikes"],
                 "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Flying", "Steel"]


### PR DESCRIPTION
This updates a few sets in Gen 1 Random Battle:
- Pikachu no longer has Thunder as a possible 4th move
- Nidoking will always have Thunderbolt
- Tentacool no longer rolls Barrier and can now obtain Substitute
- Gastly, Haunter, and Gengar will always have Psychic
- Tangela no longer runs Growth
- Seadra can now roll Rest as a possible 4th move
- Starmie will always have Thunder Wave

Also, fixes two small oversights in https://github.com/smogon/pokemon-showdown/pull/11156: Wooper-Paldea will always have Poison STAB in Gen 9 Baby Random Battle, and Honchkrow no longer gets Choice Band in Gen 4 Random Battle.