### PR TITLE
Dex-Data: Prevent isName crash on non-string args

### DIFF
--- a/data/mods/thecardgame/scripts.ts
+++ b/data/mods/thecardgame/scripts.ts
@@ -115,7 +115,9 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			return false;
 		},
-		runImmunity(type, message) {
+		runImmunity(source: ActiveMove | string, message?: string | boolean) {
+			if (!source) return true;
+			const type: string = typeof source !== 'string' ? source.type : source;
 			if (!type || type === '???') return true;
 			if (!this.battle.dex.types.isName(type)) {
 				throw new Error("Use runStatusImmunity for " + type);

--- a/data/mods/thecardgame/scripts.ts
+++ b/data/mods/thecardgame/scripts.ts
@@ -115,7 +115,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			return false;
 		},
-		runImmunity(source: ActiveMove | string, message?: string | boolean) {
+		runImmunity(source, message) {
 			if (!source) return true;
 			const type: string = typeof source !== 'string' ? source.type : source;
 			if (!type || type === '???') return true;

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -317,7 +317,7 @@ export class DexTypes {
 	}
 
 	isName(name: string): boolean {
-		if (typeof name !== 'string') return false;
+		if (name === null || name === undefined) return false;
 		const id = name.toLowerCase();
 		const typeName = id.charAt(0).toUpperCase() + id.substr(1);
 		return name === typeName && this.dex.data.TypeChart.hasOwnProperty(id);

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -317,6 +317,7 @@ export class DexTypes {
 	}
 
 	isName(name: string): boolean {
+		if (typeof name !== 'string') return false;
 		const id = name.toLowerCase();
 		const typeName = id.charAt(0).toUpperCase() + id.substr(1);
 		return name === typeName && this.dex.data.TypeChart.hasOwnProperty(id);

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -317,7 +317,7 @@ export class DexTypes {
 	}
 
 	isName(name: string): boolean {
-		if (name === null || name === undefined) return false;
+		if (!name) return false;
 		const id = name.toLowerCase();
 		const typeName = id.charAt(0).toUpperCase() + id.substr(1);
 		return name === typeName && this.dex.data.TypeChart.hasOwnProperty(id);

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -99,14 +99,13 @@ describe('DexTypes#isName', () => {
 	});
 
 	it('should return false for invalid type names', () => {
-		assert.equal(Dex.types.isName('fire'), false); // lowercase
-		assert.equal(Dex.types.isName('FIRE'), false); // uppercase
-		assert.equal(Dex.types.isName('Unknown'), false); // non-existent type
-		assert.equal(Dex.types.isName(''), false); // empty string
+		assert.equal(Dex.types.isName('fire'), false);
+		assert.equal(Dex.types.isName('FIRE'), false);
+		assert.equal(Dex.types.isName('Unknown'), false);
+		assert.equal(Dex.types.isName(''), false);
 	});
 
 	it('should handle non-string inputs without crashing', () => {
-		// This is the key test for our fix
 		assert.equal(Dex.types.isName(undefined), false);
 		assert.equal(Dex.types.isName(null), false);
 		assert.equal(Dex.types.isName(123), false);
@@ -119,11 +118,9 @@ describe('DexTypes#isName', () => {
 
 	it('should work properly in the Card Game mod context', () => {
 		const cardGameDex = Dex.mod('thecardgame');
-		// Test valid types for the card game mod
 		assert.equal(cardGameDex.types.isName('Fire'), true);
 		assert.equal(cardGameDex.types.isName('Water'), true);
 
-		// Test non-string inputs in card game mod
 		assert.equal(cardGameDex.types.isName(undefined), false);
 		assert.equal(cardGameDex.types.isName(null), false);
 		assert.equal(cardGameDex.types.isName({}), false);

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -109,23 +109,4 @@ describe('DexTypes#isName', () => {
 		assert.equal(Dex.types.isName(undefined), false);
 		assert.equal(Dex.types.isName(null), false);
 	});
-
-	it('should throw for non-string inputs (except null/undefined)', () => {
-		assert.throws(() => Dex.types.isName(123));
-		assert.throws(() => Dex.types.isName({}));
-		assert.throws(() => Dex.types.isName([]));
-		assert.throws(() => Dex.types.isName(true));
-		assert.throws(() => Dex.types.isName(false));
-		assert.throws(() => Dex.types.isName(() => {}));
-	});
-
-	it('should work properly in the Card Game mod context', () => {
-		const cardGameDex = Dex.mod('thecardgame');
-		assert.equal(cardGameDex.types.isName('Fire'), true);
-		assert.equal(cardGameDex.types.isName('Water'), true);
-
-		assert.equal(cardGameDex.types.isName(undefined), false);
-		assert.equal(cardGameDex.types.isName(null), false);
-		assert.throws(() => cardGameDex.types.isName({}));
-	});
 });

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -88,3 +88,44 @@ describe('Dex#getMove', () => {
 		assert.equal(Dex.forGen(8).moves.get('G-Max Befuddle').isNonstandard, "Gigantamax");
 	});
 });
+
+describe('DexTypes#isName', () => {
+	it('should return true for valid type names', () => {
+		assert.equal(Dex.types.isName('Fire'), true);
+		assert.equal(Dex.types.isName('Water'), true);
+		assert.equal(Dex.types.isName('Psychic'), true);
+		assert.equal(Dex.types.isName('Fighting'), true);
+		assert.equal(Dex.types.isName('Normal'), true);
+	});
+
+	it('should return false for invalid type names', () => {
+		assert.equal(Dex.types.isName('fire'), false); // lowercase
+		assert.equal(Dex.types.isName('FIRE'), false); // uppercase
+		assert.equal(Dex.types.isName('Unknown'), false); // non-existent type
+		assert.equal(Dex.types.isName(''), false); // empty string
+	});
+
+	it('should handle non-string inputs without crashing', () => {
+		// This is the key test for our fix
+		assert.equal(Dex.types.isName(undefined), false);
+		assert.equal(Dex.types.isName(null), false);
+		assert.equal(Dex.types.isName(123), false);
+		assert.equal(Dex.types.isName({}), false);
+		assert.equal(Dex.types.isName([]), false);
+		assert.equal(Dex.types.isName(true), false);
+		assert.equal(Dex.types.isName(false), false);
+		assert.equal(Dex.types.isName(() => {}), false);
+	});
+
+	it('should work properly in the Card Game mod context', () => {
+		const cardGameDex = Dex.mod('thecardgame');
+		// Test valid types for the card game mod
+		assert.equal(cardGameDex.types.isName('Fire'), true);
+		assert.equal(cardGameDex.types.isName('Water'), true);
+
+		// Test non-string inputs in card game mod
+		assert.equal(cardGameDex.types.isName(undefined), false);
+		assert.equal(cardGameDex.types.isName(null), false);
+		assert.equal(cardGameDex.types.isName({}), false);
+	});
+});

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -105,15 +105,18 @@ describe('DexTypes#isName', () => {
 		assert.equal(Dex.types.isName(''), false);
 	});
 
-	it('should handle non-string inputs without crashing', () => {
+	it('should return false for null and undefined', () => {
 		assert.equal(Dex.types.isName(undefined), false);
 		assert.equal(Dex.types.isName(null), false);
-		assert.equal(Dex.types.isName(123), false);
-		assert.equal(Dex.types.isName({}), false);
-		assert.equal(Dex.types.isName([]), false);
-		assert.equal(Dex.types.isName(true), false);
-		assert.equal(Dex.types.isName(false), false);
-		assert.equal(Dex.types.isName(() => {}), false);
+	});
+
+	it('should throw for non-string inputs (except null/undefined)', () => {
+		assert.throws(() => Dex.types.isName(123));
+		assert.throws(() => Dex.types.isName({}));
+		assert.throws(() => Dex.types.isName([]));
+		assert.throws(() => Dex.types.isName(true));
+		assert.throws(() => Dex.types.isName(false));
+		assert.throws(() => Dex.types.isName(() => {}));
 	});
 
 	it('should work properly in the Card Game mod context', () => {
@@ -123,6 +126,6 @@ describe('DexTypes#isName', () => {
 
 		assert.equal(cardGameDex.types.isName(undefined), false);
 		assert.equal(cardGameDex.types.isName(null), false);
-		assert.equal(cardGameDex.types.isName({}), false);
+		assert.throws(() => cardGameDex.types.isName({}));
 	});
 });


### PR DESCRIPTION
This PR fixes a crash that occurs during battles in The Card Game mod when checking type immunities.