### PR TITLE
35 Pokes: Update list of allowed Pokemon for January 2026

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2892,10 +2892,10 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'Last Respects', 'Shed Tail', 'Baton Pass + Contrary', 'Baton Pass + Rapid Spin',
 		],
 		unbanlist: [
-			'Beedrill-Base', 'Blastoise-Base', 'Bombirdier', 'Braviary-Hisui', 'Centiskorch', 'Cherrim', 'Cyclizar', 'Delcatty', 'Drampa-Base', 'Falinks-Base',
-			'Galvantula', 'Glastrier', 'Goodra-Base', 'Gothitelle', 'Hypno', 'Klinklang', 'Lurantis-Base', 'Mamoswine', 'Mandibuzz', 'Mismagius', 'Mothim',
-			'Oricorio-Baile', 'Perrserker', 'Revavroom', 'Scrafty-Base', 'Serperior', 'Sinistcha', 'Skarmory-Base', 'Squawkabilly-Green', 'Swoobat', 'Uxie',
-			'Vanilluxe', 'Walrein', 'Wishiwashi', 'Wyrdeer', 'Ultranecrozium Z', 'Solganium Z', 'Lunalium Z', 'Mewnium Z', 'Marshadium Z',
+			'Carracosta', 'Celebi', 'Cinccino', 'Cobalion', 'Cradily', 'Dedenne', 'Fezandipiti', 'Gabite', 'Granbull', 'Greedent', 'Hatterene', 'Heatmor',
+			'Houndstone', 'Indeedee-M', 'Lilligant-Base', 'Medicham-Base', 'Orbeetle', 'Oricorio-Pom-Pom', 'Overqwil', 'Pincurchin', 'Pinsir-Base', 'Rotom-Wash',
+			'Samurott-Base', 'Scovillain-Base', 'Sharpedo-Base', 'Shedinja', 'Shiftry', 'Steelix-Base', 'Tropius', 'Type: Null', 'Typhlosion-Hisui', 'Tyrantrum',
+			'Veluza', 'Vivillon', 'Whimsicott', 'Ultranecrozium Z', 'Solganium Z', 'Lunalium Z', 'Mewnium Z', 'Marshadium Z',
 		],
 		// Stupid hardcode
 		onValidateSet(set, format, setHas, teamHas) {

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -233,10 +233,10 @@ describe('Team Validator', () => {
 			))
 			.reduce((x, y) => x + y);
 
-		// Dex.species.all skips over cosmetic formes
 		const accepted = Dex.species.all().filter(species => !(
 			// ruleTable.isBannedSpecies blind spots
-			species.natDexTier === 'Illegal' || species.isNonstandard === 'CAP'
+			species.natDexTier === 'Illegal' || species.isNonstandard === 'CAP' ||
+			Dex.species.get(species.baseSpecies).cosmeticFormes?.includes(species.name)
 		) && !ruleTable.isBannedSpecies(species)).length;
 
 		assert.equal(accepted, allowed);


### PR DESCRIPTION
The format's unit test makes a wrong assumption (some cosmetic formes are included in `Dex.species.all()`, namely: Burmy, Shellos, Gastrodon, Deerling, Vivillon, Minior, Alcremie) so this PR amends that as well.