### PR TITLE
Implement AfterMoveSelf correctly

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -23,9 +23,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 				this.hint("In Gen 1, Toxic's counter is retained after Rest and applies to PSN/BRN.", true);
 			}
 		},
-		onAfterSwitchInSelf(pokemon) {
-			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
-		},
 	},
 	par: {
 		name: 'par',
@@ -118,9 +115,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			if (pokemon.volatiles['residualdmg']) {
 				this.hint("In Gen 1, Toxic's counter is retained after Rest and applies to PSN/BRN.", true);
 			}
-		},
-		onAfterSwitchInSelf(pokemon) {
-			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
 		},
 	},
 	tox: {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -69,13 +69,11 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			pokemon.statusState.time--;
 			if (pokemon.statusState.time > 0) {
 				this.add('cant', pokemon, 'slp');
+			} else {
+				pokemon.cureStatus();
 			}
 			pokemon.lastMove = null;
 			return false;
-		},
-		onAfterMoveSelfPriority: 3,
-		onAfterMoveSelf(pokemon) {
-			if (pokemon.statusState.time <= 0) pokemon.cureStatus();
 		},
 		onDisableMove(target) {
 			target.maybeLocked = false; // the player knows it is locked

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -157,11 +157,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				}
 			}
 
-			const abortMove = () => {
-				this.battle.clearActiveMove(true);
-				this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
-			};
-
 			if (move.id === 'cannotmove') {
 				if (pokemon.status === 'slp') {
 					this.battle.hint(
@@ -179,7 +174,7 @@ export const Scripts: ModdedBattleScriptsData = {
 						"the move execution will never resolve."
 					);
 				}
-				abortMove();
+				this.battle.clearActiveMove(true);
 				return;
 			}
 
@@ -188,11 +183,11 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.battle.setActiveMove(move, pokemon, target);
 
 			if (pokemon.moveThisTurn || !this.battle.runEvent('BeforeMove', pokemon, target, move)) {
-				abortMove();
+				this.battle.clearActiveMove(true);
 				return;
 			}
 			if (move.beforeMoveCallback?.call(this.battle, pokemon, target, move)) {
-				abortMove();
+				this.battle.clearActiveMove(true);
 				return;
 			}
 
@@ -212,7 +207,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					this.battle.hint(
 						"In Gen 1, a Pokémon might default to using a move that doesn't match the move of the slot it last selected.",
 					);
-					abortMove();
+					this.battle.clearActiveMove(true);
 					return;
 				}
 			}
@@ -268,9 +263,6 @@ export const Scripts: ModdedBattleScriptsData = {
 					pokemon.side.lastMove = move;
 
 					this.battle.runEvent('AfterMove', pokemon, target, move);
-					if (!target || target.hp > 0) {
-						this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
-					}
 				}
 			}
 			return moveResult;

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -9,9 +9,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onAfterMoveSelf(pokemon) {
 			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
 		},
