### PR TITLE
Passwords: Fix off-by-one in crypto.randomInt

### DIFF
--- a/server/chat-plugins/teams.ts
+++ b/server/chat-plugins/teams.ts
@@ -294,7 +294,7 @@ export const TeamsHandler = new class {
 	}
 	generatePassword(len = 20) {
 		let pw = '';
-		for (let i = 0; i < len; i++) pw += ALPHABET[crypto.randomInt(0, ALPHABET.length - 1)];
+		for (let i = 0; i < len; i++) pw += ALPHABET[crypto.randomInt(0, ALPHABET.length)];
 		return pw;
 	}
 	updateViews(teamid: string) {

--- a/server/replays.ts
+++ b/server/replays.ts
@@ -144,7 +144,7 @@ export const Replays = new class {
 	generatePassword(length = 31) {
 		let password = '';
 		for (let i = 0; i < length; i++) {
-			password += this.passwordCharacters[crypto.randomInt(0, this.passwordCharacters.length - 1)];
+			password += this.passwordCharacters[crypto.randomInt(0, this.passwordCharacters.length)];
 		}
 
 		return password;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -845,7 +845,7 @@ export abstract class BasicRoom {
 				// This is the same password generation approach as genPassword in the client replays.lib.php
 				// but obviously will not match given mt_rand there uses a different RNG and seed.
 				let password = '';
-				for (let i = 0; i < 31; i++) password += ALPHABET[crypto.randomInt(0, ALPHABET.length - 1)];
+				for (let i = 0; i < 31; i++) password += ALPHABET[crypto.randomInt(0, ALPHABET.length)];
 
 				this.rename(this.title, `${this.roomid}-${password}pw` as RoomID, true);
 			} else {


### PR DESCRIPTION
`crypto.randomInt(min, max)` returns a value in the half-open range `[min, max)`: max is exclusive, see [node documentation](https://nodejs.org/api/crypto.html#cryptorandomintmin-max-callback).

All the call sites were passing `ALPHABET.length - 1` (or equivalent) as the upper bound, so the last character of the 36-char alphabet (z) could never be selected.