### PR TITLE
ADV 200 Doubles: Ban Wobbuffet and Wynaut

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -5251,7 +5251,6 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		searchShow: false,
 		ruleset: ['Standard', '!Switch Priority Clause Mod'],
 		banlist: ['Uber', 'Quick Claw', 'Soul Dew', 'Swagger'],
-		unbanlist: ['Wobbuffet', 'Wynaut'],
 	},
 	{
 		name: "[Gen 3] Orre Colosseum",


### PR DESCRIPTION
In the official [ADV200 Discord](https://discord.gg/vwWT3D3s) a consensus was reached to ban Wobbuffet and Wynaut in ADV200 Doubles, please reach out there if there are any questions. Thanks!