### PR TITLE
Fix Conversion2 in Gens 3 and 4

### DIFF
--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -154,6 +154,30 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			this.add('-start', target, 'typechange', type);
 		},
 	},
+	conversion2: {
+		inherit: true,
+		onHit(target, source) {
+			if (!target.lastMoveUsed) {
+				return false;
+			}
+			const possibleTypes = [];
+			const lastMoveUsed = target.lastMoveUsed;
+			const attackType = lastMoveUsed.id === 'struggle' ? 'Normal' : lastMoveUsed.type;
+			for (const typeName of this.dex.types.names()) {
+				const typeCheck = this.dex.types.get(typeName).damageTaken[attackType];
+				if (typeCheck === 2 || typeCheck === 3) {
+					possibleTypes.push(typeName);
+				}
+			}
+			if (!possibleTypes.length) {
+				return false;
+			}
+			const randomType = this.sample(possibleTypes);
+
+			if (!source.setType(randomType)) return false;
+			this.add('-start', source, 'typechange', randomType);
+		},
+	},
 	counter: {
 		inherit: true,
 		condition: {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -225,6 +225,31 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			this.add('-start', target, 'typechange', type);
 		},
 	},
+	conversion2: {
+		inherit: true,
+		onHit(target, source) {
+			if (!target.lastMoveUsed) {
+				return false;
+			}
+			const possibleTypes = [];
+			const lastMoveUsed = target.lastMoveUsed;
+			const attackType = lastMoveUsed.id === 'struggle' ? 'Normal' : lastMoveUsed.type;
+			for (const typeName of this.dex.types.names()) {
+				if (source.hasType(typeName)) continue;
+				const typeCheck = this.dex.types.get(typeName).damageTaken[attackType];
+				if (typeCheck === 2 || typeCheck === 3) {
+					possibleTypes.push(typeName);
+				}
+			}
+			if (!possibleTypes.length) {
+				return false;
+			}
+			const randomType = this.sample(possibleTypes);
+
+			if (!source.setType(randomType)) return false;
+			this.add('-start', source, 'typechange', randomType);
+		},
+	},
 	copycat: {
 		inherit: true,
 		onHit(pokemon) {

--- a/test/sim/moves/conversion2.js
+++ b/test/sim/moves/conversion2.js
@@ -16,7 +16,6 @@ describe('Conversion2', () => {
 			[{ species: 'raticate', moves: ['tackle'] },
 				{ species: 'zapdos', moves: ['thundershock', 'sleeptalk'] }],
 		]);
-
 		battle.makeChoices('move conversion2', 'move tackle');
 		assert(['Rock', 'Ghost', 'Steel'].includes(battle.p1.active[0].getTypes()[0]));
 		battle.makeChoices('move spore', 'switch 2');
@@ -29,9 +28,49 @@ describe('Conversion2', () => {
 			[{ species: 'porygon2', moves: ['electrify', 'conversion2'] }],
 			[{ species: 'shuckle', moves: ['tackle'] }],
 		]);
-
 		battle.makeChoices('move electrify', 'move tackle');
 		battle.makeChoices('move conversion2', 'move tackle');
 		assert(['Electric', 'Grass', 'Ground', 'Dragon'].includes(battle.p1.active[0].getTypes()[0]), 'Tackle should be considered Electric');
+	});
+
+	it('should fail if the last move was typeless', () => {
+		battle = common.createBattle([
+			[{ species: 'porygon2', moves: ['conversion2'] }],
+			[{ species: 'raticate', item: 'assaultvest', moves: ['taunt'] }],
+		]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].getTypes()[0], 'Normal');
+	});
+
+	it('should fail to change to a type the user already has', () => {
+		// Gen 5 to force Steel-type
+		battle = common.gen(5).createBattle([
+			[{ species: 'forretress', moves: ['conversion2'] }],
+			[{ species: 'salamence', moves: ['dragonrage'] }],
+		]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].getTypes()[0], 'Bug');
+	});
+
+	describe('[Gen 4]', () => {
+		it('should not fail if the last move was Struggle', () => {
+			battle = common.gen(4).createBattle([
+				[{ species: 'porygon2', moves: ['conversion2'] }],
+				[{ species: 'raticate', item: 'assaultvest', moves: ['taunt'] }],
+			]);
+			battle.makeChoices();
+			assert(['Rock', 'Ghost', 'Steel'].includes(battle.p1.active[0].getTypes()[0]));
+		});
+	});
+
+	describe('[Gen 3]', () => {
+		it('should not fail to change to a type the user already has', () => {
+			battle = common.gen(3).createBattle([
+				[{ species: 'forretress', moves: ['conversion2'] }],
+				[{ species: 'salamence', moves: ['dragonrage'] }],
+			]);
+			battle.makeChoices();
+			assert.equal(battle.p1.active[0].getTypes()[0], 'Steel');
+		});
 	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/conversion2-should-treat-struggle-as-a-normal-type-move-in-gens-2-4.3769245/
In Gen 2-4, Conversion2 treated Struggle as a Normal-type move.
In Gen 2-3, Conversion2 could select a type that the user already had.