### PR TITLE
Fix randomNormal

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -954,6 +954,8 @@ export class Pokemon {
 				return [{
 					move: moveSlot.move,
 					id: moveSlot.id,
+					// Keep original targeting (e.g. randomNormal for Outrage)
+					target: moveSlot.target,
 				}];
 			}
 			// does this happen?


### PR DESCRIPTION
Fixes #10164

This fixes randomNormal targeting when the randomNormal move is locked in (eg. Outrage). Before, the target was being overwritten to 'normal' because the target wasn't being assigned for lockedMove situations. This is now fixed.