### PR TITLE
Fix Gen 3/4 Light Screen and Reflect foe check for damage multiplier

### DIFF
--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -727,7 +727,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				if (target !== source && this.effectState.target.hasAlly(target) && this.getCategory(move) === 'Special') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
-						if (target.alliesAndSelf().length > 1) return this.chainModify(2, 3);
+						if (target.side.allies(true).filter(p => !p.fainted).length > 1) return this.chainModify(2, 3);
 						return this.chainModify(0.5);
 					}
 				}
@@ -1114,7 +1114,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				if (target !== source && this.effectState.target.hasAlly(target) && this.getCategory(move) === 'Physical') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
-						if (target.alliesAndSelf().length > 1) return this.chainModify(2, 3);
+						if (target.side.allies(true).filter(p => !p.fainted).length > 1) return this.chainModify(2, 3);
 						return this.chainModify(0.5);
 					}
 				}


### PR DESCRIPTION
https://www.smogon.com/forums/threads/past-gens-research-thread.3506992/post-9880360

If, during a spread move, the first target faints, the Light Screen multiplier applied to the second target should be 1/2 in Gen 4 and 2/3 in Gen 3. Right now, it is applying 1/2 in both gens.

This is the correct solution causing Gen 3 to be 2/3. Gen 4 going back to 1/2 would be implemented by this other PR that fixes the Gen 4 move routine https://github.com/smogon/pokemon-showdown/pull/11180