### PR TITLE
Fix Gen 4 decreased Fractional Priority

### DIFF
--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -413,6 +413,13 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		onResidualOrder: 10,
 		onResidualSubOrder: 3,
 	},
+	stall: {
+		inherit: true,
+		onFractionalPriority(priority, pokemon) {
+			// don't override Lagging Tail and Full Incense's -0.2 fractional priority
+			if (priority >= 0) return -0.1;
+		}
+	},
 	static: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -418,7 +418,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		onFractionalPriority(priority, pokemon) {
 			// don't override Lagging Tail and Full Incense's -0.2 fractional priority
 			if (priority >= 0) return -0.1;
-		}
+		},
 	},
 	static: {
 		inherit: true,

--- a/data/mods/gen4/items.ts
+++ b/data/mods/gen4/items.ts
@@ -164,6 +164,11 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 			},
 		},
 	},
+	fullincense: {
+		inherit: true,
+		onFractionalPriorityPriority: 1,
+		onFractionalPriority: -0.2,
+	},
 	griseousorb: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {
@@ -206,6 +211,11 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 				});
 			}
 		},
+	},
+	laggingtail: {
+		inherit: true,
+		onFractionalPriorityPriority: 1,
+		onFractionalPriority: -0.2,
 	},
 	laxincense: {
 		inherit: true,

--- a/data/mods/gen4/scripts.ts
+++ b/data/mods/gen4/scripts.ts
@@ -1,7 +1,18 @@
 export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen5',
 	gen: 4,
-
+	pokemon: {
+		inherit: true,
+		getActionSpeed() {
+			let speed = this.getStat('spe', false, false);
+			const trickRoomCheck = this.battle.ruleTable.has('twisteddimensionmod') ?
+				!this.battle.field.getPseudoWeather('trickroom') : this.battle.field.getPseudoWeather('trickroom');
+			if (trickRoomCheck) {
+				speed = -speed;
+			}
+			return speed;
+		},
+	},
 	actions: {
 		inherit: true,
 		runSwitch(pokemon) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2663,6 +2663,11 @@ export class Battle {
 			action.speed = 1;
 		} else {
 			action.speed = action.pokemon.getActionSpeed();
+			if (this.gen <= 4 && action.choice === 'move' && action.fractionalPriority < 0) {
+				// in Gen 4, Pokemon with decrease fractional priority act in reverse speed order
+				// ignores Trick Room, does not ignore boosts and Simple
+				action.speed = -action.pokemon.getStat('spe', false, false);
+			}
 		}
 	}
 

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -53,7 +53,7 @@ export interface EventMethods {
 	onEntryHazard?: (this: Battle, pokemon: Pokemon) => void;
 	onFaint?: CommonHandlers['VoidEffect'];
 	onFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean;
-	onFractionalPriority?: CommonHandlers['ModifierSourceMove'] | -0.1;
+	onFractionalPriority?: CommonHandlers['ModifierSourceMove'] | -0.1 | -0.2;
 	onHit?: MoveEventMethods['onHit'];
 	onImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void;
 	onLockMove?: string | ((this: Battle, pokemon: Pokemon) => void | string);

--- a/test/sim/abilities/intimidate.js
+++ b/test/sim/abilities/intimidate.js
@@ -36,8 +36,8 @@ describe('Intimidate', () => {
 			{ species: "Gengar", level: 1, item: 'leftovers', ability: 'levitate', moves: ['substitute'] },
 			{ species: "Suicune", level: 1, item: 'leftovers', ability: 'pressure', moves: ['substitute'] },
 		], [
-			{ species: "Gliscor", item: 'laggingtail', ability: 'sandveil', moves: ['uturn'] },
-			{ species: "Scizor", item: 'laggingtail', ability: 'technician', moves: ['batonpass'] },
+			{ species: "Scizor", item: 'laggingtail', ability: 'sandveil', moves: ['uturn'] },
+			{ species: "Gliscor", item: 'laggingtail', ability: 'technician', moves: ['batonpass'] },
 			{ species: "Gyarados", item: 'leftovers', ability: 'intimidate', moves: ['splash'] },
 			{ species: "Salamence", item: 'leftovers', ability: 'intimidate', moves: ['splash'] },
 		]]);


### PR DESCRIPTION
I'll copy paste from Bulbapedia because I don't feel like rewritting it:

> If multiple Pokémon have the Ability Stall and use moves with the same priority, the Pokémon with the lower Speed will move first (regardless of Trick Room).
> 
> A Pokémon with Stall moves before Pokémon holding a Lagging Tail or Full Incense. If a Pokémon with Stall also holds a Lagging Tail or Full Incense, Stall does not affect when the Pokémon moves.

The Simple ability does affect the Pokémon's speed calculation if it has Lagging Tail.