### PR TITLE
Show the hint message for Ogerpon Terastallization only on one side

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1928,7 +1928,7 @@ export class BattleActions {
 	terastallize(pokemon: Pokemon) {
 		if (pokemon.species.baseSpecies === 'Ogerpon' && !['Fire', 'Grass', 'Rock', 'Water'].includes(pokemon.teraType) &&
 			(!pokemon.illusion || pokemon.illusion.species.baseSpecies === 'Ogerpon')) {
-			this.battle.hint("If Ogerpon Terastallizes into a type other than Fire, Grass, Rock, or Water, the game softlocks.");
+			this.battle.hint("If Ogerpon Terastallizes into a type other than Fire, Grass, Rock, or Water, the game softlocks.", false, pokemon.side);
 			return;
 		}
 


### PR DESCRIPTION
To avoid providing information that it tried to Terastallize.