### PR TITLE
Fix Berserk Gene inheriting stale confusion duration

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -8049,6 +8049,7 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		spritenum: 388,
 		onUpdate(pokemon) {
 			if (pokemon.useItem()) {
+				pokemon.removeVolatile('confusion');
 				pokemon.addVolatile('confusion');
 			}
 		},


### PR DESCRIPTION
Berserk Gene applied confusion without resetting the volatile state,
causing it to inherit previous confusion durations. This clears any
existing confusion before reapplying it, ensuring a fresh duration
via the confusion onStart callback.
