### PR TITLE
Lock gender in best-of-x series

### DIFF
--- a/server/room-battle-bestof.ts
+++ b/server/room-battle-bestof.ts
@@ -214,7 +214,11 @@ export class BestOfGame extends RoomGame<BestOfPlayer> {
 				if (set.gender) continue;
 				const species = Dex.species.get(set.species || set.name);
 				if (!species.exists || species.gender) continue;
-				set.gender = Math.random() < 0.5 ? 'M' : 'F';
+				const maleRatio = species.genderRatio?.M ?? 0.5;
+				const femaleRatio = species.genderRatio?.F ?? 0.5;
+				const ratioTotal = maleRatio + femaleRatio;
+				if (!ratioTotal) continue;
+				set.gender = Math.random() * ratioTotal < maleRatio ? 'M' : 'F';
 				changed = true;
 			}
 			if (changed) player.options.team = Teams.pack(team);

--- a/server/room-battle-bestof.ts
+++ b/server/room-battle-bestof.ts
@@ -205,10 +205,26 @@ export class BestOfGame extends RoomGame<BestOfPlayer> {
 			players,
 		};
 	}
+	lockTeams() {
+		for (const player of this.players) {
+			const team = Teams.unpack(player.options.team || "");
+			if (!team) continue;
+			let changed = false;
+			for (const set of team) {
+				if (set.gender) continue;
+				const species = Dex.species.get(set.species || set.name);
+				if (!species.exists || species.gender) continue;
+				set.gender = Math.random() < 0.5 ? 'M' : 'F';
+				changed = true;
+			}
+			if (changed) player.options.team = Teams.pack(team);
+		}
+	}
 	nextGame() {
 		const prevBattleRoom = this.waitingBattle;
 		if (!prevBattleRoom && this.games.length) return; // should never happen
 		this.clearWaiting();
+		if (!this.games.length) this.lockTeams();
 
 		const options = this.getOptions();
 		if (!options) {


### PR DESCRIPTION
Observing these replays in a best-of-3 team locked set, I noticed that Abomasnow's gender changed between games 2 and 3.

https://replay.pokemonshowdown.com/gen4vgc2010-2594166195
https://replay.pokemonshowdown.com/gen4vgc2010-2594168108

While this is a trivial issue and wouldn't have any effect unless a player brings a gimmicky Infautation strategy or a Pokemon with Rivalry, it's still not possible in a team lock series.

I have posted a Smogon thread on this bug [here](https://www.smogon.com/forums/threads/lock-gender-in-best-of-x-series.3781777/). My pull request incorporates DaWoblefet's suggestion [here](https://www.smogon.com/forums/threads/have-randomized-genders-reflect-in-game-gender-ratio-of-pokemon.3700500/post-9184371) as well.

I'm a first time contributor so please let me know if this is the right way to approach this, thank you!