### PR TITLE
Fix interaction between Magic Guard and Toxic Spikes in Gen 4

### DIFF
--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1817,7 +1817,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				if (pokemon.hasType('Poison')) {
 					this.add('-sideend', pokemon.side, 'move: Toxic Spikes', `[of] ${pokemon}`);
 					pokemon.side.removeSideCondition('toxicspikes');
-				} else if (pokemon.volatiles['substitute'] || pokemon.hasType('Steel')) {
+				} else if (pokemon.volatiles['substitute'] || pokemon.hasType('Steel') || pokemon.hasAbility('magicguard')) {
 					// do nothing
 				} else if (this.effectState.layers >= 2) {
 					pokemon.trySetStatus('tox', pokemon.side.foe.active[0]);


### PR DESCRIPTION
> Generation IV
If a Pokémon with Magic Guard is [paralyzed](https://bulbapedia.bulbagarden.net/wiki/Paralysis_(status_condition)), it cannot be prevented from using a move due to paralysis, although its [Speed](https://bulbapedia.bulbagarden.net/wiki/Stat#Speed) is still reduced. A Pokémon with Magic Guard cannot be poisoned by [Toxic Spikes](https://bulbapedia.bulbagarden.net/wiki/Toxic_Spikes_(move)).

I saw this on Bulbapedia. The paralysis part is already implemented and I tested the Toxic Spikes part in Pokémon Heart Gold.