### PR TITLE
SV OU: Add Evasion Abilities Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -71,8 +71,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 	{
 		name: "[Gen 9] OU",
 		mod: 'gen9',
-		ruleset: ['Standard', 'Sleep Moves Clause', '!Sleep Clause Mod'],
-		banlist: ['Uber', 'AG', 'Arena Trap', 'Moody', 'Sand Veil', 'Shadow Tag', 'Snow Cloak', 'King\'s Rock', 'Razor Fang', 'Baton Pass', 'Last Respects', 'Shed Tail'],
+		ruleset: ['Standard', 'Evasion Abilities Clause', 'Sleep Moves Clause', '!Sleep Clause Mod'],
+		banlist: ['Uber', 'AG', 'Arena Trap', 'Moody', 'Shadow Tag', 'King\'s Rock', 'Razor Fang', 'Baton Pass', 'Last Respects', 'Shed Tail'],
 	},
 	{
 		name: "[Gen 9] Ubers",


### PR DESCRIPTION
Replaces the manual bans of Snow Cloak and Sand Veil with Evasion Abilities Clause. There is no actual impact on legality, this is a consistency change. This change is approved by star and finch:

starmaster — 10:32 AM
we did literally create it for ou
so idk why that is
it should just have the clause
UT ⛵ — 10:35 AM
@Finch do you mind if I submit a pull request to remove Sand Veil + Snow Cloak bans from OU and replace it with Evasion Abilities Clause? This should have absolutely no change on the tier and is a backend consistency thing Finch — 10:36 AM
@Ruft good with you? Checks out to me