### PR TITLE
Database: Fix PostgreSQL compatibility in DatabaseTable replace() and upsert() methods

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -314,14 +314,14 @@ export class DatabaseTable<Row, DB extends Database> {
 	}
 	replace(partialRow: PartialOrSQL<Row>, where?: SQLStatement) {
 		if (this.db.type === 'pg') {
-		  if (!this.primaryKeyName) throw new Error(`Cannot replace() without a single-column primary key`);
-		  return this.queryExec(`
-		    INSERT INTO "${this.name}" (${partialRow as SQLValue})
-		    ON CONFLICT ("${this.primaryKeyName}")
-		    DO UPDATE
-		    SET ${partialRow as SQLValue}
-		    ${where}
-		  `);
+			if (!this.primaryKeyName) throw new Error(`Cannot replace() without a single-column primary key`);
+			return this.queryExec()`
+			  INSERT INTO "${this.name}" (${partialRow as any})
+			  ON CONFLICT ("${this.primaryKeyName}")
+			  DO UPDATE
+			  SET ${partialRow as any}
+			  ${where}
+			`;
 		}
 		return this.queryExec()`REPLACE INTO "${this.name}" (${partialRow as SQLValue}) ${where}`;
 	}

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -315,13 +315,9 @@ export class DatabaseTable<Row, DB extends Database> {
 	replace(partialRow: PartialOrSQL<Row>, where?: SQLStatement) {
 		if (this.db.type === 'pg') {
 			if (!this.primaryKeyName) throw new Error(`Cannot replace() without a single-column primary key`);
-			return this.queryExec()`
-			  INSERT INTO "${this.name}" (${partialRow as any})
-			  ON CONFLICT ("${this.primaryKeyName}")
-			  DO UPDATE
-			  SET ${partialRow as any}
-			  ${where}
-			`;
+			return this.queryExec(
+			)`INSERT INTO "${this.name}" (${partialRow as any}) ON CONFLICT ("${this.primaryKeyName
+			}") DO UPDATE SET ${partialRow as any} ${where}`;
 		}
 		return this.queryExec()`REPLACE INTO "${this.name}" (${partialRow as SQLValue}) ${where}`;
 	}

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -313,10 +313,16 @@ export class DatabaseTable<Row, DB extends Database> {
 		return this.replace(partialRow, where);
 	}
 	replace(partialRow: PartialOrSQL<Row>, where?: SQLStatement) {
-		if (this.db.type === 'pg') {
-			if (!this.primaryKeyName) throw new Error(`Cannot replace() without a single-column primary key`);
-			return this.queryExec()`INSERT INTO "${this.name}" (${partialRow as SQLValue}) ON CONFLICT ("${this.primaryKeyName}") DO UPDATE SET ${partialRow as SQLValue} ${where}`;
-		}
+	if (this.db.type === 'pg') {
+	  if (!this.primaryKeyName) throw new Error(`Cannot replace() without a single-column primary key`);
+	  return this.queryExec(`
+	    INSERT INTO "${this.name}" (${partialRow as SQLValue})
+	    ON CONFLICT ("${this.primaryKeyName}")
+	    DO UPDATE
+	    SET ${partialRow as SQLValue}
+	    ${where}
+	  `);
+	}
 		return this.queryExec()`REPLACE INTO "${this.name}" (${partialRow as SQLValue}) ${where}`;
 	}
 	get(primaryKey: BasicSQLValue, entries?: (keyof Row & string)[] | SQLStatement) {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -275,7 +275,7 @@ export class DatabaseTable<Row, DB extends Database> {
 	eval<T>():
 	(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<T | undefined> {
 		return (strings, ...rest) =>
-			this.queryOne<{ result: T; }>(
+			this.queryOne<{ result: T }>(
 			)`SELECT ${new SQLStatement(strings, rest)} AS result FROM "${this.name}" LIMIT 1`
 				.then(row => row?.result);
 	}

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -10,7 +10,7 @@ import * as mysql from 'mysql2';
 import * as pg from 'pg';
 
 export type BasicSQLValue = string | number | null;
-export type SQLRow = { [k: string]: BasicSQLValue; };
+export type SQLRow = { [k: string]: BasicSQLValue };
 export type SQLValue =
 	BasicSQLValue | SQLStatement | SQLStatement[] | PartialOrSQL<SQLRow> | BasicSQLValue[] | undefined;
 
@@ -146,7 +146,7 @@ export function SQL(strings: TemplateStringsArray | string[] | string, ...values
 	return new SQLStatement(strings, values);
 }
 
-export interface ResultRow { [k: string]: BasicSQLValue; }
+export interface ResultRow { [k: string]: BasicSQLValue }
 
 export const connectedDatabases: Database[] = [];
 
@@ -239,41 +239,41 @@ export class DatabaseTable<Row, DB extends Database> {
 	// low-level
 
 	selectAll<T = Row>(entries?: (keyof Row & string)[] | SQLStatement):
-		(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<T[]> {
+	(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<T[]> {
 		if (!entries) entries = SQL`*`;
 		if (Array.isArray(entries)) entries = SQL`"${entries}"`;
 		return (strings, ...rest) =>
 			this.query<T>()`SELECT ${entries} FROM "${this.name}" ${new SQLStatement(strings, rest)}`;
 	}
 	selectOne<T = Row>(entries?: (keyof Row & string)[] | SQLStatement):
-		(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<T | undefined> {
+	(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<T | undefined> {
 		if (!entries) entries = SQL`*`;
 		if (Array.isArray(entries)) entries = SQL`"${entries}"`;
 		return (strings, ...rest) =>
 			this.queryOne<T>()`SELECT ${entries} FROM "${this.name}" ${new SQLStatement(strings, rest)} LIMIT 1`;
 	}
 	updateAll(partialRow: PartialOrSQL<Row>):
-		(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<OkPacketOf<DB>> {
+	(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<OkPacketOf<DB>> {
 		return (strings, ...rest) =>
 			this.queryExec()`UPDATE "${this.name}" SET ${partialRow as any} ${new SQLStatement(strings, rest)}`;
 	}
 	updateOne(partialRow: PartialOrSQL<Row> | SQLStatement):
-		(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<OkPacketOf<DB>> {
+	(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<OkPacketOf<DB>> {
 		return (s, ...r) =>
 			this.queryExec()`UPDATE "${this.name}" SET ${partialRow as any} ${new SQLStatement(s, r)}`;
 	}
 	deleteAll():
-		(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<OkPacketOf<DB>> {
+	(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<OkPacketOf<DB>> {
 		return (strings, ...rest) =>
 			this.queryExec()`DELETE FROM "${this.name}" ${new SQLStatement(strings, rest)}`;
 	}
 	deleteOne():
-		(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<OkPacketOf<DB>> {
+	(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<OkPacketOf<DB>> {
 		return (strings, ...rest) =>
 			this.queryExec()`DELETE FROM "${this.name}" ${new SQLStatement(strings, rest)} LIMIT 1`;
 	}
 	eval<T>():
-		(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<T | undefined> {
+	(strings: TemplateStringsArray, ...rest: SQLValue[]) => Promise<T | undefined> {
 		return (strings, ...rest) =>
 			this.queryOne<{ result: T; }>(
 			)`SELECT ${new SQLStatement(strings, rest)} AS result FROM "${this.name}" LIMIT 1`
@@ -335,7 +335,7 @@ export class DatabaseTable<Row, DB extends Database> {
 
 export class MySQLDatabase extends Database<mysql.Pool, mysql.OkPacket> {
 	override type = 'mysql' as const;
-	constructor(config: mysql.PoolOptions & { prefix?: string; }) {
+	constructor(config: mysql.PoolOptions & { prefix?: string }) {
 		const prefix = config.prefix || "";
 		if (config.prefix) {
 			config = { ...config };
@@ -381,7 +381,7 @@ export class MySQLDatabase extends Database<mysql.Pool, mysql.OkPacket> {
 	}
 }
 
-export class PGDatabase extends Database<pg.Pool, { affectedRows: number | null; }> {
+export class PGDatabase extends Database<pg.Pool, { affectedRows: number | null }> {
 	override type = 'pg' as const;
 	constructor(config: pg.PoolConfig) {
 		super(config ? new pg.Pool(config) : null!);

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -313,16 +313,16 @@ export class DatabaseTable<Row, DB extends Database> {
 		return this.replace(partialRow, where);
 	}
 	replace(partialRow: PartialOrSQL<Row>, where?: SQLStatement) {
-	if (this.db.type === 'pg') {
-	  if (!this.primaryKeyName) throw new Error(`Cannot replace() without a single-column primary key`);
-	  return this.queryExec(`
-	    INSERT INTO "${this.name}" (${partialRow as SQLValue})
-	    ON CONFLICT ("${this.primaryKeyName}")
-	    DO UPDATE
-	    SET ${partialRow as SQLValue}
-	    ${where}
-	  `);
-	}
+		if (this.db.type === 'pg') {
+		  if (!this.primaryKeyName) throw new Error(`Cannot replace() without a single-column primary key`);
+		  return this.queryExec(`
+		    INSERT INTO "${this.name}" (${partialRow as SQLValue})
+		    ON CONFLICT ("${this.primaryKeyName}")
+		    DO UPDATE
+		    SET ${partialRow as SQLValue}
+		    ${where}
+		  `);
+		}
 		return this.queryExec()`REPLACE INTO "${this.name}" (${partialRow as SQLValue}) ${where}`;
 	}
 	get(primaryKey: BasicSQLValue, entries?: (keyof Row & string)[] | SQLStatement) {


### PR DESCRIPTION
Fixes a PostgreSQL syntax error crash in the `/teams setprivacy` command by making the `DatabaseTable.replace()` and `upsert()` methods database-agnostic.