### PR TITLE
Deprecate the fakepartiallytrapped condition

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -193,28 +193,23 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		// TODO: research exact mechanics
 		onBeforeMovePriority: 9,
 		onBeforeMove(pokemon) {
+			if (this.effectState.fake) return;
 			this.add('cant', pokemon, 'partiallytrapped');
 			return false;
 		},
 		onRestart() {
 			this.effectState.duration = 2;
+			delete this.effectState.fake;
 		},
 		onAccuracy(accuracy, target, source, move) {
+			if (this.effectState.fake) return;
 			if (source === this.effectState.source) return true;
 		},
 		onLockMove() {
+			if (this.effectState.fake) return;
 			// exact move doesn't matter, no move is ever actually used
 			return 'struggle';
 		},
-		onDisableMove(target) {
-			target.maybeLocked = true;
-		},
-	},
-	fakepartiallytrapped: {
-		name: 'fakepartiallytrapped',
-		// Wrap ended this turn, but you don't know that
-		// until you try to use an attack
-		duration: 2,
 		onDisableMove(target) {
 			target.maybeLocked = true;
 		},
@@ -247,15 +242,9 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 				delete pokemon.volatiles['partialtrappinglock'];
 				return;
 			}
-			if (this.effectState.duration === 1) {
-				if (this.effectState.totalDuration !== 5) {
-					pokemon.addVolatile('fakepartiallytrapped');
-					pokemon.volatiles['fakepartiallytrapped'].counterpart = target;
-					target.addVolatile('fakepartiallytrapped');
-					target.volatiles['fakepartiallytrapped'].counterpart = pokemon;
-				}
-			} else {
-				target.addVolatile('partiallytrapped', pokemon, move);
+			target.addVolatile('partiallytrapped', pokemon, move);
+			if (this.effectState.duration === 1 && this.effectState.totalDuration !== 5) {
+				target.volatiles['partiallytrapped'].fake = true;
 			}
 		},
 		onLockMove() {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1639,12 +1639,6 @@ export class Battle {
 						delete pokemon.volatiles['partiallytrapped'];
 					}
 				}
-				if (pokemon.volatiles['fakepartiallytrapped']) {
-					const counterpart = pokemon.volatiles['fakepartiallytrapped'].counterpart;
-					if (counterpart.hp <= 0 || !counterpart.volatiles['fakepartiallytrapped']) {
-						delete pokemon.volatiles['fakepartiallytrapped'];
-					}
-				}
 			}
 		}
 


### PR DESCRIPTION
There are a lot of places where `partiallytrapped` is deleted, but `fakepartiallytrapped` is not. This makes sure everything is synced.

Edit: hmm I guess this is not necessary because the `partialtrappinglock` end-of-turn check happens right before `DisableMove`. There is no time between those two things.