### PR TITLE
Randomized formats update

### DIFF
--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -450,7 +450,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["explosion", "icebeam", "rapidspin", "spikes", "surf", "toxic"]
+                "movepool": ["explosion", "icebeam", "spikes", "surf"]
             },
             {
                 "role": "Generalist",
@@ -1360,11 +1360,7 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["haze", "hydropump", "rest", "sleeptalk", "sludgebomb", "spikes"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["curse", "hiddenpowerground", "hydropump", "sludgebomb", "spikes"]
+                "movepool": ["curse", "haze", "hydropump", "sludgebomb", "spikes"]
             }
         ]
     },

--- a/data/random-battles/gen2/teams.ts
+++ b/data/random-battles/gen2/teams.ts
@@ -473,6 +473,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 		return {
 			name: species.baseSpecies,
 			species: forme,
+			speciesId: species.id,
 			level,
 			moves: shuffledMoves,
 			ability: 'No Ability',
@@ -484,6 +485,34 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			shiny: false,
 			gender: species.gender ? species.gender : 'M',
 		};
+	}
+
+	/**
+	 * Checks if the new species is compatible with the other mons currently on the team.
+	 */
+	override getPokemonCompatibility(
+		species: Species,
+		pokemon: RandomTeamsTypes.RandomSet[],
+	): boolean {
+		const spikesSetters = ['cloyster', 'delibird', 'qwilfish', 'forretress', 'smeargle'];
+		const incompatiblePokemon = [
+			// These combinations are prevented to avoid double spikes.
+			[spikesSetters, spikesSetters],
+		];
+
+		const incompatibilityList = incompatiblePokemon;
+		for (const pair of incompatibilityList) {
+			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
+			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];
+			if (monsArrayB.includes(species.id)) {
+				if (pokemon.some(m => monsArrayA.includes(m.speciesId!))) return false;
+			}
+			if (monsArrayA.includes(species.id)) {
+				if (pokemon.some(m => monsArrayB.includes(m.speciesId!))) return false;
+			}
+		}
+
+		return true;
 	}
 }
 

--- a/data/random-battles/gen2/teams.ts
+++ b/data/random-battles/gen2/teams.ts
@@ -495,12 +495,11 @@ export class RandomGen2Teams extends RandomGen3Teams {
 		pokemon: RandomTeamsTypes.RandomSet[],
 	): boolean {
 		const spikesSetters = ['cloyster', 'delibird', 'qwilfish', 'forretress', 'smeargle'];
-		const incompatiblePokemon = [
+		const incompatibilityList = [
 			// These combinations are prevented to avoid double spikes.
 			[spikesSetters, spikesSetters],
 		];
 
-		const incompatibilityList = incompatiblePokemon;
 		for (const pair of incompatibilityList) {
 			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
 			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -188,8 +188,13 @@
         "level": 82,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["earthquake", "fireblast", "icebeam", "shadowball", "sludgebomb", "substitute", "thunderbolt"],
+                "abilities": ["Poison Point"]
+            },
+                        {
+                "role": "Wallbreaker",
+                "movepool": ["earthquake", "fireblast", "icebeam", "rockslide", "shadowball", "sludgebomb"],
                 "abilities": ["Poison Point"]
             }
         ]
@@ -198,8 +203,13 @@
         "level": 82,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "shadowball", "sludgebomb", "substitute", "thunderbolt"],
+                "abilities": ["Poison Point"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "rockslide", "shadowball", "sludgebomb"],
                 "abilities": ["Poison Point"]
             }
         ]
@@ -607,6 +617,11 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "hiddenpowerghost", "hiddenpowerground", "surf", "swordsdance"],
+                "abilities": ["Hyper Cutter"]
+            },
+                        {
+                "role": "Bulky Setup",
+                "movepool": ["doubleedge", "hiddenpowerghost", "mudshot", "swordsdance"],
                 "abilities": ["Hyper Cutter"]
             }
         ]
@@ -1544,7 +1559,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "protect", "psychic", "return", "shadowball", "thunderbolt", "thunderwave", "toxic", "wish"],
+                "movepool": ["doubleedge", "earthquake", "protect", "psychic", "return", "thunderwave", "toxic", "wish"],
                 "abilities": ["Early Bird"]
             }
         ]

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -618,6 +618,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		return {
 			name: species.baseSpecies,
 			species: forme,
+			speciesId: species.id,
 			gender: species.gender,
 			shiny: this.randomChance(1, 1024),
 			level,
@@ -628,6 +629,36 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			item,
 			role,
 		};
+	}
+
+	/**
+	 * Checks if the new species is compatible with the other mons currently on the team.
+	 */
+	override getPokemonCompatibility(
+		species: Species,
+		pokemon: RandomTeamsTypes.RandomSet[],
+	): boolean {
+		const incompatiblePokemon = [
+			// These Pokemon are incompatible because the presence of one actively harms the other.
+			// Prevent Shedinja + Tyranitar
+			['shedinja', 'tyranitar'],
+			// Prevent Reversal/Flail users + Tyranitar
+			[['dodrio', 'raticate', 'primeape', 'hitmonlee', 'furret', 'yanma', 'heracross', 'blaziken', 'medicham'], 'tyranitar'],
+		];
+
+		const incompatibilityList = incompatiblePokemon;
+		for (const pair of incompatibilityList) {
+			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
+			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];
+			if (monsArrayB.includes(species.id)) {
+				if (pokemon.some(m => monsArrayA.includes(m.speciesId!))) return false;
+			}
+			if (monsArrayA.includes(species.id)) {
+				if (pokemon.some(m => monsArrayB.includes(m.speciesId!))) return false;
+			}
+		}
+
+		return true;
 	}
 
 	override randomTeam() {
@@ -658,9 +689,6 @@ export class RandomGen3Teams extends RandomGen4Teams {
 
 			// Limit to one of each species (Species Clause)
 			if (baseFormes[species.baseSpecies]) continue;
-
-			// Prevent Shedinja from generating after Tyranitar
-			if (species.name === 'Shedinja' && teamDetails.sand) continue;
 
 			// Limit to one Wobbuffet per battle (not just per team)
 			if (species.name === 'Wobbuffet' && this.battleHasWobbuffet) continue;
@@ -707,6 +735,9 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				if (!this.adjustLevel && (this.getLevel(species) === 100) && numMaxLevelPokemon >= limitFactor) {
 					continue;
 				}
+
+				// Check compatibility with team
+				if (!this.getPokemonCompatibility(species, pokemon)) continue;
 			}
 
 			// Okay, the set passes, add it to our team

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -638,7 +638,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		species: Species,
 		pokemon: RandomTeamsTypes.RandomSet[],
 	): boolean {
-		const incompatiblePokemon = [
+		const incompatibilityList = [
 			// These Pokemon are incompatible because the presence of one actively harms the other.
 			// Prevent Shedinja + Tyranitar
 			['shedinja', 'tyranitar'],
@@ -646,7 +646,6 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			[['dodrio', 'raticate', 'primeape', 'hitmonlee', 'furret', 'yanma', 'heracross', 'blaziken', 'medicham'], 'tyranitar'],
 		];
 
-		const incompatibilityList = incompatiblePokemon;
 		for (const pair of incompatibilityList) {
 			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
 			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1512,7 +1512,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "hypnosis", "megahorn", "return", "suckerpunch", "thunderbolt"],
+                "movepool": ["doubleedge", "earthquake", "hypnosis", "megahorn", "return", "suckerpunch", "thunderbolt", "thunderwave"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -786,7 +786,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		species: Species,
 		pokemon: RandomTeamsTypes.RandomSet[],
 	): boolean {
-		const incompatiblePokemon = [
+		const incompatibilityList = [
 			// These Pokemon are incompatible because the presence of one actively harms the other.
 			// Prevent Dry Skin + sun setting ability
 			[['parasect', 'toxicroak'], 'groudon'],
@@ -794,7 +794,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			['shedinja', ['tyranitar', 'hippowdon', 'abomasnow']],
 		];
 
-		const incompatibilityList = incompatiblePokemon;
 		for (const pair of incompatibilityList) {
 			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
 			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -210,7 +210,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
-		const statusInflictingMoves = ['stunspore', 'thunderwave', 'toxic', 'willowisp', 'yawn'];
+		const statusInflictingMoves = ['hypnosis', 'stunspore', 'thunderwave', 'toxic', 'willowisp', 'yawn'];
 		if (role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -766,6 +766,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		return {
 			name: species.baseSpecies,
 			species: forme,
+			speciesId: species.id,
 			gender: species.gender,
 			shiny: this.randomChance(1, 1024),
 			level,
@@ -776,6 +777,36 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			item,
 			role,
 		};
+	}
+
+	/**
+	 * Checks if the new species is compatible with the other mons currently on the team.
+	 */
+	override getPokemonCompatibility(
+		species: Species,
+		pokemon: RandomTeamsTypes.RandomSet[],
+	): boolean {
+		const incompatiblePokemon = [
+			// These Pokemon are incompatible because the presence of one actively harms the other.
+			// Prevent Dry Skin + sun setting ability
+			[['parasect', 'toxicroak'], 'groudon'],
+			// Prevent Shedinja + sand/hail setting ability
+			['shedinja', ['tyranitar', 'hippowdon', 'abomasnow']],
+		];
+
+		const incompatibilityList = incompatiblePokemon;
+		for (const pair of incompatibilityList) {
+			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
+			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];
+			if (monsArrayB.includes(species.id)) {
+				if (pokemon.some(m => monsArrayA.includes(m.speciesId!))) return false;
+			}
+			if (monsArrayA.includes(species.id)) {
+				if (pokemon.some(m => monsArrayB.includes(m.speciesId!))) return false;
+			}
+		}
+
+		return true;
 	}
 }
 

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -458,7 +458,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
                 "abilities": ["Regenerator"],
                 "preferredTypes": ["Psychic"]
@@ -1269,7 +1269,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
                 "abilities": ["Regenerator"],
                 "preferredTypes": ["Psychic"]
@@ -3309,7 +3309,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "gigadrain", "hiddenpowerfire", "leechseed", "morningsun", "powerwhip", "rockslide", "sleeppowder"],
+                "movepool": ["earthquake", "gigadrain", "hiddenpowerfire", "leafstorm", "leechseed", "morningsun", "rockslide", "sleeppowder"],
                 "abilities": ["Regenerator"]
             },
             {
@@ -4010,7 +4010,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "megahorn", "superpower"],
                 "abilities": ["Torrent"]
             },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -460,18 +460,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
