### PR TITLE
Make Chromera a Sub-Legendary

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -19330,6 +19330,7 @@ export const Pokedex: import('../sim/dex-species').SpeciesDataTable = {
 		weightkg: 215,
 		color: "Purple",
 		eggGroups: ["Undiscovered"],
+		tags: ["Sub-Legendary"],
 		gen: 8,
 	},
 	nohface: {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/cap-29-final-product-playtesting-submit-your-replays-teams-here.3683014/

> After considerable consultation with the CAP moderators and the Topic Leadership Team, we've decided to confirm that Chromera would follow the classic Legendary mold from in-game Pokemon. This would put it in the same general group as Pokemon such as Latios, Latias, Heatran, Cresselia, Zygarde, and Necrozma.

> Its legendary status means that Chromera is Genderless, and all movepool creators should remember to not give it any Egg moves as a result.

> The CAP moderation team gave me the green light to announce CAP29's legendary status here to help aid movepool creators and Pokedex writers in the upcoming flavor stages