### PR TITLE
Fix sleep talk to execute two moves in one turn

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -954,4 +954,14 @@ export const Conditions: import('../sim/dex-conditions').ConditionDataTable = {
 			return bp;
 		},
 	},
+
+	instantcharge: {
+		name: 'instantcharge',
+		noCopy: true,
+		duration: 1,
+		onChargeMove(pokemon) {
+			pokemon.removeVolatile('instantcharge');
+			return false;
+		},
+	},
 };

--- a/data/mods/gen3/conditions.ts
+++ b/data/mods/gen3/conditions.ts
@@ -53,13 +53,4 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		inherit: true,
 		onModifySpD: undefined, // no inherit
 	},
-	sleeptalkcharge: {
-		name: 'sleeptalkcharge',
-		noCopy: true,
-		duration: 1,
-		onChargeMove(pokemon) {
-			pokemon.removeVolatile('sleeptalkcharge');
-			return false;
-		},
-	},
 };

--- a/data/mods/gen3/conditions.ts
+++ b/data/mods/gen3/conditions.ts
@@ -53,4 +53,13 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		inherit: true,
 		onModifySpD: undefined, // no inherit
 	},
+	sleeptalkcharge: {
+		name: 'sleeptalkcharge',
+		noCopy: true,
+		duration: 1,
+		onChargeMove(pokemon) {
+			pokemon.removeVolatile('sleeptalkcharge');
+			return false;
+		},
+	},
 };

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -531,7 +531,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				const moveid = moveSlot.id;
 				const pp = moveSlot.pp;
 				const move = this.dex.moves.get(moveid);
-				if (moveid && !move.flags['nosleeptalk'] && !move.flags['charge']) {
+				if (moveid && (!move.flags['nosleeptalk'] || move.flags['charge'])) {
 					moves.push({ move: moveid, pp });
 				}
 			}
@@ -542,6 +542,9 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			if (!randomMove.pp) {
 				this.add('cant', pokemon, 'nopp', randomMove.move);
 				return;
+			}
+			if (this.dex.moves.get(randomMove.move).flags['charge']) {
+				pokemon.addVolatile('sleeptalkcharge');
 			}
 			this.actions.useMove(randomMove.move, pokemon);
 		},

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -544,7 +544,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				return;
 			}
 			if (this.dex.moves.get(randomMove.move).flags['charge']) {
-				pokemon.addVolatile('sleeptalkcharge');
+				pokemon.addVolatile('instantcharge');
 			}
 			this.actions.useMove(randomMove.move, pokemon);
 		},

--- a/test/sim/moves/sleeptalk.js
+++ b/test/sim/moves/sleeptalk.js
@@ -44,3 +44,47 @@ describe('Sleep Talk', () => {
 		assert.equal(move.pp, move.maxpp - 2);
 	});
 });
+
+describe('Sleep Talk [Gen 3]', () => {
+	afterEach(() => {
+		battle.destroy();
+	});
+
+	it('should be able to call two-turn moves, executing them in one turn', () => {
+		battle = common.gen(3).createBattle([[
+			{ species: 'Mew', moves: ['sleeptalk', 'fly'] },
+		], [
+			{ species: 'Breloom', moves: ['spore', 'sleeptalk'] },
+		]]);
+		const mew = battle.p1.active[0];
+		const breloom = battle.p2.active[0];
+
+		battle.makeChoices('move sleeptalk', 'move spore');
+		assert.equal(mew.status, 'slp');
+		mew.statusState.time = 5;
+
+		const startHP = breloom.hp;
+		battle.makeChoices('move sleeptalk', 'move sleeptalk');
+		assert.notEqual(breloom.hp, startHP);
+		assert(!mew.volatiles['fly']);
+	});
+
+	it('should not be able to call two-turn moves in Gen 4+', () => {
+		battle = common.gen(4).createBattle([[
+			{ species: 'Mew', moves: ['sleeptalk', 'fly'] },
+		], [
+			{ species: 'Breloom', moves: ['spore', 'sleeptalk'] },
+		]]);
+		const mew = battle.p1.active[0];
+		const breloom = battle.p2.active[0];
+
+		battle.makeChoices('move sleeptalk', 'move spore');
+		assert.equal(mew.status, 'slp');
+		mew.statusState.time = 5;
+
+		const startHP = breloom.hp;
+		battle.makeChoices('move sleeptalk', 'move sleeptalk');
+		assert.equal(breloom.hp, startHP);
+	});
+});
+

--- a/test/sim/moves/sleeptalk.js
+++ b/test/sim/moves/sleeptalk.js
@@ -87,4 +87,3 @@ describe('Sleep Talk [Gen 3]', () => {
 		assert.equal(breloom.hp, startHP);
 	});
 });
-


### PR DESCRIPTION
Sleep Talk can call two-turn charge moves (Fly, Dig, Dive, Bounce, Skull Bash, Solar Beam, Razor Wind, etc.) and executes them immediately no charge phase. This was incorrectly blocked because the gen 3 `sleeptalk` override filtered out moves with either `nosleeptalk` or `charge` flags; all two-turn moves carry both.