### PR TITLE
chore: Add a battles command

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -104,10 +104,12 @@ export const commands: Chat.ChatCommands = {
 	whoare: 'whois',
 	altsnorecurse: 'whois',
 	profile: 'whois',
+	battles: 'whois',
 	whois(target, room, user, connection, cmd) {
 		if (room?.roomid === 'staff' && !this.runBroadcast()) return;
 		const targetUser = this.getUserOrSelf(target, { exactName: user.tempGroup === ' ' });
-		const showAll = (cmd === 'ip' || cmd === 'whoare' || cmd === 'alt' || cmd === 'alts' || cmd === 'altsnorecurse');
+		const showAllVariants = ['ip', 'whoare', 'alt', 'alts', 'altsnorecurse', 'battles'];
+		const showAll = showAllVariants.includes(cmd);
 		const showRecursiveAlts = showAll && (cmd !== 'altsnorecurse');
 		if (!targetUser) {
 			if (showAll) return this.parse('/offlinewhois ' + target);


### PR DESCRIPTION
A lot of people in the Help room ask how to check recent battles - having the answer be `/ip` or `/alts` doesn't make sense, since there's no intuitive reason for those to show recent battles. The `/profile` command would've worked but it doesn't show battle rooms at all, so I've added a `/battles` command that lists everything (including recent battles)

cc @aQrator 