-                "abilities": ["Regenerator"]
+                "abilities": ["Regenerator"],
+                "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Staller",
                 "movepool": ["calmmind", "psyshock", "scald", "slackoff"],
                 "abilities": ["Regenerator"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["fireblast", "icebeam", "psyshock", "surf", "trick", "trickroom"],
-                "abilities": ["Regenerator"],
-                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -1276,11 +1271,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
-                "abilities": ["Regenerator"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["fireblast", "icebeam", "psyshock", "surf", "trick", "trickroom"],
                 "abilities": ["Regenerator"],
                 "preferredTypes": ["Psychic"]
             }
@@ -1397,7 +1387,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
+                "movepool": ["destinybond", "poisonjab", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
                 "abilities": ["Intimidate"]
             }
         ]
@@ -1579,7 +1569,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "hypnosis", "jumpkick", "megahorn", "suckerpunch", "thunderwave"],
+                "movepool": ["doubleedge", "earthquake", "hypnosis", "jumpkick", "megahorn", "return", "suckerpunch", "thunderwave"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
@@ -3319,12 +3309,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hiddenpowerfire", "leafstorm", "leechseed", "morningsun", "powerwhip", "rockslide", "sleeppowder"],
+                "movepool": ["earthquake", "gigadrain", "hiddenpowerfire", "leechseed", "morningsun", "powerwhip", "rockslide", "sleeppowder"],
                 "abilities": ["Regenerator"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "hiddenpowerfire", "leafstorm", "powerwhip", "rockslide", "sleeppowder"],
+                "movepool": ["earthquake", "gigadrain", "hiddenpowerfire", "leafstorm", "rockslide", "sleeppowder"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -4025,8 +4015,13 @@
                 "abilities": ["Torrent"]
             },
             {
-                "role": "Wallbreaker",
+                "role": "Setup Sweeper",
                 "movepool": ["aquajet", "megahorn", "superpower", "swordsdance", "waterfall"],
+                "abilities": ["Torrent"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["grassknot", "hydropump", "icebeam", "scald"],
                 "abilities": ["Torrent"]
             }
         ]

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -850,7 +850,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		species: Species,
 		pokemon: RandomTeamsTypes.RandomSet[],
 	): boolean {
-		const incompatiblePokemon = [
+		const incompatibilityList = [
 			// These Pokemon with support roles are considered too similar to each other.
 			['blissey', 'chansey'],
 			['illumise', 'volbeat'],
@@ -862,7 +862,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			['shedinja', ['tyranitar', 'hippowdon', 'abomasnow']],
 		];
 
-		const incompatibilityList = incompatiblePokemon;
 		for (const pair of incompatibilityList) {
 			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
 			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -830,6 +830,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		return {
 			name: species.baseSpecies,
 			species: forme,
+			speciesId: species.id,
 			gender: species.gender,
 			shiny: this.randomChance(1, 1024),
 			level,
@@ -840,6 +841,40 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			item,
 			role,
 		};
+	}
+
+	/**
+	 * Checks if the new species is compatible with the other mons currently on the team.
+	 */
+	override getPokemonCompatibility(
+		species: Species,
+		pokemon: RandomTeamsTypes.RandomSet[],
+	): boolean {
+		const incompatiblePokemon = [
+			// These Pokemon with support roles are considered too similar to each other.
+			['blissey', 'chansey'],
+			['illumise', 'volbeat'],
+
+			// These Pokemon are incompatible because the presence of one actively harms the other.
+			// Prevent Dry Skin + sun setting ability
+			[['parasect', 'jynx', 'toxicroak'], ['ninetales', 'groudon']],
+			// Prevent Shedinja + sand/hail setting ability
+			['shedinja', ['tyranitar', 'hippowdon', 'abomasnow']],
+		];
+
+		const incompatibilityList = incompatiblePokemon;
+		for (const pair of incompatibilityList) {
+			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
+			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];
+			if (monsArrayB.includes(species.id)) {
+				if (pokemon.some(m => monsArrayA.includes(m.speciesId!))) return false;
+			}
+			if (monsArrayA.includes(species.id)) {
+				if (pokemon.some(m => monsArrayB.includes(m.speciesId!))) return false;
+			}
+		}
+
+		return true;
 	}
 
 	override randomTeam() {
@@ -873,9 +908,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 			// Illusion shouldn't be in the last slot
 			if (species.name === 'Zoroark' && pokemon.length >= (this.maxTeamSize - 1)) continue;
-
-			// Prevent Shedinja from generating after Sandstorm/Hail setters
-			if (species.name === 'Shedinja' && (teamDetails.sand || teamDetails.hail)) continue;
 
 			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
 			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
@@ -924,6 +956,9 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				if (!this.adjustLevel && (this.getLevel(species) === 100) && numMaxLevelPokemon >= limitFactor) {
 					continue;
 				}
+
+				// Check compatibility with team
+				if (!this.getPokemonCompatibility(species, pokemon)) continue;
 			}
 
 			const set = this.randomSet(species, teamDetails, pokemon.length === 0);

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -501,14 +501,10 @@
         "level": 82,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
-                "abilities": ["Regenerator"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["fireblast", "futuresight", "icebeam", "psyshock", "scald"],
-                "abilities": ["Regenerator"]
+                "role": "Bulky Attacker",
+                "movepool": ["calmmind", "fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -1382,14 +1378,10 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
-                "abilities": ["Regenerator"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["dragontail", "fireblast", "futuresight", "icebeam", "psyshock", "scald"],
-                "abilities": ["Regenerator"]
+                "role": "Bulky Attacker",
+                "movepool": ["dragontail", "fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -1738,7 +1730,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch", "thunderwave"],
+                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "return", "suckerpunch", "thunderwave"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
@@ -3135,11 +3127,6 @@
                 "role": "Bulky Support",
                 "movepool": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
                 "abilities": ["Pressure"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["focusblast", "nastyplot", "psychic", "psyshock", "recover", "signalbeam"],
-                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3752,12 +3739,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "knockoff", "leafstorm", "leechseed", "morningsun", "powerwhip", "rockslide", "sleeppowder", "sludgebomb"],
+                "movepool": ["earthquake", "gigadrain", "knockoff", "leafstorm", "leechseed", "morningsun", "rockslide", "sleeppowder", "sludgebomb"],
                 "abilities": ["Regenerator"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["earthquake", "gigadrain", "knockoff", "powerwhip", "rockslide", "sludgebomb"],
+                "movepool": ["earthquake", "gigadrain", "knockoff", "leafstorm", "rockslide", "sludgebomb"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -4008,7 +3995,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["hiddenpowerice", "leafstorm", "thunderbolt", "trick", "voltswitch", "willowisp"],
                 "abilities": ["Levitate"]
             }
@@ -4494,8 +4481,13 @@
                 "abilities": ["Torrent"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["aquajet", "knockoff", "megahorn", "superpower", "swordsdance", "waterfall"],
+                "abilities": ["Torrent"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["grassknot", "hydropump", "icebeam", "scald"],
                 "abilities": ["Torrent"]
             }
         ]

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -260,7 +260,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			this.incompatibleMoves(moves, movePool, 'knockoff', ['pursuit', 'suckerpunch']);
 		}
 
-		const statusInflictingMoves = ['thunderwave', 'toxic', 'willowisp', 'yawn'];
+		const statusInflictingMoves = ["nuzzle", 'thunderwave', 'toxic', 'willowisp', 'yawn'];
 		if (!abilities.includes('Prankster') && role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -883,6 +883,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		return {
 			name: species.baseSpecies,
 			species: forme,
+			speciesId: species.id,
 			gender: species.gender || (this.random(2) ? 'F' : 'M'),
 			shiny: this.randomChance(1, 1024),
 			level,

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -642,14 +642,10 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
-                "abilities": ["Regenerator"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["fireblast", "futuresight", "icebeam", "psyshock", "scald"],
-                "abilities": ["Regenerator"]
+                "role": "Bulky Attacker",
+                "movepool": ["calmmind", "fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -1594,14 +1590,10 @@
         "level": 89,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
-                "abilities": ["Regenerator"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["dragontail", "fireblast", "futuresight", "icebeam", "psyshock", "scald"],
-                "abilities": ["Regenerator"]
+                "role": "Bulky Attacker",
+                "movepool": ["dragontail", "fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+                "abilities": ["Regenerator"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -1958,7 +1950,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch", "throatchop", "thunderwave"],
+                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "return", "suckerpunch", "throatchop", "thunderwave"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             }
@@ -3420,11 +3412,6 @@
                 "role": "Bulky Support",
                 "movepool": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
                 "abilities": ["Pressure"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["focusblast", "nastyplot", "psychic", "psyshock", "recover", "signalbeam"],
-                "abilities": ["Pressure"]
             }
         ]
     },
@@ -3466,12 +3453,6 @@
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"],
                 "abilities": ["Blaze", "Iron Fist"]
-            },
-            {
-                "role": "Z-Move user",
-                "movepool": ["fireblast", "focusblast", "grassknot", "nastyplot", "vacuumwave"],
-                "abilities": ["Blaze"],
-                "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Fast Support",
@@ -4069,12 +4050,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "knockoff", "leafstorm", "leechseed", "morningsun", "powerwhip", "rockslide", "sleeppowder", "sludgebomb"],
+                "movepool": ["earthquake", "gigadrain", "knockoff", "leafstorm", "leechseed", "morningsun", "rockslide", "sleeppowder", "sludgebomb"],
                 "abilities": ["Regenerator"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["earthquake", "gigadrain", "knockoff", "powerwhip", "rockslide", "sludgebomb"],
+                "movepool": ["earthquake", "gigadrain", "knockoff", "leafstorm", "rockslide", "sludgebomb"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -4343,7 +4324,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["defog", "hiddenpowerice", "leafstorm", "thunderbolt", "trick", "voltswitch", "willowisp"],
                 "abilities": ["Levitate"]
             }
@@ -4864,8 +4845,13 @@
                 "abilities": ["Torrent"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["aquajet", "knockoff", "liquidation", "megahorn", "sacredsword", "swordsdance"],
+                "abilities": ["Torrent"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["grassknot", "hydropump", "icebeam", "scald"],
                 "abilities": ["Torrent"]
             }
         ]
@@ -5095,6 +5081,11 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["bulkup", "facade", "knockoff", "stormthrow"],
+                "abilities": ["Guts"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["facade", "knockoff", "stormthrow", "superpower"],
                 "abilities": ["Guts"]
             },
             {
@@ -7446,6 +7437,11 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["calmmind", "hydropump", "icebeam", "moonblast", "surf", "taunt"],
+                "abilities": ["Misty Surge"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["defog", "hydropump", "knockoff", "moonblast", "naturesmadness", "surf", "taunt"],
                 "abilities": ["Misty Surge"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -6666,6 +6666,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["hydropump", "moonblast", "psychic", "scald"],
                 "abilities": ["Torrent"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["moonblast", "rest", "scald", "sleeptalk"],
+                "abilities": ["Torrent"]
             }
         ]
     },

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -377,7 +377,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			this.incompatibleMoves(moves, movePool, 'knockoff', ['pursuit', 'suckerpunch']);
 		}
 
-		const statusInflictingMoves = ['thunderwave', 'toxic', 'willowisp', 'yawn'];
+		const statusInflictingMoves = ["nuzzle", 'thunderwave', 'toxic', 'willowisp', 'yawn'];
 		if (!abilities.includes('Prankster') && role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -1172,6 +1172,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		return {
 			name: species.baseSpecies,
 			species: forme,
+			speciesId: species.id,
 			gender: species.baseSpecies === 'Greninja' ? 'M' : (species.gender || (this.random(2) ? 'F' : 'M')),
 			shiny: this.randomChance(1, 1024),
 			level,
@@ -1182,6 +1183,61 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			item,
 			role,
 		};
+	}
+
+	/**
+	 * Checks if the new species is compatible with the other mons currently on the team.
+	 */
+	getPokemonCompatibility(
+		species: Species,
+		pokemon: RandomTeamsTypes.RandomSet[],
+	): boolean {
+		const webSetters = [
+			'ariados', 'shuckle', 'smeargle', 'masquerain', 'kricketune', 'leavanny', 'galvantula', 'ribombee', 'araquanid',
+		];
+
+		// Some pokes are setters in gen 7 but not gen 6
+		const gen6ScreenSetters = ['meowstic', 'carbink'];
+		const screenSetters = (this.gen === 7) ? [...gen6ScreenSetters, 'electrode', 'ninetalesalola'] : gen6ScreenSetters;
+
+		const gen6SunSetters = ['charizardmegay', 'ninetales', 'groudon'];
+		const sunSetters = (this.gen === 7) ? [...gen6SunSetters, 'torkoal'] : gen6SunSetters;
+
+		const gen6SandSetters = ['tyranitar', 'tyranitarmega', 'hippowdon'];
+		const sandSetters = (this.gen === 7) ? [...gen6SandSetters, 'gigalith'] : gen6SandSetters;
+
+		const gen6HailSetters = ['abomasnow', 'abomasnowmega', 'aurorus'];
+		const hailSetters = (this.gen === 7) ? [...gen6HailSetters, 'vanilluxe', 'ninetalesalola'] : gen6HailSetters;
+
+		const incompatiblePokemon = [
+			// These Pokemon with support roles are considered too similar to each other.
+			['blissey', 'chansey'],
+			['illumise', 'volbeat'],
+
+			// These combinations are prevented to avoid double webs or screens.
+			[webSetters, webSetters],
+			[screenSetters, screenSetters],
+
+			// These Pokemon are incompatible because the presence of one actively harms the other.
+			// Prevent Dry Skin + sun setting ability
+			['parasect', 'jynx', 'toxicroak', 'heliolisk', sunSetters],
+			// Prevent Shedinja + sand/hail setting ability
+			['shedinja', [...sandSetters, ...hailSetters]],
+		];
+
+		const incompatibilityList = incompatiblePokemon;
+		for (const pair of incompatibilityList) {
+			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
+			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];
+			if (monsArrayB.includes(species.id)) {
+				if (pokemon.some(m => monsArrayA.includes(m.speciesId!))) return false;
+			}
+			if (monsArrayA.includes(species.id)) {
+				if (pokemon.some(m => monsArrayB.includes(m.speciesId!))) return false;
+			}
+		}
+
+		return true;
 	}
 
 	override randomTeam() {
@@ -1300,6 +1356,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 						if (!this.adjustLevel && (this.getLevel(species) === 100) && numMaxLevelPokemon >= limitFactor) {
 							continue;
 						}
+
+						// Check compatibility with team
+						if (!this.getPokemonCompatibility(species, pokemon)) continue;
 					}
 
 					// Limit three of any type combination in Monotype

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -1209,7 +1209,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		const gen6HailSetters = ['abomasnow', 'abomasnowmega', 'aurorus'];
 		const hailSetters = (this.gen === 7) ? [...gen6HailSetters, 'vanilluxe', 'ninetalesalola'] : gen6HailSetters;
 
-		const incompatiblePokemon = [
+		const incompatibilityList = [
 			// These Pokemon with support roles are considered too similar to each other.
 			['blissey', 'chansey'],
 			['illumise', 'volbeat'],
@@ -1225,7 +1225,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			['shedinja', [...sandSetters, ...hailSetters]],
 		];
 
-		const incompatibilityList = incompatiblePokemon;
 		for (const pair of incompatibilityList) {
 			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
 			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -1526,7 +1526,7 @@ export class RandomGen8Teams {
 		case 'Cloud Nine':
 			return (!isNoDynamax || species.id !== 'golduck');
 		case 'Competitive':
-			return (!counter.get('Special') || moves.has('rest') && moves.has('sleeptalk'));
+			return species.id === 'boltund';
 		case 'Compound Eyes': case 'No Guard':
 			return !counter.get('inaccurate');
 		case 'Cursed Body':

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -150,15 +150,15 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Heal Pulse", "Icy Wind", "Knock Off", "Life Dew", "Moonblast", "Thunder Wave"],
-                "abilities": ["Magic Guard", "Unaware"],
-                "teraTypes": ["Fire", "Steel", "Water"]
+                "movepool": ["Dazzling Gleam", "Fire Blast", "Icy Wind", "Moonblast", "Protect", "Thunder Wave"],
+                "abilities": ["Magic Guard"],
+                "teraTypes": ["Fire", "Steel"]
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Fire Blast", "Follow Me", "Helping Hand", "Life Dew", "Moonblast", "Moonlight"],
+                "movepool": ["Follow Me", "Helping Hand", "Knock Off", "Life Dew", "Moonblast", "Moonlight"],
                 "abilities": ["Unaware"],
-                "teraTypes": ["Fire", "Steel", "Water"]
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -195,7 +195,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Dazzling Gleam", "Disable", "Encore", "Fire Blast", "Heal Pulse", "Helping Hand", "Icy Wind", "Thunder Wave"],
+                "movepool": ["Dazzling Gleam", "Encore", "Fire Blast", "Helping Hand", "Icy Wind", "Thunder Wave"],
                 "abilities": ["Competitive"],
                 "teraTypes": ["Fire", "Steel"]
             }
@@ -207,6 +207,18 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Pollen Puff", "Sludge Bomb", "Strength Sap", "Stun Spore"],
+                "abilities": ["Effect Spore"],
+                "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Energy Ball", "Sludge Bomb", "Strength Sap", "Stun Spore"],
+                "abilities": ["Effect Spore"],
+                "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Bulky Protect",
+                "movepool": ["Leech Seed", "Pollen Puff", "Protect", "Sludge Bomb"],
                 "abilities": ["Effect Spore"],
                 "teraTypes": ["Steel", "Water"]
             }
@@ -451,8 +463,8 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Drain Punch", "Gunk Shot", "Helping Hand", "Ice Punch", "Knock Off", "Poison Gas", "Poison Jab", "Shadow Sneak"],
-                "abilities": ["Poison Touch", "Sticky Hold"],
+                "movepool": ["Drain Punch", "Gunk Shot", "Helping Hand", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak", "Toxic Spikes"],
+                "abilities": ["Poison Touch"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -814,7 +826,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Crunch", "Double-Edge", "Hammer Arm", "Heat Crash", "High Horsepower"],
+                "movepool": ["Body Slam", "Crunch", "Double-Edge", "Hammer Arm", "Heat Crash", "High Horsepower"],
                 "abilities": ["Thick Fat"],
                 "teraTypes": ["Fire", "Ghost", "Ground"]
             },
@@ -825,9 +837,9 @@
                 "teraTypes": ["Ghost", "Ground"]
             },
             {
-                "role": "Doubles Bulky Setup",
-                "movepool": ["Body Slam", "Crunch", "Curse", "High Horsepower", "Protect", "Recycle"],
-                "abilities": ["Gluttony"],
+                "role": "Bulky Protect",
+                "movepool": ["Body Slam", "Curse", "High Horsepower", "Protect"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ground", "Poison"]
             }
         ]
@@ -1172,7 +1184,7 @@
         "level": 91,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
+                "role": "Doubles Support",
                 "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Liquidation", "Recover", "Yawn"],
                 "abilities": ["Unaware", "Water Absorb"],
                 "teraTypes": ["Fire", "Poison", "Steel"]
@@ -1401,8 +1413,14 @@
         "level": 86,
         "sets": [
             {
-                "role": "Doubles Fast Attacker",
+                "role": "Offensive Protect",
                 "movepool": ["Dark Pulse", "Heat Wave", "Nasty Plot", "Protect", "Sucker Punch"],
+                "abilities": ["Flash Fire", "Unnerve"],
+                "teraTypes": ["Dark", "Fire", "Ghost", "Grass"]
+            },
+            {
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Dark Pulse", "Heat Wave", "Nasty Plot", "Protect"],
                 "abilities": ["Flash Fire", "Unnerve"],
                 "teraTypes": ["Dark", "Fire", "Ghost", "Grass"]
             }
@@ -1620,8 +1638,8 @@
         "level": 82,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Flip Turn", "High Horsepower", "Ice Beam", "Icy Wind", "Knock Off", "Muddy Water"],
+                "role": "Doubles Support",
+                "movepool": ["Flip Turn", "High Horsepower", "Icy Wind", "Knock Off", "Muddy Water"],
                 "abilities": ["Torrent"],
                 "teraTypes": ["Fire", "Steel"]
             }
@@ -1659,7 +1677,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Doubles Fast Attacker",
+                "role": "Doubles Wallbreaker",
                 "movepool": ["Fake Out", "Knock Off", "Leaf Blade", "Tailwind"],
                 "abilities": ["Wind Rider"],
                 "teraTypes": ["Ghost"]
@@ -1817,7 +1835,7 @@
         "level": 92,
         "sets": [
             {
-                "role": "Doubles Fast Attacker",
+                "role": "Doubles Setup Sweeper",
                 "movepool": ["Alluring Voice", "Nasty Plot", "Protect", "Thunderbolt"],
                 "abilities": ["Lightning Rod"],
                 "teraTypes": ["Flying"]
@@ -1874,7 +1892,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Encore", "Gunk Shot", "Helping Hand", "Knock Off", "Poison Gas", "Thunder Wave", "Toxic Spikes"],
+                "movepool": ["Encore", "Gunk Shot", "Helping Hand", "Knock Off", "Thunder Wave", "Toxic Spikes"],
                 "abilities": ["Gluttony"],
                 "teraTypes": ["Dark"]
             }
@@ -1990,7 +2008,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
+                "role": "Doubles Support",
                 "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Muddy Water", "Protect"],
                 "abilities": ["Oblivious"],
                 "teraTypes": ["Fire", "Steel"]
@@ -2317,7 +2335,7 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Headlong Rush", "Protect", "Rock Slide", "Shell Smash"],
-                "abilities": ["Overgrow"],
+                "abilities": ["Shell Armor"],
                 "teraTypes": ["Rock"]
             }
         ]
@@ -2454,8 +2472,14 @@
         "level": 82,
         "sets": [
             {
+                "role": "Doubles Support",
+                "movepool": ["Earth Power", "Helping Hand", "Icy Wind", "Muddy Water", "Recover", "Yawn"],
+                "abilities": ["Storm Drain"],
+                "teraTypes": ["Fire"]
+            },
+            {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Clear Smog", "Earth Power", "Helping Hand", "Icy Wind", "Muddy Water", "Recover"],
+                "movepool": ["Earth Power", "Ice Beam", "Recover", "Yawn"],
                 "abilities": ["Storm Drain"],
                 "teraTypes": ["Fire"]
             }
@@ -2594,7 +2618,13 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Close Combat", "Fake Out", "Gunk Shot", "Protect", "Sucker Punch", "Swords Dance"],
+                "movepool": ["Close Combat", "Fake Out", "Gunk Shot", "Protect", "Sucker Punch"],
+                "abilities": ["Dry Skin"],
+                "teraTypes": ["Dark", "Fighting", "Poison"]
+            },
+            {
+                "role": "Doubles Setup Sweeper",
+                "movepool": ["Close Combat", "Gunk Shot", "Protect", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Dry Skin"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
@@ -2656,7 +2686,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Electroweb", "Flash Cannon", "Protect", "Thunderbolt", "Volt Switch"],
-                "abilities": ["Sturdy"],
+                "abilities": ["Magnet Pull"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -2683,13 +2713,13 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Cross Chop", "Flamethrower", "Ice Punch", "Protect", "Volt Switch", "Wild Charge"],
+                "movepool": ["Flamethrower", "Ice Punch", "Protect", "Wild Charge"],
                 "abilities": ["Motor Drive"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Cross Chop", "Flamethrower", "Ice Punch", "Knock Off", "Volt Switch", "Wild Charge"],
+                "movepool": ["Electroweb", "Ice Punch", "Knock Off", "Volt Switch", "Wild Charge"],
                 "abilities": ["Motor Drive"],
                 "teraTypes": ["Flying"]
             }
@@ -2720,6 +2750,12 @@
                 "movepool": ["Air Slash", "Bug Buzz", "Giga Drain", "U-turn"],
                 "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
+            },
+            {
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Air Slash", "Bug Buzz", "Protect", "Tailwind"],
+                "abilities": ["Tinted Lens"],
+                "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Tera Blast user",
@@ -2962,16 +2998,16 @@
         "level": 83,
         "sets": [
             {
-                "role": "Doubles Fast Attacker",
-                "movepool": ["Dazzling Gleam", "Energy Ball", "Fire Blast", "Nasty Plot", "Psychic", "U-turn"],
-                "abilities": ["Levitate"],
-                "teraTypes": ["Fairy", "Fire"]
-            },
-            {
                 "role": "Offensive Protect",
                 "movepool": ["Dazzling Gleam", "Fire Blast", "Nasty Plot", "Protect", "Psychic", "Thunderbolt"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Electric", "Fairy", "Fire"]
+            },
+            {
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Dazzling Gleam", "Fire Blast", "Psychic", "U-turn"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Fairy", "Fire"]
             }
         ]
     },
@@ -3280,12 +3316,6 @@
         "level": 72,
         "sets": [
             {
-                "role": "Doubles Setup Sweeper",
-                "movepool": ["Brick Break", "Extreme Speed", "Phantom Force", "Swords Dance"],
-                "abilities": ["Multitype"],
-                "teraTypes": ["Normal"]
-            },
-            {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Calm Mind", "Focus Blast", "Judgment", "Recover"],
                 "abilities": ["Multitype"],
@@ -3471,13 +3501,13 @@
         "level": 87,
         "sets": [
             {
-                "role": "Offensive Protect",
+                "role": "Doubles Fast Attacker",
                 "movepool": ["High Horsepower", "Overheat", "Protect", "Wild Charge"],
                 "abilities": ["Sap Sipper"],
                 "teraTypes": ["Ground"]
             },
             {
-                "role": "Doubles Fast Attacker",
+                "role": "Doubles Wallbreaker",
                 "movepool": ["High Horsepower", "Overheat", "Protect", "Thunderbolt"],
                 "abilities": ["Lightning Rod"],
                 "teraTypes": ["Flying", "Water"]
@@ -3847,14 +3877,20 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Close Combat", "Fake Out", "Knock Off", "Triple Axel", "U-turn"],
+                "movepool": ["Close Combat", "Fake Out", "Knock Off", "U-turn"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Dark"]
+                "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Fake Out", "Knock Off", "U-turn"],
                 "abilities": ["Regenerator"],
+                "teraTypes": ["Dark", "Steel"]
+            },
+            {
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Close Combat", "Knock Off", "Triple Axel", "U-turn"],
+                "abilities": ["Inner Focus"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -4251,8 +4287,14 @@
         "level": 88,
         "sets": [
             {
-                "role": "Doubles Support",
+                "role": "Doubles Fast Attacker",
                 "movepool": ["Hurricane", "Pollen Puff", "Protect", "Sleep Powder"],
+                "abilities": ["Compound Eyes"],
+                "teraTypes": ["Flying", "Steel"]
+            },
+                        {
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Hurricane", "Protect", "Sleep Powder", "Tailwind"],
                 "abilities": ["Compound Eyes"],
                 "teraTypes": ["Flying", "Steel"]
             }
@@ -4508,9 +4550,9 @@
             },
             {
                 "role": "Bulky Protect",
-                "movepool": ["Diamond Storm", "Moonblast", "Protect", "Trick Room"],
+                "movepool": ["Body Press", "Diamond Storm", "Moonblast", "Trick Room"],
                 "abilities": ["Clear Body"],
-                "teraTypes": ["Grass", "Steel"]
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -4596,8 +4638,8 @@
                 "teraTypes": ["Water"]
             },
             {
-                "role": "Bulky Protect",
-                "movepool": ["Calm Mind", "Hyper Voice", "Moonblast", "Protect"],
+                "role": "Offensive Protect",
+                "movepool": ["Hyper Voice", "Icy Wind", "Life Dew", "Moonblast", "Protect"],
                 "abilities": ["Liquid Voice"],
                 "teraTypes": ["Grass", "Steel"]
             }
@@ -4725,7 +4767,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Doubles Support",
+                "role": "Doubles Fast Attacker",
                 "movepool": ["Moonblast", "Pollen Puff", "Protect", "Tailwind"],
                 "abilities": ["Shield Dust"],
                 "teraTypes": ["Steel"]
@@ -4844,7 +4886,7 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Encore", "Fake Out", "Fire Blast", "Heat Wave", "Poison Gas", "Protect", "Sludge Bomb"],
+                "movepool": ["Encore", "Fake Out", "Fire Blast", "Heat Wave", "Protect", "Sludge Bomb"],
                 "abilities": ["Corrosion"],
                 "teraTypes": ["Fire", "Flying", "Water"]
             }
@@ -5877,15 +5919,15 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Double-Edge", "Helping Hand", "Lash Out", "Protect", "Yawn"],
-                "abilities": ["Gluttony"],
+                "movepool": ["Double-Edge", "Helping Hand", "Protect", "Yawn"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Double-Edge", "High Horsepower", "Lash Out", "Play Rough"],
+                "movepool": ["Body Slam", "Double-Edge", "High Horsepower", "Lash Out"],
                 "abilities": ["Thick Fat"],
-                "teraTypes": ["Fairy", "Ground", "Normal"]
+                "teraTypes": ["Ground", "Normal"]
             }
         ]
     },
@@ -5894,15 +5936,15 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Double-Edge", "Helping Hand", "Lash Out", "Protect", "Yawn"],
-                "abilities": ["Gluttony"],
+                "movepool": ["Double-Edge", "Helping Hand", "Protect", "Yawn"],
+                "abilities": ["Thick Fat"],
                 "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Double-Edge", "High Horsepower", "Lash Out", "Play Rough"],
+                "movepool": ["Body Slam", "Double-Edge", "High Horsepower", "Lash Out"],
                 "abilities": ["Thick Fat"],
-                "teraTypes": ["Fairy", "Ground", "Normal"]
+                "teraTypes": ["Ground", "Normal"]
             }
         ]
     },
@@ -5927,13 +5969,13 @@
                 "teraTypes": ["Bug"]
             },
             {
-                "role": "Doubles Fast Attacker",
+                "role": "Doubles Wallbreaker",
                 "movepool": ["First Impression", "Knock Off", "Protect", "Sucker Punch"],
                 "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug", "Dark"]
             },
             {
-                "role": "Doubles Wallbreaker",
+                "role": "Offensive Protect",
                 "movepool": ["First Impression", "Knock Off", "Leech Life", "Protect"],
                 "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"] 
