### PR TITLE
Reduce repetitive code for -ate and priority blocking abilities

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -204,19 +204,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 71,
 	},
 	armortail: {
-		onFoeTryMove(target, source, move) {
-			const targetAllExceptions = ['perishsong', 'flowershield', 'rototiller'];
-			if (move.target === 'foeSide' || (move.target === 'all' && !targetAllExceptions.includes(move.id))) {
-				return;
-			}
-
-			const armorTailHolder = this.effectState.target;
-			if ((source.isAlly(armorTailHolder) || move.target === 'all') && move.priority > 0.1) {
-				this.attrLastMove('[still]');
-				this.add('cant', armorTailHolder, 'ability: Armor Tail', move, `[of] ${target}`);
-				return false;
-			}
-		},
+		...priorityBlockAbilityTemplate("Armor Tail"),
 		flags: { breakable: 1 },
 		name: "Armor Tail",
 		rating: 2.5,
@@ -848,19 +836,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 235,
 	},
 	dazzling: {
-		onFoeTryMove(target, source, move) {
-			const targetAllExceptions = ['perishsong', 'flowershield', 'rototiller'];
-			if (move.target === 'foeSide' || (move.target === 'all' && !targetAllExceptions.includes(move.id))) {
-				return;
-			}
-
-			const dazzlingHolder = this.effectState.target;
-			if ((source.isAlly(dazzlingHolder) || move.target === 'all') && move.priority > 0.1) {
-				this.attrLastMove('[still]');
-				this.add('cant', dazzlingHolder, 'ability: Dazzling', move, `[of] ${target}`);
-				return false;
-			}
-		},
+		...priorityBlockAbilityTemplate("Dazzling"),
 		flags: { breakable: 1 },
 		name: "Dazzling",
 		rating: 2.5,
@@ -3602,19 +3578,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 282,
 	},
 	queenlymajesty: {
-		onFoeTryMove(target, source, move) {
-			const targetAllExceptions = ['perishsong', 'flowershield', 'rototiller'];
-			if (move.target === 'foeSide' || (move.target === 'all' && !targetAllExceptions.includes(move.id))) {
-				return;
-			}
-
-			const dazzlingHolder = this.effectState.target;
-			if ((source.isAlly(dazzlingHolder) || move.target === 'all') && move.priority > 0.1) {
-				this.attrLastMove('[still]');
-				this.add('cant', dazzlingHolder, 'ability: Queenly Majesty', move, `[of] ${target}`);
-				return false;
-			}
-		},
+		...priorityBlockAbilityTemplate("Queenly Majesty"),
 		flags: { breakable: 1 },
 		name: "Queenly Majesty",
 		rating: 2.5,
@@ -5576,7 +5540,6 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 };
 
