### PR TITLE
Fix Fusion Evolution Random Battle

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -356,7 +356,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 	{
 		section: "Pet Mods",
 	},
-	/* {
+	{
 		name: "[Gen 9] Fusion Evolution Random Battle",
 		desc: "A random battle format featuring Fakemon created by fusing together the stats, types, and abilities of two Pokemon.",
 		mod: 'gen9fe',
@@ -376,7 +376,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 				this.add('-start', pokemon, 'typechange', (pokemon.illusion || pokemon).getTypes(true).join('/'), '[silent]');
 			}
 		},
-	}, */
+	},
 	{
 		name: "[Gen 9] CCAPM 2024 Random Battle",
 		desc: "A random battle format featuring Fakemon created during the Community Create-A-Pet Mod event in the Pet Mods room in 2024.",

--- a/data/mods/gen9fe/scripts.ts
+++ b/data/mods/gen9fe/scripts.ts
@@ -519,7 +519,9 @@ export const Scripts: ModdedBattleScriptsData = {
 		}, */
 	},
 	pokemon: {
-		runImmunity(type: string, message?: string | boolean) {
+		runImmunity(source: ActiveMove | string, message?: string | boolean) {
+			if (!source) return true;
+			const type: string = typeof source !== 'string' ? source.type : source;
 			if (!type || type === '???') return true;
 			if (!this.battle.dex.types.isName(type)) {
 				throw new Error("Use runStatusImmunity for " + type);


### PR DESCRIPTION
Type signature of runImmunity was different than it should be, causing variables to have unexpected types.