### PR TITLE
Have room banwords apply on hangmans in both creation and guessing phases.

### DIFF
--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -110,7 +110,7 @@ export class Hangman extends Rooms.SimpleRoomGame {
 		}
 
 		if (sanitized.length > 1) {
-			if (!this.banwordCheck(this.room, sanitized)) {
+			if (!this.isSafeGuess(this.room, sanitized)) {
 				throw new Chat.ErrorMessage(`Your guess contained a phrase banned by this room.`);
 			} else if (!this.guessWord(sanitized, user.name)) {
 				throw new Chat.ErrorMessage(`Your guess "${sanitized}" is invalid.`);
@@ -124,7 +124,7 @@ export class Hangman extends Rooms.SimpleRoomGame {
 		}
 	}
 
-	banwordCheck(room: BasicRoom, message: string): boolean {
+	isSafeGuess(room: BasicRoom, message: string): boolean {
 		{
 			if (!room) return true;
 			if (!room.banwordRegex) {
@@ -138,7 +138,7 @@ export class Hangman extends Rooms.SimpleRoomGame {
 			if (room.banwordRegex !== true && room.banwordRegex.test(message)) {
 				return false;
 			}
-			return this.banwordCheck(room.parent as ChatRoom, message);
+			return this.isSafeGuess(room.parent as ChatRoom, message);
 		}
 	}
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/allow-banwords-to-apply-on-hangman-guesses.3756068/post-10360446 partial implementation of the linked suggestion, only to the extent of room banwords. I am unable to verify/test global filtered phrases on my server due to not knowing how to enable the global filters and also not knowing how it works, so leaving that part to someone more knowledgeable on that. If there is anything to be altered or improved, do inform and I will try my best to improve it.