### PR TITLE
Gen 3: Pressure should affect Spikes

### DIFF
--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -155,6 +155,13 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		onStart(pokemon) {
 			this.addSplit(pokemon.side.id, ['-ability', pokemon, 'Pressure', '[silent]']);
 		},
+		onDeductPP(target, source) {
+			if (target === source) return;
+			if (this.activeMove && this.activeMove.target === 'foeSide') {
+				return 1;
+			}
+			return 1;
+		},
 	},
 	raindish: {
 		inherit: true,


### PR DESCRIPTION
Fixes #9696

Videos demonstrating the interactions:

Spiker moves before Pressure Pokemon:
[Screencast 2025-07-08 09:40:46.webm](https://github.com/user-attachments/assets/42afed17-475c-4e9b-8f0d-81b767c7a2b4)

Pressure Pokemon moves before Spiker:
[Screencast 2025-07-08 09:31:05.webm](https://github.com/user-attachments/assets/57a496a4-b5fb-4664-9b0a-8854b018b06d)
