### PR TITLE
[Gen 3] UUBL: Revert Regice, Raikou, and Porygon2 to UUBL

### DIFF
--- a/data/mods/gen3/formats-data.ts
+++ b/data/mods/gen3/formats-data.ts
@@ -465,7 +465,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "ZU",
 	},
 	porygon2: {
-		tier: "(OU)",
+		tier: "UUBL",
 	},
 	omanyte: {
 		tier: "PU",
@@ -732,7 +732,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UUBL",
 	},
 	raikou: {
-		tier: "(OU)",
+		tier: "UUBL",
 	},
 	entei: {
 		tier: "UUBL",
@@ -1137,7 +1137,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UUBL",
 	},
 	regice: {
-		tier: "(OU)",
+		tier: "UUBL",
 	},
 	registeel: {
 		tier: "UUBL",


### PR DESCRIPTION
PR #11957 moved Regice, Raikou, and Porygon2 in Gen 3 from `UUBL` to `(OU)`. These Pokémon are part of the active ADV UUBL format and should remain in `UUBL` so they can continue to be used there.

Changes:
- `porygon2`: `(OU)` → `UUBL`
- `raikou`: `(OU)` → `UUBL`
- `regice`: `(OU)` → `UUBL`

Gen 2 Porygon2 (also changed in #11957) is not touched here.