### PR TITLE
Labels for priority in the sim were flipped.

### DIFF
--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -20,9 +20,9 @@ export interface MoveAction {
 	/** action type */
 	choice: 'move' | 'beforeTurnMove' | 'priorityChargeMove';
 	order: 3 | 5 | 200 | 201 | 199 | 106;
-	/** priority of the action (lower first) */
+	/** priority of the action (Higher first) */
 	priority: number;
-	/** fractional priority of the action (lower first) */
+	/** fractional priority of the action (Higher first) */
 	fractionalPriority: number;
 	/** speed of pokemon using move (higher first if priority tie) */
 	speed: number;
@@ -51,7 +51,7 @@ export interface SwitchAction {
 	/** action type */
 	choice: 'switch' | 'instaswitch' | 'revivalblessing';
 	order: 3 | 6 | 103;
-	/** priority of the action (lower first) */
+	/** priority of the action (Higher first) */
 	priority: number;
 	/** speed of pokemon switching (higher first if priority tie) */
 	speed: number;
@@ -67,7 +67,7 @@ export interface SwitchAction {
 export interface TeamAction {
 	/** action type */
 	choice: 'team';
-	/** priority of the action (lower first) */
+	/** priority of the action (Higher first) */
 	priority: number;
 	/** unused for this action type */
 	speed: 1;
@@ -81,7 +81,7 @@ export interface TeamAction {
 export interface FieldAction {
 	/** action type */
 	choice: 'start' | 'residual' | 'pass' | 'beforeTurn';
-	/** priority of the action (lower first) */
+	/** priority of the action (Higher first) */
 	priority: number;
 	/** unused for this action type */
 	speed: 1;
@@ -93,7 +93,7 @@ export interface FieldAction {
 export interface PokemonAction {
 	/** action type */
 	choice: 'megaEvo' | 'megaEvoX' | 'megaEvoY' | 'shift' | 'runSwitch' | 'event' | 'runDynamax' | 'terastallize';
-	/** priority of the action (lower first) */
+	/** priority of the action (Higher first) */
 	priority: number;
 	/** speed of pokemon doing action (higher first if priority tie) */
 	speed: number;


### PR DESCRIPTION
According to [smogon docs](https://www.smogon.com/bw/articles/priority), higher priority takes precedence over lower priority values. This is inverted from order. sim/battle_queue.ts had this labelled backwards, but it seems that the queue sorter was doing this properly.