### PR TITLE
Fix more button in /modlog

### DIFF
--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -234,13 +234,18 @@ export const commands: Chat.ChatCommands = {
 		const possibleParam = cmd.slice(2);
 		const targets = target.split(',').map(f => f.trim()).filter(Boolean);
 		const search: ModlogSearch = { note: [], user: [], ip: [], action: [], actionTaker: [] };
+		let searchCmd = target.replace(/^\s?([^,=]*)(,\s?|$)/, '').replace(/,?\s*(room|lines)\s*=[^,]*,?/g, '');
 
 		switch (possibleParam) {
 		case 'id':
-			targets.unshift(`user='${targets.shift()}'`);
+			const id = targets.shift();
+			searchCmd = `user='${id}'${searchCmd.length ? `, ${searchCmd}` : ``}`
+			targets.unshift(`user='${id}'`);
 			break;
 		case 'ip':
-			targets.unshift(`ip=${targets.shift()}`);
+			const ip = targets.shift();
+			searchCmd = `user='${ip}'${searchCmd.length ? `, ${searchCmd}` : ``}`
+			targets.unshift(`ip=${ip}`);
 			break;
 		}
 
@@ -317,7 +322,7 @@ export const commands: Chat.ChatCommands = {
 			connection,
 			roomid,
 			search,
-			target.replace(/^\s?([^,=]*),\s?/, '').replace(/,?\s*(room|lines)\s*=[^,]*,?/g, ''),
+			searchCmd,
 			lines,
 			onlyPunishments,
 			cmd === 'timedmodlog',

--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -361,7 +361,7 @@ export const commands: Chat.ChatCommands = {
 		if (!target) return this.parse(`/help modlogstats`);
 		return this.parse(`/join view-modlogstats-${target}`);
 	},
-	modlogstatshelp: [`/modlogstats [userid] - Fetch all information on that [userid] from the modlog (IPs, alts, etc). Requires: @ ~`],
+	modlogstatshelp: [`/modlogstats [userid] - Fetch all information on that [userid] from the modlog (IPs, alts, etc). Requires: % @ ~`],
 };
 
 export const pages: Chat.PageTable = {


### PR DESCRIPTION
- `/modlog` with only one argument which doesn't contain a = returns a broken more button ([bug report](https://www.smogon.com/forums/threads/modlog-results-button-lacking-proper-arguments-when-using-mlid.3757137/))
- `/mlid` and `/mlip` discards the first argument when clicking the more button