### PR TITLE
Fix typos in Acupressure test and Mafia plugin

### DIFF
--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -2226,10 +2226,10 @@ export const pages: Chat.PageTable = {
 			} else if (!isPlayer?.isEliminated()) {
 				if ((!isPlayer && game.subs.includes(user.id)) || (isPlayer && !game.requestedSub.includes(user.id))) {
 					buf += `<p><details><summary class="button" style="text-align:left; display:inline-block">${isPlayer ? 'Request to be subbed out' : 'Cancel sub request'}</summary>`;
-					buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia sub out">${isPlayer ? 'Confirm request to be subbed out' : 'Confirm cancelation of sub request'}</button></details></p>`;
+					buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia sub out">${isPlayer ? 'Confirm request to be subbed out' : 'Confirm cancellation of sub request'}</button></details></p>`;
 				} else {
 					buf += `<p><details><summary class="button" style="text-align:left; display:inline-block">${isPlayer ? 'Cancel sub request' : 'Join the game as a sub'}</summary>`;
-					buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia sub in">${isPlayer ? 'Confirm cancelation of sub request' : 'Confirm that you want to join the game'}</button></details></p>`;
+					buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia sub in">${isPlayer ? 'Confirm cancellation of sub request' : 'Confirm that you want to join the game'}</button></details></p>`;
 				}
 			}
 		}

--- a/test/sim/moves/acupressure.js
+++ b/test/sim/moves/acupressure.js
@@ -54,7 +54,7 @@ describe('Acupressure', () => {
 		assert(Object.values(battle.p1.active[0].boosts).some(n => n === 2));
 	});
 
-	it(`in Gen 5, should not redirect to the uesr if a targeted ally faints`, () => {
+	it(`in Gen 5, should not redirect to the user if a targeted ally faints`, () => {
 		battle = common.gen(5).createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Shuckle', moves: ['acupressure'] },
 			{ species: 'Dugtrio', moves: ['memento'] },


### PR DESCRIPTION
Fixed minor typos found in the codebase:

- `test/sim/moves/acupressure.js`: `uesr` -> `user`
- `server/chat-plugins/mafia.ts`: `cancelation` -> `cancellation` (standardizing spelling)