### PR TITLE
Gen9FE: Fix Serene Sync crash with onHit effects

### DIFF
--- a/data/mods/gen9fe/abilities.ts
+++ b/data/mods/gen9fe/abilities.ts
@@ -3535,7 +3535,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 
 			for (const secondary of secondaries) {
 				const selfEffect: AnyObject = {};
-				
+		
 				for (const prop of copyProps) {
 					if (secondary[prop] !== undefined) {
 						selfEffect[prop] = secondary[prop];

--- a/data/mods/gen9fe/abilities.ts
+++ b/data/mods/gen9fe/abilities.ts
@@ -3521,18 +3521,26 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	serenesync: {
 		shortDesc: "Secondaries against this Pokemon also proc against the attacker",
 		onModifySecondaries(secondaries) {
+			const copyProps = [
+				'onHit',
+				'boosts',
+				'status',
+				'volatileStatus',
+				'sideCondition',
+				'slotCondition',
+				'pseudoWeather',
+				'terrain',
+				'weather',
+			] as const;
+
 			for (const secondary of secondaries) {
 				const selfEffect: AnyObject = {};
-
-				if (secondary.onHit) selfEffect.onHit = secondary.onHit;
-				if (secondary.boosts) selfEffect.boosts = secondary.boosts;
-				if (secondary.status) selfEffect.status = secondary.status;
-				if (secondary.volatileStatus) selfEffect.volatileStatus = secondary.volatileStatus;
-				if (secondary.sideCondition) selfEffect.sideCondition = secondary.sideCondition;
-				if (secondary.slotCondition) selfEffect.slotCondition = secondary.slotCondition;
-				if (secondary.pseudoWeather) selfEffect.pseudoWeather = secondary.pseudoWeather;
-				if (secondary.terrain) selfEffect.terrain = secondary.terrain;
-				if (secondary.weather) selfEffect.weather = secondary.weather;
+				
+				for (const prop of copyProps) {
+					if (secondary[prop] !== undefined) {
+						selfEffect[prop] = secondary[prop];
+					}
+				}
 
 				if (Object.keys(selfEffect).length > 0) {
 					secondary.self = selfEffect;

--- a/data/mods/gen9fe/abilities.ts
+++ b/data/mods/gen9fe/abilities.ts
@@ -3535,7 +3535,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 
 			for (const secondary of secondaries) {
 				const selfEffect: AnyObject = {};
-		
+
 				for (const prop of copyProps) {
 					if (secondary[prop] !== undefined) {
 						selfEffect[prop] = secondary[prop];

--- a/data/mods/gen9fe/abilities.ts
+++ b/data/mods/gen9fe/abilities.ts
@@ -3522,13 +3522,20 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		shortDesc: "Secondaries against this Pokemon also proc against the attacker",
 		onModifySecondaries(secondaries) {
 			for (const secondary of secondaries) {
-				secondary.self ||= {};
-				for (const i in secondary) {
-					if (!['self', 'chance'].includes(i)) {
-						const secClone = structuredClone(secondary);
-						secClone.self = undefined;
-						secondary.self = secClone;
-					}
+				const selfEffect: AnyObject = {};
+
+				if (secondary.onHit) selfEffect.onHit = secondary.onHit;
+				if (secondary.boosts) selfEffect.boosts = secondary.boosts;
+				if (secondary.status) selfEffect.status = secondary.status;
+				if (secondary.volatileStatus) selfEffect.volatileStatus = secondary.volatileStatus;
+				if (secondary.sideCondition) selfEffect.sideCondition = secondary.sideCondition;
+				if (secondary.slotCondition) selfEffect.slotCondition = secondary.slotCondition;
+				if (secondary.pseudoWeather) selfEffect.pseudoWeather = secondary.pseudoWeather;
+				if (secondary.terrain) selfEffect.terrain = secondary.terrain;
+				if (secondary.weather) selfEffect.weather = secondary.weather;
+
+				if (Object.keys(selfEffect).length > 0) {
+					secondary.self = selfEffect;
 				}
 			}
 		},

--- a/data/mods/gen9fe/abilities.ts
+++ b/data/mods/gen9fe/abilities.ts
@@ -3542,7 +3542,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 					}
 				}
 
-				if (Object.keys(selfEffect).length > 0) {
+				if (Object.keys(selfEffect).length) {
 					secondary.self = selfEffect;
 				}
 			}


### PR DESCRIPTION
Fixes a DataCloneError that caused battles to crash when moves with `onHit` functions (like Anchor Shot) were used against Pokémon with the Serene Sync ability.

## The Problem
The Serene Sync ability tries to copy secondary effects to also apply to the attacker. However, it was using `structuredClone()` which cannot clone functions, causing a DataCloneError when moves had `onHit` callbacks.

## The Solution
Replaced `structuredClone()` with manual property copying that preserves functions by reference. The ability now explicitly copies effect properties (onHit, boosts, status, etc.) while excluding meta properties like 'self' and 'chance'.

## Testing
Tested with various moves including:
- Anchor Shot (onHit that adds trapped volatile) - previously crashed, now works
- Moves with stat drops, status effects, and self-boosts - all working correctly

The fix preserves the original functionality while preventing the crash.