### PR TITLE
Aliases: Remove Wormadams

### DIFF
--- a/data/aliases.ts
+++ b/data/aliases.ts
@@ -470,7 +470,6 @@ export const Aliases: import('../sim/dex').AliasesTable = {
 	wormadamg: "Wormadam-Sandy",
 	wormadamground: "Wormadam-Sandy",
 	wormadamsandycloak: "Wormadam-Sandy",
-	wormadams: "Wormadam-Trash",
 	wormadamsteel: "Wormadam-Trash",
 	wormadamtrashcloak: "Wormadam-Trash",
 	zacianh: "Zacian",


### PR DESCRIPTION
Wormadams used to be the alias to wormadam-trash, when it should be wormadam-sandy. Removing the line for the wormadams alias fixes this.