### PR TITLE
fix: emergency exit now triggers after dragon tail drags in opponent

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -532,7 +532,7 @@ export class BattleActions {
 			this.battle.singleEvent('AfterMoveSecondarySelf', move, null, pokemon, target, move);
 			this.battle.runEvent('AfterMoveSecondarySelf', pokemon, target, move);
 			if (pokemon && pokemon !== target && move.category !== 'Status') {
-				if (pokemon.hp <= pokemon.maxhp / 2 && originalHp > pokemon.maxhp / 2) {
+				if (!move.forceSwitch && pokemon.hp <= pokemon.maxhp / 2 && originalHp > pokemon.maxhp / 2) {
 					this.battle.runEvent('EmergencyExit', pokemon, pokemon);
 				}
 			}
@@ -1142,7 +1142,7 @@ export class BattleActions {
 					this.battle.singleEvent('AfterHit', moveData, {}, t, pokemon, move);
 				}
 			}
-			if (pokemon.hp && pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {
+			if (!moveData.forceSwitch && pokemon.hp && pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {
 				this.battle.runEvent('EmergencyExit', pokemon);
 			}
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2860,6 +2860,16 @@ export class Battle {
 			}
 		}
 
+		if (action.choice === 'move' && action.pokemon && action.move && pokemonOriginalHP) {
+			const pokemon = action.pokemon;
+			const target = this.getTarget(pokemon, action.move, action.targetLoc);
+			if (pokemon !== target && action.move.category !== 'Status') {
+				if (pokemon.hp && pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {
+					this.runEvent('EmergencyExit', pokemon);
+				}
+			}
+		}
+
 		this.clearActiveMove();
 
 		// fainting

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -134,7 +134,7 @@ describe(`Emergency Exit`, () => {
 		assert.equal(battle.requestState, 'switch');
 	});
 
-	it.skip('should request switch-out after taking recoil and dragging in an opponent', () => {
+	it('should request switch-out after taking recoil and dragging in an opponent', () => {
 		battle = common.createBattle([[
 			{ species: "Golisopod", ability: 'emergencyexit', moves: ['dragontail'] },
 			{ species: "Wynaut", moves: ['sleeptalk'] },


### PR DESCRIPTION
#11752  continuation. as suggested by @andrebastosdias, i have rewritten the dynamax HP calculations to be much simpler. this resolves the complexity concerns while correctly fixing the Emergency Exit bug.