### PR TITLE
Drop some references that could retain memory on hotpatch

### DIFF
--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -1,7 +1,7 @@
 import type { SSBSet } from "./random-teams";
 import type { ChosenAction } from '../../../sim/side';
 import { FS } from '../../../lib';
-import { toID } from '../../../sim/dex-data';
+import { toID } from '../../../lib/to-id';
 import { type SwitchAction } from "../../../sim/battle-queue";
 
 // Similar to User.usergroups. Cannot import here due to users.ts requiring Chat

--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -564,7 +564,7 @@ export class QueryProcessManager<T = string, U = string> extends ProcessManager<
 		this._query = query;
 	}
 	async query(input: T, process = this.acquire()) {
-		if (!process) return this._query(input);
+		if (!process) return this._query!(input);
 
 		const timeout = setTimeout(() => {
 			const debugInfo = process.debug || "No debug information found.";
@@ -604,7 +604,7 @@ export class QueryProcessManager<T = string, U = string> extends ProcessManager<
 				return;
 			}
 
-			void Promise.resolve(this._query(JSON.parse(message))).then(
+			void Promise.resolve(this._query!(JSON.parse(message))).then(
 				response => process.send!(`${taskId}\n${JSON.stringify(response)}`)
 			);
 		});

--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -539,7 +539,7 @@ export abstract class ProcessManager<T extends ProcessWrapper = ProcessWrapper> 
 }
 
 export class QueryProcessManager<T = string, U = string> extends ProcessManager<QueryProcessWrapper<T, U>> {
-	_query: (input: T) => U | Promise<U>;
+	_query: null | ((input: T) => U | Promise<U>);
 	messageCallback?: (message: string) => any;
 	timeout: number;
 
@@ -549,7 +549,7 @@ export class QueryProcessManager<T = string, U = string> extends ProcessManager<
 	constructor(
 		id: string,
 		ctx: NodeJS.Module,
-		query: (input: T) => U | Promise<U>,
+		query: null | ((input: T) => U | Promise<U>),
 		timeout = 15 * 60 * 1000,
 		debugCallback?: (message: string) => any
 	) {
@@ -582,7 +582,7 @@ export class QueryProcessManager<T = string, U = string> extends ProcessManager<
 	}
 	queryTemporaryProcess(input: T, force?: boolean) {
 		const process = this.spawnOne(force);
-		const result = this.query(input, process);
+		const result = this.query!(input, process);
 		void this.unspawnOne(process);
 		return result;
 	}

--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -560,6 +560,9 @@ export class QueryProcessManager<T = string, U = string> extends ProcessManager<
 
 		processManagers.push(this);
 	}
+	setQuery(query: (input: T) => U | Promise<U>) {
+		this._query = query;
+	}
 	async query(input: T, process = this.acquire()) {
 		if (!process) return this._query(input);
 

--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -582,7 +582,7 @@ export class QueryProcessManager<T = string, U = string> extends ProcessManager<
 	}
 	queryTemporaryProcess(input: T, force?: boolean) {
 		const process = this.spawnOne(force);
-		const result = this.query!(input, process);
+		const result = this.query(input, process);
 		void this.unspawnOne(process);
 		return result;
 	}

