### PR TITLE
Add command help for /randffats

### DIFF
--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -609,6 +609,7 @@ export const commands: Chat.ChatCommands = {
 	randombattleshelp: [
 		`/randombattles OR /randbats [pokemon], [gen] - Displays a Pok\u00e9mon's Random Battle Moves. Defaults to Gen 9. If used in a battle, defaults to the gen of that battle.`,
 		`/randomdoublesbattle OR /randdubs [pokemon], [gen] - Same as above, but instead displays Random Doubles Battle moves.`,
+		'/randffats [pokemon] - (Gen 9 only) Shows the potential moves for a Pok\u00e9mon in Free-For-All Random Battle.',
 	],
 
 	'1v1factory': 'battlefactory',


### PR DESCRIPTION
https://www.smogon.com/forums/threads/add-randffats-command-help.3777636/

The randffats command was added silently when FFA Random Battle received its own (Gen 9) sets. It has been without command help since then. Just adding it to the /randbats master helplist as the command without arguments already leads there.