### PR TITLE
Fix HP bar percentages and colours

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -4768,7 +4768,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		searchShow: false,
 		ruleset: [
 			'Picked Team Size = 3', 'Min Level = 50', 'Max Level = 55', 'Max Total Level = 155',
-			'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Species Clause', 'Nickname Clause', 'HP Percentage Mod', 'Cancel Mod', 'NC 1997 Move Legality',
+			'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Species Clause', 'Nickname Clause', 'Cancel Mod', 'NC 1997 Move Legality',
 		],
 		banlist: ['Uber'],
 	},

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -2011,7 +2011,7 @@ export class Pokemon {
 		} else if (this.battle.reportPercentages || this.battle.gen >= 8) {
 			// HP Percentage Mod mechanics
 			let percentage = Math.ceil(100 * this.hp / this.maxhp);
-			if ((percentage === 100) && (ratio < 1.0)) {
+			if (percentage === 100 && this.hp < this.maxhp) {
 				percentage = 99;
 			}
 			shared = `${percentage}/100`;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -2010,19 +2010,21 @@ export class Pokemon {
 			shared = secret;
 		} else if (this.battle.reportPercentages || this.battle.gen >= 8) {
 			// HP Percentage Mod mechanics
-			let percentage = Math.ceil(ratio * 100);
+			let percentage = Math.ceil(100 * this.hp / this.maxhp);
 			if ((percentage === 100) && (ratio < 1.0)) {
 				percentage = 99;
 			}
 			shared = `${percentage}/100`;
 		} else {
 			// In-game accurate pixel health mechanics
-			const pixels = Math.floor(ratio * 48) || 1;
+			const pixels = Math.floor(48 * this.hp / this.maxhp) || 1;
 			shared = `${pixels}/48`;
-			if ((pixels === 9) && (ratio > 0.2)) {
-				shared += 'y'; // force yellow HP bar
-			} else if ((pixels === 24) && (ratio > 0.5)) {
-				shared += 'g'; // force green HP bar
+			if (this.battle.gen >= 5) {
+				if (pixels === 9 && ratio > 0.2) {
+					shared += 'y'; // force yellow HP bar
+				} else if (pixels === 24 && ratio > 0.5) {
+					shared += 'g'; // force green HP bar
+				}
 			}
 		}
 		if (this.status) {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -2005,7 +2005,6 @@ export class Pokemon {
 		if (!this.hp) return { side: this.side.id, secret: '0 fnt', shared: '0 fnt' };
 		let secret = `${this.hp}/${this.maxhp}`;
 		let shared;
-		const ratio = this.hp / this.maxhp;
 		if (this.battle.reportExactHP) {
 			shared = secret;
 		} else if (this.battle.reportPercentages || this.battle.gen >= 8) {
@@ -2020,10 +2019,10 @@ export class Pokemon {
 			const pixels = Math.floor(48 * this.hp / this.maxhp) || 1;
 			shared = `${pixels}/48`;
 			if (this.battle.gen >= 5) {
-				if (pixels === 9 && ratio > 0.2) {
-					shared += 'y'; // force yellow HP bar
-				} else if (pixels === 24 && ratio > 0.5) {
-					shared += 'g'; // force green HP bar
+				if (pixels === 9) {
+					shared += this.hp * 5 > this.maxhp ? 'y' : 'r';
+				} else if (pixels === 24) {
+					shared += this.hp * 2 > this.maxhp ? 'g' : 'y';
 				}
 			}
 		}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -2015,7 +2015,7 @@ export class Pokemon {
 			}
 			shared = `${percentage}/100`;
 		} else {
-			/** 
+			/**
 			 * In-game accurate pixel health mechanics
 			 * PS doesn't use pixels after Gen 6, but for reference:
 			 * - [Gen 7] SM uses 99 pixels

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -2007,7 +2007,7 @@ export class Pokemon {
 		let shared;
 		if (this.battle.reportExactHP) {
 			shared = secret;
-		} else if (this.battle.reportPercentages || this.battle.gen >= 8) {
+		} else if (this.battle.reportPercentages || this.battle.gen >= 7) {
 			// HP Percentage Mod mechanics
 			let percentage = Math.ceil(100 * this.hp / this.maxhp);
 			if (percentage === 100 && this.hp < this.maxhp) {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -2015,7 +2015,12 @@ export class Pokemon {
 			}
 			shared = `${percentage}/100`;
 		} else {
-			// In-game accurate pixel health mechanics
+			/** 
+			 * In-game accurate pixel health mechanics
+			 * PS doesn't use pixels after Gen 6, but for reference:
+			 * - [Gen 7] SM uses 99 pixels
+			 * - [Gen 7] USUM uses 86 pixels
+			 * */
 			const pixels = Math.floor(48 * this.hp / this.maxhp) || 1;
 			shared = `${pixels}/48`;
 			if (this.battle.gen >= 5) {


### PR DESCRIPTION
Client PR: https://github.com/smogon/pokemon-showdown-client/pull/2463
___
The change to `Math.ceil(100 * this.hp / this.maxhp)` fixes [HP Percentage mod inaccuracies](https://www.smogon.com/forums/threads/hp-percentage-mod-inaccuracies.3746113/) caused by floating-point imprecision.
___
### Regarding the other changes:
In Generations 1–4, pixels are used to determine the HP bar color. Only in Generations 5 and later is the actual HP value used.

While in Gen 2, 24 pixels should be green (and in Gen 1, the bar should be yellow until 27 pixels), these details do not reveal additional information and could therefore be implemented on the client side if there is motivation to do so.

Gen 5 original post: https://www.smogon.com/forums/threads/hp-bar-colours.3481364/
@Marty-D 's work (can be confirmed in the projects by this account https://github.com/pret/):

```
Gen 2:

75/150	green	24 pixels	0.5

32/171	red	8 pixels	0.187134503
33/171	red	9 pixels	0.192982456
34/171	red	9 pixels	0.198830409
35/171	red	9 pixels	0.204678363
36/171	yellow	10 pixels	0.210526316


35/175	red	9 pixels	0.2
36/175	red	9 pixels	0.205714286
37/175	yellow	10 pixels	0.211428571



Gen 3 Emerald:

41/82	yellow	24 pixels	0.5
42/82	yellow	24 pixels	0.512195122
43/82	green	25 pixels	0.524390244

29/143	red	9 pixels	0.202797203

Gen 4 SoulSilver:

31/152	red	9 pixels	0.203947368

51/246	red	9 pixels	0.207317073
52/246	yellow	10 pixels	0.211382114


Gen 5 White:

Sep-48	red	9 pixels	
Oct-48	yellow	10 pixels	

51/260	red	9 pixels	0.196153846
52/260	red	9 pixels	0.2
53/260	yellow	9 pixels	0.203846154
130/260	yellow	24 pixels	0.5

141/714	red	9 pixels	0.197478992
144/714	yellow	9 pixels	0.201680672

167/334	yellow	24 pixels	0.5
168/334	green	24 pixels	0.502994012

White 2:

142/714	red	9 pixels	0.198879552
144/714	yellow	9 pixels	0.201680672
```