### PR TITLE
Shell Bell should activate for each hit in Gen 3

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -76,7 +76,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 184,
 	},
 	aftermath: {
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			if (!target.hp && this.checkMoveMakesContact(move, source, target, true)) {
 				this.damage(source.baseMaxhp / 4, source, target);
@@ -1172,7 +1172,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 226,
 	},
 	electromorphosis: {
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			target.addVolatile('charge');
 		},
@@ -2103,7 +2103,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 151,
 	},
 	innardsout: {
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			if (!target.hp) {
 				this.damage(target.getUndynamaxedHP(damage), source, target);
@@ -2186,7 +2186,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 234,
 	},
 	ironbarbs: {
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			if (this.checkMoveMakesContact(move, source, target, true)) {
 				this.damage(source.baseMaxhp / 8, source, target);
@@ -3880,7 +3880,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 276,
 	},
 	roughskin: {
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			if (this.checkMoveMakesContact(move, source, target, true)) {
 				this.damage(source.baseMaxhp / 8, source, target);
@@ -5448,7 +5448,7 @@ export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 		num: 193,
 	},
 	windpower: {
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			if (move.flags['wind']) {
 				target.addVolatile('charge');

--- a/data/items.ts
+++ b/data/items.ts
@@ -5293,7 +5293,7 @@ export const Items: import('../sim/dex-items').ItemDataTable = {
 		fling: {
 			basePower: 60,
 		},
-		onDamagingHitOrder: 2,
+		onDamagingHitPriority: -2,
 		onDamagingHit(damage, target, source, move) {
 			if (this.checkMoveMakesContact(move, source, target)) {
 				this.damage(source.baseMaxhp / 6, source, target);

--- a/data/mods/chatbats/abilities.ts
+++ b/data/mods/chatbats/abilities.ts
@@ -191,7 +191,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		shortDesc: "-20 BP on attacks targeting Glastrier, at 50% HP become Calyrex-Ice.",
 	},
 	flipflop: {
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onTryHit(target, source, move) {
 			if (move.flags['contact']) {
 				let flipFlopBoosts = false;
@@ -339,7 +339,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	// stockpile on hit
 	omnivore: {
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			if (!target.hp) return;
 			this.add('-activate', target, 'ability: Omnivore');

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -337,6 +337,7 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	shellbell: {
 		inherit: true,
 		onAfterMoveSecondarySelf: undefined, // no inherit
+		onSourceDamagingHitPriority: -1,
 		onSourceDamagingHit(damage, target, pokemon, move) {
 			if (damage && !pokemon.forceSwitchFlag) {
 				this.heal(damage / 8, pokemon);

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -337,9 +337,9 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	shellbell: {
 		inherit: true,
 		onAfterMoveSecondarySelf: undefined, // no inherit
-		onSourceAfterMoveSecondary(target, pokemon, move) {
-			if (move.totalDamage && !pokemon.forceSwitchFlag) {
-				this.heal(move.totalDamage / 8, pokemon);
+		onSourceDamagingHit(damage, target, pokemon, move) {
+			if (damage && !pokemon.forceSwitchFlag) {
+				this.heal(damage / 8, pokemon);
 			}
 		},
 	},

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -334,6 +334,15 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 			}
 		},
 	},
+	shellbell: {
+		inherit: true,
+		onAfterMoveSecondarySelf: undefined, // no inherit
+		onSourceAfterMoveSecondary(target, pokemon, move) {
+			if (move.totalDamage && !pokemon.forceSwitchFlag) {
+				this.heal(move.totalDamage / 8, pokemon);
+			}
+		},
+	},
 	silkscarf: {
 		inherit: true,
 		onBasePower: undefined, // no inherit

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -337,7 +337,7 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	shellbell: {
 		inherit: true,
 		onAfterMoveSecondarySelf: undefined, // no inherit
-		onSourceDamagingHitPriority: -1,
+		onSourceDamagingHitPriority: -2,
 		onSourceDamagingHit(damage, target, pokemon, move) {
 			if (damage && !pokemon.forceSwitchFlag) {
 				this.heal(damage / 8, pokemon);

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -796,7 +796,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				pokemon.maybeTrapped = true;
 			}
 		},
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			if (!target.hp) {
 				this.damage(target.getUndynamaxedHP(damage), source, target);

--- a/data/mods/gen9ssb/conditions.ts
+++ b/data/mods/gen9ssb/conditions.ts
@@ -2966,7 +2966,7 @@ export const Conditions: { [id: IDEntry]: ModdedConditionData & { innateName?: s
 				status: 'brn',
 			});
 		},
-		onDamagingHitOrder: 1,
+		onDamagingHitPriority: -1,
 		onDamagingHit(damage, target, source, move) {
 			if (this.checkMoveMakesContact(move, source, target, true)) {
 				this.damage(source.baseMaxhp / 8, source, target);

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -437,7 +437,6 @@ export interface EventMethods {
 	onAnyFaintPriority?: number;
 	onAnyPrepareHitPriority?: number;
 	onAnySwitchInPriority?: number;
-	onAnySwitchInSubOrder?: number;
 	onAllyBasePowerPriority?: number;
 	onAllyModifyAtkPriority?: number;
 	onAllyModifySpAPriority?: number;
@@ -484,7 +483,6 @@ export interface EventMethods {
 	onSourceModifyDamagePriority?: number;
 	onSourceModifySpAPriority?: number;
 	onSwitchInPriority?: number;
-	onSwitchInSubOrder?: number;
 	onTrapPokemonPriority?: number;
 	onTryBoostPriority?: number;
 	onTryEatItemPriority?: number;

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -426,7 +426,7 @@ export interface EventMethods {
 
 	// Priorities (incomplete list)
 	onAccuracyPriority?: number;
-	onDamagingHitOrder?: number;
+	onDamagingHitPriority?: number;
 	onAfterMoveSecondaryPriority?: number;
 	onAfterMoveSecondarySelfPriority?: number;
 	onAfterMoveSelfPriority?: number;
@@ -477,6 +477,7 @@ export interface EventMethods {
 	onResidualPriority?: number;
 	onResidualSubOrder?: number;
 	onSourceBasePowerPriority?: number;
+	onSourceDamagingHitPriority?: number;
 	onSourceInvulnerabilityPriority?: number;
 	onSourceModifyAccuracyPriority?: number;
 	onSourceModifyAtkPriority?: number;

--- a/test/sim/items/shellbell.js
+++ b/test/sim/items/shellbell.js
@@ -39,4 +39,21 @@ describe('Shell Bell', () => {
 		const cloyster = battle.p2.active[0];
 		assert.equal(cloyster.hp, 1 + Math.floor(landorus.maxhp / 8));
 	});
+
+	describe('[Gen 3]', () => {
+		it(`should heal from the damage against all targets of the move`, () => {
+			battle = common.gen(3).createBattle({ gameType: 'doubles' }, [[
+				{ species: 'tornadus', ability: 'compoundeyes', moves: ['superfang'] },
+				{ species: 'landorus', item: 'shellbell', moves: ['earthquake'] },
+			], [
+				{ species: 'roggenrola', level: 1, moves: ['sleeptalk'] },
+				{ species: 'aron', level: 1, moves: ['sleeptalk'] },
+			]]);
+			battle.makeChoices('move superfang -2, move earthquake', 'auto');
+			assert.equal(
+				battle.getDebugLog().split('\n').filter(line => line.endsWith('|[from] item: Shell Bell')).length,
+				2
+			);
+		});
+	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/past-gens-research-thread.3506992/post-9880360
https://www.smogon.com/forums/threads/bug-report-mechanics.3781318/

Edit: it actually activates after each individual hit of a multi-hit move.

Edit2: Shell Bell is the last effect to activate before moving to the next target. While adjusting the priorities, I noticed that, aside from residuals, only DamagingHit used order instead of priority, so I changed it to priority.