### PR TITLE
Add May 2026 Randomized Format Spotlight

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -557,7 +557,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		team: 'randomMegaInvasion',
 		ruleset: ['[Gen 9] Random Battle', 'Terastal Clause'],
 		onBegin() {
-			this.add(`raw|<div class="broadcast-blue"><b>Pok&eacute;mon that could undergo mega evolution or primal reversion in Gen 7 can do so here, too. Their sets are based on Gen 9 movepools, and can be viewed using the /randbats command.`);
+			this.add(`raw|<div class="broadcast-blue"><b>Pok&eacute;mon that could undergo mega evolution or primal reversion in Gen 7 can do so here, too. Their sets are based on Gen 9 movepools, and can be viewed using the /randbats command.</b></div>`);
 		},
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -552,13 +552,10 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		column: 2,
 	},
 	{
-		name: "[Gen 9] Godly Gift Random Battle",
-		desc: `Each Pok&eacute;mon receives one base stat from the God in the first slot depending on its position in the team.`,
-		team: 'randomGodlyGift',
-		ruleset: ['[Gen 9] Random Battle', 'Godly Gift Mod', 'Team Preview'],
-		onBegin() {
-			this.add(`raw|<div class="broadcast-blue"><b>In this format, the "God" in the first slot has "gifted" (shared) its base attack to the Pok&eacute;mon in the second slot, defense to the one in the third slot, etc."`);
-		},
+		name: "[Gen 9] Mega Invasion Random Battle",
+		desc: `Each Pok&eacute;mon that could mega evolve in gen 7 using a mega stone can do so here, too. Terastallizing is banned for all Pok&eacute;mon.`,
+		team: 'randomMegaInvasion',
+		ruleset: ['[Gen 9] Random Battle', 'Terastal Clause'],
 	},
 	{
 		name: "[Gen 9] Inheritance",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -556,6 +556,9 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		desc: `Each Pok&eacute;mon that could mega evolve in gen 7 using a mega stone can do so here, too. Terastallizing is banned for all Pok&eacute;mon.`,
 		team: 'randomMegaInvasion',
 		ruleset: ['[Gen 9] Random Battle', 'Terastal Clause'],
+		onBegin() {
+			this.add(`raw|<div class="broadcast-blue"><b>Pok&eacute;mon that could undergo mega evolution or primal reversion in Gen 7 can do so here, too. Their sets are based on Gen 9 movepools, and can be viewed using the /randbats command.`);
+		},
 	},
 	{
 		name: "[Gen 9] Inheritance",

--- a/data/random-battles/gen9/sets-megainvasion.json
+++ b/data/random-battles/gen9/sets-megainvasion.json
@@ -222,9 +222,15 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Earthquake", "Ice Punch", "Liquidation", "Poison Jab", "Rain Dance"],
+                "movepool": ["Earthquake", "Ice Punch", "Liquidation", "Rain Dance"],
                 "abilities": ["Damp"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earthquake", "Liquidation", "Poison Jab", "Rain Dance"],
+                "abilities": ["Damp"],
+                "teraTypes": ["Stellar"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets-megainvasion.json
+++ b/data/random-battles/gen9/sets-megainvasion.json
@@ -306,12 +306,14 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Body Slam", "Earthquake", "Freeze-Dry", "Ice Shard"],
-                "abilities": ["Inner Focus"]
+                "abilities": ["Inner Focus"],
+                "teraTypes": ["Stellar"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Body Slam", "Earthquake", "Freeze-Dry", "Spikes"],
-                "abilities": ["Inner Focus"]
+                "abilities": ["Inner Focus"],
+                "teraTypes": ["Stellar"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets-megainvasion.json
+++ b/data/random-battles/gen9/sets-megainvasion.json
@@ -211,7 +211,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Flare Blitz", "High Jump Kick", "Knock Off", "Protect", "Stone Edge", "Swords Dance"],
+                "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Protect", "Stone Edge", "Swords Dance"],
                 "abilities": ["Speed Boost"],
                 "teraTypes": ["Stellar"]
             }
@@ -256,7 +256,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Fake Out", "Ice Punch", "Poison Jab", "Thief", "Trailblaze", "Zen Headbutt"],
-                "abilities": ["Huge Power"],
+                "abilities": ["Pure Power"],
                 "teraTypes": ["Stellar"]
             }
         ]
@@ -450,7 +450,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Calm Mind", "Diamond Storm", "Earth Power", "Moonblast", "Mystical Fire", "Stealth Rock"],
+                "movepool": ["Calm Mind", "Diamond Storm", "Earth Power", "Moonblast", "Stealth Rock"],
                 "abilities": ["Clear Body"],
                 "teraTypes": ["Ground"]
             }

