### PR TITLE
Don't consider user active on '/cmd rooms'

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -604,7 +604,9 @@ export class CommandContext extends MessageContext {
 			return this.popupReply(`You tried to send "${message}" to the room "${this.room.roomid}" but it failed because you were not in that room.`);
 		}
 
-		if (this.user.statusType === 'idle' && !['unaway', 'unafk', 'back'].includes(this.cmd)) {
+		if (this.user.statusType === 'idle' &&
+			this.message !== '/cmd rooms' &&
+			!['unaway', 'unafk', 'back'].includes(this.cmd)) {
 			this.user.setStatusType('online');
 		}
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -605,7 +605,7 @@ export class CommandContext extends MessageContext {
 		}
 
 		if (this.user.statusType === 'idle' &&
-			this.message !== '/cmd rooms' &&
+			this.cmd !== 'cmd' &&
 			!['unaway', 'unafk', 'back'].includes(this.cmd)) {
 			this.user.setStatusType('online');
 		}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -605,7 +605,7 @@ export class CommandContext extends MessageContext {
 		}
 
 		if (this.user.statusType === 'idle' &&
-			this.cmd !== 'cmd' &&
+			this.message !== '/cmd rooms' &&
 			!['unaway', 'unafk', 'back'].includes(this.cmd)) {
 			this.user.setStatusType('online');
 		}


### PR DESCRIPTION
 On preact client
 - if an user uses `/idle` it updates the user's state client side and on every user state update it is made to send `/cmd rooms` to server which then immediately marks the user as active
 
 On old client
 - when roomslist page is **opened**, it sends '/cmd rooms' command every 20 seconds which also marks the user active
 
To fix this, we prevent '/cmd rooms' from updating the user's away/unaway status.