### PR TITLE
fix order up and sheer force interaction

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13524,7 +13524,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		onAfterMoveSecondarySelf(pokemon, target, move) {
 			if (!pokemon.volatiles['commanded']) return;
 			const tatsugiri = pokemon.volatiles['commanded'].source;
-			if (tatsugiri.baseSpecies.baseSpecies !== 'Tatsugiri') return; // Should never happen
+			if (tatsugiri.baseSpecies.baseSpecies !== 'Tatsugiri') return;
 			switch (tatsugiri.baseSpecies.forme) {
 			case 'Droopy':
 				this.boost({ def: 1 }, pokemon, pokemon);
@@ -13538,6 +13538,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			}
 		},
 		secondary: null,
+		alwaysAfterMoveSecondarySelf: true,
 		hasSheerForce: true,
 		target: "normal",
 		type: "Dragon",

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -527,7 +527,8 @@ export class BattleActions {
 			return false;
 		}
 
-		if (!(move.hasSheerForce && pokemon.hasAbility('sheerforce')) && !move.flags['futuremove']) {
+		const sheerForceBlocks = move.hasSheerForce && pokemon.hasAbility('sheerforce') && !move.alwaysAfterMoveSecondarySelf;
+		if (!sheerForceBlocks && !move.flags['futuremove']) {
 			const originalHp = pokemon.hp;
 			this.battle.singleEvent('AfterMoveSecondarySelf', move, null, pokemon, target, move);
 			this.battle.runEvent('AfterMoveSecondarySelf', pokemon, target, move);

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -210,6 +210,7 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	secondaries?: SecondaryEffect[] | null;
 	self?: SecondaryEffect | null;
 	hasSheerForce?: boolean;
+	alwaysAfterMoveSecondarySelf?: boolean;
 
 	// Hit effect modifiers
 	// --------------------

--- a/test/sim/moves/orderup.js
+++ b/test/sim/moves/orderup.js
@@ -10,7 +10,7 @@ describe('Order Up', () => {
 		battle.destroy();
 	});
 
-	it.skip(`should boost Dondozo's stat even if Sheer Force-boosted`, () => {
+	it(`should boost Dondozo's stat even if Sheer Force-boosted`, () => {
 		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'wynaut', moves: ['sleeptalk'] },
 			{ species: 'mew', ability: 'shellarmor', moves: ['sleeptalk'] },


### PR DESCRIPTION
order up's stat boost wasn't working right with sheer force `dondozo`. it was only giving +2 to the stat instead of +3 because sheer force blocked the move's self effect.
when dondozo with sheer force used order up while commanded by `tatsugiri`, it should get +2 from commander volatile +1 from order up move = total +3
but sheer force was blocking the +1 from order up, leaving it at +2.