### PR TITLE
Allow past gen moves to be learned via HOME relearner

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2533,6 +2533,7 @@ export class TeamValidator {
 				}
 			}
 
+			let canUseHomeRelearner = false;
 			for (let learned of sources) {
 				// Every `learned` represents a single way a pokemon might
 				// learn a move. This can be handled one of several ways:
@@ -2560,7 +2561,7 @@ export class TeamValidator {
 					}
 					continue;
 				}
-				if (learnedGen < this.minSourceGen) {
+				if (learnedGen < this.minSourceGen && !canUseHomeRelearner) {
 					if (!cantLearnReason) {
 						cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${this.minSourceGen}.`;
 					}
@@ -2572,6 +2573,8 @@ export class TeamValidator {
 					}
 					continue;
 				}
+
+				if (learnedGen === 9 && learned.charAt(1) !== 'S') canUseHomeRelearner = true;
 
 				if (
 					baseSpecies.evoRegion === 'Alola' && checkingPrevo && learnedGen >= 8 &&

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -241,4 +241,12 @@ describe('Team Validator', () => {
 
 		assert.equal(accepted, allowed);
 	});
+
+	it('should allow moves learned via HOME relearner', () => {
+		const team = [
+			{ species: 'bronzor', level: 1, ability: 'levitate', moves: ['hypnosis'] },
+			{ species: 'porygon', level: 25, ability: 'trace', moves: ['triattack'], evs: { hp: 1 } },
+		];
+		assert.legalTeam(team, 'gen9ubers');
+	});
 });


### PR DESCRIPTION
Implements mechanics based on the following bug reports: [1](https://www.smogon.com/forums/threads/home-move-relearner.3736649/) [2](https://www.smogon.com/forums/threads/sv-should-allow-low-level-move-learns-from-past-gens.3737265/)

This should allow Pokemon transferred from SM/USUM or SWSH to retain their moves when transferred to SV, as long as it can learn the moves in some way in SV. This does not fully implement relearner mechanics, as doing so would also require moves from BDSP and LA, the latter of which is currently not in PS's data at all.