### PR TITLE
Challenge Cup: Properly enforce monotype for non-base formes

### DIFF
--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2167,7 +2167,9 @@ export class RandomTeams {
 					if (!species.changesFrom) throw new Error(`${species.name} needs a changesFrom value`);
 
 					if (!dex.species.get(species.changesFrom).types.includes(type!)) {
-						const legalRequiredItems = species.requiredItems.filter(i => dex.items.get(i).gen <= this.gen && !dex.items.get(i).isNonstandard);
+						const legalRequiredItems = species.requiredItems.filter(i => (
+							dex.items.get(i).gen <= this.gen && !dex.items.get(i).isNonstandard
+						));
 						if (!legalRequiredItems.length) throw new Error(`${species.name} has no legal required items`);
 						item = this.sample(legalRequiredItems);
 					}
@@ -2183,7 +2185,7 @@ export class RandomTeams {
 				}
 				forme = species.name;
 			}
-			if (species.requiredItems?.some(req => toID(req) !== toID(item))) {
+			if (species.requiredItems?.every(req => toID(req) !== toID(item))) {
 				if (!species.changesFrom) throw new Error(`${species.name} needs a changesFrom value`);
 				species = dex.species.get(species.changesFrom);
 				forme = species.name;

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2161,6 +2161,17 @@ export class RandomTeams {
 					isIllegalItem = this.dex.items.get(item).gen > this.gen || this.dex.items.get(item).isNonstandard;
 					isBadItem = item.startsWith("TR") || this.dex.items.get(item).isPokeball;
 				} while (isIllegalItem || (isBadItem && this.randomChance(19, 20)));
+
+				// We don't want to revert to different types in monotype
+				if (isMonotype && species.requiredItems) {
+					if (!species.changesFrom) throw new Error(`${species.name} needs a changesFrom value`);
+
+					if (!dex.species.get(species.changesFrom).types.includes(type!)) {
+						const legalRequiredItems = species.requiredItems.filter(item => dex.items.get(item).gen <= this.gen && !dex.items.get(item).isNonstandard);
+						if (legalRequiredItems.length === 0) throw new Error(`${species.name} has no legal required items`);
+						item = this.sample(legalRequiredItems);
+					}
+				}
 			}
 
 			// Make sure forme is legal
@@ -2172,15 +2183,10 @@ export class RandomTeams {
 				}
 				forme = species.name;
 			}
-			if (species.requiredItems && !species.requiredItems.some(req => toID(req) === item)) {
+			if (species.requiredItems && !species.requiredItems.some(req => toID(req) === toID(item))) {
 				if (!species.changesFrom) throw new Error(`${species.name} needs a changesFrom value`);
-				// We don't want to revert Arceus and Silvally to normal type in monotype
-				if (isMonotype && ["Arceus", "Silvally"].includes(species.changesFrom))
-					item = this.sample(species.requiredItems);
-				else {
-					species = dex.species.get(species.changesFrom);
-					forme = species.name;
-				}
+				species = dex.species.get(species.changesFrom);
+				forme = species.name;
 			}
 
 			// Make sure that a base forme does not hold any forme-modifier items.

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2167,8 +2167,8 @@ export class RandomTeams {
 					if (!species.changesFrom) throw new Error(`${species.name} needs a changesFrom value`);
 
 					if (!dex.species.get(species.changesFrom).types.includes(type!)) {
-						const legalRequiredItems = species.requiredItems.filter(item => dex.items.get(item).gen <= this.gen && !dex.items.get(item).isNonstandard);
-						if (legalRequiredItems.length === 0) throw new Error(`${species.name} has no legal required items`);
+						const legalRequiredItems = species.requiredItems.filter(i => dex.items.get(i).gen <= this.gen && !dex.items.get(i).isNonstandard);
+						if (!legalRequiredItems.length) throw new Error(`${species.name} has no legal required items`);
 						item = this.sample(legalRequiredItems);
 					}
 				}
@@ -2183,7 +2183,7 @@ export class RandomTeams {
 				}
 				forme = species.name;
 			}
-			if (species.requiredItems && !species.requiredItems.some(req => toID(req) === toID(item))) {
+			if (species.requiredItems?.some(req => toID(req) !== toID(item))) {
 				if (!species.changesFrom) throw new Error(`${species.name} needs a changesFrom value`);
 				species = dex.species.get(species.changesFrom);
 				forme = species.name;


### PR DESCRIPTION
#11994 had a band-aid fix for different arceus formes, but monotype across formes never really worked, including before that commit.
I finally figured out how to make it *actually* work.

Tested by genning 10000 teams and doing some basic checks (occurrence rates of different formes as expected, and no errors obviously).