### PR TITLE
Add Mega Darkrai as a Dark Void user

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -3480,7 +3480,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		flags: { protect: 1, reflectable: 1, mirror: 1, metronome: 1, nosketch: 1 },
 		status: 'slp',
 		onTry(source, target, move) {
-			if (source.species.name === 'Darkrai' || source.species.name=== "Mega Darkrai" || move.hasBounced) {
+			if (source.species.baseSpecies === 'Darkrai' || move.hasBounced) {
 				return;
 			}
 			this.add('-fail', source, 'move: Dark Void');


### PR DESCRIPTION
Darkrai currently is able to use dark void, but not as a mega. See the following game for example. https://replay.pokemonshowdown.com/gen9doublescustomgame-2518661117