### PR TITLE
NatDex: Fix Salamence and Gardevoir-Mega's Tiers

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1877,7 +1877,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	gardevoirmega: {
 		isNonstandard: "Past",
 		tier: "Illegal",
-		natDexTier: "RU",
+		natDexTier: "RUBL",
 	},
 	gallade: {
 		tier: "RU",
@@ -2390,7 +2390,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	salamence: {
 		tier: "RUBL",
 		doublesTier: "(DUU)",
-		natDexTier: "RU",
+		natDexTier: "RUBL",
 	},
 	salamencemega: {
 		isNonstandard: "Past",


### PR DESCRIPTION
Should be marked RUBL but seems to be a typo