### PR TITLE
Separate gen9legends and gen9legendsou format data

### DIFF
--- a/data/mods/gen8legends/formats-data.ts
+++ b/data/mods/gen8legends/formats-data.ts
@@ -1412,9 +1412,6 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	arceuswater: {
 		isNonstandard: null,
 	},
-	arceuslegend: {
-		isNonstandard: null,
-	},
 	victini: {
 		isNonstandard: "Past",
 	},

--- a/data/mods/gen9legends/formats-data.ts
+++ b/data/mods/gen9legends/formats-data.ts
@@ -1,75 +1,75 @@
 export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	ivysaur: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	venusaur: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	venusaurmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	charmander: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	charmeleon: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	charizard: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	charizardmegax: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	charizardmegay: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	squirtle: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	wartortle: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	blastoise: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	blastoisemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	weedle: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	kakuna: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	beedrill: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	beedrillmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pidgey: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	pidgeotto: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	pidgeot: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pidgeotmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	ekans: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	arbok: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pikachu: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	pikachuoriginal: {
 		isNonstandard: "Past",
@@ -96,10 +96,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	raichu: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	raichualola: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	sandshrew: {
 		isNonstandard: "Past",
@@ -114,13 +114,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	clefairy: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	clefable: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	clefablemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	vulpix: {
 		isNonstandard: "Past",
@@ -216,37 +216,37 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	abra: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	kadabra: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	alakazam: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	alakazammega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	machop: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	machoke: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	machamp: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	bellsprout: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	weepinbell: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	victreebel: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	victreebelmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	tentacool: {
 		isNonstandard: "Past",
@@ -273,19 +273,19 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	slowpoke: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	slowpokegalar: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	slowbro: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	slowbromega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	slowbrogalar: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	magnemite: {
 		isNonstandard: "Past",
@@ -324,19 +324,19 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	gastly: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	haunter: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	gengar: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	gengarmega: {
-		tier: "Uber",
+		isNonstandard: null,
 	},
 	onix: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	drowzee: {
 		isNonstandard: "Past",
@@ -390,10 +390,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	kangaskhan: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	kangaskhanmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	horsea: {
 		isNonstandard: "Past",
@@ -402,16 +402,16 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	staryu: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	starmie: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	starmiemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	scyther: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	electabuzz: {
 		isNonstandard: "Past",
@@ -420,10 +420,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	pinsir: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pinsirmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	tauros: {
 		isNonstandard: "Past",
@@ -438,13 +438,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	magikarp: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	gyarados: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	gyaradosmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	lapras: {
 		isNonstandard: "Past",
@@ -453,25 +453,25 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	eevee: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	vaporeon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	jolteon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	flareon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	porygon: {
 		isNonstandard: "Past",
 	},
 	aerodactyl: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	aerodactylmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	snorlax: {
 		isNonstandard: "Past",
@@ -495,40 +495,40 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	dratini: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	dragonair: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	dragonite: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	dragonitemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	mewtwo: {
-		tier: "Uber",
+		isNonstandard: "Unobtainable",
 	},
 	mewtwomegax: {
-		tier: "Uber",
+		isNonstandard: "Unobtainable",
 	},
 	mewtwomegay: {
-		tier: "Uber",
+		isNonstandard: "Unobtainable",
 	},
 	mew: {
 		isNonstandard: "Past",
 	},
 	chikorita: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	bayleef: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	meganium: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	meganiummega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	cyndaquil: {
 		isNonstandard: "Past",
@@ -543,16 +543,16 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	totodile: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	croconaw: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	feraligatr: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	feraligatrmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	sentret: {
 		isNonstandard: "Past",
@@ -567,10 +567,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	spinarak: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	ariados: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	chinchou: {
 		isNonstandard: "Past",
@@ -579,25 +579,25 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	pichu: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	cleffa: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	igglybuff: {
 		isNonstandard: "Past",
 	},
 	mareep: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	flaaffy: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	ampharos: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	ampharosmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	bellossom: {
 		isNonstandard: "Past",
@@ -645,19 +645,19 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	espeon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	umbreon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	murkrow: {
 		isNonstandard: "Past",
 	},
 	slowking: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	slowkinggalar: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	misdreavus: {
 		isNonstandard: "Past",
@@ -678,10 +678,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	steelix: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	steelixmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	snubbull: {
 		isNonstandard: "Past",
@@ -696,16 +696,16 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	scizor: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	scizormega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	heracross: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	heracrossmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	sneasel: {
 		isNonstandard: "Past",
@@ -732,22 +732,22 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	delibird: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	skarmory: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	skarmorymega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	houndour: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	houndoom: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	houndoommega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	kingdra: {
 		isNonstandard: "Past",
@@ -792,16 +792,16 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	larvitar: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	pupitar: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	tyranitar: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	tyranitarmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	lugia: {
 		isNonstandard: "Past",
@@ -867,16 +867,16 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	ralts: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	kirlia: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	gardevoir: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	gardevoirmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	surskit: {
 		isNonstandard: "Past",
@@ -912,46 +912,46 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	sableye: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	sableyemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	mawile: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	mawilemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	aron: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	lairon: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	aggron: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	aggronmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	meditite: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	medicham: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	medichammega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	electrike: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	manectric: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	manectricmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	plusle: {
 		isNonstandard: "Past",
@@ -966,7 +966,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	roselia: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	gulpin: {
 		isNonstandard: "Past",
@@ -975,22 +975,22 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	carvanha: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	sharpedo: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	sharpedomega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	numel: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	camerupt: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	cameruptmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	torkoal: {
 		isNonstandard: "Past",
@@ -1017,13 +1017,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	swablu: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	altaria: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	altariamega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	zangoose: {
 		isNonstandard: "Past",
@@ -1050,13 +1050,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	shuppet: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	banette: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	banettemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	duskull: {
 		isNonstandard: "Past",
@@ -1071,46 +1071,46 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	absol: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	absolmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	snorunt: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	glalie: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	glaliemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	luvdisc: {
 		isNonstandard: "Past",
 	},
 	bagon: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	shelgon: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	salamence: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	salamencemega: {
-		tier: "Uber",
+		isNonstandard: null,
 	},
 	beldum: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	metang: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	metagross: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	metagrossmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	regirock: {
 		isNonstandard: "Past",
@@ -1203,10 +1203,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	budew: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	roserade: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	cranidos: {
 		isNonstandard: "Past",
@@ -1251,13 +1251,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	buneary: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	lopunny: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	lopunnymega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	mismagius: {
 		isNonstandard: "Past",
@@ -1290,34 +1290,34 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	gible: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	gabite: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	garchomp: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	garchompmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	munchlax: {
 		isNonstandard: "Past",
 	},
 	riolu: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	lucario: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	lucariomega: {
-		tier: "Uber",
+		isNonstandard: null,
 	},
 	hippopotas: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	hippowdon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	croagunk: {
 		isNonstandard: "Past",
@@ -1332,13 +1332,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	snover: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	abomasnow: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	abomasnowmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	weavile: {
 		isNonstandard: "Past",
@@ -1359,10 +1359,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	leafeon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	glaceon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	gliscor: {
 		isNonstandard: "Past",
@@ -1374,10 +1374,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	gallade: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	gallademega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	probopass: {
 		isNonstandard: "Past",
@@ -1386,10 +1386,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	froslass: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	froslassmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	rotom: {
 		isNonstandard: "Past",
@@ -1524,16 +1524,16 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	tepig: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	pignite: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	emboar: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	emboarmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	oshawott: {
 		isNonstandard: "Past",
@@ -1548,28 +1548,28 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	patrat: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	watchog: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pansage: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	simisage: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pansear: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	simisear: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	panpour: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	simipour: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	blitzle: {
 		isNonstandard: "Past",
@@ -1578,19 +1578,19 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	drilbur: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	excadrill: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	excadrillmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	audino: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	audinomega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	timburr: {
 		isNonstandard: "Past",
@@ -1611,16 +1611,16 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	venipede: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	whirlipede: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	scolipede: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	scolipedemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	cottonee: {
 		isNonstandard: "Past",
@@ -1647,28 +1647,28 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	sandile: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	krokorok: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	krookodile: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	scraggy: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	scrafty: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	scraftymega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	trubbish: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	garbodor: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	zorua: {
 		isNonstandard: "Past",
@@ -1713,13 +1713,13 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	vanillite: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	vanillish: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	vanilluxe: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	deerling: {
 		isNonstandard: "Past",
@@ -1728,7 +1728,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	emolga: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	foongus: {
 		isNonstandard: "Past",
@@ -1746,28 +1746,28 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	tynamo: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	eelektrik: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	eelektross: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	eelektrossmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	litwick: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	lampent: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	chandelure: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	chandeluremega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	axew: {
 		isNonstandard: "Past",
@@ -1788,10 +1788,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	stunfisk: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	stunfiskgalar: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	mienfoo: {
 		isNonstandard: "Past",
@@ -1896,309 +1896,309 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	chespin: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	quilladin: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	chesnaught: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	chesnaughtmega: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	fennekin: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	braixen: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	delphox: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	delphoxmega: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	froakie: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	frogadier: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	greninja: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	greninjabond: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	greninjamega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	bunnelby: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	diggersby: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	fletchling: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	fletchinder: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	talonflame: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	scatterbug: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	spewpa: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	vivillon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	vivillonfancy: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	vivillonpokeball: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	litleo: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	pyroar: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pyroarmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	flabebe: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	floette: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	floetteeternal: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	floettemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	florges: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	skiddo: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	gogoat: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pancham: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	pangoro: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	furfrou: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	espurr: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	meowstic: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	meowsticf: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	honedge: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	doublade: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	aegislash: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	aegislashblade: {
 	},
 	spritzee: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	aromatisse: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	swirlix: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	slurpuff: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	inkay: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	malamar: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	malamarmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	binacle: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	barbaracle: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	barbaraclemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	skrelp: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	dragalge: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	dragalgemega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	clauncher: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	clawitzer: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	helioptile: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	heliolisk: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	tyrunt: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	tyrantrum: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	amaura: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	aurorus: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	sylveon: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	hawlucha: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	hawluchamega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	dedenne: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	carbink: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	goomy: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	sliggoo: {
-		tier: "NFE",
+		isNonstandard: null,
 	},
 	sliggoohisui: {
-		tier: "NFE",
+		isNonstandard: "Unobtainable",
 	},
 	goodra: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	goodrahisui: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	klefki: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	phantump: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	trevenant: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pumpkaboo: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	pumpkaboosmall: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	pumpkaboolarge: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	pumpkaboosuper: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	gourgeist: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	gourgeistsmall: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	gourgeistlarge: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	gourgeistsuper: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	bergmite: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	avalugg: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	avalugghisui: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	noibat: {
-		tier: "LC",
+		isNonstandard: null,
 	},
 	noivern: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	xerneas: {
-		tier: "Uber",
+		isNonstandard: null,
 	},
 	xerneasneutral: {
 		isNonstandard: "Custom", // can't be used in battle
 	},
 	yveltal: {
-		tier: "Uber",
+		isNonstandard: null,
 	},
 	zygarde: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	zygarde10: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	zygardecomplete: {
-		tier: "Uber",
+		isNonstandard: null,
 	},
 	zygardemega: {
-		tier: "Uber",
+		isNonstandard: null,
 	},
 	diancie: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	dianciemega: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	hoopa: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	hoopaunbound: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	volcanion: {
-		tier: "OU",
+		isNonstandard: "Unobtainable",
 	},
 	rowlet: {
 		isNonstandard: "Past",
@@ -2366,10 +2366,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	drampa: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	drampamega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	jangmoo: {
 		isNonstandard: "Past",
@@ -2543,10 +2543,10 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		isNonstandard: "Past",
 	},
 	falinks: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	falinksmega: {
-		tier: "OU",
+		isNonstandard: null,
 	},
 	pincurchin: {
 		isNonstandard: "Past",

--- a/data/mods/gen9legendsou/formats-data.ts
+++ b/data/mods/gen9legendsou/formats-data.ts
@@ -1,0 +1,976 @@
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
+	bulbasaur: {
+		tier: "LC",
+	},
+	ivysaur: {
+		tier: "NFE",
+	},
+	venusaur: {
+		tier: "OU",
+	},
+	venusaurmega: {
+		tier: "OU",
+	},
+	charmander: {
+		tier: "LC",
+	},
+	charmeleon: {
+		tier: "NFE",
+	},
+	charizard: {
+		tier: "OU",
+	},
+	charizardmegax: {
+		tier: "OU",
+	},
+	charizardmegay: {
+		tier: "OU",
+	},
+	squirtle: {
+		tier: "LC",
+	},
+	wartortle: {
+		tier: "NFE",
+	},
+	blastoise: {
+		tier: "OU",
+	},
+	blastoisemega: {
+		tier: "OU",
+	},
+	weedle: {
+		tier: "LC",
+	},
+	kakuna: {
+		tier: "NFE",
+	},
+	beedrill: {
+		tier: "OU",
+	},
+	beedrillmega: {
+		tier: "OU",
+	},
+	pidgey: {
+		tier: "LC",
+	},
+	pidgeotto: {
+		tier: "NFE",
+	},
+	pidgeot: {
+		tier: "OU",
+	},
+	pidgeotmega: {
+		tier: "OU",
+	},
+	ekans: {
+		tier: "LC",
+	},
+	arbok: {
+		tier: "OU",
+	},
+	pikachu: {
+		tier: "NFE",
+	},
+	raichu: {
+		tier: "OU",
+	},
+	raichualola: {
+		tier: "OU",
+	},
+	clefairy: {
+		tier: "NFE",
+	},
+	clefable: {
+		tier: "OU",
+	},
+	clefablemega: {
+		tier: "OU",
+	},
+	abra: {
+		tier: "LC",
+	},
+	kadabra: {
+		tier: "LC",
+	},
+	alakazam: {
+		tier: "OU",
+	},
+	alakazammega: {
+		tier: "OU",
+	},
+	machop: {
+		tier: "LC",
+	},
+	machoke: {
+		tier: "NFE",
+	},
+	machamp: {
+		tier: "OU",
+	},
+	bellsprout: {
+		tier: "LC",
+	},
+	weepinbell: {
+		tier: "NFE",
+	},
+	victreebel: {
+		tier: "OU",
+	},
+	victreebelmega: {
+		tier: "OU",
+	},
+	slowpoke: {
+		tier: "LC",
+	},
+	slowpokegalar: {
+		tier: "LC",
+	},
+	slowbro: {
+		tier: "OU",
+	},
+	slowbromega: {
+		tier: "OU",
+	},
+	slowbrogalar: {
+		tier: "OU",
+	},
+	gastly: {
+		tier: "LC",
+	},
+	haunter: {
+		tier: "NFE",
+	},
+	gengar: {
+		tier: "OU",
+	},
+	gengarmega: {
+		tier: "Uber",
+	},
+	onix: {
+		tier: "LC",
+	},
+	kangaskhan: {
+		tier: "OU",
+	},
+	kangaskhanmega: {
+		tier: "OU",
+	},
+	staryu: {
+		tier: "LC",
+	},
+	starmie: {
+		tier: "OU",
+	},
+	starmiemega: {
+		tier: "OU",
+	},
+	scyther: {
+		tier: "LC",
+	},
+	pinsir: {
+		tier: "OU",
+	},
+	pinsirmega: {
+		tier: "OU",
+	},
+	magikarp: {
+		tier: "LC",
+	},
+	gyarados: {
+		tier: "OU",
+	},
+	gyaradosmega: {
+		tier: "OU",
+	},
+	eevee: {
+		tier: "LC",
+	},
+	vaporeon: {
+		tier: "OU",
+	},
+	jolteon: {
+		tier: "OU",
+	},
+	flareon: {
+		tier: "OU",
+	},
+	aerodactyl: {
+		tier: "OU",
+	},
+	aerodactylmega: {
+		tier: "OU",
+	},
+	dratini: {
+		tier: "LC",
+	},
+	dragonair: {
+		tier: "NFE",
+	},
+	dragonite: {
+		tier: "OU",
+	},
+	dragonitemega: {
+		tier: "OU",
+	},
+	mewtwo: {
+		tier: "Uber",
+	},
+	mewtwomegax: {
+		tier: "Uber",
+	},
+	mewtwomegay: {
+		tier: "Uber",
+	},
+	chikorita: {
+		tier: "LC",
+	},
+	bayleef: {
+		tier: "NFE",
+	},
+	meganium: {
+		tier: "OU",
+	},
+	meganiummega: {
+		tier: "OU",
+	},
+	totodile: {
+		tier: "LC",
+	},
+	croconaw: {
+		tier: "NFE",
+	},
+	feraligatr: {
+		tier: "OU",
+	},
+	feraligatrmega: {
+		tier: "OU",
+	},
+	spinarak: {
+		tier: "LC",
+	},
+	ariados: {
+		tier: "OU",
+	},
+	pichu: {
+		tier: "LC",
+	},
+	cleffa: {
+		tier: "LC",
+	},
+	mareep: {
+		tier: "LC",
+	},
+	flaaffy: {
+		tier: "NFE",
+	},
+	ampharos: {
+		tier: "OU",
+	},
+	ampharosmega: {
+		tier: "OU",
+	},
+	espeon: {
+		tier: "OU",
+	},
+	umbreon: {
+		tier: "OU",
+	},
+	slowking: {
+		tier: "OU",
+	},
+	slowkinggalar: {
+		tier: "OU",
+	},
+	steelix: {
+		tier: "OU",
+	},
+	steelixmega: {
+		tier: "OU",
+	},
+	scizor: {
+		tier: "OU",
+	},
+	scizormega: {
+		tier: "OU",
+	},
+	heracross: {
+		tier: "OU",
+	},
+	heracrossmega: {
+		tier: "OU",
+	},
+	delibird: {
+		tier: "OU",
+	},
+	skarmory: {
+		tier: "OU",
+	},
+	skarmorymega: {
+		tier: "OU",
+	},
+	houndour: {
+		tier: "LC",
+	},
+	houndoom: {
+		tier: "OU",
+	},
+	houndoommega: {
+		tier: "OU",
+	},
+	larvitar: {
+		tier: "LC",
+	},
+	pupitar: {
+		tier: "NFE",
+	},
+	tyranitar: {
+		tier: "OU",
+	},
+	tyranitarmega: {
+		tier: "OU",
+	},
+	ralts: {
+		tier: "LC",
+	},
+	kirlia: {
+		tier: "NFE",
+	},
+	gardevoir: {
+		tier: "OU",
+	},
+	gardevoirmega: {
+		tier: "OU",
+	},
+	sableye: {
+		tier: "OU",
+	},
+	sableyemega: {
+		tier: "OU",
+	},
+	mawile: {
+		tier: "OU",
+	},
+	mawilemega: {
+		tier: "OU",
+	},
+	aron: {
+		tier: "LC",
+	},
+	lairon: {
+		tier: "NFE",
+	},
+	aggron: {
+		tier: "OU",
+	},
+	aggronmega: {
+		tier: "OU",
+	},
+	meditite: {
+		tier: "LC",
+	},
+	medicham: {
+		tier: "OU",
+	},
+	medichammega: {
+		tier: "OU",
+	},
+	electrike: {
+		tier: "LC",
+	},
+	manectric: {
+		tier: "OU",
+	},
+	manectricmega: {
+		tier: "OU",
+	},
+	roselia: {
+		tier: "NFE",
+	},
+	carvanha: {
+		tier: "LC",
+	},
+	sharpedo: {
+		tier: "OU",
+	},
+	sharpedomega: {
+		tier: "OU",
+	},
+	numel: {
+		tier: "LC",
+	},
+	camerupt: {
+		tier: "OU",
+	},
+	cameruptmega: {
+		tier: "OU",
+	},
+	swablu: {
+		tier: "LC",
+	},
+	altaria: {
+		tier: "OU",
+	},
+	altariamega: {
+		tier: "OU",
+	},
+	shuppet: {
+		tier: "LC",
+	},
+	banette: {
+		tier: "OU",
+	},
+	banettemega: {
+		tier: "OU",
+	},
+	absol: {
+		tier: "OU",
+	},
+	absolmega: {
+		tier: "OU",
+	},
+	snorunt: {
+		tier: "LC",
+	},
+	glalie: {
+		tier: "OU",
+	},
+	glaliemega: {
+		tier: "OU",
+	},
+	bagon: {
+		tier: "LC",
+	},
+	shelgon: {
+		tier: "NFE",
+	},
+	salamence: {
+		tier: "OU",
+	},
+	salamencemega: {
+		tier: "Uber",
+	},
+	beldum: {
+		tier: "LC",
+	},
+	metang: {
+		tier: "NFE",
+	},
+	metagross: {
+		tier: "OU",
+	},
+	metagrossmega: {
+		tier: "OU",
+	},
+	budew: {
+		tier: "LC",
+	},
+	roserade: {
+		tier: "OU",
+	},
+	buneary: {
+		tier: "LC",
+	},
+	lopunny: {
+		tier: "OU",
+	},
+	lopunnymega: {
+		tier: "OU",
+	},
+	gible: {
+		tier: "LC",
+	},
+	gabite: {
+		tier: "NFE",
+	},
+	garchomp: {
+		tier: "OU",
+	},
+	garchompmega: {
+		tier: "OU",
+	},
+	riolu: {
+		tier: "LC",
+	},
+	lucario: {
+		tier: "OU",
+	},
+	lucariomega: {
+		tier: "Uber",
+	},
+	hippopotas: {
+		tier: "LC",
+	},
+	hippowdon: {
+		tier: "OU",
+	},
+	snover: {
+		tier: "LC",
+	},
+	abomasnow: {
+		tier: "OU",
+	},
+	abomasnowmega: {
+		tier: "OU",
+	},
+	leafeon: {
+		tier: "OU",
+	},
+	glaceon: {
+		tier: "OU",
+	},
+	gallade: {
+		tier: "OU",
+	},
+	gallademega: {
+		tier: "OU",
+	},
+	froslass: {
+		tier: "OU",
+	},
+	froslassmega: {
+		tier: "OU",
+	},
+	tepig: {
+		tier: "LC",
+	},
+	pignite: {
+		tier: "NFE",
+	},
+	emboar: {
+		tier: "OU",
+	},
+	emboarmega: {
+		tier: "OU",
+	},
+	patrat: {
+		tier: "LC",
+	},
+	watchog: {
+		tier: "OU",
+	},
+	pansage: {
+		tier: "LC",
+	},
+	simisage: {
+		tier: "OU",
+	},
+	pansear: {
+		tier: "LC",
+	},
+	simisear: {
+		tier: "OU",
+	},
+	panpour: {
+		tier: "LC",
+	},
+	simipour: {
+		tier: "OU",
+	},
+	drilbur: {
+		tier: "LC",
+	},
+	excadrill: {
+		tier: "OU",
+	},
+	excadrillmega: {
+		tier: "OU",
+	},
+	audino: {
+		tier: "OU",
+	},
+	audinomega: {
+		tier: "OU",
+	},
+	venipede: {
+		tier: "LC",
+	},
+	whirlipede: {
+		tier: "NFE",
+	},
+	scolipede: {
+		tier: "OU",
+	},
+	scolipedemega: {
+		tier: "OU",
+	},
+	sandile: {
+		tier: "LC",
+	},
+	krokorok: {
+		tier: "NFE",
+	},
+	krookodile: {
+		tier: "OU",
+	},
+	scraggy: {
+		tier: "LC",
+	},
+	scrafty: {
+		tier: "OU",
+	},
+	scraftymega: {
+		tier: "OU",
+	},
+	trubbish: {
+		tier: "LC",
+	},
+	garbodor: {
+		tier: "OU",
+	},
+	vanillite: {
+		tier: "LC",
+	},
+	vanillish: {
+		tier: "NFE",
+	},
+	vanilluxe: {
+		tier: "OU",
+	},
+	emolga: {
+		tier: "OU",
+	},
+	tynamo: {
+		tier: "LC",
+	},
+	eelektrik: {
+		tier: "NFE",
+	},
+	eelektross: {
+		tier: "OU",
+	},
+	eelektrossmega: {
+		tier: "OU",
+	},
+	litwick: {
+		tier: "LC",
+	},
+	lampent: {
+		tier: "NFE",
+	},
+	chandelure: {
+		tier: "OU",
+	},
+	chandeluremega: {
+		tier: "OU",
+	},
+	stunfisk: {
+		tier: "OU",
+	},
+	stunfiskgalar: {
+		tier: "OU",
+	},
+	chespin: {
+		tier: "LC",
+	},
+	quilladin: {
+		tier: "NFE",
+	},
+	chesnaught: {
+		tier: "OU",
+	},
+	chesnaughtmega: {
+		tier: "OU",
+	},
+	fennekin: {
+		tier: "LC",
+	},
+	braixen: {
+		tier: "NFE",
+	},
+	delphox: {
+		tier: "OU",
+	},
+	delphoxmega: {
+		tier: "OU",
+	},
+	froakie: {
+		tier: "LC",
+	},
+	frogadier: {
+		tier: "NFE",
+	},
+	greninja: {
+		tier: "OU",
+	},
+	greninjabond: {
+		tier: "OU",
+	},
+	greninjamega: {
+		tier: "OU",
+	},
+	bunnelby: {
+		tier: "LC",
+	},
+	diggersby: {
+		tier: "OU",
+	},
+	fletchling: {
+		tier: "LC",
+	},
+	fletchinder: {
+		tier: "NFE",
+	},
+	talonflame: {
+		tier: "OU",
+	},
+	scatterbug: {
+		tier: "LC",
+	},
+	spewpa: {
+		tier: "NFE",
+	},
+	vivillon: {
+		tier: "OU",
+	},
+	vivillonfancy: {
+		tier: "OU",
+	},
+	vivillonpokeball: {
+		tier: "OU",
+	},
+	litleo: {
+		tier: "LC",
+	},
+	pyroar: {
+		tier: "OU",
+	},
+	pyroarmega: {
+		tier: "OU",
+	},
+	flabebe: {
+		tier: "LC",
+	},
+	floette: {
+		tier: "NFE",
+	},
+	floetteeternal: {
+		tier: "OU",
+	},
+	floettemega: {
+		tier: "OU",
+	},
+	florges: {
+		tier: "OU",
+	},
+	skiddo: {
+		tier: "LC",
+	},
+	gogoat: {
+		tier: "OU",
+	},
+	pancham: {
+		tier: "LC",
+	},
+	pangoro: {
+		tier: "OU",
+	},
+	furfrou: {
+		tier: "OU",
+	},
+	espurr: {
+		tier: "LC",
+	},
+	meowstic: {
+		tier: "OU",
+	},
+	meowsticf: {
+		tier: "OU",
+	},
+	honedge: {
+		tier: "LC",
+	},
+	doublade: {
+		tier: "NFE",
+	},
+	aegislash: {
+		tier: "OU",
+	},
+	aegislashblade: {
+	},
+	spritzee: {
+		tier: "LC",
+	},
+	aromatisse: {
+		tier: "OU",
+	},
+	swirlix: {
+		tier: "LC",
+	},
+	slurpuff: {
+		tier: "OU",
+	},
+	inkay: {
+		tier: "LC",
+	},
+	malamar: {
+		tier: "OU",
+	},
+	malamarmega: {
+		tier: "OU",
+	},
+	binacle: {
+		tier: "LC",
+	},
+	barbaracle: {
+		tier: "OU",
+	},
+	barbaraclemega: {
+		tier: "OU",
+	},
+	skrelp: {
+		tier: "LC",
+	},
+	dragalge: {
+		tier: "OU",
+	},
+	dragalgemega: {
+		tier: "OU",
+	},
+	clauncher: {
+		tier: "LC",
+	},
+	clawitzer: {
+		tier: "OU",
+	},
+	helioptile: {
+		tier: "LC",
+	},
+	heliolisk: {
+		tier: "OU",
+	},
+	tyrunt: {
+		tier: "LC",
+	},
+	tyrantrum: {
+		tier: "OU",
+	},
+	amaura: {
+		tier: "LC",
+	},
+	aurorus: {
+		tier: "OU",
+	},
+	sylveon: {
+		tier: "OU",
+	},
+	hawlucha: {
+		tier: "OU",
+	},
+	hawluchamega: {
+		tier: "OU",
+	},
+	dedenne: {
+		tier: "OU",
+	},
+	carbink: {
+		tier: "OU",
+	},
+	goomy: {
+		tier: "LC",
+	},
+	sliggoo: {
+		tier: "NFE",
+	},
+	sliggoohisui: {
+		tier: "NFE",
+	},
+	goodra: {
+		tier: "OU",
+	},
+	goodrahisui: {
+		tier: "OU",
+	},
+	klefki: {
+		tier: "OU",
+	},
+	phantump: {
+		tier: "LC",
+	},
+	trevenant: {
+		tier: "OU",
+	},
+	pumpkaboo: {
+		tier: "LC",
+	},
+	pumpkaboosmall: {
+		tier: "LC",
+	},
+	pumpkaboolarge: {
+		tier: "LC",
+	},
+	pumpkaboosuper: {
+		tier: "LC",
+	},
+	gourgeist: {
+		tier: "OU",
+	},
+	gourgeistsmall: {
+		tier: "OU",
+	},
+	gourgeistlarge: {
+		tier: "OU",
+	},
+	gourgeistsuper: {
+		tier: "OU",
+	},
+	bergmite: {
+		tier: "LC",
+	},
+	avalugg: {
+		tier: "OU",
+	},
+	avalugghisui: {
+		tier: "OU",
+	},
+	noibat: {
+		tier: "LC",
+	},
+	noivern: {
+		tier: "OU",
+	},
+	xerneas: {
+		tier: "Uber",
+	},
+	yveltal: {
+		tier: "Uber",
+	},
+	zygarde: {
+		tier: "OU",
+	},
+	zygarde10: {
+		tier: "OU",
+	},
+	zygardecomplete: {
+		tier: "Uber",
+	},
+	zygardemega: {
+		tier: "Uber",
+	},
+	diancie: {
+		tier: "OU",
+	},
+	dianciemega: {
+		tier: "OU",
+	},
+	hoopa: {
+		tier: "OU",
+	},
+	hoopaunbound: {
+		tier: "OU",
+	},
+	volcanion: {
+		tier: "OU",
+	},
+	drampa: {
+		tier: "OU",
+	},
+	drampamega: {
+		tier: "OU",
+	},
+	falinks: {
+		tier: "OU",
+	},
+	falinksmega: {
+		tier: "OU",
+	},
+};

--- a/test/sim/data.js
+++ b/test/sim/data.js
@@ -355,7 +355,7 @@ describe('Dex data', () => {
 	// Pikachu (6) + Mega (48) [Floette (1)]
 	formes[6] = formes[5] + 1 + 2 + 1 + 2 + 1 + 3 + 3 + 1 + 6 + 48;
 	// Alola (18) + Totem (12) + Pikachu (7) - Pikachu (6) + Greninja (2) + Zygarde (2) +
-	// Oricorio (3) + Rockruff (1) + Lycanroc (2) + Wishiwashi (1) + Silvally (17) + Minior (1)
+	// Oricorio (3) + Rockruff (1) + Lycanroc (2) + Wishiwashi (1) + Silvally (17) + Minior (1) +
 	// Mimikyu (1) + Necrozma (3) [Magearna (1) + LGPE Starters/Meltan/Melmetal (4)]
 	formes[7] = formes[6] + 18 + 12 + 7 - 6 + 2 + 2 + 3 + 1 + 2 + 1 + 17 + 1 + 1 + 3;
 	// Silvally (17) + Rotom (5) + Basculin (1) + Meowstic (1) +
@@ -400,10 +400,10 @@ describe('Dex data', () => {
 	// Vulpix (1) + Ninetales (1) + Wormadam (2) + Cherrim (1) + Rotom (5) + Origin (3) + Arceus (17) +
 	// Shaymin (1) + Therian (4) + Hisui (16) + Basculin (1) + Basculegion (1)
 	formes['gen8legends'] = 1 + 1 + 2 + 1 + 5 + 3 + 17 + 1 + 4 + 16 + 1 + 1;
-	species['gen9legends'] = 234;
-	// Mega (68) + Greninja (1) + Vivillon (2) + Floette (1) + Meowstic (1) + Aegislash (1) + Pumpkaboo (3) +
-	// Gourgeist (3) + Zygarde (2) + Hoopa (1) + Alola (1) + Galar (4) + Hisui (3)
-	formes['gen9legends'] = 68 + 1 + 2 + 1 + 1 + 1 + 3 + 3 + 2 + 1 + 1 + 4 + 3;
+	species['gen9legends'] = 230;
+	// Mega (63) + Vivillon (2) + Floette (1) + Meowstic (1) + Aegislash (1) + Pumpkaboo (3) + Gourgeist (3) +
+	// Zygarde (2) + Alola (1) + Galar (4)
+	formes['gen9legends'] = 63 + 2 + 1 + 1 + 1 + 3 + 3 + 2 + 1 + 4;
 
 	for (const mod of ['gen7letsgo', 'gen8bdsp', 'gen8legends', 'gen9legends']) {
 		it(`${mod} should have ${species[mod]} species and ${formes[mod]} formes`, () => {


### PR DESCRIPTION
I think this is better in case we have access to Pokémon HOME but some Pokémon are still unavailable, so the learnsets of those unavailable ones don't propagate. Also, I accidentally added Arceus-Legends.