### PR TITLE
UNO: Fix autodq crash during wild color selection

### DIFF
--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -221,7 +221,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 				}
 				this.topCard.changedColor = this.lastColor;
 				this.sendToRoom(
-					`|raw|${Utils.escapeHTML(name)} has not picked a color, the color will stay as ` +
+					`|raw|${Utils.escapeHTML(name)} failed to pick a color. It will remain ` +
 					`<span style="color: ${textColors[this.topCard.changedColor]}">${this.topCard.changedColor}</span>.`
 				);
 			}

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -98,7 +98,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 	spectators: { [k: string]: number } = Object.create(null);
 	isPlusFour = false;
 	gameNumber: number;
-	lastColor: Color | null = null; // The color of the last card played except for wild cards.
+	lastColor: Color | null = null;
 
 	constructor(room: Room, cap: number, suppressMessages: boolean) {
 		super(room);

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -98,6 +98,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 	spectators: { [k: string]: number } = Object.create(null);
 	isPlusFour = false;
 	gameNumber: number;
+	lastColor: Color | null = null; // The color of the last card played except for wild cards.
 
 	constructor(room: Room, cap: number, suppressMessages: boolean) {
 		super(room);
@@ -157,6 +158,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 			this.topCard = this.drawCard(1)[0];
 			this.discards.unshift(this.topCard);
 		} while (this.topCard.color === 'Black');
+		this.lastColor = this.topCard.color;
 
 		this.sendToRoom(`|raw|The top card is <span style="font-weight:bold;color: ${textColors[this.topCard.color]}">${this.topCard.name}</span>.`);
 
@@ -213,12 +215,15 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 		const removingCurrentPlayer = player === this.currentPlayer;
 		if (removingCurrentPlayer) {
 			if (this.state === 'color') {
-				if (!this.topCard) {
+				if (!this.topCard || !this.lastColor) {
 					// should never happen
-					throw new Error(`No top card in the discard pile.`);
+					throw new Error(`No top card in the discard pile or last color.`);
 				}
-				this.topCard.changedColor = this.discards[1].changedColor || this.discards[1].color;
-				this.sendToRoom(`|raw|${Utils.escapeHTML(name)} has not picked a color, the color will stay as <span style="color: ${textColors[this.topCard.changedColor]}">${this.topCard.changedColor}</span>.`);
+				this.topCard.changedColor = this.lastColor;
+				this.sendToRoom(
+					`|raw|${Utils.escapeHTML(name)} has not picked a color, the color will stay as ` +
+					`<span style="color: ${textColors[this.topCard.changedColor]}">${this.topCard.changedColor}</span>.`
+				);
 			}
 		}
 
@@ -376,6 +381,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 
 		// update the game information.
 		this.topCard = card;
+		if (card.color !== 'Black') this.lastColor = card.color;
 		player.removeCard(cardName);
 		this.discards.unshift(card);
 
@@ -457,6 +463,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 			throw new Error(`No top card in the discard pile.`);
 		}
 		this.topCard.changedColor = color;
+		this.lastColor = color;
 		this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|~|The color has been changed to ${color}.`);
 		if (this.timer) clearTimeout(this.timer);
 
@@ -691,7 +698,7 @@ export const commands: Chat.ChatCommands = {
 		end(target, room, user) {
 			room = this.requireRoom();
 			this.checkCan('minigame', null, room);
-			if (!room.game || room.game.gameid !== 'uno') {
+			if (room.game?.gameid !== 'uno') {
 				throw new Chat.ErrorMessage("There is no UNO game going on in this room.");
 			}
 			room.game.destroy();


### PR DESCRIPTION
https://www.smogon.com/forums/threads/uno-error.3780852/

TLDR: An UNO game crashed and an user was dqed but wasnt kicked out of the game.

the crash happened because when someone timed out while picking a color for a Wild +4 card, the code tried to look at the top discard card `discards[1]` to keep the previous color but sometimes the deck reshuffle logic empties discards array during those forced draws so `discards[1] ` was undefined and it crashed.

a fix i recommend is by tracking the last nonwild color in a `lastColor` field (set at game start, updated on normal plays and when a wild color is chose) and using that during the timeout instead of reading from the discard pile.