### PR TITLE
Sim: Optimize event handler lookups in `battle.ts`

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -115,7 +115,7 @@ export class Battle {
 	readonly format: Format;
 	readonly formatData: EffectState;
 	readonly gameType: GameType;
-	
+
 	hasAnyEventHandlers = false;
 	hasPokemonEventHandlers = false;
 	/**
@@ -1052,32 +1052,32 @@ export class Battle {
 	 */
 	private checkForAnyEventHandlers(): boolean {
 		if (this.events && Object.keys(this.events).length > 0) return true;
-		
+
 		if (Object.keys(this.field.pseudoWeather).length > 0) return true;
 		if (this.field.weather) return true;
 		if (this.field.terrain) return true;
-		
+
 		for (const side of this.sides) {
 			if (Object.keys(side.sideConditions).length > 0) return true;
 			for (const slotConditions of side.slotConditions) {
 				if (Object.keys(slotConditions).length > 0) return true;
 			}
 		}
-		
+
 		return this.checkForPokemonEventHandlers();
 	}
 
 	/**
 	 * Checks if any Pokemon have event handlers (status, volatiles, abilities, items, species).
-	 * This is expensive so we cache the result in hasPokemonEventHandlers.  
+	 * This is expensive so we cache the result in hasPokemonEventHandlers.
 	 */
 	private checkForPokemonEventHandlers(): boolean {
 		for (const side of this.sides) {
 			for (const pokemon of side.pokemon) {
 				if (pokemon.status) return true;
-				
+
 				if (Object.keys(pokemon.volatiles).length > 0) return true;
-				
+
 				if (pokemon.getAbility().id !== 'noability') return true;
 				if (pokemon.getItem().id !== '') return true;
 				return true;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1714,6 +1714,7 @@ export class Pokemon {
 		if (status.id && !this.battle.runEvent('AfterSetStatus', this, source, sourceEffect, status)) {
 			return false;
 		}
+		this.battle.updateEventHandlerFlags();
 		return true;
 	}
 
@@ -1858,6 +1859,7 @@ export class Pokemon {
 		if (item.id) {
 			this.battle.singleEvent('Start', item, this.itemState, this, source, effect);
 		}
+		this.battle.updateEventHandlerFlags();
 		return true;
 	}
 
@@ -1907,6 +1909,7 @@ export class Pokemon {
 			(!isTransform || oldAbility.id !== ability.id || this.battle.gen <= 4)) {
 			this.battle.singleEvent('Start', ability, this.abilityState, this, source);
 		}
+		this.battle.updateEventHandlerFlags();
 		return oldAbility.id;
 	}
 
@@ -1977,6 +1980,7 @@ export class Pokemon {
 			delete this.volatiles[status.id];
 			return result;
 		}
+		this.battle.updateEventHandlerFlags();
 		if (linkedStatus && source) {
 			if (!source.volatiles[linkedStatus.toString()]) {
 				source.addVolatile(linkedStatus, this, sourceEffect);
@@ -2007,6 +2011,7 @@ export class Pokemon {
 		if (linkedPokemon) {
 			this.removeLinkedVolatiles(linkedStatus, linkedPokemon);
 		}
+		this.battle.updateEventHandlerFlags();
 		return true;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/smogon/pokemon-showdown/issues/10629

Optimizes `findEventHandlers` and `findPokemonEventHandlers` which are hot paths during battle simulation and testing.

### Problem
During `npm run full-test`, these methods are called millions of times but return empty arrays 94-99% of the time:
- `findEventHandlers`: 6.5M calls, 42+ seconds, 94% empty results  
- `findPokemonEventHandlers`: 38.5M calls, 37+ seconds, 99% empty results