### PR TITLE
Automodchat: Prevent idle or busy staff from being treated as online

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1078,7 +1078,7 @@ export abstract class BasicRoom {
 	runAutoModchat() {
 		if (!this.settings.autoModchat || this.settings.autoModchat.active) return;
 		// they are staff and online
-		const staff = Object.values(this.users).filter(u => this.auth.atLeast(u, '%'));
+		const staff = Object.values(this.users).filter(u => this.auth.atLeast(u, '%') && u.statusType === 'online');
 		if (!staff.length) {
 			const { time } = this.settings.autoModchat;
 			if (!time || time < 5) {


### PR DESCRIPTION
Forum approved:
https://www.smogon.com/forums/threads/do-not-count-idle-busy-staff-as-online-staff-when-setting-automodchat.3777093/#post-10854002