### PR TITLE
Use multi-pass algorithm for /choose switch NAME

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -517,6 +517,14 @@ export class Pokemon {
 		return this.baseMoveSlots.map(moveSlot => moveSlot.id);
 	}
 
+	get matchSetSpecies(): ID {
+		return this.species.name === this.set.species ? this.species.id : toID(this.set.species);
+	}
+
+	get matchSetBaseSpecies(): ID {
+		return toID(this.battle.dex.species.get(this.set.species).baseSpecies);
+	}
+
 	getSlot(): PokemonSlot {
 		const positionOffset = Math.floor(this.side.n / 2) * this.side.active.length;
 		const positionLetter = 'abcdef'.charAt(this.position + positionOffset);

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -912,6 +912,51 @@ export class Side {
 		return update(req) ?? true;
 	}
 
+	findSwitchTargetByName(slotText: string) {
+		// The official PS client sends switch targets as base-one numbers.
+		// However, we also support raw commands with the Pokémon name.
+		// This is meant for users on assistive devices, as well as a
+		// convenient CLI for developers.
+
+		const targetLowerCase = slotText.toLowerCase();
+		const targetId = toID(targetLowerCase);
+
+		for (let step = 0; step < 10; step++) {
+			// Half of our 10 passes are complementary, ensuring nice error handling
+			// on attempts to switch to an active Pokémon.
+			const isErrorPass = step >= 5;
+			for (let slot = 0; slot < this.pokemon.length; slot++) {
+				const isErrorTarget = (
+					(slot < this.active.length && !this.slotConditions[slot]['revivalblessing']) ||
+					this.choice.switchIns.has(slot)
+				);
+				if (isErrorPass !== isErrorTarget) continue;
+				const pokemon = this.pokemon[slot];
+				switch (step % 5) {
+				case 0:
+					if (pokemon.name.toLowerCase() === targetLowerCase) return slot;
+					break;
+				case 1:
+					if ((pokemon.transformed ? pokemon.matchSetSpecies : pokemon.species.id) === targetId) return slot;
+					break;
+				case 2:
+					if ((pokemon.transformed ? pokemon.matchSetBaseSpecies : pokemon.baseSpecies.id) === targetId) return slot;
+					break;
+				case 3:
+					// Ensure preferred cosmetic form is always supported even after Mega-Evolution.
+					if (!pokemon.transformed && pokemon.matchSetSpecies === targetId) return slot;
+					break;
+				case 4:
+					// Ensure base forme is always supported even after Mega-Evolution.
+					if (!pokemon.transformed && pokemon.matchSetBaseSpecies === targetId) return slot;
+					break;
+				}
+			}
+		}
+
+		return -1;
+	}
+
 	chooseSwitch(slotText?: string) {
 		if (this.requestState !== 'move' && this.requestState !== 'switch') {
 			return this.emitChoiceError(`Can't switch: You need a ${this.requestState} response`);
@@ -924,7 +969,7 @@ export class Side {
 			return this.emitChoiceError(`Can't switch: You sent more choices than unfainted Pokémon`);
 		}
 		const pokemon = this.active[index];
-		let slot;
+		let slot = -1;
 		if (!slotText) {
 			if (this.requestState !== 'switch') {
 				return this.emitChoiceError(`Can't switch: You need to select a Pokémon to switch in`);
@@ -938,17 +983,11 @@ export class Side {
 				while (this.choice.switchIns.has(slot) || this.pokemon[slot].fainted) slot++;
 			}
 		} else {
-			slot = parseInt(slotText) - 1;
+			slot = Utils.parseExactInt(slotText) - 1;
 		}
-		if (isNaN(slot) || slot < 0) {
+		if (Number.isNaN(slot) /* only from parseExactInt path */ || slot < 0) {
 			// maybe it's a name/species id!
-			slot = -1;
-			for (const [i, mon] of this.pokemon.entries()) {
-				if (slotText!.toLowerCase() === mon.name.toLowerCase() || toID(slotText) === mon.species.id) {
-					slot = i;
-					break;
-				}
-			}
+			slot = this.findSwitchTargetByName(slotText!);
 			if (slot < 0) {
 				return this.emitChoiceError(`Can't switch: You do not have a Pokémon named "${slotText}" to switch to`);
 			}

--- a/test/sim/choice-parser.js
+++ b/test/sim/choice-parser.js
@@ -463,7 +463,7 @@ describe('Choice parser', () => {
 			battle.makeChoices('switch Magikarp', 'move splash');
 			assert.species(battle.p1.active[0], 'Magikarp');
 
-			battle.makeChoices(`switch ${p1.pokemon[1].species.name}`, 'move splash');
+			battle.makeChoices(`switch ${battle.p1.pokemon[1].species.name}`, 'move splash');
 			assert(battle.p1.active[0].species.isMega);
 		});
 

--- a/test/sim/choice-parser.js
+++ b/test/sim/choice-parser.js
@@ -386,4 +386,156 @@ describe('Choice parser', () => {
 			});
 		});
 	});
+
+	describe('Switch by name', () => {
+		it('should prefer nickname over species name', () => {
+			battle = common.createBattle([[
+				{ species: 'Magikarp', moves: ['splash'] },
+				{ species: 'Charizard', name: "Pikachu", moves: ['tackle'] },
+				{ species: 'Pikachu', name: "Charizard", moves: ['tackle'] },
+			], [
+				{ species: 'Magikarp', moves: ['splash'] },
+			]]);
+
+			battle.makeChoices('switch Charizard', 'move splash');
+			assert.species(battle.p1.active[0], 'Pikachu');
+		});
+
+		it('should support nicknames starting with a digit', () => {
+			battle = common.createBattle([[
+				{ species: 'Magikarp', moves: ['splash'] },
+				{ species: 'Dusclops', name: "1-Eyed", moves: ['tackle'] },
+				{ species: 'Ariados', name: "4-Legged", moves: ['tackle'] },
+				{ species: 'Durant', name: "6-Legged", moves: ['tackle'] },
+			], [
+				{ species: 'Magikarp', moves: ['splash'] },
+			]]);
+
+			battle.makeChoices('switch 1-Eyed', 'move splash');
+			assert.species(battle.p1.active[0], 'Dusclops');
+			battle.makeChoices('switch 4-Legged', 'move splash');
+			assert.species(battle.p1.active[0], 'Ariados');
+			battle.makeChoices('switch 6-Legged', 'move splash');
+			assert.species(battle.p1.active[0], 'Durant');
+		});
+
+		it('should ignore temporarily transformed species', () => {
+			battle = common.createBattle([[
+				{ species: 'Ditto', ability: 'imposter', moves: ['transform'] },
+				{ species: 'Pikachu', moves: ['splash'] },
+			], [
+				{ species: 'Pikachu', moves: ['splash'] },
+			]]);
+
+			assert(battle.p1.active[0].transformed);
+			assert.species(battle.p1.active[0], 'Pikachu');
+
+			battle.makeChoices('switch Pikachu', 'move splash');
+
+			assert(!battle.p1.active[0].transformed);
+			assert.species(battle.p1.active[0], 'Pikachu');
+		});
+
+		it('should error when attempting to switch to an active Pokémon', () => {
+			battle = common.createBattle([[
+				{ species: 'Pikachu', moves: ['tackle'] },
+				{ species: 'Charizard', moves: ['tackle'] },
+			], [
+				{ species: 'Magikarp', moves: ['splash'] },
+			]]);
+
+			assert.throws(() => {
+				battle.makeChoices('switch Pikachu', 'move splash');
+			});
+		});
+
+		it('should match final formes after Mega-Evolution', () => {
+			battle = common.gen(9).createBattle({ formatid: 'gen9nationaldex@@@!teampreview' }, [[
+				{ species: 'Magearna-Original', name: "Magi", item: 'magearnite', moves: ['agility'] },
+				{ species: 'Magikarp', moves: ['splash'] },
+			], [
+				{ species: 'Magikarp', moves: ['splash'] },
+			]]);
+
+			battle.makeChoices('move agility mega', 'move splash');
+			assert(battle.p1.active[0].species.isMega);
+
+			battle.makeChoices('switch Magikarp', 'move splash');
+			assert.species(battle.p1.active[0], 'Magikarp');
+
+			battle.makeChoices(`switch ${p1.pokemon[1].species.name}`, 'move splash');
+			assert(battle.p1.active[0].species.isMega);
+		});
+
+		it('should match base formes after Mega-Evolution', () => {
+			battle = common.gen(9).createBattle({ formatid: 'gen9nationaldex@@@!teampreview' }, [[
+				{ species: 'Magearna-Original', name: "Magi", item: 'magearnite', moves: ['agility'] },
+				{ species: 'Magikarp', moves: ['splash'] },
+			], [
+				{ species: 'Magikarp', moves: ['splash'] },
+			]]);
+
+			battle.makeChoices('move agility mega', 'move splash');
+			assert(battle.p1.active[0].species.isMega);
+
+			battle.makeChoices('switch Magikarp', 'move splash');
+			assert.species(battle.p1.active[0], 'Magikarp');
+
+			battle.makeChoices('switch Magearna', 'move splash');
+			assert(battle.p1.active[0].species.isMega);
+		});
+
+		it('should match cosmetic formes after Mega-Evolution', () => {
+			battle = common.gen(9).createBattle({ formatid: 'gen9nationaldex@@@!teampreview' }, [[
+				{ species: 'Magearna-Original', name: "Magi", item: 'magearnite', moves: ['agility'] },
+				{ species: 'Magikarp', moves: ['splash'] },
+			], [
+				{ species: 'Magikarp', moves: ['splash'] },
+			]]);
+
+			battle.makeChoices('move agility mega', 'move splash');
+			assert(battle.p1.active[0].species.isMega);
+
+			battle.makeChoices('switch Magikarp', 'move splash');
+			assert.species(battle.p1.active[0], 'Magikarp');
+
+			battle.makeChoices('switch Magearna-Original', 'move splash');
+			assert(battle.p1.active[0].species.isMega);
+		});
+
+		it('should allow switching into two identical Pokémon in the same turn', () => {
+			battle = common.createBattle({ gameType: 'doubles' }, [[
+				{ species: 'Pikachu', moves: ['tackle'] },
+				{ species: 'Eevee', moves: ['tackle'] },
+				{ species: 'Garchomp', moves: ['tackle'] },
+				{ species: 'Garchomp', moves: ['tackle'] },
+			], [
+				{ species: 'Magikarp', moves: ['splash'] },
+				{ species: 'Magikarp', moves: ['splash'] },
+			]]);
+
+			battle.makeChoices('switch Garchomp, switch Garchomp', 'move splash, move splash');
+			assert.species(battle.p1.active[0], 'Garchomp');
+			assert.species(battle.p1.active[1], 'Garchomp');
+			assert.notEqual(battle.p1.active[0], battle.p1.active[1]);
+		});
+
+		it('should reject switching into the same Pokémon twice in the same turn', () => {
+			battle = common.createBattle({ gameType: 'doubles' }, [[
+				{ species: 'Pikachu', moves: ['tackle'] },
+				{ species: 'Eevee', moves: ['tackle'] },
+				{ species: 'Garchomp', moves: ['tackle'] },
+				{ species: 'Salamence', moves: ['tackle'] },
+			], [
+				{ species: 'Magikarp', moves: ['splash'] },
+				{ species: 'Magikarp', moves: ['splash'] },
+			]]);
+
+			assert.throws(() => {
+				battle.makeChoices('switch Garchomp, switch Garchomp', 'move splash, move splash');
+			});
+			assert.species(battle.p1.active[0], 'Pikachu');
+			assert.species(battle.p1.active[1], 'Eevee');
+		});
+	});
 });


### PR DESCRIPTION
- All Pokémon names are scanned first. Relevant when Nickname Clause is OFF.
- Temporary species for transformed Pokémon are now correctly ignored.
- Base formes are now also very widely accepted.
- A second pass ensures nice error handling on attempts to switch to an active Pokémon