### PR TITLE
Fix interaction between Emergency Exit and Substitute

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -273,6 +273,7 @@ export class BattleActions {
 			}
 		}
 		pokemon.lastDamage = 0;
+		pokemon.hurtThisMove = null;
 		let lockedMove;
 		if (!externalMove) {
 			lockedMove = this.battle.runEvent('LockMove', pokemon);
@@ -1026,7 +1027,7 @@ export class BattleActions {
 				// The previous check was for `move.multihit`, but that fails for Dragon Darts
 				const curDamage = targets.length === 1 ? move.totalDamage : d;
 				if (typeof curDamage === 'number' && targets[i].hp) {
-					const targetHPBeforeDamage = (targets[i].hurtThisTurn || 0) + curDamage;
+					const targetHPBeforeDamage = (targets[i].hurtThisMove || 0) + curDamage;
 					if (targets[i].hp <= targets[i].maxhp / 2 && targetHPBeforeDamage > targets[i].maxhp / 2) {
 						this.battle.runEvent('EmergencyExit', targets[i], pokemon);
 					}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1634,6 +1634,7 @@ export class Battle {
 					// It shouldn't be possible in a normal battle for a Pokemon to be damaged before turn 1's move selection
 					// However, this could be potentially relevant in certain OMs
 					pokemon.hurtThisTurn = null;
+					pokemon.hurtThisMove = null;
 				}
 
 				pokemon.maybeDisabled = false;
@@ -2089,7 +2090,7 @@ export class Battle {
 			}
 
 			retVals[i] = targetDamage = target.damage(targetDamage, source, effect);
-			if (targetDamage !== 0) target.hurtThisTurn = target.hp;
+			if (targetDamage !== 0) target.hurtThisTurn = target.hurtThisMove = target.hp;
 			if (source && effect.effectType === 'Move') source.lastDamage = targetDamage;
 
 			const name = effect.fullname === 'tox' ? 'psn' : effect.fullname;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -228,9 +228,16 @@ export class Pokemon {
 	 * The undynamaxed HP value this Pokemon was reduced to by damage this turn,
 	 * or false if it hasn't taken damage yet this turn
 	 *
-	 * Used for Assurance, Emergency Exit, and Wimp Out
+	 * Used for Assurance
 	 */
 	hurtThisTurn: number | null;
+	/**
+	 * The undynamaxed HP value this Pokemon was reduced to by damage during the current move,
+	 * or false if it hasn't taken damage
+	 *
+	 * Used for Emergency Exit and Wimp Out
+	 */
+	hurtThisMove: number | null;
 	lastDamage: number;
 	attackedBy: Attacker[];
 	timesAttacked: number;
@@ -457,6 +464,7 @@ export class Pokemon {
 		this.statsRaisedThisTurn = false;
 		this.statsLoweredThisTurn = false;
 		this.hurtThisTurn = null;
+		this.hurtThisMove = null;
 		this.lastDamage = 0;
 		this.attackedBy = [];
 		this.timesAttacked = 0;
@@ -1517,6 +1525,7 @@ export class Pokemon {
 		this.lastDamage = 0;
 		this.attackedBy = [];
 		this.hurtThisTurn = null;
+		this.hurtThisMove = null;
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -176,14 +176,16 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it(`should not request switch-out on usage of Substitute`, () => {
-		battle = common.createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', moves: ['substitute'], ivs: EMPTY_IVS }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-			[{ species: "Deoxys-Attack", ability: 'pressure', item: 'laggingtail', moves: ['thunderbolt'] }],
+		battle = common.createBattle([[
+				{ species: "Golisopod", ability: 'emergencyexit', moves: ['substitute'] },
+				{ species: "Clefable", ability: 'Unaware', moves: ['sleeptalk'] },
+			], [
+				{ species: "Deoxys-Attack", ability: 'pressure', moves: ['seismictoss'] },
+			],
 		]);
 		const eePokemon = battle.p1.active[0];
-		battle.makeChoices('move substitute', 'move thunderbolt');
-		assert.false.atMost(eePokemon.hp, eePokemon.maxhp / 2);
-		battle.makeChoices('move substitute', 'move thunderbolt');
+		battle.makeChoices('move substitute', 'move seismictoss');
+		console.log(battle.log);
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 		assert.equal(battle.requestState, 'move');
 	});


### PR DESCRIPTION
Another subset of https://github.com/smogon/pokemon-showdown/pull/10902
Fixes https://www.smogon.com/forums/threads/emergency-exit-incorrectly-activates-with-substitute-damage.3766866/
Emergency Exit would activate from Substitute damage if the Pokémon had been damaged by a move earlier in the same turn.