### PR TITLE
Wi-Fi: Change Z-A GA background color for readability

### DIFF
--- a/server/chat-plugins/wifi.tsx
+++ b/server/chat-plugins/wifi.tsx
@@ -162,7 +162,7 @@ abstract class Giveaway extends Rooms.SimpleRoomGame {
 		const css: { [k: string]: string | { [k: string]: string } } = { class: "broadcast-blue" };
 		if (this.game === 'BDSP') css.style = { background: '#aa66a9', color: '#fff' };
 		if (this.game === 'SV') css.style = { background: '#CD5C5C', color: '#fff' };
-		if (this.game === 'Z-A') css.style = { background: '#9BC53B', color: '#fff' };
+		if (this.game === 'Z-A') css.style = { background: '#10a14f', color: '#fff' };
 		return css;
 	}
 


### PR DESCRIPTION
Approved by Wi-Fi staff because the current color is a bit too hard to read.