### PR TITLE
Hotfix Sitrus Berry Iron Bundle in Gen 9 Random Doubles Battle

### DIFF
--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -6698,7 +6698,7 @@
         "level": 78,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
+                "role": "Doubles Wallbreaker",
                 "movepool": ["Encore", "Freeze-Dry", "Hydro Pump", "Icy Wind", "Protect"],
                 "abilities": ["Quark Drive"],
                 "teraTypes": ["Dragon", "Water"]


### PR DESCRIPTION
This removes the unintentional Sitrus Berry set, and it's back to Booster Energy.