### PR TITLE
Shared Power: Add sharedAbilities to request data

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1150,6 +1150,13 @@ export class Pokemon {
 			pokeball: this.pokeball,
 		};
 		if (this.battle.gen > 6) entry.ability = this.ability;
+		let format = this.battle.format;
+		if (!format.getSharedPower && format.mod === 'sharedpower') {
+			format = this.battle.dex.formats.get('gen9sharedpower');
+		}
+		if (format.getSharedPower) {
+			entry.sharedAbilities = [...format.getSharedPower(this)] as ID[];
+		}
 		if (this.battle.gen >= 9) {
 			entry.commanding = !!this.volatiles['commanding'] && !this.fainted;
 			entry.reviving = this.isActive && !!this.side.slotConditions[this.position]['revivalblessing'];

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -83,6 +83,8 @@ export interface PokemonSwitchRequestData {
 	pokeball: ID;
 	/** Current ability. Only sent in Gen 7+. */
 	ability?: ID;
+	/** Additional abilities currently shared to this Pokemon in Shared Power-style formats. */
+	sharedAbilities?: ID[];
 	/** @see https://dex.pokemonshowdown.com/abilities/commander */
 	commanding?: boolean;
 	/** @see https://dex.pokemonshowdown.com/moves/revivalblessing */

--- a/test/sim/misc/sharedpower.js
+++ b/test/sim/misc/sharedpower.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Shared Power request data', () => {
+	afterEach(() => battle.destroy());
+
+	it('should include sharedAbilities in request data', () => {
+		battle = common.createBattle({ formatid: 'gen9randombattlesharedpowerb12p6' }, [[
+			{ species: 'Arcanine', ability: 'intimidate', moves: ['sleeptalk'] },
+			{ species: 'Medicham', ability: 'purepower', moves: ['sleeptalk'] },
+			{ species: 'Inteleon', ability: 'torrent', moves: ['sleeptalk'] },
+			{ species: 'Delphox', ability: 'blaze', moves: ['sleeptalk'] },
+			{ species: 'Oranguru', ability: 'innerfocus', moves: ['sleeptalk'] },
+			{ species: 'Ariados', ability: 'insomnia', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Blissey', ability: 'naturalcure', moves: ['sleeptalk'] },
+			{ species: 'Mew', ability: 'synchronize', moves: ['sleeptalk'] },
+			{ species: 'Pikachu', ability: 'static', moves: ['sleeptalk'] },
+			{ species: 'Eevee', ability: 'runaway', moves: ['sleeptalk'] },
+			{ species: 'Ditto', ability: 'limber', moves: ['transform'] },
+			{ species: 'Snorlax', ability: 'immunity', moves: ['sleeptalk'] },
+		]]);
+
+		// Team preview: no shared abilities yet
+		const previewRequest = battle.p1.activeRequest;
+		assert(previewRequest.teamPreview);
+		assert.deepEqual(previewRequest.side.pokemon[0].sharedAbilities, []);
+
+		battle.makeChoices('team 123456', 'team 123456');
+		battle.makeChoices('switch 2', 'move sleeptalk');
+
+		// After switching in Medicham, it should share Arcanine's Intimidate
+		const switchedIn = battle.p1.activeRequest.side.pokemon[0];
+		assert.equal(switchedIn.baseAbility, 'purepower');
+		assert.deepEqual(switchedIn.sharedAbilities, ['intimidate']);
+	});
+});


### PR DESCRIPTION
The server currently uses shared abilities internally for calculations but doesn't expose them to the client, so we can't cleanly display them in the frontend.

This adds a sharedAbilities field to the switch request data, containing the IDs of abilities currently shared to each Pokemon. 

https://github.com/smogon/pokemon-showdown-client/pull/2616 depends on this.