### PR TITLE
Fix interaction between Receiver and Soul-Heart

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -265,7 +265,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		onFoeTryEatItem() {
 			return !this.effectState.unnerved;
 		},
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.boost({ atk: length }, source, source, this.dex.abilities.get('chillingneigh'));
 			}
@@ -289,7 +289,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		onFoeTryEatItem() {
 			return !this.effectState.unnerved;
 		},
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.boost({ spa: length }, source, source, this.dex.abilities.get('grimneigh'));
 			}
@@ -355,7 +355,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 4,
 	},
 	battlebond: {
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (source.bondTriggered) return;
 			if (effect?.effectType !== 'Move') return;
 			if (source.species.id === 'greninjabond' && source.hp && !source.transformed && source.side.foePokemonLeft()) {
@@ -395,7 +395,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 284,
 	},
 	beastboost: {
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				const bestStat = source.getBestStat(true, true);
 				this.boost({ [bestStat]: length }, source);
@@ -499,7 +499,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 167,
 	},
 	chillingneigh: {
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.boost({ atk: length }, source);
 			}
@@ -1661,7 +1661,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 229,
 	},
 	grimneigh: {
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.boost({ spa: length }, source);
 			}
@@ -2682,7 +2682,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 78,
 	},
 	moxie: {
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.boost({ atk: length }, source);
 			}
