### PR TITLE
[Gen 3] UUBL: Allow Regice, Raikou, and Porygon2

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -5415,7 +5415,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'OU', 'Smeargle + Ingrain', 'Baton Pass + Block', 'Baton Pass + Mean Look', 'Baton Pass + Spider Web', 'Flail', 'Reversal',
 			'Baton Pass + Speed Boost', 'Baton Pass + Agility', 'Baton Pass + Dragon Dance', 'Baton Pass + Salac Berry',
 		],
-		unbanlist: ['Soundproof', 'Sand Veil'],
+		unbanlist: ['Soundproof', 'Sand Veil', 'Regice', 'Raikou', 'Porygon2'],
 	},
 	{
 		name: "[Gen 3] ZU",


### PR DESCRIPTION
PR #11957 reclassified Regice, Raikou, and Porygon2 as `(OU)` in Gen 3. However, this inadvertently prevents them from being used in the active `[Gen 3] UUBL` format, since that format bans the `OU` tier tag.

This PR adds them to the `unbanlist` of `[Gen 3] UUBL` so they remain playable in that format while keeping the `(OU)` classification intact.