### PR TITLE
Fix Doom Desire animation in Gens 3 and 4

### DIFF
--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -279,7 +279,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				},
 			});
 			this.add('-start', source, 'Doom Desire');
-			return null;
+			return this.NOT_FAIL;
 		},
 	},
 	encore: {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -397,7 +397,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				},
 			});
 			this.add('-start', source, 'Doom Desire');
-			return null;
+			return this.NOT_FAIL;
 		},
 	},
 	doubleedge: {


### PR DESCRIPTION
Fixes a bug where Doom Desire causes the previous move's miss animation to play in gen 3 and 4, even when the move hits, as documented [here](https://www.smogon.com/forums/threads/the-last-attack-before-doom-desire-misses-will-visually-appear-to-miss.3767982/).

Note: This bug was inconsistent in testing, so it's difficult to guarantee a complete fix, but I could not reproduce the issue after making these changes. 