### PR TITLE
Allow silent promotions (and demotions from Whitelist)

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -216,6 +216,11 @@ export const commands: Chat.ChatCommands = {
 			const userid = toID(toPromote);
 			if (!userid) return this.parse('/help roompromote');
 
+			if (silent && nextSymbol === '#') {
+				this.errorReply('You cannot silently appoint Room Owners.');
+				continue;
+			}
+
 			// weird ts bug (?) - 7022
 			// it implicitly is 'any' because it has no annotation and is "is referenced directly or indirectly in its own initializer."
 			// dunno why this happens, but for now we can just cast over it.
@@ -249,11 +254,7 @@ export const commands: Chat.ChatCommands = {
 				this.modlog(`ROOM${nextGroupName.toUpperCase()}`, userid, '(demote)');
 				shouldPopup?.popup(`You were demoted to Room ${nextGroupName} by ${user.name} in ${room.roomid}.`);
 			} else if (nextSymbol === '#') {
-				if (silent) {
-					this.privateModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
-				} else {
-					this.addModAction(`${name} was promoted to ${nextGroupName} by ${user.name}.`);
-				}
+				this.addModAction(`${name} was promoted to ${nextGroupName} by ${user.name}.`);
 				const logRoom = Rooms.get(room.settings.isPrivate === true ? 'upperstaff' : 'staff');
 				logRoom?.addByUser(user, `<<${room.roomid}>> ${name} was appointed Room Owner by ${user.name}.`);
 				this.modlog('ROOM OWNER', userid);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -179,6 +179,7 @@ export const commands: Chat.ChatCommands = {
 	forceroompromote: 'roompromote',
 	forceroomdemote: 'roompromote',
 	silentroompromote: 'roompromote',
+	forcesilentroompromote: 'roompromote',
 	roompromote(target, room, user, connection, cmd) {
 		if (!room) {
 			// this command isn't marked as room-only because it's usable in PMs through /invite
@@ -188,9 +189,9 @@ export const commands: Chat.ChatCommands = {
 		if (!target) return this.parse('/help roompromote');
 
 		const force = cmd.startsWith('force');
-		const silent = cmd.startsWith('silent');
 		const users = target.split(',').map(part => part.trim());
 		let nextSymbol = users.pop() as GroupSymbol | 'deauth';
+		const silent = cmd.startsWith('silent') || cmd.startsWith('forcesilent') || nextSymbol === 'deauth';
 		if (nextSymbol === 'deauth') nextSymbol = Users.Auth.defaultSymbol();
 		const nextGroup = Users.Auth.getGroup(nextSymbol);
 
@@ -248,20 +249,20 @@ export const commands: Chat.ChatCommands = {
 				this.modlog(`ROOM${nextGroupName.toUpperCase()}`, userid, '(demote)');
 				shouldPopup?.popup(`You were demoted to Room ${nextGroupName} by ${user.name} in ${room.roomid}.`);
 			} else if (nextSymbol === '#') {
-				if (!silent) {
-					this.addModAction(`${name} was promoted to ${nextGroupName} by ${user.name}.`);
+				if (silent) {
+					this.privateModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
 				} else {
-				this.privateModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
+					this.addModAction(`${name} was promoted to ${nextGroupName} by ${user.name}.`);
 				}
 				const logRoom = Rooms.get(room.settings.isPrivate === true ? 'upperstaff' : 'staff');
 				logRoom?.addByUser(user, `<<${room.roomid}>> ${name} was appointed Room Owner by ${user.name}.`);
 				this.modlog('ROOM OWNER', userid);
 				shouldPopup?.popup(`You were promoted to ${nextGroupName} by ${user.name} in ${room.roomid}.`);
 			} else {
-				if (!silent) {
-					this.addModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
+				if (silent) {
+					this.privateModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
 				} else {
-				this.privateModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
+					this.addModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
 				}
 				this.modlog(`ROOM${nextGroupName.toUpperCase()}`, userid);
 				shouldPopup?.popup(`You were promoted to Room ${nextGroupName} by ${user.name} in ${room.roomid}.`);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -178,6 +178,7 @@ export const commands: Chat.ChatCommands = {
 	roomdemote: 'roompromote',
 	forceroompromote: 'roompromote',
 	forceroomdemote: 'roompromote',
+	silentroompromote: 'roompromote',
 	roompromote(target, room, user, connection, cmd) {
 		if (!room) {
 			// this command isn't marked as room-only because it's usable in PMs through /invite
@@ -187,6 +188,7 @@ export const commands: Chat.ChatCommands = {
 		if (!target) return this.parse('/help roompromote');
 
 		const force = cmd.startsWith('force');
+		const silent = cmd.startsWith('silent');
 		const users = target.split(',').map(part => part.trim());
 		let nextSymbol = users.pop() as GroupSymbol | 'deauth';
 		if (nextSymbol === 'deauth') nextSymbol = Users.Auth.defaultSymbol();
@@ -246,13 +248,21 @@ export const commands: Chat.ChatCommands = {
 				this.modlog(`ROOM${nextGroupName.toUpperCase()}`, userid, '(demote)');
 				shouldPopup?.popup(`You were demoted to Room ${nextGroupName} by ${user.name} in ${room.roomid}.`);
 			} else if (nextSymbol === '#') {
-				this.addModAction(`${name} was promoted to ${nextGroupName} by ${user.name}.`);
+				if (!silent) {
+					this.addModAction(`${name} was promoted to ${nextGroupName} by ${user.name}.`);
+				} else {
+				this.privateModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
+				}
 				const logRoom = Rooms.get(room.settings.isPrivate === true ? 'upperstaff' : 'staff');
 				logRoom?.addByUser(user, `<<${room.roomid}>> ${name} was appointed Room Owner by ${user.name}.`);
 				this.modlog('ROOM OWNER', userid);
 				shouldPopup?.popup(`You were promoted to ${nextGroupName} by ${user.name} in ${room.roomid}.`);
 			} else {
-				this.addModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
+				if (!silent) {
+					this.addModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
+				} else {
+				this.privateModAction(`${name} was promoted to Room ${nextGroupName} by ${user.name}.`);
+				}
 				this.modlog(`ROOM${nextGroupName.toUpperCase()}`, userid);
 				shouldPopup?.popup(`You were promoted to Room ${nextGroupName} by ${user.name} in ${room.roomid}.`);
 			}
@@ -273,6 +283,7 @@ export const commands: Chat.ChatCommands = {
 	},
 	roompromotehelp: [
 		`/roompromote OR /roomdemote [comma-separated usernames], [group symbol] - Promotes/demotes the user(s) to the specified room rank. Requires: @ # ~`,
+		`/silentroompromote [comma-separated usernames], [group symbol] - Promotes the user(s) to the specified room rank without broadcasting to the chat. Requires: @ # ~`,
 		`/room[group] [comma-separated usernames] - Promotes/demotes the user(s) to the specified room rank. Requires: @ # ~`,
 		`/roomdeauth [comma-separated usernames] - Removes all room rank from the user(s). Requires: @ # ~`,
 	],

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -216,8 +216,8 @@ export const commands: Chat.ChatCommands = {
 			const userid = toID(toPromote);
 			if (!userid) return this.parse('/help roompromote');
 
-			if (silent && nextSymbol === '#') {
-				this.errorReply('You cannot silently appoint Room Owners.');
+			if (silent && nextSymbol === '#' && !this.checkCan('bypassall')) {
+				this.errorReply('Access denied for silently promoting Room Owners.');
 				continue;
 			}
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/make-demotions-from-whitelist-staff-only-visibility.3720140/

This PR fixes the error of Whitelist/fake rank demotions showing as promotions to regular user. It also generally adds the "silent" parameter to roompromotions, allowing for staff to silently change a user's auth. I mainly envisioned it so that users, especially those who are notified on "was promoted to", aren't unnecessarily pinged on events such as namechanges (where nobody is really getting "promoted", it's just transferring auth rank, as the demotion is already silent).