### PR TITLE
Remove BDSP Eject Button inheritance

### DIFF
--- a/data/mods/gen8bdsp/items.ts
+++ b/data/mods/gen8bdsp/items.ts
@@ -102,18 +102,6 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	ejectbutton: {
 		inherit: true,
 		isNonstandard: "Unobtainable",
-		onAfterMoveSecondary(target, source, move) {
-			if (source && source !== target && target.hp && move && move.category !== 'Status' && !move.flags['futuremove']) {
-				if (!this.canSwitch(target.side) || target.forceSwitchFlag || target.beingCalledBack || target.isSkyDropped()) return;
-				for (const pokemon of this.getAllActive()) {
-					if (pokemon.switchFlag === true) return;
-				}
-				// TODO: Confirm mechanics
-				this.add("-activate", target, "item: Eject Button");
-				target.switchFlag = true;
-				source.switchFlag = false;
-			}
-		},
 	},
 	ejectpack: {
 		inherit: true,


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/commit/e8ec5d2c61ff4142f7b82d7912774d3cdbed2dd8
Is there a reason to have this code?