### PR TITLE
Six By Six: Remove Gunk Rock

### DIFF
--- a/data/random-battles/sixbysix/random-sets.json
+++ b/data/random-battles/sixbysix/random-sets.json
@@ -139,7 +139,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Accelerock", "Earthquake", "Gunk Rock", "Stone Edge"],
+                "movepool": ["Accelerock", "Earthquake", "Gunk Shot", "Stone Edge"],
                 "abilities": ["Earth Eater"]
             }
         ]
@@ -555,3 +555,4 @@
         ]
     }
 }
+


### PR DESCRIPTION
Gunk Rock is not a move in Six by Six (or any other format, for that matter), so I switched it out with Gunk Shot, which appears to be the intended move.