### PR TITLE
Make Ignore Nicknames work when the opponent switches out

### DIFF
--- a/data/text/default.ts
+++ b/data/text/default.ts
@@ -14,7 +14,7 @@ export const DefaultText: { [id: IDEntry]: DefaultText } = {
 		turn: "== Turn [NUMBER] ==",
 		switchIn: "[TRAINER] sent out [FULLNAME]!",
 		switchInOwn: "Go! [FULLNAME]!",
-		switchOut: "[TRAINER] withdrew [FULLNAME]!",
+		switchOut: "[TRAINER] withdrew [POKEMON]!",
 		switchOutOwn: "[NICKNAME], come back!",
 		drag: "[FULLNAME] was dragged out!",
 		faint: "[POKEMON] fainted!",


### PR DESCRIPTION
Currently nicknames still show in the battle chat with Ignore Nicknames on when the opponent switches out, as seen in [this video](https://youtu.be/dkKXcRozJKc?t=1674) (timestamped).
I'm not sure whether [FULLNAME] or [POKEMON] is correct to use, though.