### PR TITLE
Add more rules to dexsearch

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1541,7 +1541,6 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 						if (matchRule === !isNotSearch) break;
 					}
 					const matchNormally = !validator.checkCanLearn(move, dex[mon], pokemonSource) === !isNotSearch;
-					
 					if ((!isNotSearch && (matchNormally || (numMoveValidationRules > 0 && matchRule))) ||
 						(isNotSearch && matchNormally && (numMoveValidationRules === 0 || matchRule))) {
 						matched = true;


### PR DESCRIPTION
This PR adds the following rules:
- Tier Shift mod.
- Inverse mod.

Tier Shift mod did not need any changes; the previously existing framework already handles it.
Inverse mod had a section added to run onEffectiveness for effectiveness mods.

Edit: Removed Convergence from the PR