### PR TITLE
Validator: Ban problematic Unicode characters

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -573,6 +573,9 @@ export class TeamValidator {
 				problems.push(`Nickname "${set.name}" too long (should be 18 characters or fewer)`);
 			}
 		}
+		if (set.name && /[\u0335\u034C\u034B\u0346\u0301]/.test(set.name)) {
+			problems.push(`Nickname "${set.name}" contains invalid characters that are not allowed`);
+		}
 		set.name = dex.getName(set.name);
 		let item = dex.items.get(Utils.getString(set.item));
 		set.item = item.name;


### PR DESCRIPTION
This is a bug that has been around for a while now and can cause some display issues. I'm not sure if I'm using the right method to implement this, so feel free to give me any feedback if needed :)

![image](https://github.com/user-attachments/assets/33711829-3e42-43e1-9555-65dd27e023f0)
