### PR TITLE
Move Ariados and Charmeleon to ZUBL

### DIFF
--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -12,7 +12,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	charmeleon: {
-		tier: "ZU",
+		tier: "ZUBL",
 	},
 	charizard: {
 		tier: "UUBL",
@@ -558,7 +558,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "LC",
 	},
 	ariados: {
-		tier: "ZU",
+		tier: "ZUBL",
 	},
 	chinchou: {
 		tier: "NU",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/zu-old-gens-hub-ariados-and-charmeleon-banned-from-gsc-zu-405.3646944/post-10829741 The two were banned from GSC ZU on January 10th, 2026