@@ -4351,8 +4351,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 116,
 	},
 	soulheart: {
-		onAnyFaintPriority: 1,
-		onAnyFaint() {
+		onAnyAfterFaint() {
 			this.boost({ spa: 1 }, this.effectState.target);
 		},
 		flags: {},

--- a/data/mods/ccapm2024/abilities.ts
+++ b/data/mods/ccapm2024/abilities.ts
@@ -400,7 +400,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	drawfour: {
 		shortDesc: "After knocking out target, if user knows less than 12 moves, it learns target's moves.",
-		onSourceAfterFaint(length, source, target, effect) {
+		onSourceFaintCount(length, source, target, effect) {
 			if (effect && effect.effectType === 'Move') {
 				for (const moveSlot of source.moveSlots) {
 					if (moveSlot === null) return;

--- a/data/mods/gen2stadium2/scripts.ts
+++ b/data/mods/gen2stadium2/scripts.ts
@@ -526,7 +526,9 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (pokemon.side.totalFainted < 100) pokemon.side.totalFainted++;
 				this.runEvent('Faint', pokemon, faintData.source, faintData.effect);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon);
+				this.singleEvent('End', pokemon.getItem(), pokemon.itemState, pokemon);
 				pokemon.clearVolatile(false);
+				this.runEvent('AfterFaint', pokemon, faintData.source, faintData.effect);
 				pokemon.fainted = true;
 				pokemon.isActive = false;
 				pokemon.isStarted = false;
@@ -579,7 +581,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			return true;
 		}
 		if (faintData) {
-			this.runEvent('AfterFaint', faintData.target, faintData.source, faintData.effect, length);
+			this.runEvent('FaintCount', faintData.target, faintData.source, faintData.effect, length);
 		}
 		return false;
 	},

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -103,7 +103,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	battlebond: {
 		inherit: true,
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (source.bondTriggered) return;
 			if (effect?.effectType !== 'Move') {
 				return;

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -2296,7 +2296,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				return this.chainModify(1.5);
 			}
 		},
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.boost({ atk: -length }, source);
 			}

--- a/data/mods/gen9ssb/conditions.ts
+++ b/data/mods/gen9ssb/conditions.ts
@@ -305,8 +305,8 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 	},
 	artemis: {
 		noCopy: true,
-		onFoeAfterFaint(target, source, effect) {
-			this.add('message', `${source.name} was banned from Pok\u00e9mon Showdown!`);
+		onFoeFaintCount(length, target) {
+			this.add('message', `${target.name} was banned from Pok\u00e9mon Showdown!`);
 		},
 	},
 	arya: {
@@ -1212,7 +1212,7 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 		onFaint() {
 			this.add(`c:|${getName('Kennedy')}|FUCK OFF, REALLY?????`);
 		},
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			const message = this.sample(['ALLEZZZZZ', 'VAMOSSSSS', 'FORZAAAAA', 'LET\'S GOOOOO']);
 			this.add(`c:|${getName('Kennedy')}|${message}`);
 			if (source.species.id === 'cinderace' && this.field.pseudoWeather['anfieldatmosphere'] &&
@@ -1384,7 +1384,7 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 				this.add(`c:|${getName('Loethalion')}|...from Zero`);
 			}
 		},
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (enemyStaff(source) === 'Swiffix') {
 				this.add(`c:|${getName('Loethalion')}|It's still pfp...`);
 			} else if (enemyStaff(source) === 'Appletun a la Mode') {
@@ -1905,7 +1905,7 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 		onFaint() {
 			this.add(`c:|${getName('PYRO')}|Just remember ALL CAPS when you spell the man name...`);
 		},
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (effect?.effectType === 'Move') {
 				if (effect.id === 'meatgrinder') {
 					this.add(`c:|${getName('PYRO')}|Tripping off the beat kinda, dripping off the meat grinder`);
@@ -2654,7 +2654,7 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 		onFaint() {
 			this.add(`c:|${getName('WarriorGallade')}|a wig flew, and now i must bid you adieu. farewell my berries accrued, for this is the end of my etude.`);
 		},
-		onSourceAfterFaint() {
+		onSourceFaintCount() {
 			this.add(`c:|${getName('WarriorGallade')}|Triumphant through trouncing tough, tenacious threats today, though testing 212 takeovers tarry. Theorizing these techniques tends to torrid, terribly tiresome tabulations, therefore torrential tactics traverse thorough thoughts.`);
 		},
 		innateName: "Nutrient Boost",
@@ -2920,7 +2920,7 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 		onResidual(target, source, effect) {
 			this.heal(target.baseMaxhp / 8);
 		},
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			this.add(`c:|${getName('Elliot')}|Get Bovriled`);
 		},
 	},

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -306,12 +306,26 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (pokemon.side.totalFainted < 100) pokemon.side.totalFainted++;
 				this.runEvent('Faint', pokemon, faintData.source, faintData.effect);
 				this.singleEvent('End', pokemon.getAbility(), pokemon.abilityState, pokemon);
+				this.singleEvent('End', pokemon.getItem(), pokemon.itemState, pokemon);
+				if (pokemon.formeRegression && !pokemon.transformed) {
+					// before clearing volatiles
+					pokemon.baseSpecies = this.dex.species.get(pokemon.set.species || pokemon.set.name);
+					pokemon.baseAbility = toID(pokemon.set.ability);
+				}
 				pokemon.clearVolatile(false);
+				delete pokemon.terastallized;
+				if (pokemon.formeRegression) {
+					// after clearing volatiles
+					pokemon.details = pokemon.getUpdatedDetails();
+					this.add('detailschange', pokemon, pokemon.details, '[silent]');
+					pokemon.updateMaxHp();
+					pokemon.formeRegression = false;
+				}
+				this.runEvent('AfterFaint', pokemon, faintData.source, faintData.effect);
 				pokemon.fainted = true;
 				pokemon.illusion = null;
 				pokemon.isActive = false;
 				pokemon.isStarted = false;
-				delete pokemon.terastallized;
 				pokemon.side.faintedThisTurn = pokemon;
 				if (this.faintQueue.length >= faintQueueLeft) checkWin = true;
 			}
@@ -345,7 +359,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		if (checkWin && this.checkWin(faintData)) return true;
 
 		if (faintData && length) {
-			this.runEvent('AfterFaint', faintData.target, faintData.source, faintData.effect, length);
+			this.runEvent('FaintCount', faintData.target, faintData.source, faintData.effect, length);
 		}
 		return false;
 	},

--- a/data/mods/vaporemons/abilities.ts
+++ b/data/mods/vaporemons/abilities.ts
@@ -1,6 +1,6 @@
 export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	zerotohero: {
-		onSourceAfterFaint(length, target, source, effect) {
+		onSourceFaintCount(length, target, source, effect) {
 			if (this.effectState.heroTriggered) return;
 			if (effect?.effectType !== 'Move') {
 				return;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2530,10 +2530,6 @@ export class Battle {
 					pokemon.baseAbility = toID(pokemon.set.ability);
 				}
 				pokemon.clearVolatile(false);
-				pokemon.fainted = true;
-				pokemon.illusion = null;
-				pokemon.isActive = false;
-				pokemon.isStarted = false;
 				delete pokemon.terastallized;
 				if (pokemon.formeRegression) {
 					// after clearing volatiles
@@ -2542,6 +2538,11 @@ export class Battle {
 					pokemon.updateMaxHp();
 					pokemon.formeRegression = false;
 				}
+				this.runEvent('AfterFaint', pokemon, faintData.source, faintData.effect);
+				pokemon.fainted = true;
+				pokemon.illusion = null;
+				pokemon.isActive = false;
+				pokemon.isStarted = false;
 				pokemon.side.faintedThisTurn = pokemon;
 				if (this.faintQueue.length >= faintQueueLeft) checkWin = true;
 			}
@@ -2575,7 +2576,7 @@ export class Battle {
 		if (checkWin && this.checkWin(faintData)) return true;
 
 		if (faintData && length) {
-			this.runEvent('AfterFaint', faintData.target, faintData.source, faintData.effect, length);
+			this.runEvent('FaintCount', faintData.target, faintData.source, faintData.effect, length);
 		}
 		return false;
 	}

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -23,7 +23,7 @@ export interface EventMethods {
 	onAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAfterTakeItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
-	onAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onAfterFaint?: CommonHandlers['VoidEffect'];
 	onAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onAfterMove?: MoveEventMethods['onAfterMove'];
@@ -52,6 +52,7 @@ export interface EventMethods {
 	onEffectiveness?: MoveEventMethods['onEffectiveness'];
 	onEntryHazard?: (this: Battle, pokemon: Pokemon) => void;
 	onFaint?: CommonHandlers['VoidEffect'];
+	onFaintCount?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean;
 	onFractionalPriority?: CommonHandlers['ModifierSourceMove'] | -0.1;
 	onHit?: MoveEventMethods['onHit'];
@@ -131,7 +132,7 @@ export interface EventMethods {
 	onFoeAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onFoeAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onFoeAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
-	onFoeAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onFoeAfterFaint?: CommonHandlers['VoidEffect'];
 	onFoeAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onFoeAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onFoeAfterMove?: MoveEventMethods['onAfterMove'];
@@ -157,6 +158,7 @@ export interface EventMethods {
 	onFoeEatItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onFoeEffectiveness?: MoveEventMethods['onEffectiveness'];
 	onFoeFaint?: CommonHandlers['VoidEffect'];
+	onFoeFaintCount?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onFoeFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean;
 	onFoeHit?: MoveEventMethods['onHit'];
 	onFoeImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void;
@@ -229,7 +231,7 @@ export interface EventMethods {
 	onSourceAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onSourceAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onSourceAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
-	onSourceAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onSourceAfterFaint?: CommonHandlers['VoidEffect'];
 	onSourceAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onSourceAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onSourceAfterMove?: MoveEventMethods['onAfterMove'];
@@ -255,6 +257,7 @@ export interface EventMethods {
 	onSourceEatItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onSourceEffectiveness?: MoveEventMethods['onEffectiveness'];
 	onSourceFaint?: CommonHandlers['VoidEffect'];
+	onSourceFaintCount?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onSourceFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean;
 	onSourceHit?: MoveEventMethods['onHit'];
 	onSourceImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void;
@@ -329,7 +332,7 @@ export interface EventMethods {
 	onAnyAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAnyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAnyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
-	onAnyAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onAnyAfterFaint?: CommonHandlers['VoidEffect'];
 	onAnyAfterMega?: (this: Battle, pokemon: Pokemon) => void;
 	onAnyAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAnyAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
@@ -357,6 +360,7 @@ export interface EventMethods {
 	onAnyEatItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAnyEffectiveness?: MoveEventMethods['onEffectiveness'];
 	onAnyFaint?: CommonHandlers['VoidEffect'];
+	onAnyFaintCount?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAnyFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean;
 	onAnyHit?: MoveEventMethods['onHit'];
 	onAnyImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void;
@@ -502,7 +506,7 @@ export interface PokemonEventMethods extends EventMethods {
 	onAllyAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAllyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAllyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
-	onAllyAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onAllyAfterFaint?: CommonHandlers['VoidEffect'];
 	onAllyAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAllyAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onAllyAfterMove?: MoveEventMethods['onAfterMove'];
@@ -528,6 +532,7 @@ export interface PokemonEventMethods extends EventMethods {
 	onAllyEatItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAllyEffectiveness?: MoveEventMethods['onEffectiveness'];
 	onAllyFaint?: CommonHandlers['VoidEffect'];
+	onAllyFaintCount?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAllyFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean;
 	onAllyHit?: MoveEventMethods['onHit'];
 	onAllyImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void;

--- a/test/sim/abilities/receiver.js
+++ b/test/sim/abilities/receiver.js
@@ -10,7 +10,7 @@ describe(`Receiver`, () => {
 		battle.destroy();
 	});
 
-	it.skip(`should gain a boost immediately if taking over a KO boost Ability`, () => {
+	it(`should gain a boost immediately if taking over a KO boost Ability`, () => {
 		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'whimsicott', ability: 'soulheart', moves: ['memento'] },
 			{ species: 'passimian', ability: 'receiver', moves: ['sleeptalk'] },
@@ -23,7 +23,7 @@ describe(`Receiver`, () => {
 		assert.statStage(passimian, 'spa', 1);
 	});
 
-	it.skip(`should do weird stuff with multiple Soul-Heart and multiple Receiver`, () => {
+	it(`should do weird stuff with multiple Soul-Heart and multiple Receiver`, () => {
 		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Passimian', ability: 'receiver', moves: ['earthquake'] },
 			{ species: 'Magearna', ability: 'soulheart', level: 1, moves: ['sleeptalk'] },


### PR DESCRIPTION
Supersedes #10894

Rather than rerunning the Faint event inside Receiver, this properly introduces the other faint event that is used by Soul-Heart. This event is notably run after forme regression, as forme regression is the reason Reciever and Power of Alchemy use a separate earlier event in order to copy the abilities of fainted Mega Pokemon and the like.

I used `onAfterFaint` as the name because it just makes the most sense in this context. That meant I needed to rename the current `onAfterFaint`, which is used for Moxie-like abilities. Because of this usage, I decided to rename it to `onFaintCount`. If there is a better name to use I am open to changing it.