### PR TITLE
Add variable gameType to challenge codes

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2266,7 +2266,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 				);
 			}
 			const gameType = this.format.gameType;
-			if (gameType === 'doubles' || gameType === 'triples') {
+			if (gameType !== 'singles') {
 				throw new Error(
 					`The game type '${gameType}' cannot be 1v1 because sides can have multiple active Pok\u00e9mon, so it is incompatible with Chimera 1v1.`
 				);
@@ -2906,11 +2906,26 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 			if (num > 9 || num < 3 || num % 2 !== 1) {
 				throw new Error("Series length must be an odd number between three and nine (inclusive).");
 			}
-			if (!['singles', 'doubles'].includes(this.format.gameType)) {
-				throw new Error("Only single and doubles battles can be a Best-of series.");
+			if (!['singles', 'doubles', 'triples'].includes(this.format.gameType)) {
+				throw new Error("Only two-player battles can be a Best-of series.");
 			}
 			return value;
 		},
+	},
+	gametype: {
+		effectType: 'Rule',
+		name: 'Game Type',
+		desc: "Overrides the format's default game type.",
+		hasValue: true,
+		onValidateRule(value) {
+			const gameType = this.dex.toID(value);
+			const validGameTypes = [ 'singles', 'doubles', 'triples', 'freeforall', 'multi' ];
+			if (!validGameTypes.includes(gameType)) {
+				throw new Error(`"${value}" is not a valid game type. Valid game types are: ${validGameTypes.join(', ')}`);
+			}
+			return gameType;
+		},
+		// effect applied in sim/dex-formats
 	},
 	illusionlevelmod: {
 		effectType: 'Rule',

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2919,7 +2919,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 		hasValue: true,
 		onValidateRule(value) {
 			const gameType = this.dex.toID(value);
-			const validGameTypes = [ 'singles', 'doubles', 'triples', 'freeforall', 'multi' ];
+			const validGameTypes = ['singles', 'doubles', 'triples', 'freeforall', 'multi'];
 			if (!validGameTypes.includes(gameType)) {
 				throw new Error(`"${value}" is not a valid game type. Valid game types are: ${validGameTypes.join(', ')}`);
 			}

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -205,13 +205,14 @@ export class RuleTable extends Map<string, string> {
 
 	/** After a RuleTable has been filled out, resolve its hardcoded numeric properties */
 	resolveNumbers(format: Format, dex: ModdedDex) {
+
 		if (this.valueRules.has('gametype')) {
 			const gameType = dex.toID(this.valueRules.get('gametype')!) as GameType;
 			const currentPlayerCount = format.gameType === 'multi' || format.gameType === 'freeforall' ? 4 : 2;
 			const newPlayerCount = gameType === 'multi' || gameType === 'freeforall' ? 4 : 2;
 			if (currentPlayerCount !== newPlayerCount) {
 				throw new Error(
-					`Changing between ${currentPlayerCount}-player (${format.gameType}) and ${newPlayerCount}-player (${gameType}) game types is not supported.`
+				`Changing between ${currentPlayerCount}- (${format.gameType}) and ${newPlayerCount}-player (${gameType}) game types is not supported.`
 				);
 			}
 			(format as any).gameType = gameType;

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -205,7 +205,6 @@ export class RuleTable extends Map<string, string> {
 
 	/** After a RuleTable has been filled out, resolve its hardcoded numeric properties */
 	resolveNumbers(format: Format, dex: ModdedDex) {
-
 		if (this.valueRules.has('gametype')) {
 			const gameType = dex.toID(this.valueRules.get('gametype')!) as GameType;
 			const currentPlayerCount = format.gameType === 'multi' || format.gameType === 'freeforall' ? 4 : 2;
@@ -213,12 +212,11 @@ export class RuleTable extends Map<string, string> {
 			if (currentPlayerCount !== newPlayerCount) {
 				throw new Error(
 				`Changing between ${currentPlayerCount}- (${format.gameType}) and ${newPlayerCount}-player (${gameType}) game types is not supported.`
-				);
+					);
 			}
 			(format as any).gameType = gameType;
 			(format as any).playerCount = newPlayerCount;
 		}
-
 		const gameTypeMinTeamSize = ['triples', 'rotation'].includes(format.gameType as 'triples') ? 3 :
 			format.gameType === 'doubles' ? 2 :
 			1;

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -205,6 +205,19 @@ export class RuleTable extends Map<string, string> {
 
 	/** After a RuleTable has been filled out, resolve its hardcoded numeric properties */
 	resolveNumbers(format: Format, dex: ModdedDex) {
+		if (this.valueRules.has('gametype')) {
+			const gameType = dex.toID(this.valueRules.get('gametype')!) as GameType;
+			const currentPlayerCount = format.gameType === 'multi' || format.gameType === 'freeforall' ? 4 : 2;
+			const newPlayerCount = gameType === 'multi' || gameType === 'freeforall' ? 4 : 2;
+			if (currentPlayerCount !== newPlayerCount) {
+				throw new Error(
+					`Changing between ${currentPlayerCount}-player (${format.gameType}) and ${newPlayerCount}-player (${gameType}) game types is not supported.`
+				);
+			}
+			(format as any).gameType = gameType;
+			(format as any).playerCount = newPlayerCount;
+		}
+
 		const gameTypeMinTeamSize = ['triples', 'rotation'].includes(format.gameType as 'triples') ? 3 :
 			format.gameType === 'doubles' ? 2 :
 			1;
@@ -976,6 +989,11 @@ export class DexFormats {
 				);
 				if (typeof value === 'string') ruleTable.valueRules.set(subFormat.id, value);
 			}
+		}
+
+		// if gameType is overridden, we check onValidateRule to catch extra restrictions
+		if (ruleTable.valueRules.has('gametype')) {
+			format.onValidateRule?.call({ format, ruleTable, dex: this.dex }, '');
 		}
 
 		if (!repeals) format.ruleTable = ruleTable;

--- a/test/common.js
+++ b/test/common.js
@@ -43,7 +43,7 @@ class TestTools {
 
 	getFormat(options) {
 		if (options.formatid) {
-			const format = Dex.formats.get(options.formatid);
+			const format = Dex.formats.get(options.formatid, true);
 			if (format.effectType !== 'Format') throw new Error(`Unidentified format: ${options.formatid}`);
 			return format;
 		}

--- a/test/sim/misc/gametype.js
+++ b/test/sim/misc/gametype.js
@@ -10,7 +10,6 @@ describe('Game Type Rule', () => {
 		if (battle && battle.destroy) battle.destroy();
 	});
 
-
 	it('should override singles -> doubles', () => {
 		battle = common.createBattle({ customRules: ['Game Type = Doubles'] });
 		assert.equal(battle.gameType, 'doubles');
@@ -26,16 +25,15 @@ describe('Game Type Rule', () => {
 		assert.equal(battle.gameType, 'triples');
 	});
 
-	it('should override ffa     -> multi'  , () => {
+	it('should override ffa -> multi'  , () => {
 		battle = common.createBattle({ gameType: 'freeforall', customRules: ['Game Type = Multi'] });
 		assert.equal(battle.gameType, 'multi');
 	});
 
-	it('should override multi   -> ffa'    , () => {
+	it('should override multi -> ffa', () => {
 		battle = common.createBattle({ gameType: 'multi', customRules: ['Game Type = FreeForAll'] });
 		assert.equal(battle.gameType, 'freeforall');
 	});
-
 
 	it('should succeed with multiple overrides', () => {
 		// set game type, then override
@@ -79,11 +77,11 @@ describe('Game Type Rule', () => {
 		battle = null;
 		assert.throws(
 			() => common.createBattle({ gameType: 'freeforall', customRules: ['Best Of = 3'] }),
-			/Only two-player battles/,
+			/Only two-player battles/
 		);
 		assert.throws(
 			() => common.createBattle({ gameType: 'multi', customRules: ['Best Of = 3'] }),
-			/Only two-player battles/,
+			/Only two-player battles/
 		);
 	});
 
@@ -119,5 +117,4 @@ describe('Game Type Rule', () => {
 			/game types is not supported/
 		);
 	});
-	
 });

--- a/test/sim/misc/gametype.js
+++ b/test/sim/misc/gametype.js
@@ -47,7 +47,7 @@ describe('Game Type Rule', () => {
 		battle = null;
 		assert.throws(
 			() => common.createBattle({ customRules: ['Game Type = Perchance'] }),
-			/Invalid game type/
+			/not a valid game type/
 		);
 	});
 
@@ -79,20 +79,20 @@ describe('Game Type Rule', () => {
 		battle = null;
 		assert.throws(
 			() => common.createBattle({ gameType: 'freeforall', customRules: ['Best Of = 3'] }),
-			/Free-For-All battles cannot be a Best-of series/,
+			/Only two-player battles/,
 		);
 		assert.throws(
 			() => common.createBattle({ gameType: 'multi', customRules: ['Best Of = 3'] }),
-			/Multi battles cannot be a Best-of series/,
+			/Only two-player battles/,
 		);
 	});
 
 	it('should reject non-singles game types with format restrictions', () => {
 		battle = null;
-		// Shared Power has an onValidateRule to disallow non-singles, it should be bypassed
+		// Shared Power has an onValidateRule to disallow non-singles, it should not be bypassed
 		assert.throws(
 			() => common.createBattle({ formatid: '[Gen 9] Shared Power @@@ Game Type = Doubles' }),
-			/Shared Power currently does not support non-singles/
+			/Shared Power currently does not support doubles battles/
 		);
 	});
 
@@ -112,11 +112,11 @@ describe('Game Type Rule', () => {
 		battle = null;
 		assert.throws(
 			() => common.createBattle({ gameType: 'multi', customRules: ['Game Type = Singles'] }),
-			/Changing between 4-player and 2-player game types is not supported/
+			/game types is not supported/
 		);
 		assert.throws(
 			() => common.createBattle({ gameType: 'freeforall', customRules: ['Game Type = Singles'] }),
-			/Changing between 4-player and 2-player game types is not supported/
+			/game types is not supported/
 		);
 	});
 	

--- a/test/sim/misc/gametype.js
+++ b/test/sim/misc/gametype.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('assert').strict;
+const common = require('../../common');
+
+let battle;
+
+describe('Game Type Rule', () => {
+	afterEach(() => {
+		if (battle && battle.destroy) battle.destroy();
+	});
+
+
+	it('should override singles -> doubles', () => {
+		battle = common.createBattle({ customRules: ['Game Type = Doubles'] });
+		assert.equal(battle.gameType, 'doubles');
+	});
+
+	it('should override doubles -> singles', () => {
+		battle = common.createBattle({ gameType: 'doubles', customRules: ['Game Type = Singles'] });
+		assert.equal(battle.gameType, 'singles');
+	});
+
+	it('should override doubles -> triples', () => {
+		battle = common.createBattle({ gameType: 'doubles', customRules: ['Game Type = Triples'] });
+		assert.equal(battle.gameType, 'triples');
+	});
+
+	it('should override ffa     -> multi'  , () => {
+		battle = common.createBattle({ gameType: 'freeforall', customRules: ['Game Type = Multi'] });
+		assert.equal(battle.gameType, 'multi');
+	});
+
+	it('should override multi   -> ffa'    , () => {
+		battle = common.createBattle({ gameType: 'multi', customRules: ['Game Type = FreeForAll'] });
+		assert.equal(battle.gameType, 'freeforall');
+	});
+
+
+	it('should succeed with multiple overrides', () => {
+		// set game type, then override
+		battle = common.createBattle({ customRules: ['Game Type = Doubles', '!! Game Type = Singles'] });
+		assert.equal(battle.gameType, 'singles');
+	});
+
+	it('should reject nonexistent game types', () => {
+		battle = null;
+		assert.throws(
+			() => common.createBattle({ customRules: ['Game Type = Perchance'] }),
+			/Invalid game type/
+		);
+	});
+
+	it('should reject doubles/triples with Chimera 1v1 Rule', () => {
+		battle = null;
+		assert.throws(
+			() => common.createBattle({ customRules: ['Chimera 1v1 Rule', 'Game Type = Doubles'] }),
+			/incompatible with Chimera 1v1|cannot be 1v1/
+		);
+		assert.throws(
+			() => common.createBattle({ customRules: ['Chimera 1v1 Rule', 'Game Type = Triples'] }),
+			/incompatible with Chimera 1v1|cannot be 1v1/
+		);
+	});
+
+	it('should allow 2 player types with Best Of', () => {
+		battle = common.createBattle({ customRules: ['Game Type = Singles', 'Best Of = 3'] });
+		assert.equal(battle.gameType, 'singles');
+		battle.destroy();
+		battle = common.createBattle({ customRules: ['Game Type = Doubles', 'Best Of = 3'] });
+		assert.equal(battle.gameType, 'doubles');
+		battle.destroy();
+		battle = common.createBattle({ gameType: 'doubles', customRules: ['Game Type = Triples', 'Best Of = 3'] });
+		assert.equal(battle.gameType, 'triples');
+		battle.destroy();
+	});
+
+	it('should reject freeforall/multi with Best Of', () => {
+		battle = null;
+		assert.throws(
+			() => common.createBattle({ gameType: 'freeforall', customRules: ['Best Of = 3'] }),
+			/Free-For-All battles cannot be a Best-of series/,
+		);
+		assert.throws(
+			() => common.createBattle({ gameType: 'multi', customRules: ['Best Of = 3'] }),
+			/Multi battles cannot be a Best-of series/,
+		);
+	});
+
+	it('should reject non-singles game types with format restrictions', () => {
+		battle = null;
+		// Shared Power has an onValidateRule to disallow non-singles, it should be bypassed
+		assert.throws(
+			() => common.createBattle({ formatid: '[Gen 9] Shared Power @@@ Game Type = Doubles' }),
+			/Shared Power currently does not support non-singles/
+		);
+	});
+
+	it('should reject changing from 2 to 4-players', () => {
+		battle = null;
+		assert.throws(
+			() => common.createBattle({ customRules: ['Game Type = Multi'] }),
+			/Changing between 2-player and 4-player game types is not supported/
+		);
+		assert.throws(
+			() => common.createBattle({ customRules: ['Game Type = FreeForAll'] }),
+			/Changing between 2-player and 4-player game types is not supported/
+		);
+	});
+
+	it('should reject changing from 4 to 2-players', () => {
+		battle = null;
+		assert.throws(
+			() => common.createBattle({ gameType: 'multi', customRules: ['Game Type = Singles'] }),
+			/Changing between 4-player and 2-player game types is not supported/
+		);
+		assert.throws(
+			() => common.createBattle({ gameType: 'freeforall', customRules: ['Game Type = Singles'] }),
+			/Changing between 4-player and 2-player game types is not supported/
+		);
+	});
+	
+});


### PR DESCRIPTION
Approved at https://www.smogon.com/forums/threads/forcedoubles-clause-for-buildformat-and-challenge-codes.3764216/

Feature:
- Switching game types between Singles, Doubles, and Triples
- Switching game types between Free-For-All and Multi

Checks:
- Blocks player count switching of the sets
- Unit tests present  in tests/misc/gametype.js
- Rewriting the gameType of a Random Battle uses the generation for the selected gameType
- Picking formats with a minimum team of >1 can't be used on formats that only pick 1 Pokemon
- Formats with specific gameType conditions cannot be overriden (i.e Shared Power)

Crash free after semi-extensive testing.