### PR TITLE
Fix the activation timing of healing berries

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -153,10 +153,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			}
 		},
 		onTryEatItem(item) {
-			const healingItems = [
-				'aguavberry', 'enigmaberry', 'figyberry', 'iapapaberry', 'magoberry', 'sitrusberry', 'wikiberry', 'oranberry', 'berryjuice',
-			];
-			if (healingItems.includes(item.id)) {
+			if (item.isBerry || item.id === 'berryjuice') {
 				return this.effectState.checkedAngerShell;
 			}
 			return true;
@@ -169,6 +166,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const damage = move.multihit ? move.totalDamage : lastAttackedBy.damage;
 			if (target.hp <= target.maxhp / 2 && target.hp + damage > target.maxhp / 2) {
 				this.boost({ atk: 1, spa: 1, spe: 1, def: -1, spd: -1 }, target, target);
+				const item = target.getItem();
+				if (item.isBerry || item.id === 'berryjuice') this.runEvent('AfterDamage', target, null, null, damage);
 			}
 		},
 		flags: {},
@@ -419,10 +418,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			}
 		},
 		onTryEatItem(item) {
-			const healingItems = [
-				'aguavberry', 'enigmaberry', 'figyberry', 'iapapaberry', 'magoberry', 'sitrusberry', 'wikiberry', 'oranberry', 'berryjuice',
-			];
-			if (healingItems.includes(item.id)) {
+			if (item.isBerry || item.id === 'berryjuice') {
 				return this.effectState.checkedBerserk;
 			}
 			return true;
@@ -435,6 +431,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			const damage = move.multihit && !move.smartTarget ? move.totalDamage : lastAttackedBy.damage;
 			if (target.hp <= target.maxhp / 2 && target.hp + damage > target.maxhp / 2) {
 				this.boost({ spa: 1 }, target, target);
+				const item = target.getItem();
+				if (item.isBerry || item.id === 'berryjuice') this.runEvent('AfterDamage', target, null, null, damage);
 			}
 		},
 		flags: {},
@@ -1566,7 +1564,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		onStart(pokemon) {
 			pokemon.abilityState.gluttony = true;
 		},
-		onDamage(item, pokemon) {
+		onAfterDamage(damage, pokemon) {
 			pokemon.abilityState.gluttony = true;
 		},
 		flags: {},

--- a/data/items.ts
+++ b/data/items.ts
@@ -160,7 +160,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 80,
 			type: "Dragon",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -269,7 +275,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 100,
 			type: "Ground",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -434,7 +446,14 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		fling: {
 			basePower: 30,
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 2) {
+				if (this.runEvent('TryHeal', pokemon, null, this.effect, 20) && pokemon.useItem()) {
+					this.heal(20);
+				}
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				if (this.runEvent('TryHeal', pokemon, null, this.effect, 20) && pokemon.useItem()) {
 					this.heal(20);
@@ -1861,7 +1880,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 80,
 			type: "Bug",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -2179,7 +2204,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 100,
 			type: "Ice",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -2635,7 +2666,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 80,
 			type: "Dark",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -2977,7 +3014,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 100,
 			type: "Flying",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -3112,7 +3155,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 100,
 			type: "Grass",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -3408,7 +3457,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 80,
 			type: "Ghost",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -4073,7 +4128,12 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 80,
 			type: "Poison",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 2) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
 			}
@@ -4213,7 +4273,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 100,
 			type: "Poison",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -5123,13 +5189,19 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 100,
 			type: "Fighting",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
 			}
 		},
-		onEat(pokemon) {
+		onAfterDamage(damage, pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onEat() {
 			this.boost({ spe: 1 });
 		},
 		num: 203,
@@ -5349,7 +5421,12 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 80,
 			type: "Psychic",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 2) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
 			}
@@ -5572,7 +5649,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 100,
 			type: "Psychic",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();
@@ -7278,7 +7361,13 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			basePower: 80,
 			type: "Rock",
 		},
