### PR TITLE
Add onChooseTeam event for formats

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -279,12 +279,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		ruleset: ['Flat Rules', '!! Picked Team Size = 2', 'Min Team Size = 4', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer'],
 		unbanlist: ['Koraidon', 'Miraidon'],
 		onValidateTeam(team) {
-			let donCount = 0;
-			for (const set of team) {
-				if (set.species === 'Koraidon' || set.species === 'Miraidon') {
-					donCount++;
-				}
-			}
+			const donCount = team.filter(set => set.species === 'Koraidon' || set.species === 'Miraidon').length;
 			if (donCount !== 1) {
 				return [
 					`You must bring either Koraidon or Miraidon, but not both.`,
@@ -293,13 +288,16 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			}
 		},
 		onChooseTeam(positions, pokemon, autoChoose) {
-			const species = pokemon.find(p => p.species.name === 'Koraidon' || p.species.name === 'Miraidon')!.species;
+			const donIndex = pokemon.findIndex(p => p.species.name === 'Koraidon' || p.species.name === 'Miraidon');
 			if (autoChoose) {
-				return [...pokemon.keys()].filter(pos => pokemon[pos].species.name === species.name)
-					.concat([...pokemon.keys()].filter(pos => pokemon[pos].species.name !== species.name));
+				positions = [donIndex];
+				for (let i = 0; i < pokemon.length; i++) {
+					if (i !== donIndex) positions.push(i);
+				}
+				return positions;
 			}
-			if (!positions.some(pos => pokemon[pos].species.name === species.name)) {
-				return `You must bring ${species.name} to the battle.`;
+			if (!positions.includes(donIndex)) {
+				return `You must bring ${pokemon[donIndex].species.name} to the battle.`;
 			}
 		},
 	},

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -276,9 +276,22 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		name: "[Gen 9] Terastal Crescendo",
 		mod: 'gen9',
 		gameType: 'doubles',
-		ruleset: ['Flat Rules', '!! Picked Team Size = 2', 'Min Team Size = 4', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer', 'Limit One Restricted'],
+		ruleset: ['Flat Rules', '!! Picked Team Size = 2', 'Min Team Size = 4', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer'],
 		unbanlist: ['Koraidon', 'Miraidon'],
-		restricted: ['Koraidon', 'Miraidon'],
+		onValidateTeam(team) {
+			let donCount = 0;
+			for (const set of team) {
+				if (set.species === 'Koraidon' || set.species === 'Miraidon') {
+					donCount++;
+				}
+			}
+			if (donCount !== 1) {
+				return [
+					`You must bring either Koraidon or Miraidon, but not both.`,
+					`(You have ${!donCount ? 'neither' : 'both'} Koraidon ${!donCount ? 'nor' : 'and'} Miraidon)`,
+				];
+			}
+		},
 		onChooseTeam(positions, pokemon, autoChoose) {
 			const species = pokemon.find(p => p.species.name === 'Koraidon' || p.species.name === 'Miraidon')!.species;
 			if (autoChoose) {
@@ -4734,7 +4747,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			}
 			const restrictedCount = positions.filter(pos => this.ruleTable.isRestrictedSpecies(pokemon[pos].species)).length;
 			if (restrictedCount > 2) {
-				return `You can only bring up to two restricted Pok\u00e9mon to the battle`;
+				return `You can only bring up to two restricted Pok\u00e9mon to the battle.`;
 			}
 		},
 	},

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -4721,8 +4721,16 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		},
 		onChooseTeam(positions, pokemon, autoChoose) {
 			if (autoChoose) {
-				return [...pokemon.keys()].filter(pos => this.ruleTable.isRestrictedSpecies(pokemon[pos].species)).slice(0, 2)
-					.concat([...pokemon.keys()].filter(pos => !this.ruleTable.isRestrictedSpecies(pokemon[pos].species)));
+				positions = [];
+				let restrictedCount = 0;
+				for (let i = 0; i < pokemon.length; i++) {
+					if (this.ruleTable.isRestrictedSpecies(pokemon[i].species)) {
+						restrictedCount++;
+						if (restrictedCount > 2) continue;
+					}
+					positions.push(i);
+				}
+				return positions;
 			}
 			const restrictedCount = positions.filter(pos => this.ruleTable.isRestrictedSpecies(pokemon[pos].species)).length;
 			if (restrictedCount > 2) {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -566,29 +566,34 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 	forceselect: {
 		effectType: 'ValidatorRule',
 		name: 'Force Select',
-		desc: `Forces a Pokemon to be on the team and selected at Team Preview. Usage: Force Select = [Pokemon], e.g. "Force Select = Magikarp" or "Force Select = Koraidon | Miraidon"`,
+		desc: `Forces a Pokemon to be on the team and selected at Team Preview. Usage: Force Select = [Pokemon], e.g. "Force Select = Magikarp"`,
 		hasValue: true,
 		onValidateRule(value) {
-			const values = value.split('|');
-			if (values.some(v => !this.dex.species.get(v).exists)) throw new Error(`Misspelled Pokemon provided in "${value}"`);
+			if (!this.dex.species.get(value).exists) throw new Error(`Misspelled Pokemon "${value}"`);
 		},
 		onValidateTeam(team) {
 			let hasSelection = false;
-			const speciesNameList = this.ruleTable.valueRules.get('forceselect')!.split('|')
-				.map(value => this.dex.species.get(value).name);
+			const species = this.dex.species.get(this.ruleTable.valueRules.get('forceselect'));
 			for (const set of team) {
-				if (speciesNameList.includes(set.species)) {
+				if (species.name === set.species) {
 					hasSelection = true;
 					break;
 				}
 			}
 			if (!hasSelection) {
-				return [
-					`Your team must contain ${speciesNameList.length > 1 ? `one of: ${speciesNameList.join(', ')}` : speciesNameList[0]}.`,
-				];
+				return [`Your team must contain ${species.name}.`];
 			}
 		},
-		// hardcoded in sim/side
+		onChooseTeam(positions, pokemon, autoChoose) {
+			const species = this.dex.species.get(this.ruleTable.valueRules.get('forceselect'));
+			if (autoChoose) {
+				return [...pokemon.keys()].filter(pos => pokemon[pos].species.name === species.name)
+					.concat([...pokemon.keys()].filter(pos => pokemon[pos].species.name !== species.name));
+			}
+			if (!positions.some(pos => pokemon[pos].species.name === species.name)) {
+				return `You must bring ${species.name} to the battle.`;
+			}
+		},
 	},
 	evlimits: {
 		effectType: 'ValidatorRule',
@@ -2137,7 +2142,17 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 				throw new Error(`A Max Total Level of ${maxTotalLevel}${ruleTable.blame('maxtotallevel')} is too low with ${maxTeamSize}${maxTeamSizeBlame} Pokémon at min level ${ruleTable.minLevel}${ruleTable.blame('minlevel')}`);
 			}
 		},
-		// hardcoded in sim/side
+		onChooseTeam(positions, pokemon, autoChoose) {
+			let totalLevel = 0;
+			for (const pos of positions) totalLevel += pokemon[pos].level;
+			if (totalLevel > this.ruleTable.maxTotalLevel!) {
+				if (autoChoose) {
+					return [...pokemon.keys()].sort((a, b) => (pokemon[a].level - pokemon[b].level));
+				} else {
+					return `Your selected team has a total level of ${totalLevel}, but it can't be above ${this.ruleTable.maxTotalLevel}.`;
+				}
+			}
+		},
 	},
 	minlevel: {
 		effectType: 'ValidatorRule',


### PR DESCRIPTION
Fixes Terastal Crescendo, and also adds support for VGC 2010's bring 4 pick 2 restricteds. Similar to `checkCanLearn`, only one `onChooseTeam` can be active at a time to prevent conflicts on auto choose.