### PR TITLE
Fix Unseen Fist + Sky Drop interaction

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -5186,7 +5186,8 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	unseenfist: {
 		onModifyMove(move) {
-			if (move.flags['contact']) delete move.flags['protect'];
+			const baseMove = this.dex.moves.get(move.id);
+			if (move.flags['contact'] || baseMove.flags['contact']) delete move.flags['protect'];
 		},
 		flags: {},
 		name: "Unseen Fist",

--- a/test/sim/abilities/unseenfist.js
+++ b/test/sim/abilities/unseenfist.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Unseen Fist', () => {
+	afterEach(() => {
+		battle.destroy();
+	});
+
+	it('should allow contact moves to bypass Protect', () => {
+		battle = common.createBattle([[
+			{ species: 'Urshifu', ability: 'unseenfist', moves: ['tackle'] },
+		], [
+			{ species: 'Wynaut', moves: ['protect'] },
+		]]);
+		battle.makeChoices();
+		assert.false.fullHP(battle.p2.active[0]);
+	});
+
+	it('should not allow non-contact moves to bypass Protect', () => {
+		battle = common.createBattle([[
+			{ species: 'Urshifu', ability: 'unseenfist', moves: ['swift'] },
+		], [
+			{ species: 'Wynaut', moves: ['protect'] },
+		]]);
+		battle.makeChoices();
+		assert.fullHP(battle.p2.active[0]);
+	});
+
+	it('should allow Sky Drop to bypass Protect', () => {
+		battle = common.createBattle([[
+			{ species: 'Urshifu', ability: 'unseenfist', moves: ['skydrop'] },
+		], [
+			{ species: 'Wynaut', moves: ['protect'] },
+		]]);
+		battle.makeChoices('move skydrop', 'move protect');
+		battle.makeChoices();
+		assert.false.fullHP(battle.p2.active[0]);
+	});
+
+	it('should allow two-turn contact moves to bypass Protect even when contact flag is removed on turn 1', () => {
+		battle = common.createBattle([[
+			{ species: 'Urshifu', ability: 'unseenfist', moves: ['skydrop'] },
+		], [
+			{ species: 'Wynaut', moves: ['protect'] },
+		]]);
+		const wynaut = battle.p2.active[0];
+		battle.makeChoices('move skydrop', 'move protect');
+		assert.fullHP(wynaut);
+		battle.makeChoices();
+		assert.false.fullHP(wynaut);
+	});
+});


### PR DESCRIPTION
Fixes bug where Sky Drop with Unseen Fist was blocked by Protect. https://www.smogon.com/forums/threads/sky-drop-with-unseen-fist-should-bypass-protect.3777333/

**NOTE**: Sky Drop was removed in Gen 8 (where Unseen Fist was introduced), so this interaction never occurred in official games. However, based on mechanics, this is the correct behavior.