### PR TITLE
/savereplay: Stop re-generating passwords

### DIFF
--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -520,6 +520,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 	override readonly timer: RoomBattleTimer;
 	started = false;
 	active = false;
+	password = "";
 	replaySaved: boolean | 'auto' = false;
 	forcedSettings: { modchat?: string | null, privacy?: string | null } = {};
 	p1: RoomBattlePlayer = null!;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -2054,7 +2054,7 @@ export class GameRoom extends BasicRoom {
 			isPrivate ? 1 :
 			0;
 		if (isPrivate && hidden === 10) {
-			password = Replays.generatePassword();
+			password = battle.password ||= Replays.generatePassword();
 		}
 		if (battle.replaySaved !== true && hidden === 10) {
 			battle.replaySaved = 'auto';

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -2054,7 +2054,7 @@ export class GameRoom extends BasicRoom {
 			isPrivate ? 1 :
 			0;
 		if (isPrivate && hidden === 10) {
-			password = battle.password ||= Replays.generatePassword();
+			password = (battle.password ||= Replays.generatePassword());
 		}
 		if (battle.replaySaved !== true && hidden === 10) {
 			battle.replaySaved = 'auto';


### PR DESCRIPTION
The same password is now used across all `/savereplay`s in a battle so replay links now don't get broken just because someone saved the replay after you.