### PR TITLE
Ladder: Approve matchmaking based on shorter queue

### DIFF
--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -354,7 +354,7 @@ class Ladder extends LadderStore {
 		// search must be within range
 		let searchRange = 100;
 		const times = matches.map(([search]) => search.time);
-		const elapsed = Date.now() - Math.min(...times);
+		const elapsed = Date.now() - Math.max(...times);
 		if (formatid === `gen${Dex.gen}ou` || formatid === `gen${Dex.gen}randombattle`) {
 			searchRange = 50;
 		}


### PR DESCRIPTION
When determining if matchmaking is OK between two players use the timer of the player who has been waiting less so if someone is at 2000 Elo for example they won't be matched up vs someone 300 Elo below them immediatley just because someone at 1700 Elo was queueing for 60 seconds