### PR TITLE
Fix ZU by usage NFEs

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -464,7 +464,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 		tier: "LC",
 	},
 	primeape: {
-		tier: "ZU",
+		tier: "NFE",
 		doublesTier: "NFE",
 		natDexTier: "NFE",
 	},


### PR DESCRIPTION
I forgot in the last fix that Primeape fell out of ZU by usage in the last three month period. Jan: 4.25%
Feb: 4.71%
Mar: 2.17%
Avg: 3.71%