### PR TITLE
Fix the priority of the Partial Trapping check in Gen 1

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -189,6 +189,8 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		// (i.e. if the attacker switches out.)
 		// the full duration is tracked in partialtrappinglock
 		duration: 2,
+		// defender still takes PSN damage, etc
+		// TODO: research exact mechanics
 		onBeforeMovePriority: 9,
 		onBeforeMove(pokemon) {
 			this.add('cant', pokemon, 'partiallytrapped');

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -189,9 +189,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		// (i.e. if the attacker switches out.)
 		// the full duration is tracked in partialtrappinglock
 		duration: 2,
-		// defender still takes PSN damage, etc
-		// TODO: research exact mechanics
-		onBeforeMovePriority: 0,
+		onBeforeMovePriority: 9,
 		onBeforeMove(pokemon) {
 			this.add('cant', pokemon, 'partiallytrapped');
 			return false;


### PR DESCRIPTION
Credits to a user (who I'm not sure wants to remain private).

> partially trapped pokemon cannot be fully paralyzed/suffer from confusion self hit etc
> binding has high priority and is the 3rd thing checked after sleep and freeze status
> and the trapped pokemons turn ends immediately so no further checks of para/confusion/etc apply
> https://github.com/pret/pokered/blob/master/engine/battle/core.asm#L3326