### PR TITLE
Fix Max PP for copied moves

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1225,7 +1225,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 
 				for (const scrambledMove of pokemon.m.scrambled.moves) {
 					const move = this.dex.moves.get(scrambledMove.thing);
-					const ppUps = move.noPPBoosts ? 0 : 3;
+					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
 					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1225,16 +1225,19 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 
 				for (const scrambledMove of pokemon.m.scrambled.moves) {
 					const move = this.dex.moves.get(scrambledMove.thing);
+					const ppUps = move.noPPBoosts ? 0 : 3;
+					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,
 						id: move.id,
-						pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-						maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+						pp: basePP,
+						maxpp: basePP,
 						target: move.target,
 						disabled: false,
 						used: false,
 					};
 					pokemon.baseMoveSlots.push(newMove);
+					pokemon.ppUps.push(ppUps);
 				}
 				pokemon.moveSlots = pokemon.baseMoveSlots.slice();
 			}

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1225,7 +1225,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 
 				for (const scrambledMove of pokemon.m.scrambled.moves) {
 					const move = this.dex.moves.get(scrambledMove.thing);
-					const basePP = this.calculatePP(move);
+					const ppUps = move.noPPBoosts ? 0 : 3;
+					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,
 						id: move.id,

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1225,7 +1225,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 
 				for (const scrambledMove of pokemon.m.scrambled.moves) {
 					const move = this.dex.moves.get(scrambledMove.thing);
-					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const ppUps = move.noPPBoosts ? 0 : 3;
 					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1225,8 +1225,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 
 				for (const scrambledMove of pokemon.m.scrambled.moves) {
 					const move = this.dex.moves.get(scrambledMove.thing);
-					const ppUps = move.noPPBoosts ? 0 : 3;
-					const basePP = this.calculatePP(move, ppUps);
+					const basePP = this.calculatePP(move);
 					const newMove = {
 						move: move.name,
 						id: move.id,

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -894,11 +894,12 @@ export const Conditions: import('../sim/dex-conditions').ConditionDataTable = {
 			const ironHeadIndex = pokemon.baseMoves.indexOf('ironhead');
 			if (ironHeadIndex >= 0) {
 				const move = this.dex.moves.get('behemothblade');
+				const pp = this.calculatePP(move, pokemon.ppUps[ironHeadIndex]);
 				pokemon.baseMoveSlots[ironHeadIndex] = {
 					move: move.name,
 					id: move.id,
-					pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-					maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+					pp,
+					maxpp: pp,
 					target: move.target,
 					disabled: false,
 					disabledSource: '',
@@ -923,11 +924,12 @@ export const Conditions: import('../sim/dex-conditions').ConditionDataTable = {
 			const ironHeadIndex = pokemon.baseMoves.indexOf('ironhead');
 			if (ironHeadIndex >= 0) {
 				const move = this.dex.moves.get('behemothbash');
+				const pp = this.calculatePP(move, pokemon.ppUps[ironHeadIndex]);
 				pokemon.baseMoveSlots[ironHeadIndex] = {
 					move: move.name,
 					id: move.id,
-					pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-					maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+					pp,
+					maxpp: pp,
 					target: move.target,
 					disabled: false,
 					disabledSource: '',

--- a/data/items.ts
+++ b/data/items.ts
@@ -3362,8 +3362,7 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			const moveSlot = pokemon.moveSlots.find(move => move.pp === 0) ||
 				pokemon.moveSlots.find(move => move.pp < move.maxpp);
 			if (!moveSlot) return;
-			moveSlot.pp += 10;
-			if (moveSlot.pp > moveSlot.maxpp) moveSlot.pp = moveSlot.maxpp;
+			moveSlot.pp = Math.min(moveSlot.pp + 10, moveSlot.maxpp);
 			this.add('-activate', pokemon, 'item: Leppa Berry', moveSlot.move, '[consumed]');
 		},
 		num: 154,

--- a/data/items.ts
+++ b/data/items.ts
@@ -3362,7 +3362,8 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 			const moveSlot = pokemon.moveSlots.find(move => move.pp === 0) ||
 				pokemon.moveSlots.find(move => move.pp < move.maxpp);
 			if (!moveSlot) return;
-			moveSlot.pp = Math.min(moveSlot.pp + 10, moveSlot.maxpp);
+			const addedPP = pokemon.hasAbility('ripen') ? 20 : 10;
+			moveSlot.pp = Math.min(moveSlot.pp + addedPP, moveSlot.maxpp);
 			this.add('-activate', pokemon, 'item: Leppa Berry', moveSlot.move, '[consumed]');
 		},
 		num: 154,

--- a/data/mods/biomechmons/abilities.ts
+++ b/data/mods/biomechmons/abilities.ts
@@ -185,17 +185,20 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 							(pokemon.m.scrambled.abilities as { thing: string, inSlot: string }[]).findIndex(e =>
 								this.toID(e.thing) === 'trace' && e.inSlot === 'Move'), 1);
 						this.add('-ability', pokemon, move.name, 'Trace');
+						const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+						const basePP = this.calculatePP(move, ppUps);
 						const newMove = {
 							move: move.name,
 							id: move.id,
-							pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-							maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+							pp: basePP,
+							maxpp: basePP,
 							target: move.target,
 							disabled: false,
 							used: false,
 						};
 						pokemon.baseMoveSlots.push(newMove);
 						pokemon.moveSlots.push(newMove);
+						pokemon.ppUps.push(ppUps);
 					}
 				}
 				return;

--- a/data/mods/biomechmons/abilities.ts
+++ b/data/mods/biomechmons/abilities.ts
@@ -185,7 +185,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 							(pokemon.m.scrambled.abilities as { thing: string, inSlot: string }[]).findIndex(e =>
 								this.toID(e.thing) === 'trace' && e.inSlot === 'Move'), 1);
 						this.add('-ability', pokemon, move.name, 'Trace');
-						const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+						const ppUps = move.noPPBoosts ? 0 : 3;
 						const basePP = this.calculatePP(move, ppUps);
 						const newMove = {
 							move: move.name,

--- a/data/mods/biomechmons/abilities.ts
+++ b/data/mods/biomechmons/abilities.ts
@@ -185,8 +185,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 							(pokemon.m.scrambled.abilities as { thing: string, inSlot: string }[]).findIndex(e =>
 								this.toID(e.thing) === 'trace' && e.inSlot === 'Move'), 1);
 						this.add('-ability', pokemon, move.name, 'Trace');
-						const ppUps = move.noPPBoosts ? 0 : 3;
-						const basePP = this.calculatePP(move, ppUps);
+						const basePP = this.calculatePP(move);
 						const newMove = {
 							move: move.name,
 							id: move.id,

--- a/data/mods/biomechmons/abilities.ts
+++ b/data/mods/biomechmons/abilities.ts
@@ -185,7 +185,8 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 							(pokemon.m.scrambled.abilities as { thing: string, inSlot: string }[]).findIndex(e =>
 								this.toID(e.thing) === 'trace' && e.inSlot === 'Move'), 1);
 						this.add('-ability', pokemon, move.name, 'Trace');
-						const basePP = this.calculatePP(move);
+						const ppUps = move.noPPBoosts ? 0 : 3;
+						const basePP = this.calculatePP(move, ppUps);
 						const newMove = {
 							move: move.name,
 							id: move.id,

--- a/data/mods/biomechmons/moves.ts
+++ b/data/mods/biomechmons/moves.ts
@@ -298,17 +298,20 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				} else {
 					source.m.scrambled.moves.push({ thing: targetAbility.id, inSlot: 'Ability' });
 					const bmmMove = Dex.moves.get(targetAbility.id);
+					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: bmmMove.name,
 						id: bmmMove.id,
-						pp: bmmMove.noPPBoosts ? bmmMove.pp : bmmMove.pp * 8 / 5,
-						maxpp: bmmMove.noPPBoosts ? bmmMove.pp : bmmMove.pp * 8 / 5,
+						pp: basePP,
+						maxpp: basePP,
 						target: bmmMove.target,
 						disabled: false,
 						used: false,
 					};
 					source.baseMoveSlots.push(newMove);
 					source.moveSlots.push(newMove);
+					source.ppUps.push(ppUps);
 				}
 			}
 			this.singleEvent('Start', sourceAbility, target.abilityState, target);
@@ -321,17 +324,20 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				} else {
 					target.m.scrambled.moves.push({ thing: sourceAbility.id, inSlot: 'Ability' });
 					const bmmMove = Dex.moves.get(sourceAbility.id);
+					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: bmmMove.name,
 						id: bmmMove.id,
-						pp: bmmMove.noPPBoosts ? bmmMove.pp : bmmMove.pp * 8 / 5,
-						maxpp: bmmMove.noPPBoosts ? bmmMove.pp : bmmMove.pp * 8 / 5,
+						pp: basePP,
+						maxpp: basePP,
 						target: bmmMove.target,
 						disabled: false,
 						used: false,
 					};
 					target.baseMoveSlots.push(newMove);
 					target.moveSlots.push(newMove);
+					target.ppUps.push(ppUps);
 				}
 			}
 		},