-		onUpdate(pokemon) {
+		onStart(pokemon) {
+			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
+				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
+				pokemon.eatItem();
+			}
+		},
+		onAfterDamage(damage, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 &&
 				pokemon.hasAbility('gluttony') && pokemon.abilityState.gluttony)) {
 				pokemon.eatItem();

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -1,7 +1,8 @@
 export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	aguavberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -12,7 +13,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	apicotberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -23,7 +25,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	berryjuice: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -89,7 +92,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	figyberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -100,7 +104,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	ganlonberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -125,7 +130,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	iapapaberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -151,7 +157,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	lansatberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -174,7 +181,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	liechiberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -212,7 +220,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	magoberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -267,7 +276,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	oranberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -278,7 +288,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	petayaberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -304,7 +315,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	salacberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -355,7 +367,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	sitrusberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -393,7 +406,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	starfberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {
@@ -414,7 +428,8 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	},
 	wikiberry: {
 		inherit: true,
-		onUpdate() {},
+		onStart() {},
+		onAfterDamage() {},
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
 		onResidual(pokemon) {

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1139,6 +1139,7 @@ export class BattleActions {
 					this.battle.singleEvent('AfterHit', moveData, {}, t, pokemon, move);
 				}
 			}
+			this.battle.runEvent('AfterDamage', damagedTargets, pokemon, move, damagedDamage);
 			if (pokemon.hp && pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {
 				this.battle.runEvent('EmergencyExit', pokemon);
 			}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2132,6 +2132,8 @@ export class Battle {
 					this.heal(amount, source, target, 'drain');
 				}
 			}
+			// for moves, it needs to run after the 'AfterHit' event
+			if (effect.effectType !== 'Move') this.runEvent('AfterDamage', target, source, effect, targetDamage);
 		}
 
 		if (instafaint) {
@@ -2224,6 +2226,7 @@ export class Battle {
 			this.add('-damage', target, target.getHealth);
 			break;
 		}
+		this.runEvent('AfterDamage', target, source, effect, damage);
 		if (target.fainted) this.faint(target);
 		return damage;
 	}

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -23,6 +23,7 @@ export interface EventMethods {
 	onAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAfterTakeItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onAfterDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];

--- a/test/sim/items/sitrusberry.js
+++ b/test/sim/items/sitrusberry.js
@@ -20,6 +20,14 @@ describe('Sitrus Berry', () => {
 		assert.equal(holder.hp, Math.floor(holder.maxhp / 4) + 1);
 	});
 
+	it('should be eaten in the middle of a multi-hit move', () => {
+		battle = common.createBattle();
+		battle.setPlayer('p1', { team: [{ species: 'Urshifu-Rapid-Strike', moves: ['surgingstrikes'] }] });
+		battle.setPlayer('p2', { team: [{ species: 'Heatran', item: 'sitrusberry', moves: ['sleeptalk'], nature: 'Gentle' }] });
+		battle.makeChoices();
+		assert.false.fainted(battle.p2.active[0]);
+	});
+
 	it('should be eaten immediately if (re)gained on low hp', () => {
 		battle = common.createBattle([
 			[{ species: 'Magnemite', ability: 'sturdy', item: 'sitrusberry', moves: ['recycle'] }],
@@ -41,7 +49,7 @@ describe('Sitrus Berry', () => {
 		assert.equal(battle.p1.active[0].hp, 1);
 	});
 
-	it.skip(`should not heal 25% HP if a confusion self-hit would bring the user into Berry trigger range`, () => {
+	it(`should not heal 25% HP if a confusion self-hit would bring the user into Berry trigger range`, () => {
 		battle = common.createBattle([[
 			{ species: 'Deoxys-Attack', item: 'sitrusberry', moves: ['sleeptalk'] },
 		], [
@@ -53,7 +61,7 @@ describe('Sitrus Berry', () => {
 		assert.false.fullHP(holder);
 	});
 
-	it.skip(`should heal 25% HP immediately after any end-of-turn effect`, () => {
+	it(`should heal 25% HP immediately after any end-of-turn effect`, () => {
 		battle = common.createBattle([[
 			{ species: 'mimikyu', moves: ['curse'] },
 		], [


### PR DESCRIPTION
Waiting for https://github.com/smogon/pokemon-showdown/pull/11347

---

Supersedes https://github.com/smogon/pokemon-showdown/pull/8354
This is a subset of #10902, as that PR is very large and unlikely to be merged.

Fixes https://www.smogon.com/forums/threads/timing-of-hp-restoring-berries-in-end-turn-resolution.3745483/

I personally confirmed that non-healing berries also activate after Anger Shell/Berserk (I tested Ganlon Berry Klawf).