### PR TITLE
Remove partiallyTrapped if the source faints later during residuals

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1647,6 +1647,23 @@ export class Battle {
 					}
 				}
 			}
+		} else {
+			for (const pokemon of this.getAllActive()) {
+				/**
+				 * We need to recheck the source of the partial trapping at the end of every turn
+				 * if the source fainted after the partially trapped residual, the Pokemon would be
+				 * trapped for an extra turn
+				 */
+				if (pokemon.volatiles['partiallytrapped']) {
+					const source = pokemon.volatiles['partiallytrapped'].source;
+					// G-Max Centiferno and G-Max Sandblast continue even after the user leaves the field
+					const gmaxEffect = ['gmaxcentiferno', 'gmaxsandblast'].includes(pokemon.volatiles['partiallytrapped'].sourceEffect.id);
+					if (source && (!source.isActive || source.hp <= 0 || !source.activeTurns) && !gmaxEffect) {
+						delete pokemon.volatiles['partiallytrapped'];
+						this.add('-end', pokemon, this.effectState.sourceEffect, '[partiallytrapped]', '[silent]');
+					}
+				}
+			}
 		}
 
 		const trappedBySide: boolean[] = [];

--- a/test/sim/misc/trapmoves.js
+++ b/test/sim/misc/trapmoves.js
@@ -179,6 +179,26 @@ describe('Partial Trapping Moves', () => {
 			assert.equal(battle.p2.active[0].species.id, 'starmie');
 		});
 
+		it('should stop trapping the Pokemon if the user faints to a faster trapping move', () => {
+			battle = common.createBattle();
+			battle.setPlayer('p1', { team: [
+				{ species: "Smeargle", moves: [toID(move), 'sleeptalk'] },
+				{ species: "Kyurem", moves: ['sleeptalk'] },
+			] });
+			battle.setPlayer('p2', { team: [
+				{ species: "Tangrowth", moves: [toID(move), 'sleeptalk'] },
+				{ species: "Starmie", moves: ['sleeptalk'] },
+			] });
+			const fastTrapper = battle.p1.active[0];
+			const slowTrapper = battle.p2.active[0];
+			battle.makeChoices('move ' + toID(move), 'move ' + toID(move));
+			slowTrapper.hp = 1;
+			battle.makeChoices('move sleeptalk', 'move sleeptalk');
+			assert.fainted(slowTrapper);
+			battle.makeChoices();
+			assert.false(fastTrapper.volatiles['partiallytrapped']);
+		});
+
 		it('should stop trapping the Pokemon if the target uses Rapid Spin', () => {
 			battle = common.createBattle();
 			battle.setPlayer('p1', { team: [
@@ -250,6 +270,19 @@ describe('Partial Trapping Moves [Gen 1]', () => {
 		battle.makeChoices('switch 2', 'auto');
 		battle.makeChoices();
 		assert(!battle.p2.active[0].volatiles['partiallytrapped']);
+	});
+
+	it('Wrap should still cause the target to fail on the same turn the wrapper switches out', () => {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', { team: [
+			{ species: "Arbok", moves: ['wrap'] },
+			{ species: "Exeggutor", moves: ['splash'] },
+		] });
+		battle.setPlayer('p2', { team: [{ species: "Snorlax", moves: ['selfdestruct'] }] });
+		battle.makeChoices('move wrap', 'move selfdestruct');
+		assert.fullHP(battle.p1.active[0]);
+		battle.makeChoices('switch 2', 'move selfdestruct');
+		assert.fullHP(battle.p1.active[0]);
 	});
 
 	it('Wrap should damage the target\'s substitute', () => {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-report-mechanics.3767990/
The event that deals the damage is the same one that checks whether the source has fainted. So if a slower source faints from residual damage, the check for the faster Pokémon has already passed.

The reason I separated the two statements in `battle.ts` was that I couldn't find them using basic regex.
Gen 5's `onResidual` is duplicated.