### PR TITLE
Thing of the Day: Add auto-start support

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -123,6 +123,8 @@ export interface RoomSettings {
 	minorActivityQueue?: MinorActivityData[];
 	repeats?: RepeatedPhrase[];
 	topics?: string[];
+	// auto start thing of the day
+	autoStartOtd?: boolean;
 	autoModchat?: {
 		rank: GroupSymbol,
 		time: number,


### PR DESCRIPTION
- adds ``autoStartOtd`` to room settings with on/off controls and displays “disabled” in rooms where -otd is not enabled.
- introduces the ``/-otd toggleautostart`` command to manage this setting.
- automatically starts the nomination process or voting round every 24 hours for daily OTDs and every week for weekly OTDs.