@@ -6095,6 +6137,12 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
+                "movepool": ["Hurricane", "Protect", "Tailwind", "Thunderbolt"],
+                "abilities": ["Competitive"],
+                "teraTypes": ["Flying", "Steel"]
+            },
+                        {
+                "role": "Doubles Wallbreaker",
                 "movepool": ["Hurricane", "Protect", "Tailwind", "Thunderbolt"],
                 "abilities": ["Competitive"],
                 "teraTypes": ["Flying", "Steel"]
@@ -6650,6 +6698,12 @@
         "level": 78,
         "sets": [
             {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Encore", "Freeze-Dry", "Hydro Pump", "Icy Wind", "Protect"],
+                "abilities": ["Quark Drive"],
+                "teraTypes": ["Dragon", "Water"]
+            },
+            {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Encore", "Freeze-Dry", "Hydro Pump", "Icy Wind", "Protect"],
                 "abilities": ["Quark Drive"],
@@ -6782,12 +6836,6 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Collision Course", "Dragon Claw", "Flare Blitz", "U-turn"],
-                "abilities": ["Orichalcum Pulse"],
-                "teraTypes": ["Fire"]
-            },
-            {
-                "role": "Offensive Protect",
-                "movepool": ["Collision Course", "Dragon Claw", "Flare Blitz", "Protect"],
                 "abilities": ["Orichalcum Pulse"],
                 "teraTypes": ["Fire"]
             }
@@ -7109,7 +7157,7 @@
         "level": 73,
         "sets": [
             {
-                "role": "Doubles Bulky Setup",
+                "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Earth Power", "Protect", "Tera Starstorm"],
                 "abilities": ["Tera Shift"],
                 "teraTypes": ["Stellar"]

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -1487,7 +1487,7 @@
                 "teraTypes": ["Ghost"]
             },
             {
-                "role": "Doubles Support",
+                "role": "Doubles Fast Attacker",
                 "movepool": ["Decorate", "Fake Out", "Follow Me", "Tailwind"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -1487,7 +1487,7 @@
                 "teraTypes": ["Ghost"]
             },
             {
-                "role": "Doubles Fast Attacker",
+                "role": "Doubles Support",
                 "movepool": ["Decorate", "Fake Out", "Follow Me", "Tailwind"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -4678,7 +4678,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Bug Buzz", "Electroweb", "Protect", "Sticky Web", "Thunderbolt"],
+                "movepool": ["Bug Buzz", "Protect", "Sticky Web", "Thunderbolt"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Electric"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -5927,7 +5927,7 @@
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Body Slam", "Double-Edge", "High Horsepower", "Lash Out"],
                 "abilities": ["Thick Fat"],
-                "teraTypes": ["Ground", "Normal"]
+                "teraTypes": ["Ghost", "Ground", "Normal"]
             }
         ]
     },
@@ -5944,7 +5944,7 @@
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Body Slam", "Double-Edge", "High Horsepower", "Lash Out"],
                 "abilities": ["Thick Fat"],
-                "teraTypes": ["Ground", "Normal"]
+                "teraTypes": ["Ghost", "Ground", "Normal"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -77,7 +77,7 @@
         "level": 93,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "AV Pivot",
                 "movepool": ["Fake Out", "Knock Off", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
                 "abilities": ["Lightning Rod"],
                 "teraTypes": ["Water"]
@@ -2136,7 +2136,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Clear Smog", "Earthquake", "Encore", "Ice Beam", "Knock Off", "Pain Split", "Sludge Bomb", "Toxic Spikes"],
+                "movepool": ["Clear Smog", "Earthquake", "Encore", "Ice Beam", "Knock Off", "Pain Split", "Sludge Bomb", "Thunder Wave", "Toxic Spikes"],
                 "abilities": ["Liquid Ooze"],
                 "teraTypes": ["Dark"]
             },
@@ -2379,7 +2379,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Disable", "Earthquake", "Freeze-Dry", "Spikes", "Taunt"],
+                "movepool": ["Earthquake", "Freeze-Dry", "Spikes", "Taunt"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Ghost", "Ground", "Water"]
             }
@@ -3063,13 +3063,13 @@
                 "role": "Fast Attacker",
                 "movepool": ["Body Press", "Flash Cannon", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Analytic", "Magnet Pull"],
-                "teraTypes": ["Electric", "Fighting", "Flying", "Water"]
+                "teraTypes": ["Electric", "Fighting", "Flying"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Body Press", "Discharge", "Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Analytic", "Magnet Pull"],
-                "teraTypes": ["Flying", "Water"]
+                "teraTypes": ["Flying"]
             },
             {
                 "role": "Bulky Setup",
@@ -3405,9 +3405,9 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dazzling Gleam", "Fire Blast", "Nasty Plot", "Psychic", "Psyshock", "Thunderbolt", "Trick", "U-turn"],
+                "movepool": ["Dazzling Gleam", "Fire Blast", "Nasty Plot", "Psychic", "Psyshock", "U-turn"],
                 "abilities": ["Levitate"],
-                "teraTypes": ["Electric", "Fairy", "Fire", "Psychic"]
+                "teraTypes": ["Fairy", "Fire", "Psychic"]
             }
         ]
     },
@@ -4273,13 +4273,13 @@
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Protect", "Scald", "Wish"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Flip Turn", "Protect", "Scald", "Wish"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },
@@ -4819,7 +4819,7 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Brave Bird", "Flare Blitz", "Swords Dance", "Tera Blast"],
-                "abilities": ["Flame Body"],
+                "abilities": ["Flame Body", "Gale Wings"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5567,7 +5567,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Boomburst", "Clanging Scales", "Clangorous Soul", "Close Combat", "Iron Head"],
+                "movepool": ["Boomburst", "Clanging Scales", "Clangorous Soul", "Close Combat", "Drain Punch", "Iron Head"],
                 "abilities": ["Soundproof"],
                 "teraTypes": ["Normal", "Steel"]
             },
@@ -5721,9 +5721,9 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Court Change", "High Jump Kick", "Pyro Ball", "Sucker Punch"],
+                "movepool": ["Court Change", "Pyro Ball", "U-turn", "Will-O-Wisp"],
                 "abilities": ["Libero"],
-                "teraTypes": ["Fighting", "Fire"]
+                "teraTypes": ["Grass"]
             },
             {
                 "role": "Fast Attacker",
@@ -7079,12 +7079,6 @@
                 "movepool": ["Body Slam", "Protect", "Psychic Noise", "Wish"],
                 "abilities": ["Sap Sipper"],
                 "teraTypes": ["Fairy", "Ground", "Water"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Future Sight", "Hyper Voice", "Protect", "Wish"],
-                "abilities": ["Sap Sipper"],
-                "teraTypes": ["Fairy", "Ground", "Water"]
             }
         ]
     },
