### PR TITLE
Fix Gen 5 Bug Bite stealing Jaboca before trigger

### DIFF
--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -86,6 +86,21 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		basePower: 20,
 	},
+	bugbite: {
+		inherit: true,
+		onHit() {},
+		onAfterHit(target, source, move) {
+			const item = target.getItem();
+			if (source.hp && item.isBerry && target.takeItem(source)) {
+				this.add('-enditem', target, item.name, '[from] stealeat', '[move] Bug Bite', `[of] ${source}`);
+				if (this.singleEvent('Eat', item, target.itemState, source, source, move)) {
+					this.runEvent('EatItem', source, source, move, item);
+					if (item.id === 'leppaberry') target.staleness = 'external';
+				}
+				if (item.onEat) source.ateBerry = true;
+			}
+		},
+	},
 	bugbuzz: {
 		inherit: true,
 		flags: { protect: 1, mirror: 1, sound: 1, metronome: 1 },

--- a/test/sim/items/jabocaberry.js
+++ b/test/sim/items/jabocaberry.js
@@ -45,4 +45,17 @@ describe('Jaboca Berry', () => {
 		assert.fullHP(battle.p1.active[0]);
 		assert.holdsItem(battle.p2.active[0]);
 	});
+
+	it(`should activate before it can be stolen by Bug Bite in Gen 5`, () => {
+		battle = common.gen(5).createBattle([[
+			{ species: "Scizor", evs: { hp: 252 }, moves: ['bugbite'] },
+		], [
+			{ species: "Snorlax", item: 'jabocaberry', moves: ['sleeptalk'] },
+		]]);
+
+		const scizor = battle.p1.active[0];
+		assert.hurtsBy(scizor, scizor.maxhp / 8, () => battle.makeChoices());
+		assert.false.holdsItem(scizor);
+		assert.false.holdsItem(battle.p2.active[0]);
+	});
 });


### PR DESCRIPTION
## Summary
- move the Gen 5 Bug Bite berry-steal/eat effect from onHit to onAfterHit
- preserve existing steal/eat behavior while allowing post-hit reactive berries to resolve first
- add a Gen 5 regression test showing Jaboca damages the Bug Bite user and cannot be stolen in that interaction

## Testing
- npx mocha --forbid-only test/sim/items/jabocaberry.js

## Related
- Fixes #9853