### PR TITLE
Update ZU by usage NFEs

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -4806,8 +4806,6 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	},
 	dipplin: {
 		tier: "NFE",
-		doublesTier: "(DUU)",
-		natDexTier: "RU",
 	},
 	silicobra: {
 		tier: "LC",


### PR DESCRIPTION
Pikachu is not ZU by usage by a longshot (<1% every month)
Dipplin: (4.89315 July + 4.81686 Aug + 2.4522 Sept) / 3 = 4.05407
Hattrem: (3.50676 July + 2.37386 Aug + 4.39834 Sept) / 3 = 3.42632
Both Dipplin and Hattrem would be no longer ZU by usage