### PR TITLE
Net: Follow HTTP redirects in NetRequest#get

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -93,6 +93,16 @@ Main's SSL deploy script from Let's Encrypt looks like:
 exports.proxyip = false;
 
 /**
+ * netHostWhitelist - restricts the hosts that the internal Net library is
+ *   allowed to connect to (and follow redirects to). An empty array disables
+ *   the restriction. This is primarily a security hardening option to avoid
+ *   unexpected outbound requests.
+ *   Example: ['raw.githubusercontent.com', 'pokeapi.co']
+ * @type {string[]}
+ */
+exports.netHostWhitelist = [];
+
+/**
  * Various debug options
  *
  * ofe[something]

--- a/server/chat-plugins/laddertours.ts
+++ b/server/chat-plugins/laddertours.ts
@@ -224,40 +224,33 @@ export class LadderTracker {
 	async getLeaderboard(display?: boolean) {
 		const url = `https://pokemonshowdown.com/ladder/${this.format}.json?prefix=${this.prefix}`;
 		const leaderboard: LeaderboardEntry[] = [];
-		const attempts = 3;
-		for (let attempt = 1; attempt <= attempts; attempt++) {
-			try {
-				const responseText = await Net(url).get({ timeout: 10000, maxRedirects: 5 });
-				const response = JSON.parse(responseText);
-				this.leaderboard.lookup = new Map();
-				for (const data of response.toplist) {
-					// TODO: move the rounding until later
-					const entry: LeaderboardEntry = {
-						name: data.username,
-						elo: Math.round(data.elo),
-						gxe: data.gxe,
-						glicko: Math.round(data.rpr),
-						glickodev: Math.round(data.rprd),
-					};
-					this.leaderboard.lookup.set(data.userid, entry);
-					if (!data.userid.startsWith(this.prefix)) continue;
-					entry.rank = leaderboard.length + 1;
-					leaderboard.push(entry);
-				}
-				if (display) {
-					this.addHTML(this.styleLeaderboard(leaderboard), true);
-					this.leaderboard.last = leaderboard;
-					this.changed = false;
-					this.lines = { them: 0, total: 0 };
-				}
-				break;
-			} catch (err) {
-				if (attempt === attempts) {
-					Monitor.crashlog(err, 'a ladder tracker request', this.config);
-					if (display) throw new Chat.ErrorMessage(`Unable to fetch the leaderboard for ${this.prefix}.`);
-				}
-				await new Promise<void>(resolve => { setTimeout(resolve, attempt * 1000); });
+		try {
+			const responseText = await Net(url).get({ timeout: 10000, maxRedirects: 5 });
+			const response = JSON.parse(responseText);
+			this.leaderboard.lookup = new Map();
+			for (const data of response.toplist) {
+				// TODO: move the rounding until later
+				const entry: LeaderboardEntry = {
+					name: data.username,
+					elo: Math.round(data.elo),
+					gxe: data.gxe,
+					glicko: Math.round(data.rpr),
+					glickodev: Math.round(data.rprd),
+				};
+				this.leaderboard.lookup.set(data.userid, entry);
+				if (!data.userid.startsWith(this.prefix)) continue;
+				entry.rank = leaderboard.length + 1;
+				leaderboard.push(entry);
 			}
+			if (display) {
+				this.addHTML(this.styleLeaderboard(leaderboard), true);
+				this.leaderboard.last = leaderboard;
+				this.changed = false;
+				this.lines = { them: 0, total: 0 };
+			}
+		} catch (err) {
+			Monitor.crashlog(err, 'a ladder tracker request', this.config);
+			if (display) throw new Chat.ErrorMessage(`Unable to fetch the leaderboard for ${this.prefix}.`);
 		}
 		return leaderboard;
 	}

--- a/server/chat-plugins/laddertours.ts
+++ b/server/chat-plugins/laddertours.ts
@@ -225,8 +225,7 @@ export class LadderTracker {
 		const url = `https://pokemonshowdown.com/ladder/${this.format}.json?prefix=${this.prefix}`;
 		const leaderboard: LeaderboardEntry[] = [];
 		try {
-			const responseText = await Net(url).get({ timeout: 10000, maxRedirects: 5 });
-			const response = JSON.parse(responseText);
+			const response = await Net(url).get().then(JSON.parse);
 			this.leaderboard.lookup = new Map();
 			for (const data of response.toplist) {
 				// TODO: move the rounding until later
@@ -248,10 +247,11 @@ export class LadderTracker {
 				this.changed = false;
 				this.lines = { them: 0, total: 0 };
 			}
-		} catch (err) {
+		} catch (err: any) {
 			Monitor.crashlog(err, 'a ladder tracker request', this.config);
 			if (display) throw new Chat.ErrorMessage(`Unable to fetch the leaderboard for ${this.prefix}.`);
 		}
+
 		return leaderboard;
 	}
 

--- a/test/lib/net.js
+++ b/test/lib/net.js
@@ -78,7 +78,7 @@ describe('NetRequest (lib/net)', () => {
 		);
 	});
 
-	it('throws on redirect with missing Location header', async () => {
+	it('rejects on redirect with missing Location header', async () => {
 		await assert.rejects(
 			Net(`${baseURL}/redirectnoloc`).get({ maxRedirects: 1 }),
 			err => err instanceof HttpError && err.message.startsWith('Redirect with no location header'),
@@ -86,7 +86,7 @@ describe('NetRequest (lib/net)', () => {
 		);
 	});
 
-	it('throws on redirect with invalid Location header', async () => {
+	it('rejects on redirect with invalid Location header', async () => {
 		await assert.rejects(
 			Net(`${baseURL}/redirectbadloc`).get({ maxRedirects: 1 }),
 			err => err instanceof HttpError && err.message.startsWith('Invalid redirect location'),
@@ -107,7 +107,7 @@ describe('NetRequest (lib/net)', () => {
 		}
 	});
 
-	it('blocks request when host is not whitelisted', async () => {
+	it('rejects request when host is not whitelisted', async () => {
 		const configObj2 = global.Config || (global.Config = {});
 		const prev2 = configObj2.netHostWhitelist;
 		configObj2.netHostWhitelist = ['example.com'];

--- a/test/lib/net.js
+++ b/test/lib/net.js
@@ -23,6 +23,8 @@ describe('NetRequest (lib/net)', () => {
 				res.writeHead(301, { Location: '/redirectloop' });
 				res.end();
 				break;
+			case '/noresponse':
+				break;
 			default:
 				res.writeHead(404);
 				res.end();
@@ -59,5 +61,16 @@ describe('NetRequest (lib/net)', () => {
 			assert.equal(e.message, 'Too many redirects');
 		}
 		if (!threw) assert.fail('Expected HttpError for too many redirects');
+	});
+
+	it('throws on request timeout', async () => {
+		let threw = false;
+		try {
+			await Net(`${baseURL}/noresponse`).get({ timeout: 100 });
+		} catch (e) {
+			threw = true;
+			assert.equal(e.message, 'Request timeout');
+		}
+		if (!threw) assert.fail('Expected timeout error');
 	});
 });

--- a/test/lib/net.js
+++ b/test/lib/net.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const assert = require('assert').strict;
+const http = require('http');
+const { Net, HttpError } = require('./../../dist/lib/net');
+
+describe('NetRequest (lib/net)', () => {
+	let server;
+	let baseURL;
+
+	before(done => {
+		server = http.createServer((req, res) => {
+			switch (req.url) {
+			case '/ok':
+				res.writeHead(200, { 'Content-Type': 'text/plain' });
+				res.end('OK');
+				break;
+			case '/redirect':
+				res.writeHead(301, { Location: '/ok' });
+				res.end();
+				break;
+			case '/redirectloop':
+				res.writeHead(301, { Location: '/redirectloop' });
+				res.end();
+				break;
+			default:
+				res.writeHead(404);
+				res.end();
+			}
+		});
+		server.listen(0, () => {
+			const { port } = server.address();
+			baseURL = `http://127.0.0.1:${port}`;
+			done();
+		});
+	});
+
+	after(done => {
+		server.close(done);
+	});
+
+	it('returns body for 200 OK', async () => {
+		const body = await Net(`${baseURL}/ok`).get();
+		assert.equal(body, 'OK');
+	});
+
+	it('follows single redirect', async () => {
+		const body = await Net(`${baseURL}/redirect`).get();
+		assert.equal(body, 'OK');
+	});
+
+	it('throws after exceeding maxRedirects', async () => {
+		let threw = false;
+		try {
+			await Net(`${baseURL}/redirectloop`).get({ maxRedirects: 3 });
+		} catch (e) {
+			threw = true;
+			assert(e instanceof HttpError, 'Error should be instance of HttpError');
+			assert.equal(e.message, 'Too many redirects');
+		}
+		if (!threw) assert.fail('Expected HttpError for too many redirects');
+	});
+});

--- a/test/lib/net.js
+++ b/test/lib/net.js
@@ -1,5 +1,4 @@
 'use strict';
-/* eslint-disable require-atomic-updates */
 
 const assert = require('assert').strict;
 const http = require('http');

