### PR TITLE
IPTools: Fix CIDR implementation

### DIFF
--- a/server/ip-tools.ts
+++ b/server/ip-tools.ts
@@ -145,11 +145,12 @@ export const IPTools = new class {
 			if (ip === null) return null;
 			return { minIP: ip, maxIP: ip };
 		}
-		const low = IPTools.ipToNumber(cidr.slice(0, index));
+		let low = IPTools.ipToNumber(cidr.slice(0, index));
 		const bits = Utils.parseExactInt(cidr.slice(index + 1));
 		// fun fact: IPTools fails if bits <= 1 because JavaScript
 		// does << with signed int32s.
 		if (low === null || !bits || bits < 2 || bits > 32) return null;
+		low &= ~((1 << (32 - bits)) - 1);
 		const high = low + (1 << (32 - bits)) - 1;
 		return { minIP: low, maxIP: high };
 	}

--- a/test/server/ip-tools.js
+++ b/test/server/ip-tools.js
@@ -27,6 +27,10 @@ describe("IP tools", () => {
 		assert.equal(range.maxIP, IPTools.ipToNumber('42.42.63.255'));
 	});
 
+	it('should parse CIDR ranges with an IP not at the start of the range', () => {
+		assert.equal(IPTools.getCidrRange('10.69.42.69/8').minIP, IPTools.ipToNumber('10.0.0.0'));
+	});
+
 	it('should guess whether a range is CIDR or hyphen', () => {
 		const cidrRange = IPTools.stringToRange('42.42.0.0/18');
 		const stringRange = IPTools.stringToRange('42.42.0.0 - 42.42.63.255');


### PR DESCRIPTION
A CIDR range should accept any IP in the range and mask the same bits. For example, the range `10.69.42.0/8` should be exactly equivalent to `10.0.0.0/8`. It was instead being incorrectly parsed as `10.69.42.0-11.69.42.0`.