--- a/data/random-battles/gen9/sets-megainvasion.json
+++ b/data/random-battles/gen9/sets-megainvasion.json
@@ -305,9 +305,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Body Slam", "Earthquake", "Freeze-Dry", "Ice Shard", "Spikes"],
-                "abilities": ["Inner Focus"],
-                "teraTypes": ["Ground"]
+                "movepool": ["Body Slam", "Earthquake", "Freeze-Dry", "Ice Shard"],
+                "abilities": ["Inner Focus"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Body Slam", "Earthquake", "Freeze-Dry", "Spikes"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets-megainvasion.json
+++ b/data/random-battles/gen9/sets-megainvasion.json
@@ -1,0 +1,459 @@
+{
+    "venusaurmega": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Sleep Powder", "Sludge Bomb", "Synthesis", "Toxic"],
+                "abilities": ["Chlorophyll"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "charizardmegax": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Claw", "Dragon Dance", "Earthquake", "Flare Blitz", "Outrage", "Thunder Punch"],
+                "abilities": ["Blaze"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Claw", "Flame Charge", "Flare Blitz", "Outrage", "Swords Dance"],
+                "abilities": ["Blaze"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "charizardmegay": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Air Slash", "Dragon Pulse", "Fire Blast", "Scorching Sands", "Solar Beam"],
+                "abilities": ["Blaze"],
+                "teraTypes": ["Grass"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Dragon Pulse", "Fire Blast", "Scorching Sands", "Solar Beam"],
+                "abilities": ["Blaze"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "blastoisemega": {
+        "level": 75,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Ice Beam", "Shell Smash", "Water Pulse"],
+                "abilities": ["Rain Dish"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "slowbromega": {
+        "level": 83,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Psychic Noise", "Psyshock", "Scald", "Slack Off"],
+                "abilities": ["Regenerator"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Scald", "Slack Off"],
+                "abilities": ["Regenerator"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "gengarmega": {
+        "level": 75,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Destiny Bond", "Encore", "Shadow Ball", "Sludge Wave"],
+                "abilities": ["Cursed Body"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Encore", "Perish Song", "Protect", "Shadow Ball", "Substitute"],
+                "abilities": ["Cursed Body"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "gyaradosmega": {
+        "level": 74,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Crunch", "Dragon Dance", "Earthquake", "Substitute", "Taunt", "Temper Flare", "Waterfall"],
+                "abilities": ["Intimidate"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "mewtwomegax": {
+        "level": 70,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bulk Up", "Drain Punch", "Knock Off", "Recover", "Zen Headbutt"],
+                "abilities": ["Unnerve"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "mewtwomegay": {
+        "level": 70,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Fire Blast", "Nasty Plot", "Psystrike", "Recover"],
+                "abilities": ["Unnerve"],
+                "teraTypes": ["Fighting", "Fire"]
+            }
+        ]
+    },
+    "ampharosmega": {
+        "level": 85,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Agility", "Dragon Pulse", "Focus Blast", "Thunderbolt"],
+                "abilities": ["Static"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Discharge", "Dragon Pulse", "Dragon Tail", "Focus Blast", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Static"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "scizormega": {
+        "level": 76,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Bullet Punch", "Close Combat", "Defog", "Knock Off", "U-turn"],
+                "abilities": ["Light Metal"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "Knock Off", "Swords Dance"],
+                "abilities": ["Light Metal"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "heracrossmega": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Earthquake", "Knock Off", "Pin Missile", "Rock Blast", "Trailblaze"],
+                "abilities": ["Moxie"],
+                "teraTypes": ["Rock"]
+            }
+        ]
+    },
+    "houndoommega": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Taunt"],
+                "abilities": ["Flash Fire"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "tyranitarmega": {
+        "level": 75,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Knock Off", "Stone Edge"],
+                "abilities": ["Sand Stream"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "sceptilemega": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dragon Pulse", "Earthquake", "Focus Blast", "Giga Drain", "Leaf Storm"],
+                "abilities": ["Overgrow"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Leaf Blade", "Outrage", "Swords Dance"],
+                "abilities": ["Overgrow"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "blazikenmega": {
+        "level": 72,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Flare Blitz", "High Jump Kick", "Knock Off", "Protect", "Stone Edge", "Swords Dance"],
+                "abilities": ["Speed Boost"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "swampertmega": {
+        "level": 81,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Ice Punch", "Liquidation", "Poison Jab", "Rain Dance"],
+                "abilities": ["Damp"],
+                "teraTypes": ["Water"]
+            }
+        ]
+    },
+    "gardevoirmega": {
+        "level": 79,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Mystical Fire", "Psyshock"],
+                "abilities": ["Trace"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "sableyemega": {
+        "level": 83,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Dark Pulse", "Recover", "Will-O-Wisp"],
+                "abilities": ["Prankster"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "medichammega": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Fake Out", "Ice Punch", "Poison Jab", "Thief", "Trailblaze", "Zen Headbutt"],
+                "abilities": ["Huge Power"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "cameruptmega": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Ancient Power", "Earth Power", "Fire Blast", "Stealth Rock", "Will-O-Wisp"],
+                "abilities": ["Solid Rock"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "altariamega": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Double-Edge", "Dragon Dance", "Earthquake", "Roost"],
+                "abilities": ["Natural Cure"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "banettemega": {
+        "level": 85,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Destiny Bond", "Encore", "Poltergeist", "Will-O-Wisp"],
+                "abilities": ["Frisk"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Destiny Bond", "Encore", "Gunk Shot", "Poltergeist"],
+                "abilities": ["Frisk"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "glaliemega": {
+        "level": 85,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Body Slam", "Earthquake", "Freeze-Dry", "Ice Shard", "Spikes"],
+                "abilities": ["Inner Focus"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
+    "salamencemega": {
+        "level": 70,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Double-Edge", "Dragon Dance", "Earthquake", "Roost"],
+                "abilities": ["Intimidate"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "metagrossmega": {
+        "level": 73,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Body Press", "Heavy Slam", "Knock Off", "Psychic Fangs"],
+                "abilities": ["Clear Body"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Body Press", "Heavy Slam", "Iron Defense", "Psychic Fangs"],
+                "abilities": ["Clear Body"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "latiasmega": {
+        "level": 79,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Draco Meteor", "Psyshock", "Recover"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "latiosmega": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Draco Meteor", "Psyshock", "Recover"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "kyogreprimal": {
+        "level": 71,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Ice Beam", "Origin Pulse", "Thunder"],
+                "abilities": ["Drizzle"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "groudonprimal": {
+        "level": 63,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Heat Crash", "Precipice Blades", "Roar", "Spikes", "Stealth Rock", "Stone Edge", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Drought"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Heat Crash", "Precipice Blades", "Stone Edge", "Swords Dance", "Thunder Wave"],
+                "abilities": ["Drought"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "garchompmega": {
+        "level": 75,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Spikes", "Stealth Rock"],
+                "abilities": ["Rough Skin"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Outrage", "Scale Shot", "Swords Dance"],
+                "abilities": ["Rough Skin"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "lucariomega": {
+        "level": 73,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Swords Dance"],
+                "abilities": ["Justified"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Aura Sphere", "Flash Cannon", "Nasty Plot", "Vacuum Wave"],
+                "abilities": ["Justified"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "abomasnowmega": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Blizzard", "Earthquake", "Ice Shard", "Wood Hammer"],
+                "abilities": ["Snow Warning"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "gallademega": {
+        "level": 77,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Knock Off", "Swords Dance", "Zen Headbutt"],
+                "abilities": ["Justified"],
+                "teraTypes": ["Stellar"]
+            }
+        ]
+    },
+    "dianciemega": {
+        "level": 75,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Calm Mind", "Diamond Storm", "Earth Power", "Moonblast", "Mystical Fire", "Stealth Rock"],
+                "abilities": ["Clear Body"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    }
+}

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -204,7 +204,7 @@ export class RandomTeams {
 
 		this.moveEnforcementCheckers = {
 			Bug: (movePool, moves, abilities, types, counter) => (
-				movePool.includes('megahorn') || movePool.includes('xscissor') ||
+				['megahorn', 'pinmissile', 'xscissor'].some(m => movePool.includes(m)) ||
 				(!counter.get('Bug') && (types.includes('Electric') || types.includes('Psychic')))
 			),
 			Dark: (

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -597,6 +597,7 @@ export class RandomTeams {
 			['aurasphere', 'focusblast'],
 			['closecombat', 'drainpunch'],
 			[['dragonpulse', 'spacialrend'], 'dracometeor'],
+			['dragonclaw', 'outrage'],
 			['heavyslam', 'flashcannon'],
 			['alluringvoice', 'dazzlinggleam'],
 
@@ -1421,6 +1422,8 @@ export class RandomTeams {
 		isDoubles: boolean,
 	): number {
 		if (this.adjustLevel) return this.adjustLevel;
+		// Temporarily modified for Mega Invasion randomized spotlight
+		if (Object.keys(this.randomMegaSets).includes(species.id)) return this.randomMegaSets[species.id]["level"]!;
 		// doubles levelling
 		if (isDoubles && this.randomDoublesSets[species.id]["level"]) return this.randomDoublesSets[species.id]["level"]!;
 		if (!isDoubles && this.randomSets[species.id]["level"]) return this.randomSets[species.id]["level"]!;
@@ -1470,7 +1473,13 @@ export class RandomTeams {
 	): RandomTeamsTypes.RandomSet {
 		const species = this.dex.species.get(s);
 		const forme = this.getForme(species);
-		const sets = this[`random${isDoubles ? 'Doubles' : ''}Sets`][species.id]["sets"];
+		let sets;
+		// Temporarily modified for Mega Invasion randomized spotlight
+		if (Object.keys(this.randomMegaSets).includes(species.id)) {
+			sets = this.randomMegaSets[species.id]["sets"];
+		} else {
+			sets = this[`random${isDoubles ? 'Doubles' : ''}Sets`][species.id]["sets"];
+		}
 		const possibleSets: RandomTeamsTypes.RandomSetData[] = [];
 
 		const ruleTable = this.dex.formats.getRuleTable(this.format);
@@ -1922,7 +1931,11 @@ export class RandomTeams {
 		return pokemon;
 	}
 
-	randomGodlyGiftTeam() {
+	randomMegaSets: { [species: string]: RandomTeamsTypes.RandomSpeciesData } = require('./sets-megainvasion.json');
+
+	randomMegaInvasionTeam(depth = 0): RandomTeamsTypes.RandomSet[] {
+		const forceResult = depth >= 4;
+
 		this.enforceNoDirectCustomBanlistChanges();
 
 		const seed = this.prng.getSeed();
@@ -1940,6 +1953,7 @@ export class RandomTeams {
 		const potd = usePotD ? this.dex.species.get(Config.potd) : null;
 
 		const baseFormes: { [k: string]: number } = {};
+		let hasMega = false;
 
 		const typeCount: { [k: string]: number } = {};
 		const typeComboCount: { [k: string]: number } = {};
@@ -1948,38 +1962,35 @@ export class RandomTeams {
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 		let numMaxLevelPokemon = 0;
 
-		const pokemonList = isDoubles ? Object.keys(this.randomDoublesSets) : Object.keys(this.randomSets);
-		// God Pokemon are those with at least 510 BST, not including HP
-		const godPokemonList = pokemonList.filter(poke => {
-			const baseStats = this.dex.species.get(poke).baseStats;
-			return baseStats.atk + baseStats.def + baseStats.spa + baseStats.spd + baseStats.spe >= 510;
-		});
+		const pokemonList = [...Object.keys(this.randomSets), ...Object.keys(this.randomMegaSets)];
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-		const [godPokemonPool, godBaseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, godPokemonList);
 
+		let leadsRemaining = this.format.gameType === 'doubles' ? 2 : 1;
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
-			let baseSpecies, species;
-			// Generate a God Pokemon in the lead slot
-			if (pokemon.length === 0) {
-				baseSpecies = this.sampleNoReplace(godBaseSpeciesPool);
-				species = this.dex.species.get(this.sample(godPokemonPool[baseSpecies]));
-			} else {
-				baseSpecies = this.sampleNoReplace(baseSpeciesPool);
-				species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
-
-				// Ensure that the species isn't harmed by Godly Gift stat passing
-				if (pokemon.length < 6) {
-					const s: StatID[] = ["hp", "atk", "def", "spa", "spd", "spe"];
-					const passedStatName = s[pokemon.length];
-					const passedStat = (this.dex.species.get(pokemon[0].speciesId).baseStats[passedStatName]);
-					// If Deoxys-Attack is the god, just make sure the def/spd stat is <= 50
-					if (Math.max(passedStat, 50) < species.baseStats[passedStatName]) continue;
-				}
+			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
+			const currentSpeciesPool: Species[] = [];
+			// Check if the base species has a mega forme available
+			let canMega = false;
+			for (const poke of pokemonPool[baseSpecies]) {
+				const species = this.dex.species.get(poke);
+				if (!hasMega && species.isMega) canMega = true;
 			}
+			for (const poke of pokemonPool[baseSpecies]) {
+				const species = this.dex.species.get(poke);
+				// Prevent multiple megas
+				if (hasMega && species.isMega) continue;
+				// Prevent base forme, if a mega is available
+				if (canMega && !species.isMega) continue;
+				currentSpeciesPool.push(species);
+			}
+			let species = this.dex.species.get(this.sample(currentSpeciesPool));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)
 			if (baseFormes[species.baseSpecies]) continue;
+
+			// Limit one Mega per team
+			if (hasMega && species.isMega) continue;
 
 			// Treat Ogerpon formes and Terapagos like the Tera Blast user role; reject if team has one already
 			if (['ogerpon', 'ogerponhearthflame', 'terapagos'].includes(species.id) && teamDetails.teraBlast) continue;
@@ -2058,8 +2069,25 @@ export class RandomTeams {
 			// The Pokemon of the Day
 			if (potd?.exists && (pokemon.length === 1 || this.maxTeamSize === 1)) species = potd;
 
-			const set = this.randomSet(species, teamDetails, false, isDoubles);
-			pokemon.push(set);
+			let set: RandomTeamsTypes.RandomSet;
+
+			if (leadsRemaining) {
+				if (
+					isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.baseSpecies) ||
+					!isDoubles && NO_LEAD_POKEMON.includes(species.baseSpecies)
+				) {
+					if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
+					set = this.randomSet(species, teamDetails, false, isDoubles);
+					pokemon.push(set);
+				} else {
+					set = this.randomSet(species, teamDetails, true, isDoubles);
+					pokemon.unshift(set);
+					leadsRemaining--;
+				}
+			} else {
+				set = this.randomSet(species, teamDetails, false, isDoubles);
+				pokemon.push(set);
+			}
 
 			// Don't bother tracking details for the last Pokemon
 			if (pokemon.length === this.maxTeamSize) break;
@@ -2101,8 +2129,13 @@ export class RandomTeams {
 			if (set.level === 100) numMaxLevelPokemon++;
 
 			// Track what the team has
-			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;
-			if (set.ability === 'Drought' || set.ability === 'Orichalcum Pulse' || set.moves.includes('sunnyday')) {
+			const item = this.dex.items.get(set.item);
+
+			if (item.megaStone) hasMega = true;
+			if (set.ability === 'Drizzle' && !item.isPrimalOrb || set.moves.includes('raindance')) teamDetails.rain = 1;
+			if (
+				set.ability === 'Drought' && !item.isPrimalOrb || set.ability === 'Orichalcum Pulse' || set.moves.includes('sunnyday')
+			) {
 				teamDetails.sun = 1;
 			}
 			if (set.ability === 'Sand Stream') teamDetails.sand = 1;
@@ -2127,6 +2160,9 @@ export class RandomTeams {
 		}
 		if (pokemon.length < this.maxTeamSize && pokemon.length < 12) { // large teams sometimes cannot be built
 			throw new Error(`Could not build a random team for ${this.format} (seed=${seed})`);
+		}
+		if (!forceResult) {
+			if (!hasMega) return this.randomMegaInvasionTeam(++depth);
 		}
 
 		return pokemon;

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -130,6 +130,7 @@ const MOVE_PAIRS = [
 	['protect', 'wish'],
 	['leechseed', 'protect'],
 	['leechseed', 'substitute'],
+	['perishsong', 'protect'],
 ];
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */

--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -167,7 +167,19 @@ function getSets(species: string | Species, format: string | Format = 'gen9rando
 			.readIfExistsSync() || '{}'
 	);
 	const data = setsFile[species.id];
-	if (!data?.sets?.length) return null;
+	// Temporarily modified for Mega Invasion randomized spotlight
+	if (!data?.sets?.length) {
+		if (format.mod === 'gen9' && !isDoubles) {
+			const megaSetsFile = JSON.parse(
+				FS(`data/random-battles/${folderName}/sets-megainvasion.json`)
+					.readIfExistsSync() || '{}'
+			);
+			const megaData = megaSetsFile[species.id];
+			if (!megaData?.sets?.length) return null;
+			return megaData;
+		}
+		return null;
+	}
 	return data;
 }
 
@@ -492,11 +504,13 @@ export const commands: Chat.ChatCommands = {
 		let isBaby = cmd === 'babyrandombattle' || cmd === 'babyrands';
 		let isFFA = cmd === 'freeforallrandombattle' || cmd === 'ffarands' || cmd === 'randffats' || cmd === 'randffa';
 		let isNoDMax = cmd.includes('nodmax');
+		let isMegaInvasion = false;
 		if (battle) {
 			if (battle.format.includes('nodmax')) isNoDMax = true;
 			if (battle.gameType === 'doubles') isDoubles = true;
 			if (battle.format.includes('baby')) isBaby = true;
 			if (battle.gameType === 'freeforall') isFFA = true;
+			if (battle.format.includes('megainvasion')) isMegaInvasion = true;
 		}
 
 		const args = target.split(',');
@@ -516,6 +530,7 @@ export const commands: Chat.ChatCommands = {
 			inexactMsg = `No Pok\u00e9mon named '${args[0]}' was found${Dex.gen > dex.gen ? ` in Gen ${dex.gen}` : ""}. Searching for '${searchResults[0].name}' instead.`;
 		}
 		const species = dex.species.get(searchResults[0].name);
+		if (species.isMega || species.forme === 'Primal') isMegaInvasion = true;
 		const extraFormatModifier = isLetsGo ? 'letsgo' : (dex.currentMod === 'gen8bdsp' ? 'bdsp' : '');
 		const babyModifier = isBaby ? 'baby' : '';
 		const doublesModifier = isDoubles ? 'doubles' : '';
@@ -548,6 +563,8 @@ export const commands: Chat.ChatCommands = {
 			if (species.otherFormes) setsToCheck.push(...species.otherFormes.map(pkmn => dex.species.get(pkmn)));
 			if ([2, 3, 4, 5, 6, 7, 9].includes(dex.gen)) {
 				for (const pokemon of setsToCheck) {
+					// For Gen 9, only show megas/primals if they were the argument or the command was used in a mega invasion battle room
+					if (dex.gen === 9 && (pokemon.isMega || pokemon.forme === 'Primal') && !isMegaInvasion) continue;
 					const data = getSets(pokemon, format.id);
 					if (!data) continue;
 					const sets = data.sets;


### PR DESCRIPTION
https://www.smogon.com/forums/threads/randbats-spotlight-cycle-25-vote-now.3781339/

[Gen 9] Random Battle, plus mega stones and primal orbs that exist in Gen 7. Like in [Gen 7] Random Battle, megas are prioritised over their non-mega counterparts, but primals are not. Since this is a temporary spotlight format, I included some measures to increase (but not guarantee) the chance of a mega generating.

The sets for megas and primals can appear in /randbats, but only if they are specifically searched for (`/randbats venusaur-mega`), or if the command is used in a Mega Inversion battle room. This ensures that `/randbats` is mostly unaffected when used normally.