### PR TITLE
Mafia: Fix IDEA games broken by role validation

### DIFF
--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -741,10 +741,10 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 
 	distributeRoles() {
 		const roles = Utils.shuffle(this.roles.slice());
-		if (roles.length < this.players.length) {
-			throw new Chat.ErrorMessage(`Not enough roles for all players. Have ${roles.length} roles but ${this.players.length} players.`);
-		}
 		if (roles.length) {
+			if (roles.length < this.players.length) {
+				throw new Chat.ErrorMessage(`Not enough roles for all players. Have ${roles.length} roles but ${this.players.length} players.`);
+			}
 			for (const p of this.players) {
 				const role = roles.shift();
 				if (!role) throw new Error(`Ran out of roles.`);


### PR DESCRIPTION
This PR fixes a regression where IDEA games would crash when trying to start.

### The Problem
A recent change added validation in distributeRoles() to prevent crashes when there aren't enough roles for all players. However, this validation was too aggressive - it would throw an error even when there were 0 roles, which is the normal state for IDEA games (where roles are assigned through the IDEA picking mechanism rather than through distributeRoles()).

### The Solution
Move the validation check inside the if (roles.length) block so it only runs when there are actually roles to distribute. This preserves the intended crash prevention while allowing IDEA games to function normally.