### PR TITLE
Fix #5936: Sky drop visual glitch when 2nd half fails

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -16700,11 +16700,10 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		},
 		onMoveFail(target, source) {
 			if (source.volatiles['twoturnmove'] && source.volatiles['twoturnmove'].duration === 1) {
+				const droppedTarget = source.volatiles['twoturnmove'].source || target;
 				source.removeVolatile('skydrop');
 				source.removeVolatile('twoturnmove');
-				if (target === this.effectState.target) {
-					this.add('-end', target, 'Sky Drop', '[interrupt]');
-				}
+				this.add('-end', droppedTarget, 'Sky Drop', '[interrupt]');
 			}
 		},
 		onTry(source, target) {
@@ -16737,6 +16736,13 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		},
 		condition: {
 			duration: 2,
+			onMoveAborted(pokemon) {
+				if (this.effectState.source && !this.effectState.source.fainted) {
+					this.add('-end', this.effectState.source, 'Sky Drop', '[interrupt]');
+				}
+				pokemon.removeVolatile('skydrop');
+				pokemon.removeVolatile('twoturnmove');
+			},
 			onAnyDragOut(pokemon) {
 				if (pokemon === this.effectState.target || pokemon === this.effectState.source) return false;
 			},

--- a/test/sim/moves/skydrop.js
+++ b/test/sim/moves/skydrop.js
@@ -269,6 +269,39 @@ describe('Sky Drop', () => {
 		battle.makeChoices();
 		assert(battle.log.indexOf('|-end|p1a: Wynaut|Sky Drop|[interrupt]') < 0, `Sky Drop should only announce that it failed, not that any Pokemon was freed.`);
 	});
+
+	it(`should return the target to the ground if the move fails on the way down.`, () => {
+		battle = common.createBattle([[
+			{ species: 'Skarmory', ability: 'sturdy', moves: ['skydrop'] },
+		], [
+			{ species: 'Manectric', moves: ['raindance'] },
+		]]);
+		assert.equal(battle.turn, 1);
+		battle.makeChoices('move skydrop', 'move raindance');
+		assert.equal(battle.turn, 2);
+		battle.forceRandomChance = false;
+		battle.makeChoices('move skydrop', 'move raindance');
+		assert(battle.log.some(line => line.includes('-miss|p1a: Skarmory|p2a: Manectric')));
+		assert(battle.log.some(line => line.includes('-end|p2a: Manectric|Sky Drop|[interrupt]')));
+	});
+
+	it(`should return the target to the ground if the second turn of the move is not executed.`, () => {
+		battle = common.createBattle({ forceRandomChance: true }, [[
+			{ species: 'Skarmory', ability: 'sturdy', moves: ['skydrop', 'curse'] },
+		], [
+			{ species: 'Jolteon', moves: ['yawn'] },
+		]]);
+		assert.equal(battle.turn, 1);
+		battle.makeChoices('move curse', 'move yawn');
+		assert.equal(battle.turn, 2);
+		battle.makeChoices('move skydrop', 'move yawn');
+		assert(battle.log.some(line => line.includes('|move|p1a: Skarmory|Sky Drop')));
+		assert.equal(battle.turn, 3);
+		assert.equal(battle.p1.active[0].status, 'slp');
+		battle.makeChoices('move skydrop', 'move yawn');
+		assert(battle.log.some(line => line.includes('cant|p1a: Skarmory|slp')));
+		assert(battle.log.some(line => line.includes('-end|p2a: Jolteon|Sky Drop|[interrupt]')));
+	});
 });
 
 describe('Sky Drop [Gen 5]', () => {


### PR DESCRIPTION
Fixed visual and battle log logic when Sky drop misses due to accuracy or status conditions.
Sky drop is now interrupted on the target via
the onMoveFail(target, source) function correctly
when the user of Sky drop misses the 2nd turn of the attack. Additionally, a new function onMoveAborted(pokemon) was added to call removeVolatile('skydrop') and
removeVolatile('twoturnmove') at the end of the 2nd turn for scenarios where the user cannot use the move at all (such as due to paralysis or sleep status conditions). The new functionality passes the previous unit tests already established.
Tests were also added to check the new functionality, while maintaining the previous unit tests intact.