### PR TITLE
Add server-side `/help` entry for `/highlight` (`/hl`) command

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -581,6 +581,11 @@ export const commands: Chat.ChatCommands = {
 		`Valid settings: autoconfirmed, trusted, unlocked, +, %, @, ~.`,
 		`/unblockinvites - Allows anyone to invite you to rooms.`,
 	],
+	hlhelp: 'highlighthelp',
+	highlighthelp: [
+		`/highlight OR /hl - Open the highlight settings menu.`,
+		`Use this to add or remove terms that trigger highlighted chat messages.`,
+	],
 
 	status(target, room, user, connection, cmd) {
 		if (user.locked || user.semilocked) {

--- a/test/server/chat.js
+++ b/test/server/chat.js
@@ -122,4 +122,15 @@ describe('Chat', () => {
 
 		assert(!Chat.toDurationString(10000000 * 24 * 60 * 60 * 1000).includes('  '));
 	});
+
+	describe('command help entries', () => {
+		it('should expose help text for highlight command aliases', () => {
+			const { commands: coreCommands } = require('../../dist/server/chat-commands/core');
+			assert.equal(coreCommands.hlhelp, 'highlighthelp');
+			assert.deepEqual(coreCommands.highlighthelp, [
+				`/highlight OR /hl - Open the highlight settings menu.`,
+				`Use this to add or remove terms that trigger highlighted chat messages.`,
+			]);
+		});
+	});
 });


### PR DESCRIPTION
Fix: https://www.smogon.com/forums/threads/add-highlight-helptext.3779418/

Fixes the issue of `/help` could not return guidance for `/highlight` (or `/hl`) because highlight is client-side and had no corresponding server-side help entry. As a result, `!help highlight` was not broadcastable even though highlight help text exists elsewhere.