### PR TITLE
Gen 5: Overcoat does not ignore powder moves

### DIFF
--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -65,6 +65,9 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	overcoat: {
 		inherit: true,
+		onImmunity(type, pokemon) {
+			if (type === 'sandstorm' || type === 'hail') return false;
+		},
 		onTryHit() {},
 		flags: {},
 		rating: 0.5,


### PR DESCRIPTION
Demonstrated of new (and intended) behavior:

[Screencast 2025-09-07 10:27:32.webm](https://github.com/user-attachments/assets/d5b37b1d-7631-4a69-b450-341eb5e1e025)