-		onAfterSwitchInSelf(pokemon) {
-			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
-		},
 	},
 	par: {
 		name: 'par',
@@ -86,9 +83,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		},
 		onAfterMoveSelfPriority: 2,
 		onAfterMoveSelf(pokemon) {
-			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
-		},
-		onAfterSwitchInSelf(pokemon) {
 			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
 		},
 	},

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -50,11 +50,9 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onBeforeMove(pokemon, target, move) {
 			pokemon.statusState.time--;
 			this.add('cant', pokemon, 'slp');
+			if (pokemon.statusState.time <= 0) pokemon.cureStatus();
 			pokemon.lastMove = null;
 			return false;
-		},
-		onAfterMoveSelf(pokemon) {
-			if (pokemon.statusState.time <= 0) pokemon.cureStatus();
 		},
 	},
 	frz: {

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -83,8 +83,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (pokemon.moveThisTurn || !this.battle.runEvent('BeforeMove', pokemon, target, move)) {
 				this.battle.debug(`${pokemon.fullname} move interrupted; movedThisTurn: ${pokemon.moveThisTurn}`);
 				this.battle.clearActiveMove(true);
-				// This is only run for sleep
-				this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
 				return;
 			}
 			if (move.beforeMoveCallback) {
@@ -142,8 +140,6 @@ export const Scripts: ModdedBattleScriptsData = {
 					// If target fainted
 					if (target && target.hp <= 0) {
 						delete pokemon.volatiles['partialtrappinglock'];
-					} else {
-						this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
 					}
 					if (pokemon.volatiles['mustrecharge']) this.battle.add('-mustrecharge', pokemon);
 

--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -9,9 +9,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onAfterMoveSelf(pokemon) {
 			residualdmg(this, pokemon);
 		},
-		onAfterSwitchInSelf(pokemon) {
-			residualdmg(this, pokemon);
-		},
 	},
 	par: {
 		name: 'par',
@@ -87,9 +84,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onAfterMoveSelf(pokemon) {
 			residualdmg(this, pokemon);
 		},
-		onAfterSwitchInSelf(pokemon) {
-			residualdmg(this, pokemon);
-		},
 	},
 	tox: {
 		name: 'tox',
@@ -108,9 +102,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			// Regular poison status and damage after a switchout -> switchin.
 			pokemon.status = 'psn' as ID;
 			this.add('-status', pokemon, 'psn', '[silent]');
-		},
-		onAfterSwitchInSelf(pokemon) {
-			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
 		},
 	},
 	confusion: {
@@ -243,9 +234,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		},
 		onAfterMoveSelfPriority: 100,
 		onAfterMoveSelf(pokemon) {
-			if (['brn', 'psn', 'tox'].includes(pokemon.status)) pokemon.volatiles['residualdmg'].counter++;
-		},
-		onAfterSwitchInSelf(pokemon) {
 			if (['brn', 'psn', 'tox'].includes(pokemon.status)) pokemon.volatiles['residualdmg'].counter++;
 		},
 	},

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -412,7 +412,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			onResidual: undefined, // no inherit
 			onAfterMoveSelfPriority: 1,
 			onAfterMoveSelf(pokemon) {
-				if (pokemon.status === 'slp') this.damage(pokemon.baseMaxhp / 4);
+				if (this.effectState.source.hp) this.damage(pokemon.baseMaxhp / 4);
 			},
 		},
 	},

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -412,7 +412,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			onResidual: undefined, // no inherit
 			onAfterMoveSelfPriority: 1,
 			onAfterMoveSelf(pokemon) {
-				if (this.effectState.source.hp) this.damage(pokemon.baseMaxhp / 4);
+				this.damage(pokemon.baseMaxhp / 4);
 			},
 		},
 	},

--- a/data/mods/gen2/scripts.ts
+++ b/data/mods/gen2/scripts.ts
@@ -114,8 +114,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (!this.battle.runEvent('BeforeMove', pokemon, target, move)) {
 				this.battle.runEvent('MoveAborted', pokemon, target, move);
 				this.battle.clearActiveMove(true);
-				// This is only run for sleep and fully paralysed.
-				this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
 				return;
 			}
 			if (move.beforeMoveCallback) {
@@ -136,7 +134,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			pokemon.moveUsed(move);
 			this.battle.actions.useMove(move, pokemon, { target, sourceEffect: options?.sourceEffect });
 			this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
-			if (!move.selfSwitch && pokemon.side.foe.active[0].hp) this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
 		},
 		tryMoveHit(target, pokemon, move) {
 			const positiveBoostTable = [1, 1.33, 1.66, 2, 2.33, 2.66, 3];

--- a/data/mods/gen2stadium2/conditions.ts
+++ b/data/mods/gen2stadium2/conditions.ts
@@ -19,9 +19,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onSwitchIn(pokemon) {
 			pokemon.addVolatile('brnattackdrop');
 		},
-		onAfterSwitchInSelf(pokemon) {
-			residualdmg(this, pokemon);
-		},
 	},
 	par: {
 		name: 'par',
@@ -116,9 +113,6 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		},
 		onAfterMoveSelfPriority: 100,
 		onAfterMoveSelf(pokemon) {
-			if (['brn', 'psn', 'tox'].includes(pokemon.status)) pokemon.volatiles['residualdmg'].counter++;
-		},
-		onAfterSwitchInSelf(pokemon) {
 			if (['brn', 'psn', 'tox'].includes(pokemon.status)) pokemon.volatiles['residualdmg'].counter++;
 		},
 	},

