### PR TITLE
NatDex: Move Slowbro-Mega to RU

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -602,7 +602,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	slowbromega: {
 		isNonstandard: "Past",
 		tier: "Illegal",
-		natDexTier: "UU",
+		natDexTier: "RU",
 	},
 	slowbrogalar: {
 		tier: "NU",


### PR DESCRIPTION
Remains legal under Slowbro-Galar x Slowbronite Mechanics, PR is rectifying a visual error in the teambuilder.