-
 function ateAbilityTemplate(targetType: string): Partial<import("../sim/dex-abilities").AbilityData> {
 	return {
 		onModifyTypePriority: -1,
@@ -5595,4 +5558,22 @@ function ateAbilityTemplate(targetType: string): Partial<import("../sim/dex-abil
 			if (move.typeChangerBoosted === this.effect) return this.chainModify([4915, 4096]);
 		},
 	}
-}
+};
+
+function priorityBlockAbilityTemplate(abilityName: string): Partial<import("../sim/dex-abilities").AbilityData> {
+	return {
+		onFoeTryMove(target, source, move) {
+			const targetAllExceptions = ['perishsong', 'flowershield', 'rototiller'];
+			if (move.target === 'foeSide' || (move.target === 'all' && !targetAllExceptions.includes(move.id))) {
+				return;
+			}
+
+			const abilityHolder = this.effectState.target;
+			if ((source.isAlly(abilityHolder) || move.target === 'all') && move.priority > 0.1) {
+				this.attrLastMove('[still]');
+				this.add('cant', abilityHolder, `ability: ${abilityName}`, move, `[of] ${target}`);
+				return false;
+			}
+		},
+	}
+};

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -55,21 +55,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 91,
 	},
 	aerilate: {
-		onModifyTypePriority: -1,
-		onModifyType(move, pokemon) {
-			const noModifyType = [
-				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
-			];
-			if (move.type === 'Normal' && (!noModifyType.includes(move.id) || this.activeMove?.isMax) &&
-				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
-				move.type = 'Flying';
-				move.typeChangerBoosted = this.effect;
-			}
-		},
-		onBasePowerPriority: 23,
-		onBasePower(basePower, pokemon, target, move) {
-			if (move.typeChangerBoosted === this.effect) return this.chainModify([4915, 4096]);
-		},
+		...ateAbilityTemplate("Flying"),
 		flags: {},
 		name: "Aerilate",
 		rating: 4,
@@ -1035,21 +1021,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	},
 	dragonize: {
 		isNonstandard: "Future",
-		onModifyTypePriority: -1,
-		onModifyType(move, pokemon) {
-			const noModifyType = [
-				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
-			];
-			if (move.type === 'Normal' && (!noModifyType.includes(move.id) || this.activeMove?.isMax) &&
-				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
-				move.type = 'Dragon';
-				move.typeChangerBoosted = this.effect;
-			}
-		},
-		onBasePowerPriority: 23,
-		onBasePower(basePower, pokemon, target, move) {
-			if (move.typeChangerBoosted === this.effect) return this.chainModify([4915, 4096]);
-		},
+		...ateAbilityTemplate("Dragon"),
 		flags: {},
 		name: "Dragonize",
 		rating: 4,
@@ -1560,21 +1532,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 177,
 	},
 	galvanize: {
-		onModifyTypePriority: -1,
-		onModifyType(move, pokemon) {
-			const noModifyType = [
-				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
-			];
-			if (move.type === 'Normal' && (!noModifyType.includes(move.id) || this.activeMove?.isMax) &&
-				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
-				move.type = 'Electric';
-				move.typeChangerBoosted = this.effect;
-			}
-		},
-		onBasePowerPriority: 23,
-		onBasePower(basePower, pokemon, target, move) {
-			if (move.typeChangerBoosted === this.effect) return this.chainModify([4915, 4096]);
-		},
+		...ateAbilityTemplate("Electric"),
 		flags: {},
 		name: "Galvanize",
 		rating: 4,
@@ -3238,21 +3196,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 53,
 	},
 	pixilate: {
-		onModifyTypePriority: -1,
-		onModifyType(move, pokemon) {
-			const noModifyType = [
-				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
-			];
-			if (move.type === 'Normal' && (!noModifyType.includes(move.id) || this.activeMove?.isMax) &&
-				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
-				move.type = 'Fairy';
-				move.typeChangerBoosted = this.effect;
-			}
-		},
-		onBasePowerPriority: 23,
-		onBasePower(basePower, pokemon, target, move) {
-			if (move.typeChangerBoosted === this.effect) return this.chainModify([4915, 4096]);
-		},
+		...ateAbilityTemplate("Fairy"),
 		flags: {},
 		name: "Pixilate",
 		rating: 4,
@@ -3754,21 +3698,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 120,
 	},
 	refrigerate: {
-		onModifyTypePriority: -1,
-		onModifyType(move, pokemon) {
-			const noModifyType = [
-				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
-			];
-			if (move.type === 'Normal' && (!noModifyType.includes(move.id) || this.activeMove?.isMax) &&
-				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
-				move.type = 'Ice';
-				move.typeChangerBoosted = this.effect;
-			}
-		},
-		onBasePowerPriority: 23,
-		onBasePower(basePower, pokemon, target, move) {
-			if (move.typeChangerBoosted === this.effect) return this.chainModify([4915, 4096]);
-		},
+		...ateAbilityTemplate("Ice"),
 		flags: {},
 		name: "Refrigerate",
 		rating: 4,
@@ -5645,3 +5575,24 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: -3,
 	},
 };
+
+
+function ateAbilityTemplate(targetType: string): Partial<import("../sim/dex-abilities").AbilityData> {
+	return {
+		onModifyTypePriority: -1,
+		onModifyType(move, pokemon) {
+			const noModifyType = [
+				'judgment', 'multiattack', 'naturalgift', 'revelationdance', 'technoblast', 'terrainpulse', 'weatherball',
+			];
+			if (move.type === 'Normal' && (!noModifyType.includes(move.id) || this.activeMove?.isMax) &&
+				!(move.isZ && move.category !== 'Status') && !(move.name === 'Tera Blast' && pokemon.terastallized)) {
+				move.type = targetType;
+				move.typeChangerBoosted = this.effect;
+			}
+		},
+		onBasePowerPriority: 23,
+		onBasePower(basePower, pokemon, target, move) {
+			if (move.typeChangerBoosted === this.effect) return this.chainModify([4915, 4096]);
+		},
+	}
+}


### PR DESCRIPTION
There's currently 5 -ate abilities and 3 priority blocking abilities, and each of them work nearly identically. So, I just separated said logic into a function that returns a Partial<AbilityData>.