--- a/data/mods/biomechmons/moves.ts
+++ b/data/mods/biomechmons/moves.ts
@@ -298,7 +298,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				} else {
 					source.m.scrambled.moves.push({ thing: targetAbility.id, inSlot: 'Ability' });
 					const bmmMove = Dex.moves.get(targetAbility.id);
-					const basePP = this.calculatePP(move);
+					const ppUps = move.noPPBoosts ? 0 : 3;
+					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: bmmMove.name,
 						id: bmmMove.id,
@@ -323,7 +324,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				} else {
 					target.m.scrambled.moves.push({ thing: sourceAbility.id, inSlot: 'Ability' });
 					const bmmMove = Dex.moves.get(sourceAbility.id);
-					const basePP = this.calculatePP(move);
+					const ppUps = move.noPPBoosts ? 0 : 3;
+					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: bmmMove.name,
 						id: bmmMove.id,

--- a/data/mods/biomechmons/moves.ts
+++ b/data/mods/biomechmons/moves.ts
@@ -298,7 +298,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				} else {
 					source.m.scrambled.moves.push({ thing: targetAbility.id, inSlot: 'Ability' });
 					const bmmMove = Dex.moves.get(targetAbility.id);
-					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const ppUps = move.noPPBoosts ? 0 : 3;
 					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: bmmMove.name,
@@ -324,7 +324,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				} else {
 					target.m.scrambled.moves.push({ thing: sourceAbility.id, inSlot: 'Ability' });
 					const bmmMove = Dex.moves.get(sourceAbility.id);
-					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const ppUps = move.noPPBoosts ? 0 : 3;
 					const basePP = this.calculatePP(move, ppUps);
 					const newMove = {
 						move: bmmMove.name,

--- a/data/mods/biomechmons/moves.ts
+++ b/data/mods/biomechmons/moves.ts
@@ -298,8 +298,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				} else {
 					source.m.scrambled.moves.push({ thing: targetAbility.id, inSlot: 'Ability' });
 					const bmmMove = Dex.moves.get(targetAbility.id);
-					const ppUps = move.noPPBoosts ? 0 : 3;
-					const basePP = this.calculatePP(move, ppUps);
+					const basePP = this.calculatePP(move);
 					const newMove = {
 						move: bmmMove.name,
 						id: bmmMove.id,
@@ -324,8 +323,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				} else {
 					target.m.scrambled.moves.push({ thing: sourceAbility.id, inSlot: 'Ability' });
 					const bmmMove = Dex.moves.get(sourceAbility.id);
-					const ppUps = move.noPPBoosts ? 0 : 3;
-					const basePP = this.calculatePP(move, ppUps);
+					const basePP = this.calculatePP(move);
 					const newMove = {
 						move: bmmMove.name,
 						id: bmmMove.id,

--- a/data/mods/biomechmons/scripts.ts
+++ b/data/mods/biomechmons/scripts.ts
@@ -167,11 +167,13 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else {
 					this.m.scrambled.moves.push({ thing: ability.id, inSlot: 'Ability' });
 					const move = Dex.moves.get(ability.id);
+					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const basePP = this.battle.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,
 						id: move.id,
-						pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-						maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+						pp: basePP,
+						maxpp: basePP,
 						target: move.target,
 						disabled: false,
 						used: false,
@@ -179,6 +181,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					if (!isTransform) {
 						this.baseMoveSlots.push(newMove);
 						this.moveSlots.push(newMove);
+						this.ppUps.push(ppUps);
 					}
 				}
 			}
@@ -322,17 +325,20 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else {
 					this.m.scrambled.moves.push({ thing: item.id, inSlot: 'Item' });
 					const move = Dex.moves.get(item.id);
+					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const basePP = this.battle.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,
 						id: move.id,
-						pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-						maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+						pp: basePP,
+						maxpp: basePP,
 						target: move.target,
 						disabled: false,
 						used: false,
 					};
 					this.baseMoveSlots.push(newMove);
 					this.moveSlots.push(newMove);
+					this.ppUps.push(ppUps);
 				}
 			}
 			return true;
@@ -483,16 +489,17 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.hpType = (this.battle.gen >= 5 ? this.hpType : pokemon.hpType);
 			this.hpPower = (this.battle.gen >= 5 ? this.hpPower : pokemon.hpPower);
 			this.timesAttacked = pokemon.timesAttacked;
-			for (const moveSlot of pokemon.moveSlots) {
+			for (const [i, moveSlot] of pokemon.moveSlots.entries()) {
 				let moveName = moveSlot.move;
 				if (moveSlot.id === 'hiddenpower') {
 					moveName = 'Hidden Power ' + this.hpType;
 				}
+				const move = this.battle.dex.moves.get(moveSlot.id);
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: moveSlot.maxpp === 1 ? 1 : 5,
-					maxpp: this.battle.gen >= 5 ? (moveSlot.maxpp === 1 ? 1 : 5) : moveSlot.maxpp,
+					pp: Math.min(5, move.pp),
+					maxpp: this.battle.gen >= 5 ? Math.min(5, move.pp) : moveSlot.maxpp,
 					target: moveSlot.target,
 					disabled: false,
 					used: false,

--- a/data/mods/biomechmons/scripts.ts
+++ b/data/mods/biomechmons/scripts.ts
@@ -167,7 +167,8 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else {
 					this.m.scrambled.moves.push({ thing: ability.id, inSlot: 'Ability' });
 					const move = Dex.moves.get(ability.id);
-					const basePP = this.battle.calculatePP(move);
+					const ppUps = move.noPPBoosts ? 0 : 3;
+					const basePP = this.battle.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,
 						id: move.id,
@@ -324,7 +325,8 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else {
 					this.m.scrambled.moves.push({ thing: item.id, inSlot: 'Item' });
 					const move = Dex.moves.get(item.id);
-					const basePP = this.battle.calculatePP(move);
+					const ppUps = move.noPPBoosts ? 0 : 3;
+					const basePP = this.battle.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,
 						id: move.id,

--- a/data/mods/biomechmons/scripts.ts
+++ b/data/mods/biomechmons/scripts.ts
@@ -167,8 +167,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else {
 					this.m.scrambled.moves.push({ thing: ability.id, inSlot: 'Ability' });
 					const move = Dex.moves.get(ability.id);
-					const ppUps = move.noPPBoosts ? 0 : 3;
-					const basePP = this.battle.calculatePP(move, ppUps);
+					const basePP = this.battle.calculatePP(move);
 					const newMove = {
 						move: move.name,
 						id: move.id,
@@ -325,8 +324,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else {
 					this.m.scrambled.moves.push({ thing: item.id, inSlot: 'Item' });
 					const move = Dex.moves.get(item.id);
-					const ppUps = move.noPPBoosts ? 0 : 3;
-					const basePP = this.battle.calculatePP(move, ppUps);
+					const basePP = this.battle.calculatePP(move);
 					const newMove = {
 						move: move.name,
 						id: move.id,

--- a/data/mods/biomechmons/scripts.ts
+++ b/data/mods/biomechmons/scripts.ts
@@ -167,7 +167,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else {
 					this.m.scrambled.moves.push({ thing: ability.id, inSlot: 'Ability' });
 					const move = Dex.moves.get(ability.id);
-					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const ppUps = move.noPPBoosts ? 0 : 3;
 					const basePP = this.battle.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,
@@ -325,7 +325,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else {
 					this.m.scrambled.moves.push({ thing: item.id, inSlot: 'Item' });
 					const move = Dex.moves.get(item.id);
-					const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+					const ppUps = move.noPPBoosts ? 0 : 3;
 					const basePP = this.battle.calculatePP(move, ppUps);
 					const newMove = {
 						move: move.name,

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -463,7 +463,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				move: move.name,
 				id: move.id,
 				pp: source.moveSlots[moveslot].pp,
-				maxpp: move.pp * 8 / 5,
+				maxpp: this.calculatePP(move, source.ppUps[moveslot] || 0),
 				target: move.target,
 				disabled: false,
 				used: false,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -870,8 +870,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			source.moveSlots[mimicIndex] = {
 				move: move.name,
 				id: move.id,
-				pp: 5,
-				maxpp: move.pp * 8 / 5,
+				pp: Math.min(5, move.pp),
+				maxpp: this.calculatePP(move, source.ppUps[mimicIndex] || 0),
 				disabled: false,
 				used: false,
 				virtual: true,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1206,7 +1206,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				move: move.name,
 				id: move.id,
 				pp: move.pp,
-				maxpp: move.pp,
+				maxpp: this.calculatePP(move, source.ppUps[sketchIndex] || 0),
 				disabled: false,
 				used: false,
 			};

--- a/data/mods/gen9dlc1/scripts.ts
+++ b/data/mods/gen9dlc1/scripts.ts
@@ -87,16 +87,18 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.hpType = (this.battle.gen >= 5 ? this.hpType : pokemon.hpType);
 			this.hpPower = (this.battle.gen >= 5 ? this.hpPower : pokemon.hpPower);
 			this.timesAttacked = pokemon.timesAttacked;
-			for (const moveSlot of pokemon.moveSlots) {
+			for (const [i, moveSlot] of pokemon.moveSlots.entries()) {
 				let moveName = moveSlot.move;
 				if (moveSlot.id === 'hiddenpower') {
 					moveName = 'Hidden Power ' + this.hpType;
 				}
+				const move = this.battle.dex.moves.get(moveSlot.id);
+				const pp = Math.min(5, move.pp);
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: moveSlot.maxpp === 1 ? 1 : 5,
-					maxpp: this.battle.gen >= 5 ? (moveSlot.maxpp === 1 ? 1 : 5) : moveSlot.maxpp,
+					pp: pp,
+					maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 					target: moveSlot.target,
 					disabled: false,
 					used: false,

--- a/data/mods/gen9dlc1/scripts.ts
+++ b/data/mods/gen9dlc1/scripts.ts
@@ -97,7 +97,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: pp,
+					pp,
 					maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 					target: moveSlot.target,
 					disabled: false,

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -942,11 +942,12 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				this.boost({ spe: 1 });
 				this.heal(pokemon.maxhp);
 				const move = this.dex.moves.get('finalgambit');
+				const pp = this.calculatePP(move, 3);
 				const finalGambit = {
 					move: move.name,
 					id: move.id,
-					pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-					maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+					pp,
+					maxpp: pp,
 					target: move.target,
 					disabled: false,
 					used: false,

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -942,7 +942,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				this.boost({ spe: 1 });
 				this.heal(pokemon.maxhp);
 				const move = this.dex.moves.get('finalgambit');
-				const pp = this.calculatePP(move, 3);
+				const pp = this.calculatePP(move);
 				const finalGambit = {
 					move: move.name,
 					id: move.id,

--- a/data/mods/gen9ssb/conditions.ts
+++ b/data/mods/gen9ssb/conditions.ts
@@ -18,11 +18,12 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 			const ironHeadIndex = pokemon.baseMoves.indexOf('ironhead');
 			if (ironHeadIndex >= 0) {
 				const move = this.dex.moves.get('behemothblade');
+				const pp = this.calculatePP(move, pokemon.ppUps[ironHeadIndex]);
 				pokemon.baseMoveSlots[ironHeadIndex] = {
 					move: move.name,
 					id: move.id,
-					pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-					maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+					pp,
+					maxpp: pp,
 					target: move.target,
 					disabled: false,
 					disabledSource: '',
@@ -47,11 +48,12 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 			const ironHeadIndex = pokemon.baseMoves.indexOf('ironhead');
 			if (ironHeadIndex >= 0) {
 				const move = this.dex.moves.get('behemothbash');
+				const pp = this.calculatePP(move, pokemon.ppUps[ironHeadIndex]);
 				pokemon.baseMoveSlots[ironHeadIndex] = {
 					move: move.name,
 					id: move.id,
-					pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-					maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+					pp,
+					maxpp: pp,
 					target: move.target,
 					disabled: false,
 					disabledSource: '',

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -142,7 +142,7 @@ export function changeMoves(context: Battle, pokemon: Pokemon, newMoves: (string
 		const moveName = Array.isArray(newMove) ? newMove[context.random(newMove.length)] : newMove;
 		const move = context.dex.moves.get(context.toID(moveName));
 		if (!move.id) continue;
-		const pp = context.calculatePP(move, 3);
+		const pp = context.calculatePP(move);
 		const moveSlot = {
 			move: move.name,
 			id: move.id,

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -142,11 +142,12 @@ export function changeMoves(context: Battle, pokemon: Pokemon, newMoves: (string
 		const moveName = Array.isArray(newMove) ? newMove[context.random(newMove.length)] : newMove;
 		const move = context.dex.moves.get(context.toID(moveName));
 		if (!move.id) continue;
+		const pp = context.calculatePP(move, 3);
 		const moveSlot = {
 			move: move.name,
 			id: move.id,
-			pp: Math.floor((move.noPPBoosts ? move.pp : move.pp * 8 / 5) * carryOver[slot]),
-			maxpp: (move.noPPBoosts ? move.pp : move.pp * 8 / 5),
+			pp: pp * carryOver[slot],
+			maxpp: pp,
 			target: move.target,
 			disabled: false,
 			disabledSource: '',

--- a/data/mods/mixandmega/scripts.ts
+++ b/data/mods/mixandmega/scripts.ts
@@ -123,14 +123,15 @@ export const Scripts: ModdedBattleScriptsData = {
 				const behemothMove: { [k: string]: string } = {
 					'Rusted Sword': 'behemothblade', 'Rusted Shield': 'behemothbash',
 				};
-				const ironHead = pokemon.baseMoves.indexOf('ironhead');
-				if (ironHead >= 0) {
+				const ironHeadIndex = pokemon.baseMoves.indexOf('ironhead');
+				if (ironHeadIndex >= 0) {
 					const move = this.dex.moves.get(behemothMove[pokemon.getItem().name]);
-					pokemon.baseMoveSlots[ironHead] = {
+					const pp = this.calculatePP(move, pokemon.ppUps[ironHeadIndex]);
+					pokemon.baseMoveSlots[ironHeadIndex] = {
 						move: move.name,
 						id: move.id,
-						pp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
-						maxpp: move.noPPBoosts ? move.pp : move.pp * 8 / 5,
+						pp,
+						maxpp: pp,
 						target: move.target,
 						disabled: false,
 						disabledSource: '',

--- a/data/mods/partnersincrime/scripts.ts
+++ b/data/mods/partnersincrime/scripts.ts
@@ -417,7 +417,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: pp,
+					pp,
 					maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 					target: moveSlot.target,
 					disabled: false,

--- a/data/mods/partnersincrime/scripts.ts
+++ b/data/mods/partnersincrime/scripts.ts
@@ -407,17 +407,18 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.hpType = (this.battle.gen >= 5 ? this.hpType : pokemon.hpType);
 			this.hpPower = (this.battle.gen >= 5 ? this.hpPower : pokemon.hpPower);
 			this.timesAttacked = pokemon.timesAttacked;
-			for (const moveSlot of pokemon.moveSlots) {
+			for (const [i, moveSlot] of pokemon.moveSlots.entries()) {
 				let moveName = moveSlot.move;
-				if (!pokemon.m.curMoves.includes(moveSlot.id)) continue;
 				if (moveSlot.id === 'hiddenpower') {
 					moveName = 'Hidden Power ' + this.hpType;
 				}
+				const move = this.battle.dex.moves.get(moveSlot.id);
+				const pp = Math.min(5, move.pp);
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: moveSlot.maxpp === 1 ? 1 : 5,
-					maxpp: this.battle.gen >= 5 ? (moveSlot.maxpp === 1 ? 1 : 5) : moveSlot.maxpp,
+					pp: pp,
+					maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 					target: moveSlot.target,
 					disabled: false,
 					used: false,

--- a/data/mods/pokebilities/scripts.ts
+++ b/data/mods/pokebilities/scripts.ts
@@ -70,16 +70,18 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.hpType = (this.battle.gen >= 5 ? this.hpType : pokemon.hpType);
 			this.hpPower = (this.battle.gen >= 5 ? this.hpPower : pokemon.hpPower);
 			this.timesAttacked = pokemon.timesAttacked;
-			for (const moveSlot of pokemon.moveSlots) {
+			for (const [i, moveSlot] of pokemon.moveSlots.entries()) {
 				let moveName = moveSlot.move;
 				if (moveSlot.id === 'hiddenpower') {
 					moveName = 'Hidden Power ' + this.hpType;
 				}
+				const move = this.battle.dex.moves.get(moveSlot.id);
+				const pp = Math.min(5, move.pp);
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: moveSlot.maxpp === 1 ? 1 : 5,
-					maxpp: this.battle.gen >= 5 ? (moveSlot.maxpp === 1 ? 1 : 5) : moveSlot.maxpp,
+					pp: pp,
+					maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 					target: moveSlot.target,
 					disabled: false,
 					used: false,

--- a/data/mods/pokebilities/scripts.ts
+++ b/data/mods/pokebilities/scripts.ts
@@ -80,7 +80,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: pp,
+					pp,
 					maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 					target: moveSlot.target,
 					disabled: false,

--- a/data/mods/trademarked/scripts.ts
+++ b/data/mods/trademarked/scripts.ts
@@ -261,7 +261,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: pp,
+					pp,
 					maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 					target: moveSlot.target,
 					disabled: false,

--- a/data/mods/trademarked/scripts.ts
+++ b/data/mods/trademarked/scripts.ts
@@ -251,16 +251,18 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.hpType = (this.battle.gen >= 5 ? this.hpType : pokemon.hpType);
 			this.hpPower = (this.battle.gen >= 5 ? this.hpPower : pokemon.hpPower);
 			this.timesAttacked = pokemon.timesAttacked;
-			for (const moveSlot of pokemon.moveSlots) {
+			for (const [i, moveSlot] of pokemon.moveSlots.entries()) {
 				let moveName = moveSlot.move;
 				if (moveSlot.id === 'hiddenpower') {
 					moveName = 'Hidden Power ' + this.hpType;
 				}
+				const move = this.battle.dex.moves.get(moveSlot.id);
+				const pp = Math.min(5, move.pp);
 				this.moveSlots.push({
 					move: moveName,
 					id: moveSlot.id,
-					pp: moveSlot.maxpp === 1 ? 1 : 5,
-					maxpp: this.battle.gen >= 5 ? (moveSlot.maxpp === 1 ? 1 : 5) : moveSlot.maxpp,
+					pp: pp,
+					maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 					target: moveSlot.target,
 					disabled: false,
 					used: false,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -20851,7 +20851,6 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		isNonstandard: "Past",
 		name: "Trump Card",
 		pp: 5,
-		noPPBoosts: true,
 		priority: 0,
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
 		secondary: null,

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2518,7 +2518,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 				const item = pokemon.getItem();
 				if (/^tr\d\d/i.test(item.name)) {
 					const move = this.dex.moves.get(item.desc.split('move ')[1].split('.')[0]);
-					const pp = this.calculatePP(move, 3);
+					const pp = this.calculatePP(move);
 					pokemon.moveSlots = (pokemon as any).baseMoveSlots = [
 						...pokemon.baseMoveSlots, {
 							id: move.id,

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2518,12 +2518,13 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 				const item = pokemon.getItem();
 				if (/^tr\d\d/i.test(item.name)) {
 					const move = this.dex.moves.get(item.desc.split('move ')[1].split('.')[0]);
+					const pp = this.calculatePP(move, 3);
 					pokemon.moveSlots = (pokemon as any).baseMoveSlots = [
 						...pokemon.baseMoveSlots, {
 							id: move.id,
 							move: move.name,
-							pp: move.pp * 8 / 5,
-							maxpp: move.pp * 8 / 5,
+							pp,
+							maxpp: pp,
 							target: move.target,
 							disabled: false,
 							disabledSource: '',

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2373,6 +2373,12 @@ export class Battle {
 		return stat;
 	}
 
+	calculatePP(move: Move, ppUps: number) {
+		let pp = move.noPPBoosts ? move.pp : move.pp * (5 + ppUps) / 5;
+		if (this.gen < 3 && move.pp === 40) pp -= ppUps;
+		return pp;
+	}
+
 	finalModify(relayVar: number) {
 		relayVar = this.modify(relayVar, this.event.modifier);
 		this.event.modifier = 1;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2374,8 +2374,9 @@ export class Battle {
 	}
 
 	calculatePP(move: Move, ppUps: number) {
-		let pp = move.noPPBoosts ? move.pp : move.pp * (5 + ppUps) / 5;
-		if (this.gen < 3 && move.pp === 40) pp -= ppUps;
+		if (move.noPPBoosts) return move.pp;
+		let pp = move.pp * (5 + ppUps) / 5;
+		if (this.gen <= 2 && move.pp === 40) pp -= ppUps;
 		return pp;
 	}
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2373,7 +2373,7 @@ export class Battle {
 		return stat;
 	}
 
-	calculatePP(move: Move, ppUps: number) {
+	calculatePP(move: Move, ppUps = 3) {
 		if (move.noPPBoosts) return move.pp;
 		let pp = move.pp * (5 + ppUps) / 5;
 		if (this.gen <= 2 && move.pp === 40) pp -= ppUps;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -384,6 +384,7 @@ interface ModdedBattleScriptsData extends Partial<BattleScriptsData> {
 	win?: (this: Battle, side?: SideID | '' | Side | null) => boolean;
 	faintMessages?: (this: Battle, lastFirst?: boolean, forceCheck?: boolean, checkWin?: boolean) => boolean | undefined;
 	tiebreak?: (this: Battle) => boolean;
+	calculatePP?: (this: Battle, move: Move, ppUps?: number) => number;
 	checkMoveMakesContact?: (
 		this: Battle, move: ActiveMove, attacker: Pokemon, defender: Pokemon, announcePads?: boolean
 	) => boolean;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -65,6 +65,8 @@ export class Pokemon {
 
 	readonly baseMoveSlots: MoveSlot[];
 	moveSlots: MoveSlot[];
+	/** Only track for base move slots */
+	ppUps: number[];
 
 	hpType: string;
 	hpPower: number;
@@ -343,6 +345,7 @@ export class Pokemon {
 
 		this.baseMoveSlots = [];
 		this.moveSlots = [];
+		this.ppUps = [];
 		if (!this.set.moves?.length) {
 			throw new Error(`Set ${this.name} has no moves`);
 		}
@@ -353,18 +356,19 @@ export class Pokemon {
 				if (!set.hpType) set.hpType = move.type;
 				move = this.battle.dex.moves.get('hiddenpower');
 			}
-			let basepp = move.noPPBoosts ? move.pp : move.pp * 8 / 5;
-			if (this.battle.gen < 3) basepp = Math.min(61, basepp);
+			const ppUps = move.noPPBoosts || move.id === 'trumpcard' ? 0 : 3;
+			const basePP = this.battle.calculatePP(move, ppUps);
 			this.baseMoveSlots.push({
 				move: move.name,
 				id: move.id,
-				pp: basepp,
-				maxpp: basepp,
+				pp: basePP,
+				maxpp: basePP,
 				target: move.target,
 				disabled: false,
 				disabledSource: '',
 				used: false,
 			});
+			this.ppUps.push(ppUps);
 		}
 
 		this.position = 0;
@@ -1288,16 +1292,18 @@ export class Pokemon {
 		this.hpType = (this.battle.gen >= 5 ? this.hpType : pokemon.hpType);
 		this.hpPower = (this.battle.gen >= 5 ? this.hpPower : pokemon.hpPower);
 		this.timesAttacked = pokemon.timesAttacked;
-		for (const moveSlot of pokemon.moveSlots) {
+		for (const [i, moveSlot] of pokemon.moveSlots.entries()) {
 			let moveName = moveSlot.move;
 			if (moveSlot.id === 'hiddenpower') {
 				moveName = 'Hidden Power ' + this.hpType;
 			}
+			const move = this.battle.dex.moves.get(moveSlot.id);
+			const pp = Math.min(5, move.pp);
 			this.moveSlots.push({
 				move: moveName,
 				id: moveSlot.id,
-				pp: moveSlot.maxpp === 1 ? 1 : 5,
-				maxpp: this.battle.gen >= 5 ? (moveSlot.maxpp === 1 ? 1 : 5) : moveSlot.maxpp,
+				pp: pp,
+				maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 				target: moveSlot.target,
 				disabled: false,
 				used: false,

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1302,7 +1302,7 @@ export class Pokemon {
 			this.moveSlots.push({
 				move: moveName,
 				id: moveSlot.id,
-				pp: pp,
+				pp,
 				maxpp: this.battle.gen >= 5 ? pp : this.battle.calculatePP(move, this.ppUps[i] || 0),
 				target: moveSlot.target,
 				disabled: false,


### PR DESCRIPTION
Prior to Gen 5, moves copied by Mimic or Transform should have their max PP recalculated based on that slot's PP Ups. Additionally, the ability Ripen duplicates the effect of a Leppa Berry.