### PR TITLE
Explicitly set type="submit" on form buttons

### DIFF
--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1233,9 +1233,9 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 			player.id ? (
 				`<form><label>Player ${player.num}: <strong>${player.name}</strong></label></form>`
 			) : player.invite ? (
-				`<form data-submitsend="/msgroom ${this.roomid},/uninvitebattle ${player.invite}"><label>Player ${player.num}: <strong>${player.invite}</strong> (invited) <button>Uninvite</button></label></form>`
+				`<form data-submitsend="/msgroom ${this.roomid},/uninvitebattle ${player.invite}"><label>Player ${player.num}: <strong>${player.invite}</strong> (invited) <button type="submit">Uninvite</button></label></form>`
 			) : (
-				`<form data-submitsend="/msgroom ${this.roomid},/invitebattle {username}, p${player.num}"><label>Player ${player.num}: <input name="username" class="textbox" placeholder="Username" /></label> <button class="button">Add Player</button></form>`
+				`<form data-submitsend="/msgroom ${this.roomid},/invitebattle {username}, p${player.num}"><label>Player ${player.num}: <input name="username" class="textbox" placeholder="Username" /></label> <button class="button" type="submit">Add Player</button></form>`
 			)
 		));
 		if (this.gameType === 'multi') {


### PR DESCRIPTION
this fixes an issue on the preact client where the “Add player” button in multi battles was treated as a regular button instead of a submit button, preventing the form submission and blocking the functionality.

Couldnt figure out the cause of the issue on client side, heres a chatgpt-summary of what i tried to debug.

What we tried / checked
We first assumed something was blocking submit, so we checked for preventDefault() everywhere. We added global click and submit listeners, monkey-patched preventDefault(), used DevTools event breakpoints, and verified no JS was cancelling anything. Nothing logged. That ruled out JavaScript interference completely.

Next, we suspected DOM mutation or re-rendering. We used MutationObserver, checked whether the button node was being replaced, tracked identity with custom properties, and compared attributes vs properties. The node stayed the same, and no mutations were observed, so it wasn’t Caja, Preact, or a re-render changing the button.

Then we focused on button semantics. We verified the button’s type, checked hasAttribute('type'), and observed how DevTools showed type="button" after interaction. This turned out to be misleading UI reflection, not an actual mutation.

Finally, we tested the form directly using:

form.requestSubmit();


This worked immediately and reliably. That proved the form was valid, the submit handler worked, and the browser could create a submit event.

What that told us

The submit event was never being created from the button click. Nothing was blocking it; the browser simply didn’t consider the click a submit action. Explicitly forcing submission (requestSubmit() or temporarily adding type="submit") worked, but implicit submit behavior did not survive in this app’s interaction model.