### PR TITLE
Dynamax Pokemon should be affected by Taunt

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -19739,7 +19739,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			},
 			onBeforeMovePriority: 5,
 			onBeforeMove(attacker, defender, move) {
-				if (!move.isZ && !move.isMax && move.category === 'Status' && move.id !== 'mefirst') {
+				if (!move.isZ && move.category === 'Status' && move.id !== 'mefirst') {
 					this.add('cant', attacker, 'move: Taunt', move);
 					return false;
 				}


### PR DESCRIPTION
https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8337140

This was clearly an oversight in https://github.com/smogon/pokemon-showdown/commit/744b25935df548ad8e21567beff631ce5ab723cc "Dynamax moves are immune to Encore etc"