@@ -7348,7 +7342,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Encore", "Flip Turn", "Freeze-Dry", "Hydro Pump", "Ice Beam", "Substitute"],
+                "movepool": ["Encore", "Flip Turn", "Freeze-Dry", "Hydro Pump", "Ice Beam"],
                 "abilities": ["Quark Drive"],
                 "teraTypes": ["Ice", "Water"]
             }
@@ -7456,7 +7450,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Ice Shard", "Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
+                "movepool": ["Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
                 "abilities": ["Sword of Ruin"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
@@ -7512,7 +7506,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Calm Mind", "Draco Meteor", "Electro Drift", "Substitute"],
+                "movepool": ["Calm Mind", "Draco Meteor", "Dragon Pulse", "Electro Drift"],
                 "abilities": ["Hadron Engine"],
                 "teraTypes": ["Electric"]
             },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -185,7 +185,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Moonblast", "Nasty Plot"],
+                "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Moonblast"],
                 "abilities": ["Snow Warning"],
                 "teraTypes": ["Steel", "Water"]
             }
@@ -2712,7 +2712,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Knock Off", "Pounce", "Sticky Web", "Swords Dance", "Taunt"],
+                "movepool": ["Knock Off", "Pounce", "Sticky Web", "Taunt"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]
             }
@@ -4018,13 +4018,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Knock Off", "Leaf Blade", "Lunge", "Sticky Web", "Swords Dance"],
+                "movepool": ["Knock Off", "Leaf Blade", "Lunge", "Sticky Web"],
                 "abilities": ["Chlorophyll", "Swarm"],
                 "teraTypes": ["Ghost", "Rock"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Bullet Seed", "Knock Off", "Sticky Web", "Swords Dance", "Triple Axel"],
+                "movepool": ["Bullet Seed", "Knock Off", "Sticky Web", "Triple Axel"],
                 "abilities": ["Chlorophyll"],
                 "teraTypes": ["Ghost", "Rock"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -7505,7 +7505,7 @@
         "level": 65,
         "sets": [
             {
-                "role": "Fast Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Draco Meteor", "Dragon Pulse", "Electro Drift"],
                 "abilities": ["Hadron Engine"],
                 "teraTypes": ["Electric"]

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1167,7 +1167,7 @@ export class RandomTeams {
 			species.id === 'froslass' || moves.has('populationbomb') ||
 			(ability === 'Hustle' && counter.get('setup') && !isDoubles && this.randomChance(1, 2))
 		) return 'Wide Lens';
-		if (species.id === 'smeargle' && !isDoubles) return 'Focus Sash';
+		if (species.id === 'smeargle') return 'Focus Sash';
 		if (moves.has('clangoroussoul') || (species.id === 'toxtricity' && moves.has('shiftgear'))) return 'Throat Spray';
 		if (
 			(species.baseSpecies === 'Magearna' && role === 'Tera Blast user') ||

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -246,7 +246,9 @@ export class RandomTeams {
 				!counter.get('Steel') &&
 				(isDoubles || species.baseStats.atk >= 90 || movePool.includes('gigatonhammer') || movePool.includes('makeitrain'))
 			),
-			Water: (movePool, moves, abilities, types, counter) => (!counter.get('Water') && !types.includes('Ground')),
+			Water: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => (
+				!counter.get('Water') && (!types.includes('Ground') || isDoubles)
+			),
 		};
 		this.poolsCacheKey = undefined;
 		this.cachedPool = undefined;
@@ -1157,8 +1159,8 @@ export class RandomTeams {
 			}
 			return this.sample(species.requiredItems);
 		}
-		if (role === 'AV Pivot') return 'Assault Vest';
 		if (species.id === 'pikachu') return 'Light Ball';
+		if (role === 'AV Pivot') return 'Assault Vest';
 		if (species.id === 'regieleki') return 'Magnet';
 		if (types.includes('Normal') && moves.has('doubleedge') && moves.has('fakeout')) return 'Silk Scarf';
 		if (
@@ -1285,9 +1287,14 @@ export class RandomTeams {
 			(role === 'Bulky Protect' && counter.get('setup')) ||
 			['irondefense', 'coil', 'acidarmor', 'wish'].some(m => moves.has(m)) ||
 			(counter.get('recovery') && !moves.has('strengthsap') && !counter.get('speedcontrol') && !offensiveRole) ||
+			(PROTECT_MOVES.some(m => moves.has(m)) && moves.has('leechseed')) ||
 			species.id === 'regigigas'
 		) return 'Leftovers';
-		if (species.id === 'sylveon') return 'Pixie Plate';
+		if (moves.has('hypervoice') && !types.includes('Normal')) return 'Throat Spray';
+		if (
+			role === 'Fast Attacker' && !counter.get('recoil') &&
+			species.baseStats.hp + species.baseStats.def + species.baseStats.spd <= 230
+		) return 'Focus Sash';
 		if (
 			(offensiveRole || (role === 'Tera Blast user' && (species.baseStats.spe >= 80 || moves.has('trickroom')))) &&
 			!moves.has('fakeout') &&
@@ -1300,7 +1307,7 @@ export class RandomTeams {
 			) ? 'Booster Energy' : 'Life Orb';
 		}
 		if (isLead && (species.id === 'glimmora' ||
-			(['Doubles Fast Attacker', 'Doubles Wallbreaker', 'Offensive Protect'].includes(role) &&
+			(['Doubles Wallbreaker', 'Offensive Protect'].includes(role) &&
 				species.baseStats.hp + species.baseStats.def + species.baseStats.spd <= 230))
 		) return 'Focus Sash';
 		if (

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1292,7 +1292,7 @@ export class RandomTeams {
 		) return 'Leftovers';
 		if (moves.has('hypervoice') && !types.includes('Normal')) return 'Throat Spray';
 		if (
-			role === 'Fast Attacker' && !counter.get('recoil') &&
+			role === 'Doubles Fast Attacker' && !counter.get('recoil') &&
 			species.baseStats.hp + species.baseStats.def + species.baseStats.spd <= 230
 		) return 'Focus Sash';
 		if (

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -496,6 +496,7 @@ declare namespace RandomTeamsTypes {
 	export interface RandomSet {
 		name: string;
 		species: string;
+		speciesId?: string;
 		gender: string | boolean;
 		moves: string[];
 		ability: string;


### PR DESCRIPTION
In addition to the usual set updates, this creates a Pokémon incompatibility system (for Gen 9 and 2-7) that prevents pairs considered excessively detrimental from generating together on randbats teams. This system will be used sparingly for the most egregious cases, and does not apply to Monotype randbats. Currently, the following pairs are prevented:
- Volbeat + Illumise (Gens 5-9 and doubles)
- Blissey + Chansey (all formats that contain both)
- Sticky Web setters (all formats)
- Screen/Veil setters (all formats)
- Dry Skin + sun ability setters (all formats)
- Shedinja + sand/hail ability setters (all formats)
- Reversal/Flail users + Tyranitar (Gen 3)
- Spikes users (Gen 2)
- Conflicting weather ability setters (doubles)
- Conflicting terrain ability setters (doubles)
- Minun/Plusle/Pachirisu/Raichu with each other (doubles), because they have similar support sets with Nuzzle

Some sets have been updated to remove moves that no longer generate, such as Swords Dance on Gen 9 Kricketune.


**Gen 9 Random Battle:**
- SD Talonflame: +Gale Wings, roll with Flame Body
- Iron Bundle: -Substitute
- Fast Support Cinderace: -HJK, -Sucker Punch, +U-turn, +Will-O-Wisp, tera grass
- SD Chien-Pao: -Ice Shard
- Removed Farigiraf's Future Sight set
- Clangorous Soul Kommo-O: +Drain Punch, roll with Close Combat
- Swalot: +Thunder Wave
- Alomomola: +tera poison
- CM Miraidon: -Substitute, +Dragon Pulse, Life Orb
- Glalie: -Disable
- Pikachu: enforce Volt Switch
- Magnezone: -Tera Water from the sets that had it
- Special Azelf: -Trick, -Thunderbolt, -tera electric. It's now STAB/Fire Blast/Dazzling Gleam/a roll between U-turn and Nasty Plot, like in Gens 6-7.

**Gen 8 Random Battle:**
- Fixed Boltund so its ability is always Strong Jaw, for real this time.

**Gens 3-7 Random Battle:**
- Gen 7: added a Bulky Support Defog Tapu Fini set with hydro/surf, moonblast, knock off, nature's madness, and taunt.
- Gen 7: Removed special (plot) Z-Infernape
- Gen 7 Throh: Added another Flame Orb set with Superpower instead of Bulk Up
- Gen 7: Added Rest talk Primarina with Scald and Moonblast
- Gens 6-7 Rotom-Mow: no longer gets Life Orb
- Gens 6-7 Deoxys-Defense: removed its plot set
- Gens 6-7 Slowbro and Slowking: removed AV sets, enforced Psyshock on their Slack Off sets, and added Dragon Tail to Slowking's Slack Off set
- Gens 6-7 Pachirisu: always has Super Fang and U-turn, as Nuzzle + Toxic no longer generate together
- Gens 5-7 Samurott: removed Choice Band sets and added Choice Specs/Scarf with hydro/scald/ice beam/grass knot
- Gens 5-7 Tangrowth: all sets are now a Giga Drain/Leaf Storm roll, Power Whip is removed so it isn't as crippled by Scald burns
- Gen 5 Slowbro and Slowking: removed offensive sets with specs/life orb
- Gen 5 Qwilfish: added Poison Jab, an oversight from the last update
- Gens 4-7: Stantler's STAB is a roll between return and dedge
- Gen 4 Stantler: +Thunder Wave, incompatible with Hypnosis
- Gen 3 physical/mixed Girafarig: -Shadow Ball, -Thunderbolt
- Gen 3 Kingler: added a second SD set with Mud Shot, HP Ghost, and no Surf
- Gen 3 Nidoqueen/Nidoking: changed some roles and moves so that Choice Band can have Rock Slide and can no longer have Thunderbolt

**Gen 9 Random Doubles Battle:**
- Doubles Fast Attacker can now generate Focus Sash if the species has HP + Def + SpD <= 230 and no recoil moves, regardless of whether it is leading. Some Pokémon have been changed to different roles to preserve their current items.
- Vivillon: added a second set with Tailwind over Pollen Puff, and both sets generate sash
- Support Ribombee and Support now get sash
- Mienshao now has three sets: Two sets with CC/Fake Out/Knock Off/U-turn with Regenerator and either Focus Sash or AV, and a Choice Band Wallbreaker set with Triple Axel instead of Fake Out. 
- Azelf's Doubles Fast Attacker has been replaced by a Choice Specs Wallbreaker set with Psychic, Dazzling Gleam, Fire Blast, and U-turn.
- Toxicroak gets Life Orb on Swords Dance sets and Focus Sash otherwise.
- Houndoom has an Offensive Protect set with Life Orb and a Nasty Plot/Sucker Punch roll, as well as a Focus Sash set with only Nasty Plot.
- Iron Bundle and Kilowattrel have two identical sets, one with Focus Sash and the other with Booster Energy/Life Orb, respectively.
- Icy Wind is now enforced on Quagsire, Swampert, Whiscash, and Gastrodon by changing role to Doubles Support. Water STAB is now enforced on Water/Grounds in doubles.
- Swampert: -Ice Beam (it would no longer generate)
- Gastrodon: -Clear Smog, +Yawn, and now runs a second set with Earth Power/Ice Beam/Yawn/Recover.
- Salazzle and Swalot: -Poison Gas
- Muk: -Poison Gas, +Toxic Spikes, -Sticky Hold
- Vileplume now has three sets: its current set (sludge sap puff stun), another set with energy ball over pollen puff, and a third set with sludge bomb, leech seed, protect, and pollen puff
- Leech Seed + Protect (or its variants) now generates Leftovers instead of Sitrus Berry
- CM Terapagos gets Leftovers
- Added a third set to Yanmega with Bug Buzz, Air Slash, Protect, and Tailwind, with Focus Sash and Tinted Lens
- Support Oinkolognes: -Lash Out, now Thick Fat with Sitrus Berry
- Band Oinkolognes: -Play Rough, -tera fairy, +Body Slam, +tera ghost
- Electivire: -Cross Chop (both sets), -Volt Switch on Life Orb, -Flamethrower and +Electroweb on AV
- Moonblast Diancie: -Protect, +Body Press, tera fighting only. Diancie always has Body Press now.
- Torterra without a grass move gets Shell Armor instead of Overgrow (oops!)
- Clefable: Doubles Bulky Attacker is Moonblast/Dazzling Gleam + Fire Blast + icy wind/twave + protect with Life Orb Magic Guard, Doubles Support is Moonblast + Follow Me + two of HH/Knock Off/Moonlight/Life Dew with Unaware
- Removed SD Arceus-Ghost
- Wigglytuff: -Disable, -Heal Pulse
- Curse Snorlax: now Thick Fat with Leftovers and Body Slam/High Horsepower/Protect
- Band Snorlax: +Body Slam
- Koraidon is back to 100% Choice Band, removed its Life Orb Protect set
- Magnezone is Magnet Pull, replacing Sturdy
- Removed Calm Mind Primarina, replaced with Offensive Protect with Hyper Voice/Moonblast/Protect/Icy Wind/Life Dew
- Non-CM Sylveon and non-specs Primarina now get Throat Spray as their item.