### PR TITLE
Fix parsing crash

### DIFF
--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -265,22 +265,22 @@ export function getPlayerStreams(stream: BattleStream) {
 		}),
 		p1: new Streams.ObjectReadWriteStream({
 			write(data: string) {
-				void stream.write(data.replace(/(^|\n)/g, `$1>p1 `));
+				void stream.write(data.replace(/([^\n]+)/g, '>p1 $1'));
 			},
 		}),
 		p2: new Streams.ObjectReadWriteStream({
 			write(data: string) {
-				void stream.write(data.replace(/(^|\n)/g, `$1>p2 `));
+				void stream.write(data.replace(/([^\n]+)/g, '>p2 $1'));
 			},
 		}),
 		p3: new Streams.ObjectReadWriteStream({
 			write(data: string) {
-				void stream.write(data.replace(/(^|\n)/g, `$1>p3 `));
+				void stream.write(data.replace(/([^\n]+)/g, '>p3 $1'));
 			},
 		}),
 		p4: new Streams.ObjectReadWriteStream({
 			write(data: string) {
-				void stream.write(data.replace(/(^|\n)/g, `$1>p4 `));
+				void stream.write(data.replace(/([^\n]+)/g, '>p4 $1'));
 			},
 		}),
 	};


### PR DESCRIPTION
A choice string starting with \n bypasses the >p1 prefix on line 2,
sending a raw > command to BattleStream._writeLine → throws
"Unrecognized command"

Repro:

```js
const { BattleStream, getPlayerStreams } = require('./dist/sim/battle-stream');
const { RandomPlayerAI } = require('./dist/sim/tools/random-player-ai');

const stream = new BattleStream();
const { omniscient, p1 } = getPlayerStreams(stream);

void omniscient.write(
	'>start {"formatid":"gen9customgame","seed":[1,2,3,4]}\n' +
	'>player p1 {"name":"P1","team":null}\n' +
	'>player p2 {"name":"P2","team":null}'
);

new RandomPlayerAI(p1).start().catch(err => { throw err; });

void p1.write('\n>notacommand');
```


Before fix

```
node awd.js
/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:230
        throw new Error(`Unrecognized command ">${type} ${message}"`);
              ^

Error: Unrecognized command ">notacommand "
    at BattleStream._writeLine (/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:230:15)
    at BattleStream._writeLines (/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:81:14)
    at BattleStream._write (/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:69:14)
    at BattleStream.write (/Users/sergio/wsp/repos/pokemon-showdown/dist/lib/streams.js:687:17)
    at ObjectReadWriteStream.write [as _write] (/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:257:21)
    at ObjectReadWriteStream.write (/Users/sergio/wsp/repos/pokemon-showdown/dist/lib/streams.js:687:17)
    at Object.<anonymous> (/Users/sergio/wsp/repos/pokemon-showdown/awd.js:15:9)
    at Module._compile (node:internal/modules/cjs/loader:1831:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1971:10)
    at Module.load (node:internal/modules/cjs/loader:1552:32)

Node.js v25.8.0
```

After fix, returns the usual

```
node awd.js
/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:330
    if (cmd === "error") return this.receiveError(new Error(rest));
                                                  ^

Error: [Invalid choice] Unrecognized choice:
    at RandomPlayerAI.receiveLine (/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:330:51)
    at RandomPlayerAI.receive (/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:322:12)
    at RandomPlayerAI.start (/Users/sergio/wsp/repos/pokemon-showdown/dist/sim/battle-stream.js:317:12)

Node.js v25.8.0
```