### PR TITLE
Fix Klutz's interaction with Iron Ball in Gen 4

### DIFF
--- a/data/mods/gen4/items.ts
+++ b/data/mods/gen4/items.ts
@@ -186,6 +186,7 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	ironball: {
 		inherit: true,
+		ignoreKlutz: true,
 		onEffectiveness() {},
 	},
 	ironplate: {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -864,12 +864,13 @@ export class Pokemon {
 	}
 
 	ignoringItem() {
-		return !this.getItem().isPrimalOrb && !!(
-			this.itemState.knockedOff || // Gen 3-4
-			(this.battle.gen >= 5 && !this.isActive) ||
-			(!this.getItem().ignoreKlutz && this.hasAbility('klutz')) ||
-			this.volatiles['embargo'] || this.battle.field.pseudoWeather['magicroom']
-		);
+		if (this.getItem().isPrimalOrb) return false;
+		if (this.itemState.knockedOff) return true; // Gen 3-4
+		if (this.battle.gen >= 5 && !this.isActive) return true;
+		// in gen 4, items that ignore Klutz also ignore Embargo
+		if (this.battle.gen <= 4 && this.getItem().ignoreKlutz) return false;
+		if (this.volatiles['embargo'] || this.battle.field.pseudoWeather['magicroom']) return true;
+		return !this.getItem().ignoreKlutz && this.hasAbility('klutz');
 	}
 
 	deductPP(move: string | Move, amount?: number | null, target?: Pokemon | null | false) {

--- a/test/sim/items/ironball.js
+++ b/test/sim/items/ironball.js
@@ -10,7 +10,7 @@ describe('Iron Ball', () => {
 		battle.destroy();
 	});
 
-	it('should reduce halve the holder\'s speed', () => {
+	it('should halve the holder\'s speed', () => {
 		battle = common.createBattle();
 		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', item: 'ironball', moves: ['bestow'] }] });
 		battle.setPlayer('p2', { team: [{ species: "Aerodactyl", ability: 'pressure', moves: ['stealthrock'] }] });
@@ -76,5 +76,29 @@ describe('Iron Ball', () => {
 		battle.setPlayer('p2', { team: [{ species: "Thundurus", ability: 'prankster', item: 'ironball', moves: ['electricterrain'] }] });
 		battle.makeChoices('move spore', 'move electricterrain');
 		assert.equal(battle.p2.active[0].status, '');
+	});
+
+	describe('[Gen 4]', () => {
+		it('should halve the speed of a Pokemon with Klutz', () => {
+			battle = common.gen(4).createBattle([[
+				{ species: "Lopunny", item: 'ironball', ability: 'klutz', moves: ['tackle'] },
+			], [
+				{ species: "Mew", moves: ['recover'] },
+			]]);
+			battle.makeChoices();
+			console.log(battle.log);
+			assert.false.fullHP(battle.p2.active[0]);
+		});
+
+		it.skip('should not ground Pokemon with Klutz that are airborne', () => {
+			battle = common.gen(4).createBattle([[
+				{ species: "Togekiss", item: 'ironball', ability: 'klutz', moves: ['sleeptalk'] },
+			], [
+				{ species: "Mamoswine", moves: ['earthquake'] },
+			]]);
+			battle.makeChoices();
+			console.log(battle.log);
+			assert.fullHP(battle.p1.active[0]);
+		});
 	});
 });


### PR DESCRIPTION
This PR fixes the Speed drop from the Iron Ball, Macho Brace and Power items not being negated by Klutz or Embargo in Gen 4 (the only items that ignore Klutz, aside from the most recent Ability Shield).

The problem is that the grounding effect from Iron Ball should still be active. I didn't want to duplicate half the logic from `Pokemon#ignoringItem` in `Pokemon#isGrounded` just to check for Iron Ball in Gen 4. I hope someone comes up with a better solution.

Klutz + Iron Ball https://www.smogon.com/forums/threads/past-gens-research-thread.3506992/post-10596407
Embargo + Iron Ball https://www.smogon.com/forums/threads/past-gens-research-thread.3506992/post-10596455