--- a/test/lib/net.js
+++ b/test/lib/net.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable require-atomic-updates */
 
 const assert = require('assert').strict;
 const http = require('http');
@@ -24,6 +25,14 @@ describe('NetRequest (lib/net)', () => {
 				res.end();
 				break;
 			case '/noresponse':
+				break;
+			case '/redirectnoloc':
+				res.writeHead(301);
+				res.end();
+				break;
+			case '/redirectbadloc':
+				res.writeHead(301, { Location: 'http://' });
+				res.end();
 				break;
 			default:
 				res.writeHead(404);
@@ -52,25 +61,66 @@ describe('NetRequest (lib/net)', () => {
 	});
 
 	it('throws after exceeding maxRedirects', async () => {
-		let threw = false;
-		try {
-			await Net(`${baseURL}/redirectloop`).get({ maxRedirects: 3 });
-		} catch (e) {
-			threw = true;
-			assert(e instanceof HttpError, 'Error should be instance of HttpError');
-			assert.equal(e.message, 'Too many redirects');
-		}
-		if (!threw) assert.fail('Expected HttpError for too many redirects');
+		await assert.rejects(
+			Net(`${baseURL}/redirectloop`).get({ maxRedirects: 3 }),
+			err => err instanceof HttpError && err.message.startsWith('Too many redirects'),
+			'Expected HttpError for too many redirects'
+		);
 	});
 
 	it('throws on request timeout', async () => {
-		let threw = false;
-		try {
-			await Net(`${baseURL}/noresponse`).get({ timeout: 100 });
-		} catch (e) {
-			threw = true;
-			assert.equal(e.message, 'Request timeout');
+		await assert.rejects(
+			Net(`${baseURL}/noresponse`).get({ timeout: 100 }),
+			err => {
+				assert.equal(err.message, 'Request timeout');
+				return true;
+			},
+			'Expected timeout error'
+		);
+	});
+
+	it('throws on redirect with missing Location header', async () => {
+		await assert.rejects(
+			Net(`${baseURL}/redirectnoloc`).get({ maxRedirects: 1 }),
+			err => err instanceof HttpError && err.message.startsWith('Redirect with no location header'),
+			'Expected HttpError for redirect without location header'
+		);
+	});
+
+	it('throws on redirect with invalid Location header', async () => {
+		await assert.rejects(
+			Net(`${baseURL}/redirectbadloc`).get({ maxRedirects: 1 }),
+			err => err instanceof HttpError && err.message.startsWith('Invalid redirect location'),
+			'Expected HttpError for redirect with invalid location header'
+		);
+	});
+
+	it('allows request when host is whitelisted', async () => {
+		const configObj = global.Config || (global.Config = {});
+		const prev = configObj.netHostWhitelist;
+		configObj.netHostWhitelist = ['127.0.0.1'];
+		const body = await Net(`${baseURL}/ok`).get();
+		assert.equal(body, 'OK');
+		if (prev !== undefined) {
+			configObj.netHostWhitelist = prev;
+		} else {
+			delete configObj.netHostWhitelist;
 		}
-		if (!threw) assert.fail('Expected timeout error');
+	});
+
+	it('blocks request when host is not whitelisted', async () => {
+		const configObj2 = global.Config || (global.Config = {});
+		const prev2 = configObj2.netHostWhitelist;
+		configObj2.netHostWhitelist = ['example.com'];
+		await assert.rejects(
+			Net(`${baseURL}/ok`).get(),
+			err => err instanceof HttpError && err.message.startsWith('Request to disallowed host'),
+			'Expected disallowed host error'
+		);
+		if (prev2 !== undefined) {
+			configObj2.netHostWhitelist = prev2;
+		} else {
+			delete configObj2.netHostWhitelist;
+		}
 	});
 });


### PR DESCRIPTION
### What
- Teach lib/net.ts’s NetRequest#get to follow up to 5 HTTP 30x redirects by default (limit configurable through opts.maxRedirects).
- Add unit-tests (test/lib/net.js) that cover:
    - normal 200 OK,
    - single 301 redirect,
    - redirect-loop error after the limit is exceeded.

### Why
The ladder tracker occasionally hit temporary 301/302 responses from pokemonshowdown.com, which bubbled up as uncaught HttpErrors and spammed Monitor.crashlog.

Following redirects is the expected behavior of an HTTP helper, and several other parts of the codebase already implement their redirect logic. Centralizing it here fixes the crashes and makes future calls safer.