### PR TITLE
Move Toxicroak to ZU

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -2754,7 +2754,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 		tier: "LC",
 	},
 	toxicroak: {
-		tier: "PU",
+		tier: "ZU",
 		doublesTier: "(DUU)",
 		natDexTier: "RU",
 	},


### PR DESCRIPTION
Toxicroak did not have enough usage to move from ZU to PU when it moved from ZU to NU in the October 2024 tier shifts. It should quickdrop back to ZU. 

https://www.smogon.com/forums/threads/usage-based-tier-update-for-october-2024-november-45-december-69.3752345/

This same situation has happened with Indeedee between UU and NU. It would be a similar situation if Torkoal rose from ZU to OU. It would not make sense for it to have to drop through UU, RU, NU, and PU to ZU again even if it remained in OU for a year if it did not see consistent usage in those tiers before it rose.