### PR TITLE
TestTools: Let common.getFormat() error out on bad format IDs

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -43,7 +43,7 @@ class TestTools {
 
 	getFormat(options) {
 		if (options.formatid) {
-			const format = Dex.formats.get(options.formatid);
+			const format = Dex.formats.get(options.formatid, true);
 			if (format.effectType !== 'Format') throw new Error(`Unidentified format: ${options.formatid}`);
 			return format;
 		}


### PR DESCRIPTION
Cherry-picked from #11641. Thanks, @TurboRx