### PR TITLE
Fix Trace activating twice

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1976,8 +1976,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 				for (const moveSlot of pokemon.moveSlots) {
 					moveSlot.used = false;
 				}
-				pokemon.abilityState.effectOrder = this.battle.effectOrder++;
-				pokemon.itemState.effectOrder = this.battle.effectOrder++;
+				pokemon.abilityState = this.battle.initEffectState({ id: pokemon.ability, target: pokemon });
+				pokemon.itemState = this.battle.initEffectState({ id: pokemon.item, target: pokemon });
 				this.battle.runEvent('BeforeSwitchIn', pokemon);
 				if (sourceEffect) {
 					this.battle.add(isDrag ? 'drag' : 'switch', pokemon, pokemon.getFullDetails, `[from] ${sourceEffect}`);

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -5552,13 +5552,14 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 			if (pokemon.baseSpecies.baseSpecies !== 'Palafin') return;
 			if (pokemon.species.forme !== 'Hero') {
 				pokemon.formeChange('Palafin-Hero', this.effect, true);
+				pokemon.heroMessageDisplayed = false;
 			}
 		},
 		onSwitchIn(pokemon) {
 			if (pokemon.baseSpecies.baseSpecies !== 'Palafin') return;
-			if (!this.effectState.heroMessageDisplayed && pokemon.species.forme === 'Hero') {
+			if (!pokemon.heroMessageDisplayed && pokemon.species.forme === 'Hero') {
 				this.add('-activate', pokemon, 'ability: Zero to Hero');
-				this.effectState.heroMessageDisplayed = true;
+				pokemon.heroMessageDisplayed = true;
 			}
 		},
 		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1 },

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1162,7 +1162,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	embodyaspectcornerstone: {
 		onStart(pokemon) {
 			if (pokemon.baseSpecies.name === 'Ogerpon-Cornerstone-Tera' && pokemon.terastallized &&
-				this.effectState.embodied) {
+				!this.effectState.embodied) {
 				this.effectState.embodied = true;
 				this.boost({ def: 1 }, pokemon);
 			}
@@ -1175,7 +1175,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	embodyaspecthearthflame: {
 		onStart(pokemon) {
 			if (pokemon.baseSpecies.name === 'Ogerpon-Hearthflame-Tera' && pokemon.terastallized &&
-				this.effectState.embodied) {
+				!this.effectState.embodied) {
 				this.effectState.embodied = true;
 				this.boost({ atk: 1 }, pokemon);
 			}
@@ -1188,7 +1188,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	embodyaspectteal: {
 		onStart(pokemon) {
 			if (pokemon.baseSpecies.name === 'Ogerpon-Teal-Tera' && pokemon.terastallized &&
-				this.effectState.embodied) {
+				!this.effectState.embodied) {
 				this.effectState.embodied = true;
 				this.boost({ spe: 1 }, pokemon);
 			}
@@ -1201,7 +1201,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	embodyaspectwellspring: {
 		onStart(pokemon) {
 			if (pokemon.baseSpecies.name === 'Ogerpon-Wellspring-Tera' && pokemon.terastallized &&
-				this.effectState.embodied) {
+				!this.effectState.embodied) {
 				this.effectState.embodied = true;
 				this.boost({ spd: 1 }, pokemon);
 			}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1162,8 +1162,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	embodyaspectcornerstone: {
 		onStart(pokemon) {
 			if (pokemon.baseSpecies.name === 'Ogerpon-Cornerstone-Tera' && pokemon.terastallized &&
-				this.effectState.embodied !== pokemon.previouslySwitchedIn) {
-				this.effectState.embodied = pokemon.previouslySwitchedIn;
+				this.effectState.embodied) {
+				this.effectState.embodied = true;
 				this.boost({ def: 1 }, pokemon);
 			}
 		},
@@ -1175,8 +1175,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	embodyaspecthearthflame: {
 		onStart(pokemon) {
 			if (pokemon.baseSpecies.name === 'Ogerpon-Hearthflame-Tera' && pokemon.terastallized &&
-				this.effectState.embodied !== pokemon.previouslySwitchedIn) {
-				this.effectState.embodied = pokemon.previouslySwitchedIn;
+				this.effectState.embodied) {
+				this.effectState.embodied = true;
 				this.boost({ atk: 1 }, pokemon);
 			}
 		},
@@ -1188,8 +1188,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	embodyaspectteal: {
 		onStart(pokemon) {
 			if (pokemon.baseSpecies.name === 'Ogerpon-Teal-Tera' && pokemon.terastallized &&
-				this.effectState.embodied !== pokemon.previouslySwitchedIn) {
-				this.effectState.embodied = pokemon.previouslySwitchedIn;
+				this.effectState.embodied) {
+				this.effectState.embodied = true;
 				this.boost({ spe: 1 }, pokemon);
 			}
 		},
@@ -1201,8 +1201,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	embodyaspectwellspring: {
 		onStart(pokemon) {
 			if (pokemon.baseSpecies.name === 'Ogerpon-Wellspring-Tera' && pokemon.terastallized &&
-				this.effectState.embodied !== pokemon.previouslySwitchedIn) {
-				this.effectState.embodied = pokemon.previouslySwitchedIn;
+				this.effectState.embodied) {
+				this.effectState.embodied = true;
 				this.boost({ spd: 1 }, pokemon);
 			}
 		},
@@ -2259,12 +2259,12 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	libero: {
 		onPrepareHit(source, target, move) {
-			if (this.effectState.libero === source.previouslySwitchedIn) return;
+			if (this.effectState.libero) return;
 			if (move.hasBounced || move.flags['futuremove'] || move.sourceEffect === 'snatch' || move.callsMove) return;
 			const type = move.type;
 			if (type && type !== '???' && source.getTypes().join() !== type) {
 				if (!source.setType(type)) return;
-				this.effectState.libero = source.previouslySwitchedIn;
+				this.effectState.libero = true;
 				this.add('-start', source, 'typechange', type, '[from] ability: Libero');
 			}
 		},
@@ -3415,12 +3415,12 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	protean: {
 		onPrepareHit(source, target, move) {
-			if (this.effectState.protean === source.previouslySwitchedIn) return;
+			if (this.effectState.protean) return;
 			if (move.hasBounced || move.flags['futuremove'] || move.sourceEffect === 'snatch' || move.callsMove) return;
 			const type = move.type;
 			if (type && type !== '???' && source.getTypes().join() !== type) {
 				if (!source.setType(type)) return;
-				this.effectState.protean = source.previouslySwitchedIn;
+				this.effectState.protean = true;
 				this.add('-start', source, 'typechange', type, '[from] ability: Protean');
 			}
 		},

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -283,9 +283,6 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				this.damage(pokemon.baseMaxhp / 8, pokemon, pokemon, this.dex.species.get(speciesid));
 			}
 		},
-		onFaint(target) {
-			delete this.effectState.busted;
-		},
 		rating: 3.5,
 	},
 	download: {

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -901,8 +901,8 @@ export const Scripts: ModdedBattleScriptsData = {
 			} else {
 				this.battle.add(isDrag ? 'drag' : 'switch', pokemon, pokemon.getFullDetails);
 			}
-			pokemon.abilityState.effectOrder = this.battle.effectOrder++;
-			pokemon.itemState.effectOrder = this.battle.effectOrder++;
+			pokemon.abilityState = this.battle.initEffectState({ id: pokemon.ability, target: pokemon });
+			pokemon.itemState = this.battle.initEffectState({ id: pokemon.item, target: pokemon });
 			if (isDrag && this.battle.gen === 2) pokemon.draggedIn = this.battle.turn;
 			pokemon.previouslySwitchedIn++;
 

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -140,8 +140,8 @@ export class BattleActions {
 		for (const moveSlot of pokemon.moveSlots) {
 			moveSlot.used = false;
 		}
-		pokemon.abilityState.effectOrder = this.battle.effectOrder++;
-		pokemon.itemState.effectOrder = this.battle.effectOrder++;
+		pokemon.abilityState = this.battle.initEffectState({ id: pokemon.ability, target: pokemon });
+		pokemon.itemState = this.battle.initEffectState({ id: pokemon.item, target: pokemon });
 		this.battle.runEvent('BeforeSwitchIn', pokemon);
 		if (sourceEffect) {
 			this.battle.add(isDrag ? 'drag' : 'switch', pokemon, pokemon.getFullDetails, `[from] ${sourceEffect}`);

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -253,6 +253,7 @@ export class Pokemon {
 	truantTurn: boolean;
 	bondTriggered: boolean;
 	// Gen 9 only
+	heroMessageDisplayed: boolean;
 	swordBoost: boolean;
 	shieldBoost: boolean;
 	syrupTriggered: boolean;
@@ -467,6 +468,7 @@ export class Pokemon {
 		this.previouslySwitchedIn = 0;
 		this.truantTurn = false;
 		this.bondTriggered = false;
+		this.heroMessageDisplayed = false;
 		this.swordBoost = false;
 		this.shieldBoost = false;
 		this.syrupTriggered = false;

--- a/test/sim/abilities/trace.js
+++ b/test/sim/abilities/trace.js
@@ -82,4 +82,20 @@ describe('Trace', () => {
 		battle.makeChoices('auto', 'switch 4, move sleeptalk');
 		assert.equal(ralts.ability, 'unburden');
 	});
+
+	// This was an existing bug https://www.smogon.com/forums/threads/trace-triggers-new-ability-twice.3772080/
+	it(`should not activate twice`, () => {
+		battle = common.createBattle([[
+			{ species: "Ralts", ability: 'trace', moves: ['sleeptalk'] },
+			{ species: "Bouffalant", moves: ['sleeptalk'] },
+		], [
+			{ species: "Iron Jugulis", ability: 'quarkdrive', moves: ['sleeptalk'] },
+			{ species: "Incineroar", ability: 'intimidate', moves: ['sleeptalk'] },
+		]]);
+
+		battle.makeChoices('switch 2', 'auto');
+		battle.makeChoices('auto', 'switch 2');
+		battle.makeChoices('switch 2', 'auto');
+		assert.statStage(battle.p2.active[0], 'atk', -1);
+	});
 });

--- a/test/sim/misc/fainted-forme-regression.js
+++ b/test/sim/misc/fainted-forme-regression.js
@@ -116,7 +116,6 @@ describe(`Fainted forme regression`, () => {
 
 		const pokemon = battle.p1.active[0];
 		assert.species(pokemon, 'Mimikyu-Busted');
-		assert(pokemon.abilityState.busted);
 		assert.equal(pokemon.hp, Math.floor(pokemon.maxhp / 2));
 	});
 
@@ -135,7 +134,6 @@ describe(`Fainted forme regression`, () => {
 
 		const pokemon = battle.p1.active[0];
 		assert.species(pokemon, 'Mimikyu');
-		assert.false(pokemon.abilityState.busted);
 		assert.equal(pokemon.hp, Math.floor(pokemon.maxhp / 2));
 	});
 
@@ -154,7 +152,6 @@ describe(`Fainted forme regression`, () => {
 
 		const pokemon = battle.p1.active[0];
 		assert.species(pokemon, 'Mimikyu');
-		assert.false(pokemon.abilityState.busted);
 		assert.equal(pokemon.hp, Math.floor(pokemon.maxhp / 2));
 	});
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/trace-triggers-new-ability-twice.3772080/

I know this specific bug could be fixed by adding a condition to Trace's `Update`, but this is a refactor I did in another PR for Neutralizing Gas. This refactor clears the ability and item states when the Pokémon switches out. From what I've seen, the only ability that needs to retain its state is Zero to Hero.

The logic is all in `sim/battle-actions.ts`, the rest are tests and code that we can simplify.

Also tagging @pyuk-bot 