### PR TITLE
RoomBattleTimer: Reset turn seconds on wait requests

### DIFF
--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -307,7 +307,10 @@ export class RoomBattleTimer {
 	}
 	nextRequest(player: RoomBattlePlayer) {
 		if (player.secondsLeft <= 0) return;
-		if (player.request.isWait) return;
+		if (player.request.isWait) {
+			player.turnSecondsLeft = this.settings.maxPerTurn;
+			return;
+		}
 
 		if (this.timer) {
 			clearTimeout(this.timer);


### PR DESCRIPTION
Previously, if a player timed out under VGC timer and knocked their opponent, they would be treated as timing out their following 'wait' request.