### PR TITLE
ChatBats: add graceful fallback for random team generation

### DIFF
--- a/data/random-battles/chatbats/teams.ts
+++ b/data/random-battles/chatbats/teams.ts
@@ -861,7 +861,7 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 	override randomSets: { [species: string]: RandomTeamsTypes.RandomSpeciesData } = require('./random-sets.json');
 
-    randomChatBatsTeam() {
+	randomChatBatsTeam() {
 		this.enforceNoDirectCustomBanlistChanges();
 
 		const seed = this.prng.getSeed();
@@ -941,13 +941,13 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 			// TEMPORARILY ADJUSTING BALANCE OF THIS BLOCK -- TOO FEW POKEMON TO GENERATE TEAMS
 			// update: reverting these changes, but leaving just in case
-            if (!isMonotype && !this.forceMonotype) {
+			if (!isMonotype && !this.forceMonotype) {
 				let skip = false;
 
 				// Limit two of any type
 				// ADJUSTING TO 6 -- ADJUST BACK AFTER MORE POKEMON HAVE BEEN ADDED
-                for (const typeName of types) {
-                    if (typeCount[typeName] >= 2 /* 6 */ * limitFactor) {
+				for (const typeName of types) {
+					if (typeCount[typeName] >= 2 /* 6 */ * limitFactor) {
 						skip = true;
 						break;
 					}
@@ -956,18 +956,18 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 				// Limit three weak to any type, and one double weak to any type
 				// ADJUSTING TO 6 -- ADJUST BACK AFTER MORE POKEMON HAVE BEEN ADDED
-                for (const typeName of this.dex.types.names()) {
+				for (const typeName of this.dex.types.names()) {
 					// it's weak to the type
 					if (this.dex.getEffectiveness(typeName, species) > 0) {
 						if (!typeWeaknesses[typeName]) typeWeaknesses[typeName] = 0;
-                        if (typeWeaknesses[typeName] >= 3 /* 6 */ * limitFactor) {
+						if (typeWeaknesses[typeName] >= 3 /* 6 */ * limitFactor) {
 							skip = true;
 							break;
 						}
 					}
 					if (this.dex.getEffectiveness(typeName, species) > 1) {
 						if (!typeDoubleWeaknesses[typeName]) typeDoubleWeaknesses[typeName] = 0;
-                        if (typeDoubleWeaknesses[typeName] >= 1 /* 6 */ * Number(limitFactor)) {
+						if (typeDoubleWeaknesses[typeName] >= 1 /* 6 */ * Number(limitFactor)) {
 							skip = true;
 							break;
 						}
@@ -977,20 +977,20 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 				// Count Dry Skin/Fluffy as Fire weaknesses
 				// ADJUSTING TO 6 -- ADJUST BACK AFTER MORE POKEMON HAVE BEEN ADDED
-                if (
+				if (
 					this.dex.getEffectiveness('Fire', species) === 0 &&
 					Object.values(species.abilities).filter(a => ['Dry Skin', 'Fluffy'].includes(a)).length
 				) {
 					if (!typeWeaknesses['Fire']) typeWeaknesses['Fire'] = 0;
-                    if (typeWeaknesses['Fire'] >= 3 /* 6 */ * limitFactor) continue;
+					if (typeWeaknesses['Fire'] >= 3 /* 6 */ * limitFactor) continue;
 				}
 
 				// Limit four weak to Freeze-Dry
 				// ADJUSTING TO 6 -- ADJUST BACK AFTER MORE POKEMON HAVE BEEN ADDED
-                if (weakToFreezeDry) {
-                    if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
-                    if (typeWeaknesses['Freeze-Dry'] >= 4 /* 6 */ * limitFactor) continue;
-                }
+				if (weakToFreezeDry) {
+					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
+					if (typeWeaknesses['Freeze-Dry'] >= 4 /* 6 */ * limitFactor) continue;
+				}
 
 				// Limit one level 100 Pokemon
 				if (!this.adjustLevel && (this.getLevel(species, isDoubles) === 100) && numMaxLevelPokemon >= limitFactor) {
@@ -1009,12 +1009,12 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 			let set: RandomTeamsTypes.RandomSet;
 
-            if (leadsRemaining) {
+			if (leadsRemaining) {
 				if (
 					isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.baseSpecies) ||
 					!isDoubles && NO_LEAD_POKEMON.includes(species.baseSpecies)
 				) {
-                    if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
+					if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
 					set = this.randomSet(species, teamDetails, false, isDoubles);
 					pokemon.push(set);
 				} else {

--- a/data/random-battles/chatbats/teams.ts
+++ b/data/random-battles/chatbats/teams.ts
@@ -62,19 +62,19 @@ const DOUBLES_NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Iron Bundle', 'Roaring Moon', 'Zacian', 'Zamazenta',
 ];
 export class RandomChatBatsTeams extends RandomTeams {
-    override randomTeam() {
-        try {
-            return super.randomTeam();
-        } catch (err) {
-            for (let attempts = 0; attempts < 2; attempts++) {
-                try {
-                    this.setSeed();
-                    return super.randomTeam();
-                } catch {}
-            }
-            throw err;
-        }
-    }
+	override randomTeam() {
+		try {
+			return super.randomTeam();
+		} catch (err) {
+			for (let attempts = 0; attempts < 2; attempts++) {
+				try {
+					this.setSeed();
+					return super.randomTeam();
+				} catch {}
+			}
+			throw err;
+		}
+	}
 	override cullMovePool(
 		types: string[],
 		moves: Set<string>,

--- a/data/random-battles/chatbats/teams.ts
+++ b/data/random-battles/chatbats/teams.ts
@@ -62,6 +62,19 @@ const DOUBLES_NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Iron Bundle', 'Roaring Moon', 'Zacian', 'Zamazenta',
 ];
 export class RandomChatBatsTeams extends RandomTeams {
+    override randomTeam() {
+        try {
+            return super.randomTeam();
+        } catch (err) {
+            for (let attempts = 0; attempts < 2; attempts++) {
+                try {
+                    this.setSeed();
+                    return super.randomTeam();
+                } catch {}
+            }
+            throw err;
+        }
+    }
 	override cullMovePool(
 		types: string[],
 		moves: Set<string>,
@@ -848,7 +861,7 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 	override randomSets: { [species: string]: RandomTeamsTypes.RandomSpeciesData } = require('./random-sets.json');
 
-	randomChatBatsTeam() {
+    randomChatBatsTeam() {
 		this.enforceNoDirectCustomBanlistChanges();
 
 		const seed = this.prng.getSeed();
@@ -928,13 +941,13 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 			// TEMPORARILY ADJUSTING BALANCE OF THIS BLOCK -- TOO FEW POKEMON TO GENERATE TEAMS
 			// update: reverting these changes, but leaving just in case
-			if (!isMonotype && !this.forceMonotype) {
+            if (!isMonotype && !this.forceMonotype) {
 				let skip = false;
 
 				// Limit two of any type
 				// ADJUSTING TO 6 -- ADJUST BACK AFTER MORE POKEMON HAVE BEEN ADDED
-				for (const typeName of types) {
-					if (typeCount[typeName] >= 2 /* 6 */ * limitFactor) {
+                for (const typeName of types) {
+                    if (typeCount[typeName] >= 2 /* 6 */ * limitFactor) {
 						skip = true;
 						break;
 					}
@@ -943,18 +956,18 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 				// Limit three weak to any type, and one double weak to any type
 				// ADJUSTING TO 6 -- ADJUST BACK AFTER MORE POKEMON HAVE BEEN ADDED
-				for (const typeName of this.dex.types.names()) {
+                for (const typeName of this.dex.types.names()) {
 					// it's weak to the type
 					if (this.dex.getEffectiveness(typeName, species) > 0) {
 						if (!typeWeaknesses[typeName]) typeWeaknesses[typeName] = 0;
-						if (typeWeaknesses[typeName] >= 3 /* 6 */ * limitFactor) {
+                        if (typeWeaknesses[typeName] >= 3 /* 6 */ * limitFactor) {
 							skip = true;
 							break;
 						}
 					}
 					if (this.dex.getEffectiveness(typeName, species) > 1) {
 						if (!typeDoubleWeaknesses[typeName]) typeDoubleWeaknesses[typeName] = 0;
-						if (typeDoubleWeaknesses[typeName] >= 1 /* 6 */ * Number(limitFactor)) {
+                        if (typeDoubleWeaknesses[typeName] >= 1 /* 6 */ * Number(limitFactor)) {
 							skip = true;
 							break;
 						}
@@ -964,20 +977,20 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 				// Count Dry Skin/Fluffy as Fire weaknesses
 				// ADJUSTING TO 6 -- ADJUST BACK AFTER MORE POKEMON HAVE BEEN ADDED
-				if (
+                if (
 					this.dex.getEffectiveness('Fire', species) === 0 &&
 					Object.values(species.abilities).filter(a => ['Dry Skin', 'Fluffy'].includes(a)).length
 				) {
 					if (!typeWeaknesses['Fire']) typeWeaknesses['Fire'] = 0;
-					if (typeWeaknesses['Fire'] >= 3 /* 6 */ * limitFactor) continue;
+                    if (typeWeaknesses['Fire'] >= 3 /* 6 */ * limitFactor) continue;
 				}
 
 				// Limit four weak to Freeze-Dry
 				// ADJUSTING TO 6 -- ADJUST BACK AFTER MORE POKEMON HAVE BEEN ADDED
-				if (weakToFreezeDry) {
-					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
-					if (typeWeaknesses['Freeze-Dry'] >= 4 /* 6 */ * limitFactor) continue;
-				}
+                if (weakToFreezeDry) {
+                    if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
+                    if (typeWeaknesses['Freeze-Dry'] >= 4 /* 6 */ * limitFactor) continue;
+                }
 
 				// Limit one level 100 Pokemon
 				if (!this.adjustLevel && (this.getLevel(species, isDoubles) === 100) && numMaxLevelPokemon >= limitFactor) {
@@ -996,12 +1009,12 @@ export class RandomChatBatsTeams extends RandomTeams {
 
 			let set: RandomTeamsTypes.RandomSet;
 
-			if (leadsRemaining) {
+            if (leadsRemaining) {
 				if (
 					isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.baseSpecies) ||
 					!isDoubles && NO_LEAD_POKEMON.includes(species.baseSpecies)
 				) {
-					if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
+                    if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
 					set = this.randomSet(species, teamDetails, false, isDoubles);
 					pokemon.push(set);
 				} else {


### PR DESCRIPTION
Add a ChatBats-only graceful fallback in data/random-battles/chatbats/teams.ts: if team generation fails, retry up to 2 times with a fresh PRNG seed.

- **Alternatives considered**
  - Expand `random-sets.json` to increase candidate diversity.
  - Relax composition caps or lead restrictions.
  - Progressive cap relaxation on fallback.