### PR TITLE
Fix tracing of non-suppressible abilities

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1889,9 +1889,6 @@ export class Pokemon {
 		if (typeof ability === 'string') ability = this.battle.dex.abilities.get(ability);
 		if (!sourceEffect && this.battle.effect) sourceEffect = this.battle.effect;
 		const oldAbility = this.battle.dex.abilities.get(this.ability);
-		if (!isFromFormeChange) {
-			if (ability.flags['cantsuppress'] || this.getAbility().flags['cantsuppress']) return false;
-		}
 		if (!isFromFormeChange && !isTransform) {
 			const setAbilityEvent: boolean | null = this.battle.runEvent('SetAbility', this, source, sourceEffect, ability);
 			if (!setAbilityEvent) return setAbilityEvent;


### PR DESCRIPTION
https://www.smogon.com/forums/threads/non-suppressible-abilities-can-still-be-traceable-e-g-gulp-missile.3776788/

This code is probably from a time when there weren't so many individual flags for Skill Swap, Trace, etc.