### PR TITLE
Mafia: Fix crash when distributing roles with insufficient roles

### DIFF
--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -736,9 +736,15 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 
 	distributeRoles() {
 		const roles = Utils.shuffle(this.roles.slice());
+		if (roles.length < this.players.length) {
+			throw new Chat.ErrorMessage(`Not enough roles for all players. Have ${roles.length} roles but ${this.players.length} players.`);
+		}
 		if (roles.length) {
 			for (const p of this.players) {
-				const role = roles.shift()!;
+				const role = roles.shift();
+				if (!role) {
+					throw new Chat.ErrorMessage(`Failed to distribute roles: ran out of roles.`);
+				}
 				p.role = role;
 				const u = Users.get(p.id);
 				p.revealed = '';

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -742,9 +742,7 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 		if (roles.length) {
 			for (const p of this.players) {
 				const role = roles.shift();
-				if (!role) {
-					throw new Chat.ErrorMessage(`Failed to distribute roles: ran out of roles.`);
-				}
+				if (!role) throw new Error(`Ran out of roles.`);
 				p.role = role;
 				const u = Users.get(p.id);
 				p.revealed = '';


### PR DESCRIPTION
This happened because the code used `roles.shift()!` with a non-null assertion operator, assuming there would always be enough roles. When the roles array was exhausted, `shift()` would return `undefined`, causing the crash when trying to access `role.safeName`.

## Solution
Added validation to ensure there are enough roles for all players before attempting distribution. The fix:
1. Checks if `roles.length < this.players.length` and throws a clear error message if insufficient
2. Removes the unsafe non-null assertion operator from `roles.shift()!`
3. Adds a runtime check to handle the edge case where `shift()` returns undefined