### PR TITLE
Update /help othermetas

### DIFF
--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -74,8 +74,11 @@ export const commands: Chat.ChatCommands = {
 		return this.run('formathelp');
 	},
 	othermetashelp: [
-		`/om - Provides links to information on the Other Metagames.`,
-		`!om - Show everyone that information. Requires: + % @ # ~`,
+		`/om - Provides a link to the Other Metagames Smogon forum.`,
+		`!om - Shows to other users a link to the Other Metagames Smogon forum. Requires: + % @ # ~`,
+		`/om all - Provides links to information on all ladderable Other Metagames.`,
+		`/om month - Provides links to information on Other Metagames of the month.`,
+		`!om month - Shows to other users links to information on Other Metagames of the month. Requires: + % @ # ~`,
 	],
 
 	mnm: 'mixandmega',


### PR DESCRIPTION
Approved Forum suggestion: https://www.smogon.com/forums/threads/make-the-om-help-command-more-helpful.3766005/

the /om is a bit weird, it's just a link to the forums not a link to direct information like /om all does, so I changed the wording there. !om is also changed since it's not descriptive.