### PR TITLE
Server: Fix Bo3 parent room expiry causing crashes

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1969,7 +1969,11 @@ export class GameRoom extends BasicRoom {
 			this.expireTimer = setTimeout(() => this.expire(), TIMEOUT_EMPTY_DEALLOCATE);
 		} else {
 			if (this.expireTimer) clearTimeout(this.expireTimer);
-			this.expireTimer = setTimeout(() => this.expire(), TIMEOUT_INACTIVE_DEALLOCATE);
+			if (this.bestOf) {
+				this.expireTimer = null;
+			} else {
+				this.expireTimer = setTimeout(() => this.expire(), TIMEOUT_INACTIVE_DEALLOCATE);
+			}
 		}
 	}
 	requestModchat(user: User | null) {


### PR DESCRIPTION
Fixes critical crashes in best-of (Bo3) battle system caused by parent room expiry timing issues.

Bo3 parent rooms were expiring after 15 minutes of perceived "inactivity" during long games, causing:
- `TypeError: Cannot read properties of undefined (reading 'name')` when players became undefined
- `RangeError: Maximum call stack size exceeded` from circular destruction cascades