### PR TITLE
loginserver: correct counter, use slice(), add MAX_PARALLEL_REQUESTS

### DIFF
--- a/server/loginserver.ts
+++ b/server/loginserver.ts
@@ -9,6 +9,7 @@
 
 const LOGIN_SERVER_TIMEOUT = 30000;
 const LOGIN_SERVER_BATCH_TIME = 1000;
+const MAX_PARALLEL_REQUESTS = 5;
 
 import { Net, FS } from '../lib';
 
@@ -52,7 +53,7 @@ class LoginServerInstance {
 	}
 
 	async instantRequest(action: string, data: AnyObject | null = null): Promise<LoginServerResponse> {
-		if (this.openRequests > 5) {
+		if (this.openRequests > MAX_PARALLEL_REQUESTS) {
 			return Promise.resolve(
 				[null, new RangeError("Request overflow")]
 			);


### PR DESCRIPTION
fix double decrement in instantrequest, switch substr->slice, and extract MAX_PARALLEL_REQUESTS constant for the overflow guard.