### PR TITLE
Show managers of top bidder during auction bid

### DIFF
--- a/server/chat-plugins/auction.ts
+++ b/server/chat-plugins/auction.ts
@@ -262,7 +262,7 @@ export class Auction extends Rooms.SimpleRoomGame {
 		if (this.type === 'auction') {
 			buf += `Top bid: <b>${this.highestBid}</b> `;
 			buf += Utils.html`Top bidder: <b>${this.highestBidder.name}</b> `;
-			buf += `Managers: ${this.highestBidder.getManagers().map(m => `<username class="username">${Utils.escapeHTML(m)}</username>`).join(' ')}`;
+			buf += `Managers: ${this.highestBidder.getManagers().map(m => `<username class="username">${Utils.escapeHTML(m)}</username>`).join(' ')}<br/>`;
 		}
 		buf += Utils.html`Tiers Played: <b>${this.nominatedPlayer.tiersPlayed.length ? `${this.nominatedPlayer.tiersPlayed.join(', ')}` : 'N/A'}</b><br/>`;
 		buf += Utils.html`Tiers Not Played: <b>${this.nominatedPlayer.tiersNotPlayed.length ? `${this.nominatedPlayer.tiersNotPlayed.join(', ')}` : 'N/A'}</b>`;


### PR DESCRIPTION
Copy formatting from `Player: <player_name>`Yesterday, I was watching the SPL auction, and while it may be easy for Mannat and Finch to connect the team names to the managers, for me (and for sure other people) it isn't. The managers' names tell me more than the team names.

<img width="729" height="320" alt="image" src="https://github.com/user-attachments/assets/2ba82004-5c95-4cb9-b943-3302131f9b35" />


**OKAY, I'M DONE FORMATTING.**