### PR TITLE
Make whitelist demotions staff view only as well as for other custom ranks

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -259,7 +259,7 @@ export const commands: Chat.ChatCommands = {
 				} else {
 					this.privateModAction(`${name} was demoted to Room ${nextGroupName} by ${user.name}.`);
 					this.modlog(`ROOM${nextGroupName.toUpperCase()}`, userid, '(demote)');
-					shouldPopup?.popup(`You were demoted to Room ${nextGroupName} by ${user.name} in ${room.roomid}.`);		
+					shouldPopup?.popup(`You were demoted to Room ${nextGroupName} by ${user.name} in ${room.roomid}.`);
 				}
 			}
 


### PR DESCRIPTION
Added an if statement to make demotions from custom ranks and whitelists show for staff only as per the smogon suggestion https://www.smogon.com/forums/threads/make-demotions-from-whitelist-staff-only-visibility.3720140/
mute rank and locked rank remain unaffected since they are at the bottom of the userlist and the rank hierarchy so making someone a regular user from there would be a promotion technically. If anything is undesired am willing to remove or fix it and try a different approach if needed.