### PR TITLE
Random Battles hotfix: prevent Weakness Policy on Emboar, Arbok, Seviper

### DIFF
--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1362,7 +1362,7 @@ export class RandomTeams {
 			);
 			return (scarfReqs && this.randomChance(1, 2)) ? 'Choice Scarf' : 'Choice Specs';
 		}
-		if (counter.get('speedsetup') && role === 'Bulky Setup') return 'Weakness Policy';
+		if (counter.get('speedsetup') && !counter.get('physicalsetup') && role === 'Bulky Setup') return 'Weakness Policy';
 		if (
 			!counter.get('Status') &&
 			!['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role)


### PR DESCRIPTION
wow we're actually using counter.get('physicalsetup') for the first time!