### PR TITLE
Permalock plugin: Fix room not updating after notice

### DIFF
--- a/server/chat-plugins/permalocks.ts
+++ b/server/chat-plugins/permalocks.ts
@@ -151,7 +151,7 @@ export const Nominations = new class {
 		Utils.sortBy(this.noms, nom => -nom.date);
 		this.save();
 		this.notifyStaff();
-		Rooms.get('staff')?.addByUser(user, `${user.name} submitted a perma nomination for ${primaryID}`);
+		Rooms.get('staff')?.addByUser(user, `${user.name} submitted a perma nomination for ${primaryID}`).update();
 	}
 	find(id: string) {
 		return this.noms.find(f => f.primaryID === id);


### PR DESCRIPTION
The notice "x submitted a perma nomination for y" is added to the room but doesn't show up right away. Adding an `update()` fixes this.