### PR TITLE
Add /hl help text

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2860,7 +2860,7 @@ export const commands: Chat.ChatCommands = {
 		`/highlight roomdelete [word 1], [word 2], [...] - Delete the provided list of words from the highlight list of whichever room you used the command in.`,
 		`/highlight clear - Clear your global highlight list.`,
 		`/highlight roomclear - Clear the highlight list of whichever room you used the command in.`,
-		`/highlight clearall - Clear your entire highlight list (all rooms and globally).`
+		`/highlight clearall - Clear your entire highlight list (all rooms and globally).`,
 	],
 
 	buildformat(target, room, user) {


### PR DESCRIPTION
Adds the helptext for the highlight command.

Depends on client PR https://github.com/smogon/pokemon-showdown-client/pull/2621

Approved at https://www.smogon.com/forums/threads/add-highlight-helptext.3779418/