### PR TITLE
chore: Bump Node required version to 22 and TS to ESNext

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         # Please freely bump this version (and the check in `pokemon-showdown`
         # and `server/index.ts`) if you want to use features from newer versions;
         # this is purely for our own reference, not to constrain programmers.
-        node-version: ['18.x']
+        node-version: ['22.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/build
+++ b/build
@@ -5,7 +5,7 @@ if (!Set.prototype.intersection) {
 	// Set#intersection was introduced in Node 22, which is currently in maintenance
 	// Might as well ask for the most recent "Active LTS" to be safe
 	// https://nodejs.org/en/about/previous-releases
-	console.error("We require Node.js version 24 or later; you're using " + process.version);
+	console.error("We require Node.js version 22 (and recommend 24) or later; you're using " + process.version);
 	process.exit(1);
 }
 

--- a/build
+++ b/build
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 "use strict";
 
-try {
-	// fetch was introduced in Node 18, which is EOL,
-	// so we'll ask for the most recent "Active LTS" with it to be safe
+if (!Set.prototype.intersection) {
+	// Set#intersection was introduced in Node 22, which is currently in maintenance
+	// Might as well ask for the most recent "Active LTS" to be safe
 	// https://nodejs.org/en/about/previous-releases
-	fetch;
-} catch (e) {
-	console.error("We require Node.js version 22 or later; you're using " + process.version);
+	console.error("We require Node.js version 24 or later; you're using " + process.version);
 	process.exit(1);
 }
 

--- a/lib/net.ts
+++ b/lib/net.ts
@@ -17,6 +17,7 @@ export interface NetRequestOptions extends https.RequestOptions {
 	body?: string | PostData;
 	writable?: boolean;
 	query?: PostData;
+	headers?: http.OutgoingHttpHeaders & NodeJS.Dict<unknown>; // Node 22 lets headers be readonly string[]
 }
 
 export class HttpError extends Error {

--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -10,14 +10,13 @@
  */
 
 import * as child_process from 'child_process';
-import * as cluster from 'cluster';
+import cluster, { type Worker } from 'cluster';
 import * as path from 'path';
 import * as Streams from './streams';
 import { FS } from './fs';
 import { Repl, type EvalType } from './repl';
 
 type ChildProcess = child_process.ChildProcess;
-type Worker = cluster.Worker;
 
 export const processManagers: ProcessManager[] = [];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@stylistic/eslint-plugin": "^5.2.2",
         "@types/better-sqlite3": "7.6.3",
         "@types/cloud-env": "^0.2.2",
-        "@types/node": "^14.18.63",
+        "@types/node": "^22.x",
         "@types/nodemailer": "^6.4.4",
         "@types/pg": "^8.6.5",
         "@types/sockjs": "^0.3.33",
@@ -932,11 +932,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/nodemailer": {
       "version": "6.4.7",
@@ -4563,6 +4566,13 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -5241,10 +5251,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/nodemailer": {
       "version": "6.4.7",
@@ -7769,6 +7782,12 @@
         "@typescript-eslint/typescript-estree": "8.38.0",
         "@typescript-eslint/utils": "8.38.0"
       }
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@stylistic/eslint-plugin": "^5.2.2",
     "@types/better-sqlite3": "7.6.3",
     "@types/cloud-env": "^0.2.2",
-    "@types/node": "^14.18.63",
+    "@types/node": "^22.x",
     "@types/nodemailer": "^6.4.4",
     "@types/pg": "^8.6.5",
     "@types/sockjs": "^0.3.33",

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -83,13 +83,10 @@ function showHelp() {
 	console.log('  Displays this reference');
 }
 
-try {
-	fetch;
-} catch (e) {
-	// fetch was introduced in Node 18, which is EOL,
-	// so we'll ask for the most recent "Active LTS" with it to be safe
-	// https://nodejs.org/en/about/previous-releases
-	console.error("We require Node.js version 22 or later; you're using " + process.version);
+if (!Set.prototype.intersection) {
+	// Set#intersection was introduced in Node 22, which is currently in maintenance
+	// Might as well ask for the most recent Active LTS to be safe (https://nodejs.org/en/about/previous-releases)
+	console.error("We require Node.js version 24 or later; you're using " + process.version);
 	process.exit(1);
 }
 

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -86,7 +86,7 @@ function showHelp() {
 if (!Set.prototype.intersection) {
 	// Set#intersection was introduced in Node 22, which is currently in maintenance
 	// Might as well ask for the most recent Active LTS to be safe (https://nodejs.org/en/about/previous-releases)
-	console.error("We require Node.js version 24 or later; you're using " + process.version);
+	console.error("We require Node.js version 22 (and recommend 24) or later; you're using " + process.version);
 	process.exit(1);
 }
 

--- a/server/README.md
+++ b/server/README.md
@@ -11,7 +11,7 @@ Installing
 
     ./pokemon-showdown
 
-(Requires Node.js v16+)
+(Requires Node.js v22+)
 
 If your distro package manager has an old Node.js version, the simplest way to upgrade is `n` – usually no root necessary:
 
@@ -22,7 +22,7 @@ If your distro package manager has an old Node.js version, the simplest way to u
 Detailed installation instructions
 ------------------------------------------------------------------------
 
-Pokémon Showdown requires you to have [Node.js][6] installed, v14.x or later.
+Pokémon Showdown requires you to have [Node.js][6] installed, v22.x or later.
 
 Next, obtain a copy of Pokémon Showdown. If you're reading this outside of GitHub, you've probably already done this. If you're reading this in GitHub, there's a "Clone or download" button near the top right (it's green). I recommend the "Open in Desktop" method - you need to install GitHub Desktop which is more work than "Download ZIP", but it makes it much easier to update in the long run (it lets you use the `/updateserver` command).
 

--- a/server/artemis/local.ts
+++ b/server/artemis/local.ts
@@ -166,7 +166,7 @@ if (!PM.isParentProcess) {
 		slow(text: string) {
 			process.send!(`CALLBACK\nSLOW\n${text}`);
 		},
-	};
+	} as typeof Monitor;
 	global.toID = toID;
 	process.on('uncaughtException', err => {
 		if (Config.crashguard) {

--- a/server/chat-plugins/battlesearch.ts
+++ b/server/chat-plugins/battlesearch.ts
@@ -491,7 +491,7 @@ if (!PM.isParentProcess) {
 		slow(text: string) {
 			process.send!(`CALLBACK\nSLOW\n${text}`);
 		},
-	};
+	} as typeof Monitor;
 	process.on('uncaughtException', err => {
 		if (Config.crashguard) {
 			Monitor.crashlog(err, 'A battle search child process');

--- a/server/global-variables.d.ts
+++ b/server/global-variables.d.ts
@@ -56,4 +56,7 @@ declare global {
 	var Users: typeof UsersType.Users;
 	var Verifier: typeof VerifierType;
 	var toID: typeof DexType.toID;
+
+	var nodeOomHeapdump: any;
+	var __version: {head: string, origin?: string, tree?: string};
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -50,16 +50,17 @@ try {
 }
 // NOTE: This file intentionally doesn't use too many modern JavaScript
 // features, so that it doesn't crash old versions of Node.js, so we
-// can successfully print the "We require Node.js 22+" message.
+// can successfully print the "We require Node.js 24+" message.
 
 // I've gotten enough reports by people who don't use the launch
 // script that this is worth repeating here
-try {
-// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-	fetch;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-} catch (e) {
-	throw new Error("We require Node.js version 22 or later; you're using " + process.version);
+if (typeof fetch === 'undefined') {
+	// We use v22 in server chat code currently (checked in the launcher), which is currently in maintenance
+	// Might as well ask for the most recent Active LTS to be safe (https://nodejs.org/en/about/previous-releases)
+	// fetch was introduced in Node v18, but people can also run this while bypassing
+	// the launcher if they want to run PS on an older version of Node
+	console.error("We require Node.js version 24 or later; you're using " + process.version);
+	process.exit(1);
 }
 
 try {

--- a/server/modlog/index.ts
+++ b/server/modlog/index.ts
@@ -475,7 +475,7 @@ if (!PM.isParentProcess) {
 			const repr = JSON.stringify([error.name, error.message, source, details]);
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
 		},
-	};
+	} as typeof Monitor;
 	process.on('uncaughtException', err => {
 		Monitor.crashlog(err, 'A modlog database process');
 	});

--- a/server/private-messages/index.ts
+++ b/server/private-messages/index.ts
@@ -220,7 +220,7 @@ if (!PM.isParentProcess) {
 			const repr = JSON.stringify([error.name, error.message, source, details]);
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
 		},
-	};
+	} as typeof Monitor;
 	process.on('uncaughtException', err => {
 		Monitor.crashlog(err, 'A private message database process');
 	});

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1382,7 +1382,7 @@ if (!PM.isParentProcess) {
 		slow(text: string) {
 			process.send!(`CALLBACK\nSLOW\n${text}`);
 		},
-	};
+	} as typeof Monitor;
 	global.__version = { head: '' };
 	try {
 		const head = execSync('git rev-parse HEAD', {

--- a/server/team-validator-async.ts
+++ b/server/team-validator-async.ts
@@ -85,7 +85,7 @@ if (!PM.isParentProcess) {
 			const repr = JSON.stringify([error.name, error.message, source, details]);
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
 		},
-	};
+	} as typeof Monitor;
 
 	if (Config.crashguard) {
 		process.on('uncaughtException', (err: Error) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "lib": ["es2020"],
+        "lib": ["ESNext"],
         "noEmit": true,
         "jsx": "react",
         "jsxFactory": "Chat.h",


### PR DESCRIPTION
Needed for (existing being EoL) + (Set#intersect being a nice-to-have for incoming Scavs code)