### PR TITLE
Fix item search duplicating search terms

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2459,6 +2459,7 @@ function runItemsearch(target: string, cmd: string, message: string) {
 		case 'atk':
 		case 'attack':
 			if (['sp', 'special'].includes(rawSearch[i - 1])) {
+				newWord = '';
 				break;
 			} else {
 				newWord = 'attack';
@@ -2471,6 +2472,7 @@ function runItemsearch(target: string, cmd: string, message: string) {
 		case 'def':
 		case 'defense':
 			if (['sp', 'special'].includes(rawSearch[i - 1])) {
+				newWord = '';
 				break;
 			} else {
 				newWord = 'defense';


### PR DESCRIPTION
https://www.smogon.com/forums/threads/eviolite-in-itemsearch.3733712/

Due to the way search terms were being parsed, commands, like the linked post mentions, such as /is lowers special defense and /is raises special defense were including false positives, such as Eviolite and Electric Seed respectively. This was because "defense" was being parsed twice, so the command was matching on "lowers/raises", "specialdefense", and, unintentionally, "defense". This removes the double parsing for defense and attack.