### PR TITLE
Chatlog: Fix plainto_tsquery syntax error with multiple search terms

### DIFF
--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -885,7 +885,7 @@ export class DatabaseLogSearcher extends Searcher {
 				search.user ? SQL`userid ${search.user[1] ? SQL`!=` : SQL`=`} ${search.user[0]} AND ` : SQL``
 			} time BETWEEN ${monthStart}::int::timestamp AND ${monthEnd}::int::timestamp AND
 			type = ${'c'} AND roomid = ${roomid}
-			${parsedSearch.length ? SQL` AND content @@ plainto_tsquery(${parsedSearch.join(',')})` : SQL``} LIMIT ${limit}
+			${parsedSearch.length ? SQL` AND content @@ plainto_tsquery(${parsedSearch.join(' ')})` : SQL``} LIMIT ${limit}
 		`;
 
 		let curDate = '';


### PR DESCRIPTION
Chatlog search crashes with PostgreSQL syntax error when searching for multiple terms:

```
plainto_tsquery(): syntax error in TSQuery: " wall fish"
```

### Root Cause

In `server/chat-plugins/chatlog.ts`, the `DatabaseLogSearcher.searchLogs()` method was incorrectly passing comma-separated terms to PostgreSQL's `plainto_tsquery()` function:

```typescript
// BEFORE (line 888)
${parsedSearch.join(',')}  // Creates "wall,fish" - invalid format
```

PostgreSQL's `plainto_tsquery()` expects space-separated plain text, not comma-separated values.
