### PR TITLE
Fix broadcast intended move before confusion self-hit in gen1 stadium

### DIFF
--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -98,6 +98,28 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			this.add('-start', target, 'confusion');
 			this.effectState.time = this.random(2, 6);
 		},
+		onBeforeMove(pokemon, target, move) {
+			pokemon.volatiles['confusion'].time--;
+			if (!pokemon.volatiles['confusion'].time) {
+				pokemon.removeVolatile('confusion');
+				return;
+			}
+			this.add('-activate', pokemon, 'confusion');
+			if (!this.randomChance(128, 256)) {
+				this.addMove('move', pokemon, move.name, `${target}`);
+				this.attrLastMove('[still]');
+				const damage = Math.floor(Math.floor((
+					(Math.floor(2 * pokemon.level / 5) + 2) * pokemon.getStat('atk') * 40
+				) / pokemon.getStat('def', false)) / 50) + 2;
+				this.directDamage(damage, pokemon, target);
+				pokemon.removeVolatile('bide');
+				pokemon.removeVolatile('twoturnmove');
+				pokemon.removeVolatile('invulnerability');
+				pokemon.removeVolatile('partialtrappinglock');
+				pokemon.removeVolatile('lockedmove');
+				return false;
+			}
+		},
 	},
 	flinch: {
 		inherit: true,

--- a/test/sim/misc/confusion.js
+++ b/test/sim/misc/confusion.js
@@ -22,3 +22,26 @@ describe('Confusion', () => {
 		assert.bounded(damage, [150, 177]);
 	});
 });
+
+describe('Confusion [Gen 1 Stadium]', () => {
+	afterEach(() => {
+		battle.destroy();
+	});
+
+	it(`should broadcast the intended move before the self-hit occurs`, () => {
+		// forceRandomChance: false forces confusion self-hit in gen1 (randomChance(128,256) returns false)
+		// accuracy in gen1stadium uses random(), not randomChance(), so confuse ray still hits
+		battle = common.mod('gen1stadium').createBattle({ forceRandomChance: false }, [[
+			{ species: 'Jolteon', moves: ['confuseray'] },
+		], [
+			{ species: 'Vaporeon', moves: ['tackle'] },
+		]]);
+		battle.makeChoices();
+		const moveIdx = battle.log.findIndex(line => line.startsWith('|move|') && line.includes('Tackle'));
+		const dmgIdx = battle.log.findIndex(line => line.includes('[from] confusion'));
+		assert(moveIdx !== -1, 'tackle should be broadcast in the log');
+		assert(dmgIdx !== -1, 'confusion self-hit damage should appear in the log');
+		assert(moveIdx < dmgIdx, 'move broadcast must precede self-hit damage');
+		assert(battle.log[moveIdx].includes('[still]'), 'move should be marked still since it does not execute');
+	});
+});


### PR DESCRIPTION
Fix: https://www.smogon.com/forums/threads/gen-1-stadium-mechanics.3777745/

currently in gen1stadium, the sim skips showing the intended move when a confused pokemon hits itself, stadium actually does show it before the self-hit animation. fixed by overriding `onBeforeMove` for confusion in gen1stadium conditions to call `addMove` before dealing the self-hit damage, same pattern as choicelock. added a test that verifies the move appears in the log before the confusion damage.