### PR TITLE
35 Pokes: Update list of allowed Pokemon for April 2026

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3215,7 +3215,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'Razor Fang', 'Last Respects', 'Shed Tail', 'Baton Pass + Contrary', 'Baton Pass + Rapid Spin', 'Baton Pass + Well-Baked Body',
 		],
 		unbanlist: [
-			'Articuno-Base', 'Brute Bonnet', 'Cacturne', 'Cobalion', 'Drifblim', 'Dugtrio-Base', 'Gabite', 'Gogoat', 'Hariyama', 'Hawlucha-Base',
+			'Articuno-Base', 'Brute Bonnet', 'Cacturne', 'Clefable-Base', 'Cobalion', 'Drifblim', 'Dugtrio-Base', 'Gabite', 'Gogoat', 'Hariyama',
 			'Hippowdon', 'Krookodile', 'Lurantis-Base', 'Lycanroc-Base', 'Mabosstiff', 'Minior-Base', 'Munkidori', 'Passimian', 'Pawmot', 'Persian-Base',
 			'Raichu-Alola', 'Roserade', 'Rotom-Heat', 'Sandaconda', 'Sceptile-Base', 'Stoutland', 'Stunfisk-Base', 'Tentacruel', 'Thwackey', 'Tinkaton',
 			'Toedscruel', 'Tsareena', 'Uxie', 'Vivillon', 'Whiscash', 'Ultranecrozium Z', 'Solganium Z', 'Lunalium Z', 'Mewnium Z', 'Marshadium Z', 'Yawn',


### PR DESCRIPTION
April 2026 meta started early for the sake of clarity with regard to the National Dex Other Tiers monthly ladder format voting

https://www.smogon.com/forums/threads/35-pokes-march-2026-happy-new-year.3749375/