### PR TITLE
Gen 1 LC ALMs and Sleep Ban

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -5393,7 +5393,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		name: "[Gen 1] LC",
 		mod: 'gen1',
 		searchShow: false,
-		ruleset: ['Little Cup', 'Standard', '!Max Level', 'Adjust Level = 5'],
+		ruleset: ['Little Cup', 'Standard', '!Max Level', 'Adjust Level = 5', 'Sleep Moves Clause', 'Accuracy Moves Clause'],
 		banlist: ['Dragon Rage', 'Fire Spin', 'Sonic Boom', 'Wrap'],
 	},
 	{


### PR DESCRIPTION
https://www.smogon.com/forums/threads/rby-little-cup-hub.3697735/page-3#post-10869605

Accuracy Lowering Moves and Sleep Moves have officially been banned from [Gen 1] LC!!!

I'll remind them next time to ping you guys so this stuff actually gets reflected and i dont end up wasting yalls time 🙏