### PR TITLE
Corrections for low-rank GSC ZU NFEs/LCs (Diglett + Slowpoke)

### DIFF
--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -162,7 +162,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "PU",
 	},
 	diglett: {
-		tier: "ZU",
+		tier: "LC",
 	},
 	dugtrio: {
 		tier: "NU",
@@ -252,7 +252,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "NU",
 	},
 	slowpoke: {
-		tier: "ZU",
+		tier: "LC",
 	},
 	slowbro: {
 		tier: "UU",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/zu-old-gens-hub-oras-bans-379.3646944/post-10502838 Both Diglett and Slowpoke are D rank on the most recent ZU viability list, the same as other Pokemon tiered as LC like Smoochum, Snubbull, Mankey, etc, so they should be tiered the same.