--- a/data/mods/gen4/scripts.ts
+++ b/data/mods/gen4/scripts.ts
@@ -5,10 +5,6 @@ export const Scripts: ModdedBattleScriptsData = {
 	actions: {
 		inherit: true,
 		runSwitch(pokemon) {
-			this.battle.runEvent('EntryHazard', pokemon);
-
-			this.battle.runEvent('SwitchIn', pokemon);
-
 			if (this.battle.gen <= 2) {
 				// pokemon.lastMove is reset for all Pokemon on the field after a switch. This affects Mirror Move.
 				for (const poke of this.battle.getAllActive()) poke.lastMove = null;
@@ -21,9 +17,6 @@ export const Scripts: ModdedBattleScriptsData = {
 							this.battle.queue.changeAction(poke, { choice: 'move', poke, moveid: 'metronome' });
 						}
 					}
-				}
-				if (!pokemon.side.faintedThisTurn && pokemon.draggedIn !== this.battle.turn) {
-					this.battle.runEvent('AfterSwitchInSelf', pokemon);
 				}
 			}
 			if (!pokemon.hp) return false;

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -150,7 +150,11 @@ export class BattleActions {
 		if (isDrag && this.battle.gen === 2) pokemon.draggedIn = this.battle.turn;
 		pokemon.previouslySwitchedIn++;
 
-		if (isDrag && this.battle.gen >= 5) {
+		if (this.battle.gen <= 4) {
+			this.battle.runEvent('EntryHazard', pokemon);
+			this.battle.runEvent('SwitchIn', pokemon);
+		}
+		if (isDrag) {
 			// runSwitch happens immediately so that Mold Breaker can make hazards bypass Clear Body and Levitate
 			this.runSwitch(pokemon);
 		} else {

--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -65,7 +65,7 @@ export interface SwitchAction {
 	pokemon: Pokemon;
 	/** pokemon to switch to */
 	target: Pokemon;
-	/** effect that called the switch (eg U */
+	/** effect that called the switch (eg U-turn) */
 	sourceEffect: Effect | null;
 }
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2815,6 +2815,14 @@ export class Battle {
 			break;
 		}
 
+		if (this.gen <= 2) {
+			if (action.choice === 'move' && !action.pokemon.switchFlag) {
+				this.runEvent('AfterMoveSelf', action.pokemon);
+			} else if (action.choice === 'switch' || (action.choice === 'instaswitch' && action.sourceEffect)) {
+				this.runEvent('AfterMoveSelf', action.target);
+			}
+		}
+
 		// Gen 4 and earlier: clear active move so Mold Breaker doesn't allow hazards to bypass Clear Body and Levitate
 		if (this.gen <= 4) this.clearActiveMove();
 
@@ -2829,16 +2837,6 @@ export class Battle {
 		}
 
 		if (this.gen > 4) this.clearActiveMove();
-
-		if (this.gen <= 2) {
-			if (action.choice === 'move' && !action.pokemon.switchFlag) {
-				this.debug("AfterMoveSelf", action.choice, action.pokemon, action.sourceEffect);
-				this.runEvent('AfterMoveSelf', action.pokemon);
-			} else if (action.choice === 'switch' || (action.choice === 'instaswitch' && action.sourceEffect)) {
-				this.debug("AfterMoveSelf", action.choice, action.target, action.sourceEffect);
-				this.runEvent('AfterMoveSelf', action.target);
-			}
-		}
 
 		// fainting
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2815,6 +2815,9 @@ export class Battle {
 			break;
 		}
 
+		// Gen 4 and earlier: clear active move so Mold Breaker doesn't allow hazards to bypass Clear Body and Levitate
+		if (this.gen <= 4) this.clearActiveMove();
+
 		// phazing (Roar, etc)
 		for (const side of this.sides) {
 			for (const pokemon of side.active) {
@@ -2825,7 +2828,17 @@ export class Battle {
 			}
 		}
 
-		this.clearActiveMove();
+		if (this.gen > 4) this.clearActiveMove();
+
+		if (this.gen <= 2) {
+			if (action.choice === 'move' && !action.pokemon.switchFlag) {
+				this.debug("AfterMoveSelf", action.choice, action.pokemon, action.sourceEffect);
+				this.runEvent('AfterMoveSelf', action.pokemon);
+			} else if (action.choice === 'switch' || (action.choice === 'instaswitch' && action.sourceEffect)) {
+				this.debug("AfterMoveSelf", action.choice, action.target, action.sourceEffect);
+				this.runEvent('AfterMoveSelf', action.target);
+			}
+		}
 
 		// fainting
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2816,7 +2816,7 @@ export class Battle {
 		}
 
 		if (this.gen <= 2) {
-			if (action.choice === 'move' && !action.pokemon.switchFlag && action.target && action.target.hp > 0) {
+			if (action.choice === 'move' && !action.pokemon.switchFlag && action.pokemon.side.foe.active[0].hp) {
 				this.runEvent('AfterMoveSelf', action.pokemon);
 			} else if (action.choice === 'switch' || (action.choice === 'instaswitch' && action.sourceEffect)) {
 				this.runEvent('AfterMoveSelf', action.target);

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2816,7 +2816,7 @@ export class Battle {
 		}
 
 		if (this.gen <= 2) {
-			if (action.choice === 'move' && !action.pokemon.switchFlag) {
+			if (action.choice === 'move' && !action.pokemon.switchFlag && action.target && action.target.hp > 0) {
 				this.runEvent('AfterMoveSelf', action.pokemon);
 			} else if (action.choice === 'switch' || (action.choice === 'instaswitch' && action.sourceEffect)) {
 				this.runEvent('AfterMoveSelf', action.target);

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -18,7 +18,6 @@ export interface EventMethods {
 	onAfterMega?: (this: Battle, pokemon: Pokemon) => void;
 	onAfterSetStatus?: (this: Battle, status: Condition, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAfterSubDamage?: MoveEventMethods['onAfterSubDamage'];
-	onAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAfterTerastallization?: (this: Battle, pokemon: Pokemon) => void;
 	onAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAfterTakeItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
@@ -27,7 +26,7 @@ export interface EventMethods {
 	onAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onAfterMove?: MoveEventMethods['onAfterMove'];
-	onAfterMoveSelf?: CommonHandlers['VoidSourceMove'];
+	onAfterMoveSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAttract?: (this: Battle, target: Pokemon, source: Pokemon) => void;
 	onAccuracy?: (
 		this: Battle, accuracy: number, target: Pokemon, source: Pokemon, move: ActiveMove
@@ -129,7 +128,6 @@ export interface EventMethods {
 	onFoeAfterHit?: MoveEventMethods['onAfterHit'];
 	onFoeAfterSetStatus?: (this: Battle, status: Condition, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onFoeAfterSubDamage?: MoveEventMethods['onAfterSubDamage'];
-	onFoeAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onFoeAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onFoeAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onFoeAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
@@ -227,7 +225,6 @@ export interface EventMethods {
 	onSourceAfterHit?: MoveEventMethods['onAfterHit'];
 	onSourceAfterSetStatus?: (this: Battle, status: Condition, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onSourceAfterSubDamage?: MoveEventMethods['onAfterSubDamage'];
-	onSourceAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onSourceAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onSourceAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onSourceAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
@@ -327,7 +324,6 @@ export interface EventMethods {
 	onAnyAfterHit?: MoveEventMethods['onAfterHit'];
 	onAnyAfterSetStatus?: (this: Battle, status: Condition, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAnyAfterSubDamage?: MoveEventMethods['onAfterSubDamage'];
-	onAnyAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAnyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAnyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAnyAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
@@ -502,7 +498,6 @@ export interface PokemonEventMethods extends EventMethods {
 	onAllyAfterHit?: MoveEventMethods['onAfterHit'];
 	onAllyAfterSetStatus?: (this: Battle, status: Condition, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAllyAfterSubDamage?: MoveEventMethods['onAfterSubDamage'];
-	onAllyAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAllyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAllyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAllyAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;


### PR DESCRIPTION
We don't need two separate events, `AfterMoveSelf` and `AfterSwitchInSelf`, across the codebase. Instead, we should have a single event that runs after every major action (moves and switches, but not instant switches), with a special case for Baton Pass. Baton Pass is a move action, but the effects should be applied to the Pokémon switching in.

The changes that moved events from Gen 4's `runSwitch` to `switchIn`, as well as the `clearActiveMove` adjustment for dragged Pokémon in earlier gens, are correct in accordance to #11185.