### PR TITLE
Update ChatBats winrates tracking

### DIFF
--- a/server/chat-plugins/randombattles/winrates.tsx
+++ b/server/chat-plugins/randombattles/winrates.tsx
@@ -186,7 +186,7 @@ async function collectStats(battle: RoomBattle, winner: ID, players: ID[]) {
 		// may need to be raised again if ladder takes off further
 		eloFloor = 1400;
 	}
-	if (!formatData || ((format.mod !== 'gen9ssb' && format.mod !== 'chatbats') && battle.rated < eloFloor) || !winner) 
+	if (!formatData || ((format.mod !== 'gen9ssb' && format.mod !== 'chatbats') && battle.rated < eloFloor) || !winner)
 		return;
 	checkRollover();
 	for (const p of battle.players) {


### PR DESCRIPTION
Set ChatBats to have no minimum ELO to start tracking winrates