### PR TITLE
Remove /nonotify from friend connection messages

### DIFF
--- a/server/chat-plugins/friends.ts
+++ b/server/chat-plugins/friends.ts
@@ -54,7 +54,7 @@ export const Friends = new class {
 			return;
 		}
 		const friends = await Chat.Friends.getFriends(user.id);
-		const message = `/nonotify Your friend <username class="username">${Utils.escapeHTML(user.name)}</username> has just connected!`;
+		const message = `Your friend <username class="username">${Utils.escapeHTML(user.name)}</username> has just connected!`;
 		for (const f of friends) {
 			const curUser = Users.getExact(f.friend);
 			if (curUser?.settings.allowFriendNotifications) {


### PR DESCRIPTION
Fixes an oversight where /nonotify was used when sending notifications to alert users a friend has come online.
The setting, titled "Notify me when my friends come online", would fail to actually _notify_ the user, instead opting to leave a silent line in the user's Chat self (oldclient) / Console (Preact).

https://github.com/orgs/smogon/projects/2?pane=issue&itemId=111176277