### PR TITLE
Challenge Cup: Support monotype

### DIFF
--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2139,7 +2139,11 @@ export class RandomTeams {
 		const natures = this.dex.natures.all();
 		const items = this.dex.items.all();
 
-		const randomN = this.randomNPokemon(this.maxTeamSize, this.forceMonotype, undefined, undefined, true);
+		const isMonotype = !!this.forceMonotype || this.dex.formats.getRuleTable(this.format).has('sametypeclause');
+		const typePool = this.dex.types.names().filter(name => name !== "Stellar");
+		const type = isMonotype ? this.forceMonotype || this.sample(typePool) : undefined;
+
+		const randomN = this.randomNPokemon(this.maxTeamSize, type, undefined, undefined, true);
 
 		for (let forme of randomN) {
 			let species = dex.species.get(forme);
@@ -2168,8 +2172,14 @@ export class RandomTeams {
 			}
 			if (species.requiredItems && !species.requiredItems.some(req => toID(req) === item)) {
 				if (!species.changesFrom) throw new Error(`${species.name} needs a changesFrom value`);
-				species = dex.species.get(species.changesFrom);
-				forme = species.name;
+				console.log(species.changesFrom);
+				// We don't want to revert Arceus and Silvally to normal type in monotype
+				if (isMonotype && ["Arceus", "Silvally"].includes(species.changesFrom))
+					item = this.sample(species.requiredItems);
+				else {
+					species = dex.species.get(species.changesFrom);
+					forme = species.name;
+				}
 			}
 
 			// Make sure that a base forme does not hold any forme-modifier items.

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2172,7 +2172,6 @@ export class RandomTeams {
 			}
 			if (species.requiredItems && !species.requiredItems.some(req => toID(req) === item)) {
 				if (!species.changesFrom) throw new Error(`${species.name} needs a changesFrom value`);
-				console.log(species.changesFrom);
 				// We don't want to revert Arceus and Silvally to normal type in monotype
 				if (isMonotype && ["Arceus", "Silvally"].includes(species.changesFrom))
 					item = this.sample(species.requiredItems);


### PR DESCRIPTION
Force monotype (i.e. specifying a specific type) was already implemented, but I added same type clause which is the more usual form of monotype.

Also added behavior for arceus/silvally because in testing i saw teams frequently getting a normal type arceus regardless of the team type.