### PR TITLE
Approximate Rebound to Magic Bounce and Magic Coat implementation

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2406,9 +2406,6 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			move.hasBounced = true; // only bounce once in free-for-all battles
 			return null;
 		},
-		condition: {
-			duration: 1,
-		},
 		flags: { breakable: 1 },
 		name: "Magic Bounce",
 		rating: 4,
@@ -5609,27 +5606,27 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		onTryHit(target, source, move) {
 			if (this.effectState.target.activeTurns) return;
 
-			if (target === source || move.hasBounced || !move.flags['reflectable']) {
+			if (target === source || move.hasBounced || !move.flags['reflectable'] || target.isSemiInvulnerable()) {
 				return;
 			}
 			const newMove = this.dex.getActiveMove(move.id);
 			newMove.hasBounced = true;
+			newMove.pranksterBoosted = false;
 			this.actions.useMove(newMove, target, { target: source });
 			return null;
 		},
 		onAllyTryHitSide(target, source, move) {
 			if (this.effectState.target.activeTurns) return;
 
-			if (target.isAlly(source) || move.hasBounced || !move.flags['reflectable']) {
+			if (target.isAlly(source) || move.hasBounced || !move.flags['reflectable'] || target.isSemiInvulnerable()) {
 				return;
 			}
 			const newMove = this.dex.getActiveMove(move.id);
 			newMove.hasBounced = true;
+			newMove.pranksterBoosted = false;
 			this.actions.useMove(newMove, this.effectState.target, { target: source });
+			move.hasBounced = true; // only bounce once in free-for-all battles
 			return null;
-		},
-		condition: {
-			duration: 1,
 		},
 		flags: { breakable: 1 },
 		name: "Rebound",

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -569,4 +569,8 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			}
 		},
 	},
+	rebound: {
+		inherit: true,
+		onTryHitSide() {},
+	},
 };

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -88,4 +88,20 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		inherit: true,
 		onAllyTryHitSide() {},
 	},
+	rebound: {
+		inherit: true,
+		onAllyTryHitSide(target, source, move) {
+			if (this.effectState.target.activeTurns) return;
+
+			if (target.isAlly(source) || move.hasBounced || !move.flags['reflectable']) {
+				return;
+			}
+			const newMove = this.dex.getActiveMove(move.id);
+			newMove.hasBounced = true;
+			newMove.pranksterBoosted = false;
+			this.actions.useMove(newMove, this.effectState.target, { target: source });
+			move.hasBounced = true; // only bounce once in free-for-all battles
+			return null;
+		},
+	},
 };

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -553,6 +553,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				newMove.hasBounced = true;
 				newMove.pranksterBoosted = false;
 				this.actions.useMove(newMove, this.effectState.target, { target: source });
+				move.hasBounced = true; // only bounce once in free-for-all battles
 				return null;
 			},
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -11131,6 +11131,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				newMove.hasBounced = true;
 				newMove.pranksterBoosted = false;
 				this.actions.useMove(newMove, this.effectState.target, { target: source });
+				move.hasBounced = true; // only bounce once in free-for-all battles
 				return null;
 			},
 		},


### PR DESCRIPTION
I standardized the implementations of Magic Bounce, Magic Coat and Rebound. Magic Bounce had some outdated condition. I also adjusted Magic Coat so it no longer reflects multiple Stealth Rocks in FFA. Magic Bounce and Magic Coat behave identically in all scenarios, though I doubt anyone can test this in Gen 7 without four consoles.
<details>
<summary>Chat with the CAP Leader</summary>
<img width="1634" height="715" alt="image" src="https://github.com/user-attachments/assets/0d49ec85-592d-49e4-982b-2f16cd61fac9" />
</details>