### PR TITLE
Support running PS in a single process again

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -101,7 +101,7 @@ exports.subprocesses = {
 	 */
 	simulator: 1,
 
-	// beyond this point, it'd be very weird if you needed more than one of these
+	// beyond this point, it'd be very weird if you needed more than one of each of these
 
 	/** for validating teams */
 	validator: 1,

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -96,6 +96,8 @@ exports.subprocesses = {
 	network: 1,
 	/**
 	 * for simulating battles
+	 *   You should leave this at 1 unless your server has a very large
+	 *   amount of traffic (i.e. hundreds of concurrent battles).
 	 */
 	simulator: 1,
 

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -432,15 +432,6 @@ exports.logchallenges = false;
 exports.loguserstats = 1000 * 60 * 10; // 10 minutes
 
 /**
- * validatorprocesses - the number of processes to use for validating teams
- * simulatorprocesses - the number of processes to use for handling battles
- * You should leave both of these at 1 unless your server has a very large
- * amount of traffic (i.e. hundreds of concurrent battles).
- */
-exports.validatorprocesses = 1;
-exports.simulatorprocesses = 1;
-
-/**
  * inactiveuserthreshold - how long a user must be inactive before being pruned
  * from the `users` array. The default is 1 hour.
  */

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -93,19 +93,17 @@ exports.subprocesses = {
 	 *   this means or you are unfamiliar with PS' networking code, leave this set
 	 *   to 1.
 	 */
-
 	network: 1,
-
 	/**
-	 * validator - for validating teams
-	 * simulator - for handling battles
-	 * verifier - for user authentication
-	 * You should leave both of these at 1 unless your server has a very large
-	 * amount of traffic (i.e. hundreds of concurrent battles).
+	 * for simulating battles
 	 */
-
-	validator: 1,
 	simulator: 1,
+
+	// beyond this point, it'd be very weird if you needed more than one of these
+
+	/** for validating teams */
+	validator: 1,
+	/** for user authentication */
 	verifier: 1,
 	localartemis: 1,
 	remoteartemis: 1,
@@ -113,12 +111,9 @@ exports.subprocesses = {
 	chatdb: 1,
 	modlog: 1,
 	pm: 1,
-
-	/**
-	 * battlesearch - for the battlesearch chat plugin
-	 * datasearch - for the datasearch chat plugin
-	 */
+	/** for the battlesearch chat plugin */
 	battlesearch: 1,
+	/** datasearch - for the datasearch chat plugin */
 	datasearch: 1,
 };
 

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -76,7 +76,7 @@ Main's SSL deploy script from Let's Encrypt looks like:
 exports.proxyip = false;
 
 // subprocesses - the number of child processes to use for various tasks.
-//   Can be set to `null` instead of `{...}` to stop using subprocesses, if you're running out of RAM.
+//   Can be set to `0` instead of `{...}` to stop using subprocesses, if you're running out of RAM.
 exports.subprocesses = {
 	/**
 	 * network - the number of networking child processes to spawn

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -75,8 +75,8 @@ Main's SSL deploy script from Let's Encrypt looks like:
  */
 exports.proxyip = false;
 
-// subprocesses - the number of child processes to use for various tasks
-//   It can be globally set to 0 for minimum hardware specs.
+// subprocesses - the number of child processes to use for various tasks.
+//   Can be set to `0` instead of `{...}` to stop using subprocesses, if you're running out of RAM.
 exports.subprocesses = {
 	/**
 	 * network - the number of networking child processes to spawn

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -16,23 +16,6 @@ exports.port = 8000;
 exports.bindaddress = '0.0.0.0';
 
 /**
- * workers - the number of networking child processes to spawn
- *   This should be no greater than the number of threads available on your
- *   server's CPU. If you're not sure how many you have, you can check from a
- *   terminal by running:
- *
- *   $ node -e "console.log(require('os').cpus().length)"
- *
- *   Using more workers than there are available threads will cause performance
- *   issues. Keeping a couple threads available for use for OS-related work and
- *   other PS processes will likely give you the best performance, if your
- *   server's CPU is capable of multithreading. If you don't know what any of
- *   this means or you are unfamiliar with PS' networking code, leave this set
- *   to 1.
- */
-exports.workers = 1;
-
-/**
  * wsdeflate - compresses WebSocket messages
  *  Toggles use of the Sec-WebSocket-Extension permessage-deflate extension.
  *  This compresses messages sent and received over a WebSocket connection
@@ -91,6 +74,53 @@ Main's SSL deploy script from Let's Encrypt looks like:
  * @type {false | string[]}.
  */
 exports.proxyip = false;
+
+// subprocesses - the number of child processes to use for various tasks
+//   It can be globally set to 0 for minimum hardware specs.
+exports.subprocesses = {
+	/**
+	 * network - the number of networking child processes to spawn
+	 *   This should be no greater than the number of threads available on your
+	 *   server's CPU. If you're not sure how many you have, you can check from a
+	 *   terminal by running:
+	 *
+	 *   $ node -e "console.log(require('os').cpus().length)"
+	 *
+	 *   Using more workers than there are available threads will cause performance
+	 *   issues. Keeping a couple threads available for use for OS-related work and
+	 *   other PS processes will likely give you the best performance, if your
+	 *   server's CPU is capable of multithreading. If you don't know what any of
+	 *   this means or you are unfamiliar with PS' networking code, leave this set
+	 *   to 1.
+	 */
+
+	network: 1,
+
+	/**
+	 * validator - for validating teams
+	 * simulator - for handling battles
+	 * verifier - for user authentication
+	 * You should leave both of these at 1 unless your server has a very large
+	 * amount of traffic (i.e. hundreds of concurrent battles).
+	 */
+
+	validator: 1,
+	simulator: 1,
+	verifier: 1,
+	localartemis: 1,
+	remoteartemis: 1,
+	friends: 1,
+	chatdb: 1,
+	modlog: 1,
+	pm: 1,
+
+	/**
+	 * battlesearch - for the battlesearch chat plugin
+	 * datasearch - for the datasearch chat plugin
+	 */
+	battlesearch: 1,
+	datasearch: 1,
+};
 
 /**
  * Various debug options

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -76,7 +76,7 @@ Main's SSL deploy script from Let's Encrypt looks like:
 exports.proxyip = false;
 
 // subprocesses - the number of child processes to use for various tasks.
-//   Can be set to `0` instead of `{...}` to stop using subprocesses, if you're running out of RAM.
+//   Can be set to `null` instead of `{...}` to stop using subprocesses, if you're running out of RAM.
 exports.subprocesses = {
 	/**
 	 * network - the number of networking child processes to spawn

--- a/server/artemis/local.ts
+++ b/server/artemis/local.ts
@@ -173,5 +173,5 @@ if (require.main === module) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`abusemonitor-local-${process.pid}`, cmd => eval(cmd));
 } else if (!process.send) {
-	PM.spawn(Config.localartemisprocesses || 1);
+	PM.spawn(global.Config?.localartemisprocesses ?? 1);
 }

--- a/server/artemis/local.ts
+++ b/server/artemis/local.ts
@@ -173,5 +173,5 @@ if (require.main === module) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`abusemonitor-local-${process.pid}`, cmd => eval(cmd));
 } else if (!process.send) {
-	PM.spawn(global.Config?.localartemisprocesses ?? 1);
+	PM.spawn(global.Config?.subprocesses?.localartemis ?? 1);
 }

--- a/server/artemis/local.ts
+++ b/server/artemis/local.ts
@@ -173,5 +173,5 @@ if (require.main === module) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`abusemonitor-local-${process.pid}`, cmd => eval(cmd));
 } else if (!process.send) {
-	PM.spawn(global.Config?.subprocesses?.localartemis ?? 1);
+	PM.spawn(global.Config?.subprocessescache?.localartemis ?? 1);
 }

--- a/server/artemis/remote.ts
+++ b/server/artemis/remote.ts
@@ -123,7 +123,7 @@ if (require.main === module) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`abusemonitor-remote-${process.pid}`, cmd => eval(cmd));
 } else if (!process.send) {
-	PM.spawn(Config.remoteartemisprocesses || 1);
+	PM.spawn(global.Config?.remoteartemisprocesses ?? 1);
 }
 
 export class RemoteClassifier {

--- a/server/artemis/remote.ts
+++ b/server/artemis/remote.ts
@@ -123,7 +123,7 @@ if (require.main === module) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`abusemonitor-remote-${process.pid}`, cmd => eval(cmd));
 } else if (!process.send) {
-	PM.spawn(global.Config?.remoteartemisprocesses ?? 1);
+	PM.spawn(global.Config?.subprocesses?.remoteartemis ?? 1);
 }
 
 export class RemoteClassifier {

--- a/server/artemis/remote.ts
+++ b/server/artemis/remote.ts
@@ -123,7 +123,7 @@ if (require.main === module) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`abusemonitor-remote-${process.pid}`, cmd => eval(cmd));
 } else if (!process.send) {
-	PM.spawn(global.Config?.subprocesses?.remoteartemis ?? 1);
+	PM.spawn(global.Config?.subprocessescache?.remoteartemis ?? 1);
 }
 
 export class RemoteClassifier {

--- a/server/chat-plugins/battlesearch.ts
+++ b/server/chat-plugins/battlesearch.ts
@@ -498,5 +498,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start('battlesearch', cmd => eval(cmd));
 } else {
-	PM.spawn(global.Config?.subprocesses?.battlesearch ?? 1);
+	PM.spawn(global.Config?.subprocessescache?.battlesearch ?? 1);
 }

--- a/server/chat-plugins/battlesearch.ts
+++ b/server/chat-plugins/battlesearch.ts
@@ -498,5 +498,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start('battlesearch', cmd => eval(cmd));
 } else {
-	PM.spawn(global.Config?.battlesearchprocesses ?? 1);
+	PM.spawn(global.Config?.subprocesses?.battlesearch ?? 1);
 }

--- a/server/chat-plugins/battlesearch.ts
+++ b/server/chat-plugins/battlesearch.ts
@@ -26,7 +26,6 @@ interface BattleSearchResults {
 	timesBattled: { [k: string]: number };
 }
 
-const MAX_BATTLESEARCH_PROCESSES = 1;
 export async function runBattleSearch(userids: ID[], month: string, tierid: ID, turnLimit?: number) {
 	const useRipgrep = await checkRipgrepAvailability();
 	const pathString = `${month}/${tierid}/`;
@@ -499,5 +498,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start('battlesearch', cmd => eval(cmd));
 } else {
-	PM.spawn(MAX_BATTLESEARCH_PROCESSES);
+	PM.spawn(global.Config?.battlesearchprocesses ?? 1);
 }

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -3118,7 +3118,7 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	require('../../lib/repl').Repl.start('dexsearch', (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(global.Config?.subprocesses?.datasearch ?? 1);
+	PM.spawn(global.Config?.subprocessescache?.datasearch ?? 1);
 }
 
 export const testables = {

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -50,7 +50,6 @@ interface MoveOrGroup {
 
 type Direction = 'less' | 'greater' | 'equal';
 
-const MAX_PROCESSES = 1;
 const RESULTS_MAX_LENGTH = 10;
 const MAX_RANDOM_RESULTS = 30;
 const dexesHelpMods = Object.keys((global.Dex?.dexes || {})).filter(x => x !== 'sourceMaps').join('</code>, <code>');
@@ -3119,7 +3118,7 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	require('../../lib/repl').Repl.start('dexsearch', (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(MAX_PROCESSES);
+	PM.spawn(global.Config?.datasearchprocesses ?? 1);
 }
 
 export const testables = {

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -3118,7 +3118,7 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	require('../../lib/repl').Repl.start('dexsearch', (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(global.Config?.datasearchprocesses ?? 1);
+	PM.spawn(global.Config?.subprocesses?.datasearch ?? 1);
 }
 
 export const testables = {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1821,7 +1821,7 @@ export const Chat = new class {
 	 */
 	database = SQL(module, {
 		file: global.Config?.nofswriting ? ':memory:' : PLUGIN_DATABASE_PATH,
-		processes: global.Config?.chatdbprocesses,
+		processes: global.Config?.subprocesses?.chatdb ?? 1,
 	});
 	databaseReadyPromise: Promise<void> | null = null;
 
@@ -2708,7 +2708,7 @@ export interface Monitor {
 
 // explicitly check this so it doesn't happen in other child processes
 if (!process.send) {
-	Chat.database.spawn(Config.chatdbprocesses || 1);
+	Chat.database.spawn(global.Config?.subprocesses?.chatdb ?? 1);
 	Chat.databaseReadyPromise = Chat.prepareDatabase();
 	// we need to make sure it is explicitly JUST the child of the original parent db process
 	// no other child processes

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1821,7 +1821,7 @@ export const Chat = new class {
 	 */
 	database = SQL(module, {
 		file: global.Config?.nofswriting ? ':memory:' : PLUGIN_DATABASE_PATH,
-		processes: global.Config?.subprocesses?.chatdb ?? 1,
+		processes: global.Config?.subprocessescache?.chatdb ?? 1,
 	});
 	databaseReadyPromise: Promise<void> | null = null;
 
@@ -2708,7 +2708,7 @@ export interface Monitor {
 
 // explicitly check this so it doesn't happen in other child processes
 if (!process.send) {
-	Chat.database.spawn(global.Config?.subprocesses?.chatdb ?? 1);
+	Chat.database.spawn(global.Config?.subprocessescache?.chatdb ?? 1);
 	Chat.databaseReadyPromise = Chat.prepareDatabase();
 	// we need to make sure it is explicitly JUST the child of the original parent db process
 	// no other child processes

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -69,7 +69,7 @@ export function load(invalidate = false) {
 		}
 	}
 
-	if ('subprocesses' in config) {
+	if (config.subprocesses !== undefined) {
 		// Leniently accept all falsy values, including `null`.
 		if (!config.subprocesses || config.subprocesses === 1) {
 			config.subprocesses = Object.fromEntries(

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -71,9 +71,10 @@ export function load(invalidate = false) {
 
 	if (config.subprocesses !== undefined) {
 		// Leniently accept all falsy values, including `null`.
-		if (!config.subprocesses || config.subprocesses === 1) {
+		config.subprocesses ||= 0;
+		if (config.subprocesses === 0 || config.subprocesses === 1) {
 			config.subprocesses = Object.fromEntries(
-				processTypes.map(k => [k, ~~Boolean(config.subprocesses)])
+				processTypes.map(k => [k, config.subprocesses])
 			) as Record<ProcessType, number>;
 		} else if (typeof config.subprocesses !== 'object') {
 			reportError(`Invalid \`subprocesses\` specification. Use any of 0, 1, or a plain old object.`);

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -80,7 +80,7 @@ export function load(invalidate = false) {
 		}
 	}
 	if (!config.subprocesses) {
-		let deprecatedKeys = [];
+		const deprecatedKeys = [];
 		if ('workers' in config) {
 			deprecatedKeys.push('workers');
 			(config.subprocesses as SubProcessesConfig) ??= {};

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -80,7 +80,7 @@ export function load(invalidate = false) {
 			reportError(`Invalid \`subprocesses\` specification. Use any of 0, 1, or a plain old object.`);
 		}
 	}
-	if (!config.subprocesses) {
+	{
 		const deprecatedKeys = [];
 		if ('workers' in config) {
 			deprecatedKeys.push('workers');

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -74,7 +74,7 @@ export function load(invalidate = false) {
 		if (!config.subprocesses || config.subprocesses === 1) {
 			config.subprocesses = Object.fromEntries(
 				processTypes.map(k => [k, ~~Boolean(config.subprocesses)])
-			) as SubProcessesConfig;
+			) as Record<ProcessType, number>;
 		} else if (typeof config.subprocesses !== 'object') {
 			reportError(`Invalid \`subprocesses\` specification. Use any of 0, 1, or a plain old object.`);
 		}

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -72,7 +72,9 @@ export function load(invalidate = false) {
 	if ('subprocesses' in config) {
 		// Leniently accept all falsy values, including `null`.
 		if (!config.subprocesses || config.subprocesses === 1) {
-			config.subprocesses = Object.fromEntries(processTypes.map(k => [k, ~~Boolean(config.subprocesses)])) as SubProcessesConfig;
+			config.subprocesses = Object.fromEntries(
+				processTypes.map(k => [k, ~~Boolean(config.subprocesses)])
+			) as SubProcessesConfig;
 		} else if (typeof config.subprocesses !== 'object') {
 			reportError(`Invalid \`subprocesses\` specification. Use any of 0, 1, or a plain old object.`);
 		}
@@ -87,7 +89,7 @@ export function load(invalidate = false) {
 		for (const processType of processTypes) {
 			const compatKey = `${processType}processes`;
 			if (compatKey in config) {
-				deprecatedKeys.push(compatKey);;
+				deprecatedKeys.push(compatKey);
 				(config.subprocesses as SubProcessesConfig) ??= {};
 				(config.subprocesses as SubProcessesConfig)[processType] = config[compatKey];
 			}

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -11,6 +11,10 @@ import { ProcessManager, FS } from '../lib';
 
 type DefaultConfig = typeof defaults;
 
+type InputConfig = Omit<DefaultConfig, 'subprocesses'> & {
+	subprocesses: null | 0 | 1 | SubProcessesConfig,
+};
+
 type ProcessType = (
 	'localartemis' | 'remoteartemis' | 'battlesearch' | 'datasearch' | 'friends' |
 	'chatdb' | 'pm' | 'modlog' | 'network' | 'simulator' | 'validator' | 'verifier'
@@ -18,7 +22,7 @@ type ProcessType = (
 
 type SubProcessesConfig = Partial<Record<ProcessType, number>>;
 
-export type ConfigType = DefaultConfig & {
+export type ConfigType = InputConfig & {
 	groups: { [symbol: string]: GroupInfo },
 	groupsranking: EffectiveGroupSymbol[],
 	greatergroupscache: { [combo: string]: GroupSymbol },

--- a/server/friends.ts
+++ b/server/friends.ts
@@ -454,5 +454,5 @@ if (require.main === module) {
 		Repl.start(`friends-${process.pid}`, cmd => eval(cmd));
 	}
 } else if (!process.send) {
-	PM.spawn(Config.friendsprocesses || 1);
+	PM.spawn(global.Config?.friendsprocesses ?? 1);
 }

--- a/server/friends.ts
+++ b/server/friends.ts
@@ -454,5 +454,5 @@ if (require.main === module) {
 		Repl.start(`friends-${process.pid}`, cmd => eval(cmd));
 	}
 } else if (!process.send) {
-	PM.spawn(global.Config?.friendsprocesses ?? 1);
+	PM.spawn(global.Config?.subprocesses?.friends ?? 1);
 }

--- a/server/friends.ts
+++ b/server/friends.ts
@@ -454,5 +454,5 @@ if (require.main === module) {
 		Repl.start(`friends-${process.pid}`, cmd => eval(cmd));
 	}
 } else if (!process.send) {
-	PM.spawn(global.Config?.subprocesses?.friends ?? 1);
+	PM.spawn(global.Config?.subprocessescache?.friends ?? 1);
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -156,7 +156,7 @@ if (Config.crashguard) {
  * Start networking processes to be connected to
  *********************************************************/
 
-import { Sockets } from './sockets';
+const { Sockets } = require('./sockets');
 global.Sockets = Sockets;
 
 export function listen(port: number, bindAddress: string, workerCount: number) {
@@ -181,7 +181,7 @@ if (require.main === module) {
  * Set up our last global
  *********************************************************/
 
-import * as TeamValidatorAsync from './team-validator-async';
+const { TeamValidatorAsync } = require('./team-validator-async');
 global.TeamValidatorAsync = TeamValidatorAsync;
 
 /*********************************************************
@@ -200,16 +200,6 @@ if (Config.startuphook) {
 }
 
 if (Config.ofemain) {
-	try {
-		require.resolve('node-oom-heapdump');
-	} catch (e: any) {
-		if (e.code !== 'MODULE_NOT_FOUND') throw e; // should never happen
-		throw new Error(
-			'node-oom-heapdump is not installed, but it is a required dependency if Config.ofe is set to true! ' +
-			'Run npm install node-oom-heapdump and restart the server.'
-		);
-	}
-
 	// Create a heapdump if the process runs out of memory.
 	global.nodeOomHeapdump = (require as any)('node-oom-heapdump')({
 		addTimestamp: true,

--- a/server/index.ts
+++ b/server/index.ts
@@ -131,7 +131,6 @@ function setupGlobals() {
 
 	const Verifier = require('./verifier');
 	global.Verifier = Verifier;
-	Verifier.PM.spawn();
 
 	const { Tournaments } = require('./tournaments');
 	global.Tournaments = Tournaments;
@@ -184,7 +183,6 @@ if (require.main === module) {
 
 import * as TeamValidatorAsync from './team-validator-async';
 global.TeamValidatorAsync = TeamValidatorAsync;
-TeamValidatorAsync.PM.spawn();
 
 /*********************************************************
  * Start up the REPL server

--- a/server/modlog/index.ts
+++ b/server/modlog/index.ts
@@ -113,7 +113,7 @@ export class Modlog {
 
 		if (Config.usesqlite) {
 			if (this.database.isParentProcess) {
-				this.database.spawn(Config.modlogprocesses || 1);
+				this.database.spawn(global.Config?.subprocesses?.modlog ?? 1);
 			} else {
 				global.Monitor = {
 					crashlog(error: Error, source = 'A modlog child process', details: AnyObject | null = null) {

--- a/server/modlog/index.ts
+++ b/server/modlog/index.ts
@@ -113,7 +113,7 @@ export class Modlog {
 
 		if (Config.usesqlite) {
 			if (this.database.isParentProcess) {
-				this.database.spawn(global.Config?.subprocesses?.modlog ?? 1);
+				this.database.spawn(global.Config?.subprocessescache?.modlog ?? 1);
 			} else {
 				global.Monitor = {
 					crashlog(error: Error, source = 'A modlog child process', details: AnyObject | null = null) {

--- a/server/private-messages/index.ts
+++ b/server/private-messages/index.ts
@@ -212,7 +212,7 @@ export const PrivateMessages = new class {
 
 if (Config.usesqlite) {
 	if (!process.send) {
-		PM.spawn(Config.pmprocesses || 1);
+		PM.spawn(global.Config?.pmprocesses ?? 1);
 		// clear super old pms on startup
 		void PM.run(statements.clearDated, [Date.now(), EXPIRY_TIME]);
 	} else if (process.send && process.mainModule === module) {

--- a/server/private-messages/index.ts
+++ b/server/private-messages/index.ts
@@ -212,7 +212,7 @@ export const PrivateMessages = new class {
 
 if (Config.usesqlite) {
 	if (!process.send) {
-		PM.spawn(global.Config?.pmprocesses ?? 1);
+		PM.spawn(global.Config?.subprocesses?.pm ?? 1);
 		// clear super old pms on startup
 		void PM.run(statements.clearDated, [Date.now(), EXPIRY_TIME]);
 	} else if (process.send && process.mainModule === module) {

--- a/server/private-messages/index.ts
+++ b/server/private-messages/index.ts
@@ -212,7 +212,7 @@ export const PrivateMessages = new class {
 
 if (Config.usesqlite) {
 	if (!process.send) {
-		PM.spawn(global.Config?.subprocesses?.pm ?? 1);
+		PM.spawn(global.Config?.subprocessescache?.pm ?? 1);
 		// clear super old pms on startup
 		void PM.run(statements.clearDated, [Date.now(), EXPIRY_TIME]);
 	} else if (process.send && process.mainModule === module) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1402,5 +1402,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`sim-${process.pid}`, cmd => eval(cmd));
 } else {
-	PM.spawn(global.Config?.subprocesses?.simulator ?? 1);
+	PM.spawn(global.Config?.subprocessescache?.simulator ?? 1);
 }

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1402,5 +1402,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`sim-${process.pid}`, cmd => eval(cmd));
 } else {
-	PM.spawn(global.Config?.simulatorprocesses ?? 1);
+	PM.spawn(global.Config?.subprocesses?.simulator ?? 1);
 }

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1402,5 +1402,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start(`sim-${process.pid}`, cmd => eval(cmd));
 } else {
-	PM.spawn(global.Config ? Config.simulatorprocesses : 1);
+	PM.spawn(global.Config?.simulatorprocesses ?? 1);
 }

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -84,9 +84,7 @@ export const Sockets = new class {
 		if (port !== undefined) {
 			Config.port = port;
 		}
-		if (workerCount === undefined) {
-			workerCount = (Config.workers !== undefined ? Config.workers : 1);
-		}
+		workerCount ??= (Config.workers ?? 1);
 
 		PM.env = { PSPORT: Config.port, PSBINDADDR: Config.bindaddress || '0.0.0.0', PSNOSSL: Config.ssl ? 0 : 1 };
 		PM.subscribeSpawn(worker => void this.onSpawn(worker));

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -84,7 +84,7 @@ export const Sockets = new class {
 		if (port !== undefined) {
 			Config.port = port;
 		}
-		workerCount ??= (Config.subprocesses?.network ?? 1);
+		workerCount ??= (Config.subprocessescache?.network ?? 1);
 
 		PM.env = { PSPORT: Config.port, PSBINDADDR: Config.bindaddress || '0.0.0.0', PSNOSSL: Config.ssl ? 0 : 1 };
 		PM.subscribeSpawn(worker => void this.onSpawn(worker));

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -84,7 +84,7 @@ export const Sockets = new class {
 		if (port !== undefined) {
 			Config.port = port;
 		}
-		workerCount ??= (Config.workers ?? 1);
+		workerCount ??= (Config.subprocesses?.network ?? 1);
 
 		PM.env = { PSPORT: Config.port, PSBINDADDR: Config.bindaddress || '0.0.0.0', PSNOSSL: Config.ssl ? 0 : 1 };
 		PM.subscribeSpawn(worker => void this.onSpawn(worker));

--- a/server/team-validator-async.ts
+++ b/server/team-validator-async.ts
@@ -97,5 +97,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	require('../lib/repl').Repl.start(`team-validator-${process.pid}`, (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(global.Config?.validatorprocesses ?? 1);
+	PM.spawn(global.Config?.subprocesses?.validator ?? 1);
 }

--- a/server/team-validator-async.ts
+++ b/server/team-validator-async.ts
@@ -97,5 +97,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	require('../lib/repl').Repl.start(`team-validator-${process.pid}`, (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(global.Config ? Config.validatorprocesses : 1);
+	PM.spawn(global.Config?.validatorprocesses ?? 1);
 }

--- a/server/team-validator-async.ts
+++ b/server/team-validator-async.ts
@@ -97,5 +97,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	require('../lib/repl').Repl.start(`team-validator-${process.pid}`, (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(global.Config?.subprocesses?.validator ?? 1);
+	PM.spawn(global.Config?.subprocessescache?.validator ?? 1);
 }

--- a/server/verifier.ts
+++ b/server/verifier.ts
@@ -40,5 +40,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start('verifier', (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(global.Config?.verifierprocesses ?? 1);
+	PM.spawn(global.Config?.subprocesses?.verifier ?? 1);
 }

--- a/server/verifier.ts
+++ b/server/verifier.ts
@@ -40,5 +40,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start('verifier', (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(global.Config?.subprocesses?.verifier ?? 1);
+	PM.spawn(global.Config?.subprocessescache?.verifier ?? 1);
 }

--- a/server/verifier.ts
+++ b/server/verifier.ts
@@ -40,5 +40,5 @@ if (!PM.isParentProcess) {
 	// eslint-disable-next-line no-eval
 	Repl.start('verifier', (cmd: string) => eval(cmd));
 } else {
-	PM.spawn(global.Config ? Config.verifierprocesses : 1);
+	PM.spawn(global.Config?.verifierprocesses ?? 1);
 }


### PR DESCRIPTION
- ``Config.validatorprocesses = 0;`` and ``Config.verifierprocesses = 0;`` were broken due to redundant spawn in ``server/index.ts``.
- The following config keys were using default semantics based on OR-short-circuiting, which prevented ``0`` from being used:

```js
Config.localartemisprocesses;
Config.remoteartemisprocesses;
Config.chatdbprocesses;
Config.friendsprocesses;
Config.modlogprocesses;
Config.pmprocesses;
```