### PR TITLE
Add support for permanent weather and terrain effects

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2064,7 +2064,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 		name: "Permanent Weather",
 		desc: "Weather effects do not naturally expire.",
 		onBegin() {
-			this.add('rule', 'Permanent Weather: Weather effects will not end naturally')
+			this.add('rule', 'Permanent Weather: Weather effects will not end naturally');
 		},
 		// hardcoded in sim/field.ts
 	},
@@ -2073,7 +2073,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 		name: "Permanent Terrain",
 		desc: "Terrain effects do not naturally expire.",
 		onBegin() {
-			this.add('rule', 'Permanent Terrain: Terrain effects will not end naturally')
+			this.add('rule', 'Permanent Terrain: Terrain effects will not end naturally');
 		},
 		// hardcoded in sim/field.ts
 	},

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2059,6 +2059,24 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 			return problems;
 		},
 	},
+	permanentweather: {
+		effectType: 'Rule',
+		name: "Permanent Weather",
+		desc: "Weather effects do not naturally expire.",
+		onBegin() {
+			this.add('rule', 'Permanent Weather: Weather effects will not end naturally')
+		},
+		// hardcoded in sim/field.ts
+	},
+	permanentterrain: {
+		effectType: 'Rule',
+		name: "Permanent Terrain",
+		desc: "Terrain effects do not naturally expire.",
+		onBegin() {
+			this.add('rule', 'Permanent Terrain: Terrain effects will not end naturally')
+		},
+		// hardcoded in sim/field.ts
+	},
 	pickedteamsize: {
 		effectType: 'Rule',
 		name: 'Picked Team Size',

--- a/sim/field.ts
+++ b/sim/field.ts
@@ -77,7 +77,11 @@ export class Field {
 		}
 		if (status.durationCallback) {
 			if (!source) throw new Error(`setting weather without a source`);
-			this.weatherState.duration = status.durationCallback.call(this.battle, source, source, sourceEffect);
+			if (this.battle.ruleTable.has('permanentweather')) {
+				this.weatherState.duration = Infinity;
+			} else {
+				this.weatherState.duration = status.durationCallback.call(this.battle, source, source, sourceEffect);
+			}
 		}
 		if (!this.battle.singleEvent('FieldStart', status, this.weatherState, this, source, sourceEffect)) {
 			this.weather = prevWeather;
@@ -145,7 +149,11 @@ export class Field {
 			duration: status.duration,
 		});
 		if (status.durationCallback) {
-			this.terrainState.duration = status.durationCallback.call(this.battle, source, source, sourceEffect);
+			if (this.battle.ruleTable.has('permanentterrain')) {
+				this.terrainState.duration = Infinity;
+			} else {
+				this.terrainState.duration = status.durationCallback.call(this.battle, source, source, sourceEffect);
+			}
 		}
 		if (!this.battle.singleEvent('FieldStart', status, this.terrainState, this, source, sourceEffect)) {
 			this.terrain = prevTerrain;


### PR DESCRIPTION
Adds battle rules to make Weather and Terrain permanent (like Battlefields / old gens) through a battle rule.

Client support isn't explicitly _needed_ for this change, but it could be useful later.

Approved at https://www.smogon.com/forums/threads/adding-permanent-weather-for-the-custom-rules.3701920/