### PR TITLE
Do Not Use Rands: Fix Hidden Power IVs

### DIFF
--- a/data/random-battles/donotuse/teams.ts
+++ b/data/random-battles/donotuse/teams.ts
@@ -227,6 +227,10 @@ export class RandomDNUTeams extends RandomTeams {
 			['dazzlinggleam', 'thunderwave'],
 			// Combee
 			['lunge', 'bugbuzz'],
+			// Nidoran-F
+			['sludgebomb', 'poisonjab'],
+			// Wattrel
+			['thunder', 'thunderbolt'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
@@ -783,9 +787,23 @@ export class RandomDNUTeams extends RandomTeams {
 			ivs.atk = 0;
 		}
 
-		if (moves.has('gyroball') || moves.has('trickroom') || moves.has('archaicglare')) {
-			evs.spe = 0;
-			ivs.spe = 0;
+		// Hidden Power Grass IVs
+		if (species.id === 'luvdisc' && moves.has('hiddenpower')) {
+			ivs.atk = 0;
+			ivs.spa = 30;
+		}
+
+		// Hidden Power Psychic IVs
+		if (species.id === 'unown') {
+			ivs.atk = 0;
+			ivs.spe = 30;
+		}
+
+		// Hidden Power Fire IVs
+		if (['fomantis', 'nincada', 'petilil'].includes(species.id) && moves.has('hiddenpower')) {
+			ivs.atk = 0;
+			ivs.spa = 30;
+			ivs.spe = 30;
 		}
 
 		// Enforce Tera Type after all set generation is done to prevent infinite generation


### PR DESCRIPTION
Fixes Hidden Power IVs for a couple mons, since they default to Dragon right now.