### PR TITLE
Fix Pressure PP deduction for Snatch in Gen 4

### DIFF
--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1234,7 +1234,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				}
 				snatchUser.removeVolatile('snatch');
 				this.add('-activate', snatchUser, 'move: Snatch', `[of] ${source}`);
-				
+
 				// check Pressure
 				const ppDrop = this.runEvent('DeductPP', source, snatchUser, this.effectState.sourceEffect);
 				const extraPP = ppDrop !== true ? ppDrop : 0;


### PR DESCRIPTION
My implementation was wrong https://github.com/smogon/pokemon-showdown/pull/10905

- Extra PP should be deducted if Snatch is successful, not the called move.
- It should actually check for Pressure ._.