--- a/lib/sql.ts
+++ b/lib/sql.ts
@@ -103,63 +103,8 @@ export class SQLDatabaseManager extends QueryProcessManager<DatabaseQuery, any> 
 	};
 	private dbReady = false;
 	constructor(id: string, module: NodeJS.Module, options: SQLOptions) {
-		super(id, module, query => {
-			if (!this.dbReady) {
-				this.setupDatabase();
-			}
-			try {
-				switch (query.type) {
-				case 'load-extension': {
-					if (!this.database) return null;
-					this.loadExtensionFile(query.data);
-					return true;
-				}
-				case 'transaction': {
-					const transaction = this.state.transactions.get(query.name);
-					// !transaction covers db not existing, typically, but this is just to appease ts
-					if (!transaction || !this.database) {
-						return null;
-					}
-					const env: TransactionEnvironment = {
-						db: this.database,
-						statements: this.state.statements,
-					};
-					return transaction(query.data, env) || null;
-				}
-				case 'exec': {
-					if (!this.database) return { changes: 0 };
-					this.database.exec(query.data);
-					return true;
-				}
-				case 'get': {
-					if (!this.database) {
-						return null;
-					}
-					return this.extractStatement(query).get(query.data);
-				}
-				case 'run': {
-					if (!this.database) {
-						return null;
-					}
-					return this.extractStatement(query).run(query.data);
-				}
-				case 'all': {
-					if (!this.database) {
-						return null;
-					}
-					return this.extractStatement(query).all(query.data);
-				}
-				case 'prepare':
-					if (!this.database) {
-						return null;
-					}
-					this.state.statements.set(query.data, this.database.prepare(query.data));
-					return query.data;
-				}
-			} catch (error: any) {
-				return this.onError(error, query);
-			}
-		});
+		super(id, module, null);
+		this.setQuery(this.onQuery.bind(this));
 
 		this.options = options;
 		this.state = {
@@ -167,6 +112,63 @@ export class SQLDatabaseManager extends QueryProcessManager<DatabaseQuery, any> 
 			statements: new Map(),
 		};
 		if (!this.isParentProcess) this.setupDatabase();
+	}
+	private onQuery(query: DatabaseQuery) {
+		if (!this.dbReady) {
+			this.setupDatabase();
+		}
+		try {
+			switch (query.type) {
+			case 'load-extension': {
+				if (!this.database) return null;
+				this.loadExtensionFile(query.data);
+				return true;
+			}
+			case 'transaction': {
+				const transaction = this.state.transactions.get(query.name);
+				// !transaction covers db not existing, typically, but this is just to appease ts
+				if (!transaction || !this.database) {
+					return null;
+				}
+				const env: TransactionEnvironment = {
+					db: this.database,
+					statements: this.state.statements,
+				};
+				return transaction(query.data, env) || null;
+			}
+			case 'exec': {
+				if (!this.database) return { changes: 0 };
+				this.database.exec(query.data);
+				return true;
+			}
+			case 'get': {
+				if (!this.database) {
+					return null;
+				}
+				return this.extractStatement(query).get(query.data);
+			}
+			case 'run': {
+				if (!this.database) {
+					return null;
+				}
+				return this.extractStatement(query).run(query.data);
+			}
+			case 'all': {
+				if (!this.database) {
+					return null;
+				}
+				return this.extractStatement(query).all(query.data);
+			}
+			case 'prepare':
+				if (!this.database) {
+					return null;
+				}
+				this.state.statements.set(query.data, this.database.prepare(query.data));
+				return query.data;
+			}
+		} catch (error: any) {
+			return this.onError(error, query);
+		}
 	}
 	private onError(err: Error, query: DatabaseQuery) {
 		if (this.options.onError) {

--- a/lib/to-id.ts
+++ b/lib/to-id.ts
@@ -1,0 +1,25 @@
+/**
+ * toID
+ *
+ * Converts anything to an ID. An ID must have only lowercase alphanumeric
+ * characters.
+ *
+ * If a string is passed, it will be converted to lowercase and
+ * non-alphanumeric characters will be stripped.
+ *
+ * If an object with an ID is passed, its ID will be returned.
+ * Otherwise, an empty string will be returned.
+ *
+ * Generally assigned to the global toID, because of how
+ * commonly it's used.
+ *
+ */
+
+export function toID(text: any): ID {
+	if (typeof text !== 'string') {
+		if (text) text = text.id || text.userid || text.roomid || text;
+		if (typeof text === 'number') text = `${text}`;
+		else if (typeof text !== 'string') return '';
+	}
+	return text.toLowerCase().replace(/[^a-z0-9]+/g, '') as ID;
+}

--- a/server/artemis/local.ts
+++ b/server/artemis/local.ts
@@ -7,7 +7,7 @@
 import * as child_process from 'child_process';
 import { ProcessManager, Streams, Utils, FS } from '../../lib';
 import * as ConfigLoader from '../config-loader';
-import { toID } from '../../sim/dex-data';
+import { toID } from '../../lib/to-id';
 
 class ArtemisStream extends Streams.ObjectReadWriteStream<string> {
 	tasks = new Set<string>();

--- a/server/artemis/remote.ts
+++ b/server/artemis/remote.ts
@@ -4,7 +4,7 @@
  */
 import { ProcessManager, Net } from '../../lib';
 import * as ConfigLoader from '../config-loader';
-import { toID } from '../../sim/dex-data';
+import { toID } from '../../lib/to-id';
 
 // 20m. this is mostly here so we can use Monitor.slow()
 const PM_TIMEOUT = 20 * 60 * 1000;

--- a/server/chat-plugins/abuse-monitor.ts
+++ b/server/chat-plugins/abuse-monitor.ts
@@ -9,7 +9,7 @@
  */
 import * as Artemis from '../artemis';
 import { FS, Utils } from '../../lib';
-import { toID } from '../../sim/dex-data';
+import { toID } from '../../lib/to-id';
 import { getBattleLog, getBattleLinks, HelpTicket } from './helptickets';
 import type { GlobalPermission } from '../user-groups';
 

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -1,6 +1,6 @@
 import { FS } from '../lib/fs';
 import type { RoomSection } from './chat-commands/room-settings';
-import { toID } from '../sim/dex-data';
+import { toID } from '../lib/to-id';
 
 export type GroupSymbol = '~' | '#' | '★' | '*' | '@' | '%' | '☆' | '§' | '+' | '^' | ' ' | '‽' | '!';
 export type EffectiveGroupSymbol = GroupSymbol | 'whitelist';

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1,4 +1,5 @@
-import { Dex, toID } from './dex';
+import { Dex } from './dex';
+import { toID } from './../lib/to-id';
 
 const CHOOSABLE_TARGETS = new Set(['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'adjacentFoe']);
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -14,7 +14,8 @@
  * @license MIT
  */
 
-import { Dex, toID } from './dex';
+import { Dex } from './dex';
+import { toID } from './../lib/to-id';
 import { Teams } from './teams';
 import { Field } from './field';
 import { Pokemon, type EffectState, RESTORATIVE_BERRIES } from './pokemon';

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -1,5 +1,6 @@
 import type { PokemonEventMethods, ConditionData } from './dex-conditions';
-import { assignMissingFields, BasicEffect, toID } from './dex-data';
+import { assignMissingFields, BasicEffect } from './dex-data';
+import { toID } from '../lib/to-id';
 import { Utils } from '../lib/utils';
 
 interface AbilityEventMethods {

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -1,5 +1,6 @@
 import { Utils } from '../lib/utils';
-import { assignMissingFields, BasicEffect, toID } from './dex-data';
+import { assignMissingFields, BasicEffect } from './dex-data';
+import { toID } from '../lib/to-id';
 import type { SecondaryEffect, MoveEventMethods } from './dex-moves';
 
 /**

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -5,28 +5,7 @@
  * @license MIT
  */
 import { Utils } from '../lib/utils';
-
-/**
-* Converts anything to an ID. An ID must have only lowercase alphanumeric
-* characters.
-*
-* If a string is passed, it will be converted to lowercase and
-* non-alphanumeric characters will be stripped.
-*
-* If an object with an ID is passed, its ID will be returned.
-* Otherwise, an empty string will be returned.
-*
-* Generally assigned to the global toID, because of how
-* commonly it's used.
-*/
-export function toID(text: any): ID {
-	if (typeof text !== 'string') {
-		if (text) text = text.id || text.userid || text.roomid || text;
-		if (typeof text === 'number') text = `${text}`;
-		else if (typeof text !== 'string') return '';
-	}
-	return text.toLowerCase().replace(/[^a-z0-9]+/g, '') as ID;
-}
+import { toID } from '../lib/to-id';
 
 /**
  * Like Object.assign but only assigns fields missing from self.

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -1,5 +1,6 @@
 import { Utils } from '../lib/utils';
-import { assignMissingFields, toID, BasicEffect } from './dex-data';
+import { assignMissingFields, BasicEffect } from './dex-data';
+import { toID } from '../lib/to-id';
 import type { EventMethods } from './dex-conditions';
 import type { SpeciesData } from './dex-species';
 import { Tags } from '../data/tags';

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -1,5 +1,6 @@
 import type { PokemonEventMethods, ConditionData } from './dex-conditions';
-import { assignMissingFields, BasicEffect, toID } from './dex-data';
+import { assignMissingFields, BasicEffect } from './dex-data';
+import { toID } from '../lib/to-id';
 import { Utils } from '../lib/utils';
 
 interface FlingData {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -1,6 +1,7 @@
 import { Utils } from '../lib/utils';
 import type { ConditionData } from './dex-conditions';
-import { assignMissingFields, BasicEffect, toID } from './dex-data';
+import { assignMissingFields, BasicEffect } from './dex-data';
+import { toID } from '../lib/to-id';
 
 /**
  * Describes the acceptable target(s) of a move.

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -1,4 +1,5 @@
-import { assignMissingFields, BasicEffect, toID } from './dex-data';
+import { assignMissingFields, BasicEffect } from './dex-data';
+import { toID } from '../lib/to-id';
 import { Utils } from '../lib/utils';
 import { isDeepStrictEqual } from 'node:util';
 

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -37,6 +37,7 @@ import { Ability, DexAbilities } from './dex-abilities';
 import { Species, DexSpecies } from './dex-species';
 import { Format, DexFormats } from './dex-formats';
 import { Utils } from '../lib/utils';
+import { toID as _toID } from '../lib/to-id';
 
 const BASE_MOD = 'gen9' as ID;
 const DATA_DIR = path.resolve(__dirname, '../data');
@@ -93,7 +94,7 @@ interface TextTableData {
 	Default: DexTable<DefaultText>;
 }
 
-export const toID = Data.toID;
+export const toID = _toID;
 
 export class ModdedDex {
 	readonly Data = Data;
@@ -110,7 +111,7 @@ export class ModdedDex {
 	readonly currentMod: string;
 	readonly dataDir: string;
 
-	readonly toID = Data.toID;
+	readonly toID = toID;
 
 	gen = 0;
 	parentMod = '';


### PR DESCRIPTION
~~This mainly impacts ``/hotpatch formats``. Previously, dex data would only be released once ``/hotpatch chat`` was performed afterwards, since chat plugins held references to the outdated Dexes.~~

This isn't as impactful as I originally thought.