### PR TITLE
Clarify Upper Hand description

### DIFF
--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -7208,8 +7208,8 @@ export const MovesText: { [id: IDEntry]: MoveText } = {
 	},
 	upperhand: {
 		name: "Upper Hand",
-		desc: "Has a 100% chance to make the target flinch. Fails if the target did not select a priority move for use this turn, or if the target moves before the user.",
-		shortDesc: "100% flinch. Fails unless target using priority.",
+		desc: "Has a 100% chance to make the target flinch. Fails if the target did not select a priority attacking move for use this turn, or if the target moves before the user.",
+		shortDesc: "100% flinch. Fails unless target using priority attack.",
 	},
 	uproar: {
 		name: "Uproar",


### PR DESCRIPTION
Upper Hand only works against priority attacks, but this isn't mentioned anywhere on the move. Added clarification that it has to be an _attacking_ priority move to work.