### PR TITLE
Remove build on postinstall

### DIFF
--- a/build
+++ b/build
@@ -48,7 +48,5 @@ try {
 // for some reason, esbuild won't be requirable until a tick has passed
 // see https://stackoverflow.com/questions/53270058/node-cant-find-certain-modules-after-synchronous-install
 setImmediate(() => {
-	// npm package, don't rebuild
-	if (process.argv[2] === 'postinstall' && fs.existsSync('dist')) return;
 	require('./tools/build-utils').transpile(force, decl);
 });

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "test": "mocha",
     "posttest": "npm run tsc",
     "full-test": "eslint --max-warnings 0 && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\" && npm run test-npm",
-    "full-test-ci": "eslint --max-warnings 0 && tsc && (([ \"$SKIPSIMTESTS\" = true ] && mocha --timeout 8000 --forbid-only -g \".*\" --exclude \"test/{sim,random-battles}/**\") || mocha --timeout 8000 --forbid-only -g \".*\") && npm run test-npm",
-    "postinstall": "npm run build postinstall"
+    "full-test-ci": "eslint --max-warnings 0 && tsc && (([ \"$SKIPSIMTESTS\" = true ] && mocha --timeout 8000 --forbid-only -g \".*\" --exclude \"test/{sim,random-battles}/**\") || mocha --timeout 8000 --forbid-only -g \".*\") && npm run test-npm"
   },
   "bin": "./pokemon-showdown",
   "homepage": "http://pokemonshowdown.com",


### PR DESCRIPTION
- Errors in the node build script will no longer cause a false perception that dependencies cannot be installed.
- Simplifies 1cea3f39cbb41c2a06838580c47450d8d76b9e99