### PR TITLE
Fix a partially trapped sourceEffect override bug

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2095,7 +2095,7 @@ export class Battle {
 			const name = effect.fullname === 'tox' ? 'psn' : effect.fullname;
 			switch (effect.id) {
 			case 'partiallytrapped':
-				this.add('-damage', target, target.getHealth, '[from] ' + this.effectState.sourceEffect.fullname, '[partiallytrapped]');
+				this.add('-damage', target, target.getHealth, '[from] ' + target.volatiles['partiallytrapped'].sourceEffect.fullname, '[partiallytrapped]');
 				break;
 			case 'powder':
 				this.add('-damage', target, target.getHealth, '[silent]');


### PR DESCRIPTION
I wasn't sure what to call this PR, but it may help prevent future bugs if, during a partially trapped residual, another effect intercepts and calls `Battle#damage`. I believe this happened during a Chat Bats battle.