### PR TITLE
Add secondary property to Light Screen move for generation 1

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -455,6 +455,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				this.add('-start', pokemon, 'Light Screen');
 			},
 		},
+		secondary: null,
 		target: "self",
 		type: "Psychic",
 	},


### PR DESCRIPTION
Really minor change, but lightscreen has no secondary property in the moves data for generation 1. Added it so it's consistent with the rest of the moves. 