### PR TITLE
Add test for 35 Pokes banlist

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1504,7 +1504,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	sneaselhisui: {
 		tier: "ZU",
 		doublesTier: "NFE",
-		natDexTier: "ZU",
+		natDexTier: "RU",
 	},
 	weavile: {
 		tier: "OU",

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1504,7 +1504,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	sneaselhisui: {
 		tier: "ZU",
 		doublesTier: "NFE",
-		natDexTier: "RU",
+		natDexTier: "NFE",
 	},
 	weavile: {
 		tier: "OU",

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -237,8 +237,8 @@ describe('Team Validator', () => {
 		const accepted = Dex.species.all().filter(species => !(
 			// ruleTable.isBannedSpecies blind spots
 			species.natDexTier === 'Illegal' || species.isNonstandard === 'CAP'
-		) && !ruleTable.isBannedSpecies(species));
+		) && !ruleTable.isBannedSpecies(species)).length;
 
-		assert.equal(accepted.length, allowed);
+		assert.equal(accepted, allowed);
 	});
 });

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -219,10 +219,11 @@ describe('Team Validator', () => {
 		this.timeout(0);
 		const formatid = 'gen9nationaldex35pokes@@@!obtainable';
 		const allowed = Dex.formats.get(formatid).unbanlist
-			.map(x => Dex.formats.validateRule(`+${x}`))
+			?.map(x => Dex.formats.validateRule(`+${x}`))
 			.filter(x => x.startsWith('+pokemon:') || x.startsWith('+basepokemon:'))
 			.flatMap(x => x.startsWith('+pokemon:') ? x.slice(9) : Dex.species.get(x.slice(13)).formeOrder)
 			.map(toID);
+		if (!allowed) return;
 		for (const species of Dex.species.all()) {
 			// These are covered by Obtainable ruleset
 			if (species.name.endsWith('-Gmax') || species.isNonstandard === 'CAP') {


### PR DESCRIPTION
Sneasel-Hisui is erroneously legal after a recent tiering change, which has happened before (Hattrem).

I propose a test that would prevent this from happening.

I will add the fix for Sneasel-Hisui in a bit, after seeing that the test catches it.