### PR TITLE
Fix ZU NFEs

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1096,7 +1096,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 		tier: "NFE",
 	},
 	porygon2: {
-		tier: "NFE",
+		tier: "ZU",
 		doublesTier: "DUU",
 		natDexTier: "NFE",
 	},
@@ -1502,7 +1502,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 		tier: "NFE",
 	},
 	sneaselhisui: {
-		tier: "NFE",
+		tier: "ZU",
 	},
 	weavile: {
 		tier: "OU",

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1503,6 +1503,8 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	},
 	sneaselhisui: {
 		tier: "ZU",
+		doublesTier: "NFE",
+		natDexTier: "ZU",
 	},
 	weavile: {
 		tier: "OU",


### PR DESCRIPTION
Hisuian Sneasel had >4.52% average usage in ZU in the last three months just like Dipplin, Hattrem, Magneton, and Primeape. Porygon2 also had >4.52% average usage in ZU and was ZU before it moved to NU, so it moves back to ZU. 

Hisuian Sneasel stats
https://www.smogon.com/stats/2025-04/gen9zu-1630.txt - 5.14% https://www.smogon.com/stats/2025-05/gen9zu-1630.txt - 8.72% https://www.smogon.com/stats/2025-06/gen9zu-1630.txt - 8.57% Average: 7.48%

Porygon2 stats
https://www.smogon.com/stats/2025-01/gen9zu-1630.txt - 10.03% https://www.smogon.com/stats/2025-02/gen9zu-1630.txt - 9.35% https://www.smogon.com/stats/2025-03/gen9zu-1630.txt - 13.80% Average: 11.15%