### PR TITLE
SSB: Fix crash when Hot Pursuit triggers with no foes

### DIFF
--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -2094,15 +2094,16 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		condition: {
 			duration: 1,
 			onBeforeSwitchOut(pokemon) {
-				const move = this.queue.willMove(pokemon.foes()[0]);
+				const foe = pokemon.foes()[0];
+				const move = foe ? this.queue.willMove(foe) : null;
 				const moveName = move && move.moveid ? move.moveid.toString() : "";
 				this.debug('Pursuit start');
 				let alreadyAdded = false;
 				pokemon.removeVolatile('destinybond');
 				for (const source of this.effectState.sources) {
 					if (!source.isAdjacent(pokemon) || !this.queue.cancelMove(source) || !source.hp) continue;
-					if (!alreadyAdded) {
-						this.add('-activate', pokemon.foes()[0], 'ability: Hot Pursuit');
+					if (!alreadyAdded && foe) {
+						this.add('-activate', foe, 'ability: Hot Pursuit');
 						alreadyAdded = true;
 					}
 					// Run through each action in queue to check if the Pursuit user is supposed to Mega Evolve this turn.


### PR DESCRIPTION
Fixes a crash in the gen9ssb mod where the Hot Pursuit ability would throw a TypeError when trying to access properties of an undefined Pokémon.