### PR TITLE
Gen 3: Add ADV 200 Doubles format

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -4886,6 +4886,15 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		banlist: ['Uber', 'Swagger'],
 	},
 	{
+		name: "[Gen 3] ADV 200 Doubles",
+		mod: 'gen3rs',
+		gameType: 'doubles',
+		searchShow: false,
+		ruleset: ['Standard', '!Switch Priority Clause Mod'],
+		banlist: ['Uber', 'Quick Claw', 'Soul Dew', 'Swagger'],
+		unbanlist: ['Wobbuffet', 'Wynaut'],
+	},
+	{
 		name: "[Gen 3] Custom Game",
 		mod: 'gen3',
 		searchShow: false,


### PR DESCRIPTION
Adds support for ADV200 Doubles, as there has been some interest in this in the ADV200 Discord, and there is no straightforward way to do this as far as I can tell using custom challenge codes. 