### PR TITLE
Ban Oricorios from ZU & update ZU by usage NFEs

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1532,6 +1532,8 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	},
 	sneasel: {
 		tier: "ZU",
+		doublesTier: "NFE",
+		natDexTier: "NFE",
 	},
 	sneaselhisui: {
 		tier: "ZU",
@@ -3137,6 +3139,8 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	},
 	gurdurr: {
 		tier: "ZU",
+		doublesTier: "NFE",
+		natDexTier: "NFE",
 	},
 	conkeldurr: {
 		tier: "UU",


### PR DESCRIPTION
Oricorio Baile and Pa'u got banned from ZU
https://www.smogon.com/forums/threads/np-zu-stage-18-flower-tier-shifts-28.3770736/post-10933930

Sneasel and Gurdurr are both ZU by usage
Sneasel: 7.50598% Jan, 12.92988% Feb, 10.38042% Mar, 10.27% Avg Gurdurr: 5.14278% Jan, 4.96214% Feb, 5.45889% Mar, 5.19% Avg