### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -216,7 +216,7 @@
     "parasect": {
         "level": 77,
         "moves": ["bodyslam", "megadrain", "spore"],
-        "exclusiveMoves": ["hyperbeam", "slash", "stunspore", "stunspore", "stunspore", "swordsdance", "swordsdance"]
+        "exclusiveMoves": ["hyperbeam", "stunspore", "stunspore", "stunspore", "swordsdance", "swordsdance"]
     },
     "venonat": {
         "level": 88,
@@ -539,7 +539,7 @@
     "kangaskhan": {
         "level": 73,
         "moves": ["bodyslam", "earthquake", "hyperbeam"],
-        "exclusiveMoves": ["counter", "rockslide", "rockslide", "surf"]
+        "exclusiveMoves": ["blizzard", "counter", "rockslide", "rockslide", "surf"]
     },
     "horsea": {
         "level": 88,

--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -1580,7 +1580,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["counter", "flamethrower", "healbell", "icebeam", "lightscreen", "present", "softboiled", "thunderwave", "toxic"]
+                "movepool": ["counter", "flamethrower", "healbell", "icebeam", "present", "softboiled", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Attacker",
@@ -1661,6 +1661,10 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "recover", "sacredfire", "thunder"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["flamethrower", "recover", "toxic", "whirlwind"]
             }
         ]
     },

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -73,13 +73,18 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["brickbreak", "endure", "hiddenpowerbug", "sludgebomb", "swordsdance"],
-                "abilities": ["Swarm"],
-                "preferredTypes": ["Bug"]
+                "movepool": ["endure", "hiddenpowerbug", "sludgebomb", "swordsdance"],
+                "abilities": ["Swarm"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["brickbreak", "doubleedge", "hiddenpowerbug", "sludgebomb", "swordsdance"],
+                "abilities": ["Swarm"],
+                "preferredTypes": ["Bug"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["doubleedge", "hiddenpowerground", "sludgebomb", "swordsdance"],
                 "abilities": ["Swarm"]
             }
         ]

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -1772,9 +1772,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["fireblast", "hiddenpowerelectric", "hiddenpowergrass", "icebeam", "surf", "thunderwave"],
-                "abilities": ["Suction Cups"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "icebeam", "surf", "thunderwave"],
+                "abilities": ["Suction Cups"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["fireblast", "hiddenpowerelectric", "hiddenpowergrass", "surf", "thunderwave"],
+                "abilities": ["Suction Cups"]
             }
         ]
     },

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -514,7 +514,12 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "batonpass", "return", "swordsdance"],
+                "movepool": ["agility", "hiddenpowerground", "return", "swordsdance"],
+                "abilities": ["Inner Focus"]
+            },
+            {
+                "role": "Berry Sweeper",
+                "movepool": ["endure", "flail", "hiddenpowerflying", "swordsdance"],
                 "abilities": ["Inner Focus"]
             }
         ]
@@ -585,7 +590,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["destinybond", "explosion", "firepunch", "icepunch", "substitute", "thunderbolt", "willowisp"],
+                "movepool": ["destinybond", "explosion", "icepunch", "substitute", "thunderbolt", "willowisp"],
                 "abilities": ["Levitate"],
                 "preferredTypes": ["Electric", "Ice"]
             }
@@ -595,8 +600,8 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "firepunch", "psychic"],
+                "role": "Setup Sweeper",
+                "movepool": ["calmmind", "firepunch", "psychic", "substitute", "thunderwave"],
                 "abilities": ["Insomnia"]
             },
             {
@@ -800,7 +805,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "encore", "firepunch", "hypnosis", "psychic", "substitute", "thunderbolt"],
+                "movepool": ["calmmind", "encore", "firepunch", "hypnosis", "psychic", "substitute", "thunderbolt"],
                 "abilities": ["Soundproof"]
             }
         ]
@@ -809,8 +814,8 @@
         "level": 81,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["aerialace", "batonpass", "hiddenpowerground", "silverwind", "swordsdance"],
+                "role": "Fast Attacker",
+                "movepool": ["aerialace", "doubleedge", "hiddenpowerground", "silverwind", "swordsdance"],
                 "abilities": ["Swarm"],
                 "preferredTypes": ["Ground"]
             }
@@ -1204,14 +1209,9 @@
         "level": 100,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["agility", "batonpass", "silverwind", "swordsdance"],
-                "abilities": ["Swarm"]
-            },
-            {
-                "role": "Generalist",
-                "movepool": ["batonpass", "silverwind", "substitute", "swordsdance"],
-                "abilities": ["Swarm"]
+                "role": "Bulky Support",
+                "movepool": ["hiddenpowerfire", "psybeam", "rest", "toxic"],
+                "abilities": ["Early Bird"]
             }
         ]
     },
@@ -1220,19 +1220,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["agility", "batonpass", "signalbeam", "sludgebomb"],
+                "movepool": ["agility", "hiddenpowerground", "signalbeam", "sludgebomb"],
                 "abilities": ["Insomnia", "Swarm"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["batonpass", "signalbeam", "sludgebomb", "spiderweb", "toxic"],
-                "abilities": ["Insomnia", "Swarm"],
-                "preferredTypes": ["Bug"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["agility", "batonpass", "sludgebomb", "spiderweb"],
-                "abilities": ["Insomnia"]
+                "movepool": ["batonpass", "signalbeam", "sludgebomb", "spiderweb"],
+                "abilities": ["Insomnia", "Swarm"]
             }
         ]
     },
@@ -1282,7 +1276,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "protect", "psychic", "wish"],
+                "movepool": ["hiddenpowerfire", "protect", "psychic", "wish"],
                 "abilities": ["Synchronize"]
             },
             {
@@ -1448,7 +1442,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "substitute"],
+                "movepool": ["calmmind", "hiddenpowerfire", "morningsun", "psychic", "substitute"],
                 "abilities": ["Synchronize"]
             }
         ]
@@ -1554,7 +1548,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "psychic", "rest", "substitute", "thunderbolt"],
+                "movepool": ["calmmind", "hiddenpowerfire", "psychic", "rest", "substitute", "thunderbolt"],
                 "abilities": ["Early Bird"]
             },
             {
@@ -1655,12 +1649,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "hiddenpowerground", "morningsun", "silverwind", "steelwing", "swordsdance"],
-                "abilities": ["Swarm"]
-            },
-            {
-                "role": "Generalist",
-                "movepool": ["agility", "batonpass", "hiddenpowerground", "silverwind", "steelwing"],
+                "movepool": ["hiddenpowerground", "morningsun", "silverwind", "steelwing", "swordsdance"],
                 "abilities": ["Swarm"]
             }
         ]
@@ -2000,7 +1989,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "rockslide", "thunderwave"],
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "rockslide", "thunderwave", "toxic"],
                 "abilities": ["Sand Stream"]
             },
             {
@@ -2046,7 +2035,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "hiddenpowergrass", "psychic", "recover"],
+                "movepool": ["calmmind", "hiddenpowerfire", "hiddenpowergrass", "psychic", "recover"],
                 "abilities": ["Natural Cure"]
             },
             {
@@ -2121,8 +2110,8 @@
         "level": 92,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["crunch", "doubleedge", "healbell", "hiddenpowerfighting", "shadowball", "toxic"],
+                "role": "Bulky Attacker",
+                "movepool": ["crunch", "doubleedge", "healbell", "hiddenpowerfighting", "toxic"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             }
@@ -2276,17 +2265,13 @@
         ]
     },
     "ninjask": {
-        "level": 79,
+        "level": 83,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["batonpass", "hiddenpowerflying", "substitute", "swordsdance"],
-                "abilities": ["Speed Boost"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["batonpass", "hiddenpowerflying", "protect", "swordsdance"],
-                "abilities": ["Speed Boost"]
+                "role": "Fast Attacker",
+                "movepool": ["aerialace", "doubleedge", "hiddenpowerground", "silverwind", "swordsdance"],
+                "abilities": ["Speed Boost"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2295,9 +2280,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["agility", "batonpass", "hiddenpowerfighting", "shadowball", "silverwind", "toxic"],
-                "abilities": ["Wonder Guard"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["agility", "hiddenpowerfighting", "shadowball", "silverwind", "toxic"],
+                "abilities": ["Wonder Guard"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["batonpass", "hiddenpowerfighting", "shadowball", "silverwind"],
+                "abilities": ["Wonder Guard"]
             }
         ]
     },
@@ -2354,11 +2343,6 @@
                 "role": "Generalist",
                 "movepool": ["bodyslam", "healbell", "protect", "wish"],
                 "abilities": ["Cute Charm"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "icebeam", "thunderbolt"],
-                "abilities": ["Cute Charm"]
             }
         ]
     },
@@ -2382,7 +2366,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "brickbreak", "hiddenpowersteel", "rockslide", "substitute", "swordsdance"],
+                "movepool": ["brickbreak", "hiddenpowersteel", "rockslide", "substitute", "swordsdance"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             },
@@ -2437,6 +2421,16 @@
                 "role": "Berry Sweeper",
                 "movepool": ["crunch", "hiddenpowerice", "substitute", "thunderbolt"],
                 "abilities": ["Static"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"],
+                "abilities": ["Static"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["hiddenpowerice", "substitute", "thunderbolt", "thunderwave", "toxic"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -2484,8 +2478,8 @@
         "level": 94,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["batonpass", "icepunch", "tailglow", "thunderbolt"],
+                "role": "Bulky Support",
+                "movepool": ["moonlight", "seismictoss", "signalbeam", "thunderwave", "toxic"],
                 "abilities": ["Swarm"]
             }
         ]
@@ -2680,7 +2674,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "hypnosis", "icebeam", "psychic"],
+                "movepool": ["calmmind", "hiddenpowerfire", "hypnosis", "icebeam", "psychic"],
                 "abilities": ["Levitate"]
             },
             {
@@ -2866,7 +2860,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "doubleedge", "hiddenpowerfighting", "quickattack", "shadowball", "swordsdance"],
+                "movepool": ["doubleedge", "hiddenpowerfighting", "quickattack", "shadowball", "swordsdance"],
                 "abilities": ["Pressure"],
                 "preferredTypes": ["Fighting", "Ghost"]
             },

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -50,7 +50,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
 			Normal: (movePool, moves, abilities, types, counter, species) => !counter.get('Normal'),
-			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison') && !counter.get('Bug'),
+			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
 			Psychic: (movePool, moves, abilities, types, counter, species) => (
 				!counter.get('Psychic') && species.baseStats.spa >= 100
 			),

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -453,12 +453,10 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		role: RandomTeamsTypes.Role,
 	): string {
 		// First, the high-priority items
-		if (species.id === 'farfetchd') return 'Stick';
 		if (species.id === 'latias' || species.id === 'latios') return 'Soul Dew';
 		if (species.id === 'linoone' && role === 'Setup Sweeper') return 'Silk Scarf';
 		if (species.id === 'marowak') return 'Thick Club';
 		if (species.id === 'pikachu') return 'Light Ball';
-		if (species.id === 'shedinja') return 'Lum Berry';
 		if (species.id === 'unown') return counter.get('Physical') ? 'Choice Band' : 'Twisted Spoon';
 		if (species.id === 'deoxys' || species.id === 'deoxysattack') return 'White Herb';
 
@@ -469,6 +467,8 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		if (counter.get('Physical') >= 3 && (moves.has('batonpass') || (role === 'Wallbreaker' && counter.get('Special')))) {
 			return 'Choice Band';
 		}
+
+		if (species.id === 'shedinja') return 'Lum Berry';
 
 		if (
 			moves.has('dragondance') && ability !== 'Natural Cure' &&
@@ -484,6 +484,8 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			if (moves.has('substitute') && counter.get('Physical') >= 3) return 'Liechi Berry';
 			if (moves.has('substitute') && counter.get('Special') >= 3) return 'Petaya Berry';
 		}
+
+		if (species.id === 'farfetchd') return 'Stick';
 
 		const salacReqs = species.baseStats.spe >= 60 && species.baseStats.spe <= 100 && !counter.get('priority');
 

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1465,8 +1465,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "iceshard", "rapidspin", "stoneedge", "toxic"],
-                "abilities": ["Sturdy"],
-                "preferredTypes": ["Rock"]
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -28,12 +28,17 @@
         "level": 85,
         "sets": [
             {
-                "role": "Spinner",
+                "role": "Bulky Support",
                 "movepool": ["icebeam", "rapidspin", "roar", "surf", "toxic"],
                 "abilities": ["Torrent"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Staller",
+                "movepool": ["haze", "icebeam", "protect", "rapidspin", "surf", "toxic"],
+                "abilities": ["Torrent"]
+            },
+            {
+                "role": "Fast Support",
                 "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"],
                 "abilities": ["Torrent"]
             }
@@ -140,9 +145,10 @@
         "level": 88,
         "sets": [
             {
-                "role": "Spinner",
-                "movepool": ["earthquake", "nightslash", "rapidspin", "stealthrock", "stoneedge", "toxic"],
-                "abilities": ["Sand Veil"]
+                "role": "Bulky Support",
+                "movepool": ["earthquake", "nightslash", "rapidspin", "stoneedge", "toxic"],
+                "abilities": ["Sand Veil"],
+                "preferredTypes": ["Rock"]
             },
             {
                 "role": "Bulky Setup",
@@ -157,7 +163,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "roar", "sludgebomb", "stealthrock", "toxicspikes"],
+                "movepool": ["earthquake", "fireblast", "icebeam", "roar", "sludgebomb", "toxicspikes"],
                 "abilities": ["Poison Point"]
             }
         ]
@@ -167,7 +173,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "sludgebomb", "stealthrock", "suckerpunch", "thunderbolt"],
+                "movepool": ["earthquake", "fireblast", "icebeam", "megahorn", "sludgebomb", "suckerpunch", "thunderbolt", "toxicspikes"],
                 "abilities": ["Poison Point"]
             }
         ]
@@ -177,7 +183,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "doubleedge", "fireblast", "icebeam", "softboiled", "stealthrock", "thunderwave"],
+                "movepool": ["aromatherapy", "doubleedge", "fireblast", "icebeam", "softboiled", "thunderwave"],
                 "abilities": ["Magic Guard"]
             },
             {
@@ -208,7 +214,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "fireblast", "healbell", "protect", "stealthrock", "wish"],
+                "movepool": ["bodyslam", "fireblast", "healbell", "protect", "wish"],
                 "abilities": ["Cute Charm"]
             },
             {
@@ -263,7 +269,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "nightslash", "stealthrock", "stoneedge", "suckerpunch"],
+                "movepool": ["earthquake", "nightslash", "stoneedge", "suckerpunch"],
                 "abilities": ["Arena Trap"],
                 "preferredTypes": ["Rock"]
             }
@@ -307,7 +313,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "morningsun", "roar", "thunderfang", "toxic", "willowisp"],
+                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "morningsun", "thunderfang", "toxic", "willowisp"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Normal"]
             },
@@ -380,7 +386,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["haze", "hydropump", "icebeam", "rapidspin", "sludgebomb", "surf", "toxicspikes"],
                 "abilities": ["Clear Body", "Liquid Ooze"],
                 "preferredTypes": ["Poison"]
@@ -392,7 +398,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
+                "movepool": ["earthquake", "explosion", "stoneedge", "suckerpunch", "toxic"],
+                "abilities": ["Rock Head"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge"],
                 "abilities": ["Rock Head"]
             }
         ]
@@ -484,12 +495,12 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Staller",
                 "movepool": ["explosion", "iceshard", "rapidspin", "rockblast", "spikes", "surf", "toxicspikes"],
                 "abilities": ["Shell Armor", "Skill Link"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Staller",
                 "movepool": ["explosion", "icebeam", "iceshard", "rapidspin", "spikes", "surf", "toxicspikes"],
                 "abilities": ["Shell Armor"]
             }
@@ -568,7 +579,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "firepunch", "stealthrock", "stoneedge", "swordsdance"],
+                "movepool": ["doubleedge", "earthquake", "firepunch", "stoneedge", "swordsdance"],
                 "abilities": ["Rock Head"],
                 "preferredTypes": ["Rock"]
             }
@@ -579,7 +590,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "machpunch", "rapidspin", "stoneedge", "suckerpunch"],
+                "movepool": ["closecombat", "earthquake", "machpunch", "stoneedge", "suckerpunch"],
                 "abilities": ["Limber"],
                 "preferredTypes": ["Rock"]
             },
@@ -594,11 +605,6 @@
     "hitmonchan": {
         "level": 86,
         "sets": [
-            {
-                "role": "Spinner",
-                "movepool": ["closecombat", "icepunch", "machpunch", "rapidspin", "stoneedge"],
-                "abilities": ["Iron Fist"]
-            },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bulkup", "closecombat", "icepunch", "machpunch", "stoneedge"],
@@ -653,11 +659,6 @@
                 "role": "Wallbreaker",
                 "movepool": ["hydropump", "icebeam", "psychic", "recover", "thunderbolt"],
                 "abilities": ["Natural Cure"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["icebeam", "psychic", "rapidspin", "recover", "surf", "thunderwave"],
-                "abilities": ["Natural Cure"]
             }
         ]
     },
@@ -707,7 +708,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "movepool": ["closecombat", "earthquake", "stoneedge", "swordsdance", "xscissor"],
                 "abilities": ["Mold Breaker"],
                 "preferredTypes": ["Rock"]
             }
@@ -818,7 +819,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "spikes", "stealthrock", "surf", "toxicspikes"],
+                "movepool": ["icebeam", "spikes", "surf", "toxicspikes"],
                 "abilities": ["Shell Armor", "Swift Swim"]
             }
         ]
@@ -827,13 +828,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Spinner",
-                "movepool": ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "waterfall"],
-                "abilities": ["Battle Armor", "Swift Swim"]
-            },
-            {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"],
+                "movepool": ["aquajet", "stoneedge", "superpower", "swordsdance", "waterfall"],
                 "abilities": ["Battle Armor", "Swift Swim"]
             }
         ]
@@ -842,13 +838,8 @@
         "level": 76,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"],
-                "abilities": ["Pressure"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["aerialace", "aquatail", "earthquake", "roost", "stealthrock", "stoneedge"],
+                "role": "Fast Attacker",
+                "movepool": ["aerialace", "aquatail", "earthquake", "roost", "stoneedge"],
                 "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             }
@@ -940,13 +931,8 @@
         "level": 77,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"],
-                "abilities": ["Synchronize"]
-            },
-            {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "softboiled"],
+                "movepool": ["aurasphere", "fireblast", "nastyplot", "psychic", "softboiled"],
                 "abilities": ["Synchronize"]
             },
             {
@@ -1114,7 +1100,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
+                "movepool": ["earthquake", "explosion", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
                 "abilities": ["Rock Head"]
             }
         ]
@@ -1262,7 +1248,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["explosion", "payback", "rapidspin", "spikes", "stealthrock", "toxicspikes"],
+                "movepool": ["explosion", "payback", "rapidspin", "spikes", "toxicspikes"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -1277,7 +1263,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bite", "bodyslam", "earthquake", "roost", "stealthrock"],
+                "movepool": ["bite", "bodyslam", "earthquake", "roost"],
                 "abilities": ["Serene Grace"],
                 "preferredTypes": ["Dark"]
             }
@@ -1288,7 +1274,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "ironhead", "roar", "stealthrock", "stoneedge", "toxic"],
+                "movepool": ["earthquake", "explosion", "ironhead", "roar", "stoneedge", "toxic"],
                 "abilities": ["Rock Head"]
             },
             {
@@ -1343,7 +1329,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "knockoff", "stealthrock", "toxic"],
+                "movepool": ["encore", "knockoff", "rest", "toxic"],
                 "abilities": ["Gluttony"]
             }
         ]
@@ -1384,7 +1370,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic"],
+                "movepool": ["earthpower", "hiddenpowerrock", "lavaplume", "recover", "toxic"],
                 "abilities": ["Flame Body"]
             }
         ]
@@ -1393,8 +1379,8 @@
         "level": 98,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["explosion", "powergem", "recover", "stealthrock", "surf", "toxic"],
+                "role": "Staller",
+                "movepool": ["explosion", "icebeam", "powergem", "recover", "surf", "toxic"],
                 "abilities": ["Natural Cure"]
             }
         ]
@@ -1413,8 +1399,8 @@
         "level": 100,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"],
+                "role": "Staller",
+                "movepool": ["counter", "icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"],
                 "abilities": ["Vital Spirit"]
             }
         ]
@@ -1439,12 +1425,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+                "movepool": ["bravebird", "roost", "spikes", "whirlwind"],
                 "abilities": ["Keen Eye"]
             },
             {
                 "role": "Staller",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"],
+                "movepool": ["bravebird", "roost", "spikes", "toxic"],
                 "abilities": ["Keen Eye"]
             }
         ]
@@ -1483,10 +1469,15 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "iceshard", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "role": "Bulky Attacker",
+                "movepool": ["earthquake", "iceshard", "rapidspin", "stoneedge", "toxic"],
                 "abilities": ["Sturdy"],
                 "preferredTypes": ["Rock"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "stoneedge", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1516,7 +1507,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["explosion", "spikes", "spore", "stealthrock", "whirlwind"],
+                "movepool": ["explosion", "spikes", "spore", "toxicspikes", "whirlwind"],
                 "abilities": ["Own Tempo"]
             }
         ]
@@ -1528,6 +1519,12 @@
                 "role": "Bulky Support",
                 "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
                 "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["bulkup", "closecombat", "earthquake", "stoneedge", "suckerpunch"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },
@@ -1536,7 +1533,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "toxic"],
                 "abilities": ["Thick Fat"]
             }
         ]
@@ -1546,7 +1543,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "thunderwave", "toxic"],
                 "abilities": ["Natural Cure"]
             },
             {
@@ -1607,7 +1604,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "pursuit", "stealthrock", "stoneedge", "superpower"],
+                "movepool": ["crunch", "earthquake", "fireblast", "pursuit", "stoneedge", "superpower", "thunderwave", "toxic"],
                 "abilities": ["Sand Stream"]
             },
             {
@@ -1652,11 +1649,6 @@
                 "preferredTypes": ["Psychic"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"],
-                "abilities": ["Natural Cure"]
-            },
-            {
                 "role": "Setup Sweeper",
                 "movepool": ["energyball", "nastyplot", "psychic", "recover"],
                 "abilities": ["Natural Cure"]
@@ -1698,7 +1690,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "roar", "stealthrock", "toxic", "waterfall"],
+                "movepool": ["earthquake", "icebeam", "toxic", "waterfall"],
                 "abilities": ["Torrent"]
             },
             {
@@ -1976,12 +1968,6 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["aquatail", "earthquake", "headsmash", "icepunch", "stealthrock"],
-                "abilities": ["Rock Head"],
-                "preferredTypes": ["Ground"]
-            },
-            {
-                "role": "Setup Sweeper",
                 "movepool": ["aquatail", "earthquake", "headsmash", "icepunch", "rockpolish"],
                 "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
@@ -2112,12 +2098,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "lavaplume", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "explosion", "lavaplume", "toxic", "yawn"],
                 "abilities": ["Solid Rock"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "explosion", "fireblast", "rockpolish", "stoneedge"],
+                "movepool": ["earthquake", "explosion", "fireblast", "rockpolish"],
                 "abilities": ["Solid Rock"]
             }
         ]
@@ -2127,7 +2113,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "lavaplume", "rapidspin", "stealthrock", "yawn"],
+                "movepool": ["earthquake", "explosion", "lavaplume", "rapidspin", "yawn"],
                 "abilities": ["White Smoke"]
             }
         ]
@@ -2245,7 +2231,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthpower", "explosion", "psychic", "stealthrock", "toxic"],
+                "movepool": ["earthpower", "explosion", "psychic", "toxic"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -2255,7 +2241,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "explosion", "rockpolish", "stealthrock", "stoneedge", "zenheadbutt"],
+                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge", "zenheadbutt"],
                 "abilities": ["Levitate"],
                 "preferredTypes": ["Ground"]
             }
@@ -2286,7 +2272,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "toxic"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -2296,7 +2282,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["curse", "earthquake", "recover", "seedbomb", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+                "movepool": ["curse", "earthquake", "recover", "seedbomb", "stoneedge", "swordsdance", "toxic"],
                 "abilities": ["Suction Cups"]
             }
         ]
@@ -2305,14 +2291,16 @@
         "level": 83,
         "sets": [
             {
-                "role": "Spinner",
-                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"],
-                "abilities": ["Battle Armor"]
+                "role": "Bulky Support",
+                "movepool": ["earthquake", "rapidspin", "stoneedge", "toxic", "xscissor"],
+                "abilities": ["Battle Armor"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquatail", "earthquake", "rockpolish", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
-                "abilities": ["Battle Armor"]
+                "movepool": ["aquatail", "earthquake", "rockpolish", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Battle Armor"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2346,7 +2334,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["recover", "seismictoss", "stealthrock", "thunderwave", "toxic"],
+                "movepool": ["recover", "seismictoss", "shadowclaw", "thunderwave", "toxic"],
                 "abilities": ["Color Change"]
             }
         ]
@@ -2421,8 +2409,8 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "roar", "superfang", "surf", "toxic"],
+                "role": "Staller",
+                "movepool": ["encore", "icebeam", "superfang", "surf", "toxic"],
                 "abilities": ["Thick Fat"]
             },
             {
@@ -2458,7 +2446,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"],
+                "movepool": ["earthquake", "headsmash", "toxic", "waterfall"],
                 "abilities": ["Rock Head"]
             },
             {
@@ -2501,7 +2489,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulletpunch", "earthquake", "explosion", "meteormash", "stealthrock", "zenheadbutt"],
+                "movepool": ["bulletpunch", "earthquake", "explosion", "meteormash", "toxic", "zenheadbutt"],
                 "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             }
@@ -2512,7 +2500,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+                "movepool": ["earthquake", "explosion", "stoneedge", "thunderwave", "toxic"],
                 "abilities": ["Clear Body"]
             },
             {
@@ -2561,11 +2549,6 @@
                 "role": "Bulky Support",
                 "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"],
                 "abilities": ["Clear Body"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"],
-                "abilities": ["Clear Body"]
             }
         ]
     },
@@ -2609,7 +2592,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "stoneedge", "thunderwave"],
+                "movepool": ["earthquake", "lavaplume", "overheat", "stoneedge", "thunderwave"],
                 "abilities": ["Drought"]
             },
             {
@@ -2645,7 +2628,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"],
+                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "toxic", "uturn", "wish"],
                 "abilities": ["Serene Grace"]
             },
             {
@@ -2691,7 +2674,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+                "movepool": ["recover", "seismictoss", "spikes", "taunt", "toxic"],
                 "abilities": ["Pressure"]
             }
         ]
@@ -2701,7 +2684,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+                "movepool": ["psychoboost", "spikes", "superpower", "taunt"],
                 "abilities": ["Pressure"]
             }
         ]
@@ -2711,7 +2694,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+                "movepool": ["earthquake", "stoneedge", "synthesis", "woodhammer"],
                 "abilities": ["Overgrow"]
             },
             {
@@ -2726,7 +2709,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"],
+                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "uturn"],
                 "abilities": ["Blaze"]
             },
             {
@@ -2741,12 +2724,12 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "stealthrock", "surf", "toxic"],
+                "movepool": ["icebeam", "protect", "surf", "toxic"],
                 "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "roar", "stealthrock", "surf", "toxic"],
+                "movepool": ["icebeam", "roar", "surf", "toxic"],
                 "abilities": ["Torrent"]
             },
             {
@@ -2802,13 +2785,13 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["crunch", "icefang", "roar", "superpower", "thunderbolt", "toxic"],
+                "role": "Staller",
+                "movepool": ["crunch", "icefang", "superpower", "thunderbolt", "toxic"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Fighting"]
             },
             {
-                "role": "Staller",
+                "role": "Bulky Attacker",
                 "movepool": ["protect", "superpower", "thunderbolt", "toxic"],
                 "abilities": ["Intimidate"]
             }
@@ -2845,7 +2828,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "metalburst", "roar", "toxic"],
+                "abilities": ["Sturdy"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "roar", "toxic"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -2875,7 +2863,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"],
+                "movepool": ["flashcannon", "rest", "sleeptalk", "toxic"],
                 "abilities": ["Anticipation"]
             }
         ]
@@ -3047,8 +3035,9 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "ironhead", "payback", "stealthrock", "toxic"],
-                "abilities": ["Levitate"]
+                "movepool": ["earthquake", "explosion", "ironhead", "payback", "toxic"],
+                "abilities": ["Levitate"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
@@ -3091,11 +3080,6 @@
         "level": 74,
         "sets": [
             {
-                "role": "Fast Support",
-                "movepool": ["earthquake", "fireblast", "outrage", "stealthrock", "stoneedge"],
-                "abilities": ["Sand Veil"]
-            },
-            {
                 "role": "Fast Attacker",
                 "movepool": ["earthquake", "firefang", "outrage", "stoneedge", "swordsdance"],
                 "abilities": ["Sand Veil"]
@@ -3123,7 +3107,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "roar", "slackoff", "stealthrock", "stoneedge", "toxic"],
+                "movepool": ["earthquake", "roar", "slackoff", "stoneedge", "toxic"],
                 "abilities": ["Sand Stream"]
             }
         ]
@@ -3235,7 +3219,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stealthrock", "stoneedge"],
+                "movepool": ["earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge"],
                 "abilities": ["Solid Rock"]
             }
         ]
@@ -3343,7 +3327,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic", "uturn"],
+                "movepool": ["earthquake", "roost", "stoneedge", "taunt", "toxic", "uturn"],
                 "abilities": ["Hyper Cutter"]
             },
             {
@@ -3358,7 +3342,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "iceshard", "stealthrock", "stoneedge", "superpower"],
+                "movepool": ["earthquake", "iceshard", "stoneedge", "superpower", "toxic"],
                 "abilities": ["Snow Cloak"]
             }
         ]
@@ -3388,7 +3372,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "explosion", "powergem", "stealthrock", "thunderwave", "toxic"],
+                "movepool": ["earthpower", "explosion", "powergem", "thunderwave", "toxic"],
                 "abilities": ["Magnet Pull"]
             }
         ]
@@ -3519,7 +3503,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"],
+                "movepool": ["healbell", "psychic", "thunderwave", "uturn", "yawn"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -3534,7 +3518,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfighting", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"],
+                "movepool": ["hiddenpowerfighting", "psychic", "thunderwave", "toxic", "uturn"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -3549,8 +3533,8 @@
                 "preferredTypes": ["Fire"]
             },
             {
-                "role": "Fast Support",
-                "movepool": ["explosion", "fireblast", "psychic", "stealthrock", "taunt", "uturn"],
+                "role": "Wallbreaker",
+                "movepool": ["explosion", "fireblast", "psychic", "uturn"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -3560,7 +3544,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aurasphere", "dracometeor", "fireblast", "roar", "stealthrock", "thunderbolt", "toxic"],
+                "movepool": ["aurasphere", "dracometeor", "fireblast", "thunderbolt", "thunderwave", "toxic"],
                 "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             },
@@ -3592,9 +3576,8 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dragonpulse", "earthpower", "explosion", "fireblast", "hiddenpowergrass", "lavaplume", "roar", "stealthrock", "toxic"],
-                "abilities": ["Flash Fire"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["earthpower", "explosion", "fireblast", "lavaplume", "toxic"],
+                "abilities": ["Flash Fire"]
             },
             {
                 "role": "Staller",
@@ -3858,12 +3841,6 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"],
-                "abilities": ["Multitype"],
-                "preferredTypes": ["Ground"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"],
                 "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1881,7 +1881,7 @@
         ]
     },
     "shedinja": {
-        "level": 100,
+        "level": 96,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2873,7 +2873,7 @@
         ]
     },
     "vespiquen": {
-        "level": 100,
+        "level": 96,
         "sets": [
             {
                 "role": "Staller",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -590,12 +590,6 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "machpunch", "stoneedge", "suckerpunch"],
-                "abilities": ["Limber"],
-                "preferredTypes": ["Rock"]
-            },
-            {
-                "role": "Setup Sweeper",
                 "movepool": ["bulkup", "closecombat", "earthquake", "machpunch", "stoneedge", "suckerpunch"],
                 "abilities": ["Limber"],
                 "preferredTypes": ["Rock"]

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -15,7 +15,7 @@
         ]
     },
     "charizard": {
-        "level": 83,
+        "level": 79,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -40,7 +40,7 @@
         ]
     },
     "butterfree": {
-        "level": 95,
+        "level": 91,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -50,7 +50,7 @@
         ]
     },
     "beedrill": {
-        "level": 97,
+        "level": 95,
         "sets": [
             {
                 "role": "Fast Support",
@@ -65,7 +65,7 @@
         ]
     },
     "pidgeot": {
-        "level": 89,
+        "level": 87,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -90,7 +90,7 @@
         ]
     },
     "fearow": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -188,7 +188,7 @@
         ]
     },
     "ninetales": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -249,7 +249,7 @@
         ]
     },
     "venomoth": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Fast Support",
@@ -303,7 +303,7 @@
         ]
     },
     "arcanine": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -398,7 +398,7 @@
         ]
     },
     "rapidash": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -440,7 +440,7 @@
         ]
     },
     "dodrio": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -450,7 +450,7 @@
         ]
     },
     "dewgong": {
-        "level": 92,
+        "level": 90,
         "sets": [
             {
                 "role": "Staller",
@@ -481,7 +481,7 @@
         ]
     },
     "cloyster": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -673,7 +673,7 @@
         ]
     },
     "scyther": {
-        "level": 82,
+        "level": 78,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -688,7 +688,7 @@
         ]
     },
     "jynx": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -703,7 +703,7 @@
         ]
     },
     "pinsir": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -724,7 +724,7 @@
         ]
     },
     "gyarados": {
-        "level": 77,
+        "level": 75,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -739,7 +739,7 @@
         ]
     },
     "lapras": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -794,7 +794,7 @@
         ]
     },
     "flareon": {
-        "level": 94,
+        "level": 92,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -839,7 +839,7 @@
         ]
     },
     "aerodactyl": {
-        "level": 78,
+        "level": 76,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -876,7 +876,7 @@
         ]
     },
     "articuno": {
-        "level": 82,
+        "level": 78,
         "sets": [
             {
                 "role": "Staller",
@@ -886,7 +886,7 @@
         ]
     },
     "zapdos": {
-        "level": 77,
+        "level": 75,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -901,7 +901,7 @@
         ]
     },
     "moltres": {
-        "level": 82,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -911,7 +911,7 @@
         ]
     },
     "dragonite": {
-        "level": 75,
+        "level": 73,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -967,7 +967,7 @@
         ]
     },
     "typhlosion": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1008,7 +1008,7 @@
         ]
     },
     "noctowl": {
-        "level": 96,
+        "level": 94,
         "sets": [
             {
                 "role": "Staller",
@@ -1038,7 +1038,7 @@
         ]
     },
     "crobat": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1058,7 +1058,7 @@
         ]
     },
     "xatu": {
-        "level": 89,
+        "level": 87,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1136,7 +1136,7 @@
         ]
     },
     "jumpluff": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1339,7 +1339,7 @@
         ]
     },
     "shuckle": {
-        "level": 92,
+        "level": 98,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1380,7 +1380,7 @@
         ]
     },
     "magcargo": {
-        "level": 99,
+        "level": 97,
         "sets": [
             {
                 "role": "Staller",
@@ -1420,7 +1420,7 @@
         ]
     },
     "mantine": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1450,7 +1450,7 @@
         ]
     },
     "houndoom": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -1573,7 +1573,7 @@
         ]
     },
     "entei": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -1618,7 +1618,7 @@
         ]
     },
     "lugia": {
-        "level": 72,
+        "level": 70,
         "sets": [
             {
                 "role": "Staller",
@@ -1633,7 +1633,7 @@
         ]
     },
     "hooh": {
-        "level": 73,
+        "level": 69,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1784,7 +1784,7 @@
         ]
     },
     "swellow": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1799,7 +1799,7 @@
         ]
     },
     "pelipper": {
-        "level": 92,
+        "level": 90,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1826,7 +1826,7 @@
         ]
     },
     "masquerain": {
-        "level": 99,
+        "level": 95,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2041,7 +2041,7 @@
         ]
     },
     "volbeat": {
-        "level": 99,
+        "level": 97,
         "sets": [
             {
                 "role": "Staller",
@@ -2051,7 +2051,7 @@
         ]
     },
     "illumise": {
-        "level": 93,
+        "level": 91,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2123,7 +2123,7 @@
         ]
     },
     "torkoal": {
-        "level": 87,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2199,7 +2199,7 @@
         ]
     },
     "altaria": {
-        "level": 87,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2302,7 +2302,7 @@
         ]
     },
     "armaldo": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Spinner",
@@ -2362,7 +2362,7 @@
         ]
     },
     "tropius": {
-        "level": 97,
+        "level": 95,
         "sets": [
             {
                 "role": "Staller",
@@ -2408,7 +2408,7 @@
         ]
     },
     "glalie": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2418,7 +2418,7 @@
         ]
     },
     "walrein": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2480,7 +2480,7 @@
         ]
     },
     "salamence": {
-        "level": 74,
+        "level": 72,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2528,7 +2528,7 @@
         ]
     },
     "regice": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2620,7 +2620,7 @@
         ]
     },
     "rayquaza": {
-        "level": 72,
+        "level": 70,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -2757,7 +2757,7 @@
         ]
     },
     "staraptor": {
-        "level": 79,
+        "level": 77,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2841,7 +2841,7 @@
         ]
     },
     "bastiodon": {
-        "level": 92,
+        "level": 96,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2871,7 +2871,7 @@
         ]
     },
     "wormadamtrash": {
-        "level": 85,
+        "level": 95,
         "sets": [
             {
                 "role": "Staller",
@@ -2881,7 +2881,7 @@
         ]
     },
     "mothim": {
-        "level": 97,
+        "level": 93,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2968,7 +2968,7 @@
         ]
     },
     "drifblim": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3013,7 +3013,7 @@
         ]
     },
     "honchkrow": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -3058,7 +3058,7 @@
         ]
     },
     "chatot": {
-        "level": 92,
+        "level": 90,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3180,7 +3180,7 @@
         ]
     },
     "abomasnow": {
-        "level": 83,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3190,7 +3190,7 @@
         ]
     },
     "weavile": {
-        "level": 77,
+        "level": 75,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3267,7 +3267,7 @@
         ]
     },
     "magmortar": {
-        "level": 83,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3278,7 +3278,7 @@
         ]
     },
     "togekiss": {
-        "level": 78,
+        "level": 76,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3298,7 +3298,7 @@
         ]
     },
     "yanmega": {
-        "level": 80,
+        "level": 76,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3324,7 +3324,7 @@
         ]
     },
     "glaceon": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3415,7 +3415,7 @@
         ]
     },
     "froslass": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3440,7 +3440,7 @@
         ]
     },
     "rotomheat": {
-        "level": 79,
+        "level": 77,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3470,7 +3470,7 @@
         ]
     },
     "rotomfrost": {
-        "level": 78,
+        "level": 76,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3485,7 +3485,7 @@
         ]
     },
     "rotomfan": {
-        "level": 78,
+        "level": 76,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3700,7 +3700,7 @@
         ]
     },
     "shayminsky": {
-        "level": 70,
+        "level": 68,
         "sets": [
             {
                 "role": "Fast Attacker",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -434,9 +434,8 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "leafblade", "nightslash", "return", "swordsdance"],
-                "abilities": ["Inner Focus"],
-                "preferredTypes": ["Grass"]
+                "movepool": ["leafblade", "nightslash", "return", "swordsdance"],
+                "abilities": ["Inner Focus"]
             }
         ]
     },
@@ -522,7 +521,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "focusblast", "nastyplot", "psychic"],
+                "movepool": ["focusblast", "nastyplot", "psychic", "shadowball"],
                 "abilities": ["Insomnia"]
             }
         ]
@@ -667,7 +666,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "encore", "focusblast", "nastyplot", "psychic", "shadowball", "substitute"],
+                "movepool": ["encore", "focusblast", "nastyplot", "psychic", "shadowball", "substitute"],
                 "abilities": ["Filter"],
                 "preferredTypes": ["Fighting"]
             }
@@ -784,7 +783,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["batonpass", "hiddenpowerice", "substitute", "thunderbolt", "toxic"],
+                "movepool": ["hiddenpowerice", "substitute", "thunderbolt", "toxic"],
                 "abilities": ["Volt Absorb"]
             },
             {
@@ -947,14 +946,13 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "batonpass", "earthpower", "fireblast", "nastyplot", "psychic", "softboiled"],
+                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "softboiled"],
                 "abilities": ["Synchronize"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["batonpass", "earthquake", "explosion", "swordsdance", "zenheadbutt"],
-                "abilities": ["Synchronize"],
-                "preferredTypes": ["Ground"]
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "explosion", "softboiled", "swordsdance", "zenheadbutt"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1025,11 +1023,6 @@
             {
                 "role": "Staller",
                 "movepool": ["encore", "focusblast", "hiddenpowerflying", "knockoff", "roost", "toxic"],
-                "abilities": ["Early Bird"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["agility", "batonpass", "encore", "swordsdance"],
                 "abilities": ["Early Bird"]
             }
         ]
@@ -1197,7 +1190,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "morningsun", "psychic", "substitute"],
+                "movepool": ["calmmind", "hiddenpowerfighting", "morningsun", "psychic", "substitute"],
                 "abilities": ["Synchronize"]
             }
         ]
@@ -1259,7 +1252,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "psychic", "substitute", "thunderbolt"],
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "substitute", "thunderbolt"],
                 "abilities": ["Inner Focus"]
             }
         ]
@@ -1665,7 +1658,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "energyball", "nastyplot", "psychic", "recover"],
+                "movepool": ["energyball", "nastyplot", "psychic", "recover"],
                 "abilities": ["Natural Cure"]
             }
         ]
@@ -1836,11 +1829,6 @@
         "level": 99,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["agility", "airslash", "batonpass", "bugbuzz", "hydropump", "roost"],
-                "abilities": ["Intimidate"]
-            },
-            {
                 "role": "Bulky Support",
                 "movepool": ["airslash", "bugbuzz", "hydropump", "roost", "stunspore", "toxic"],
                 "abilities": ["Intimidate"]
@@ -1896,13 +1884,13 @@
         "level": 86,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["batonpass", "substitute", "swordsdance", "xscissor"],
+                "role": "Fast Attacker",
+                "movepool": ["aerialace", "nightslash", "swordsdance", "uturn", "xscissor"],
                 "abilities": ["Speed Boost"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["batonpass", "protect", "swordsdance", "xscissor"],
+                "role": "Setup Sweeper",
+                "movepool": ["aerialace", "swordsdance", "uturn", "xscissor"],
                 "abilities": ["Speed Boost"]
             }
         ]
@@ -1912,7 +1900,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+                "movepool": ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
                 "abilities": ["Wonder Guard"]
             }
         ]
@@ -1955,11 +1943,6 @@
                 "role": "Fast Support",
                 "movepool": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "toxic"],
                 "abilities": ["Cute Charm"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "icebeam", "thunderbolt"],
-                "abilities": ["Cute Charm"]
             }
         ]
     },
@@ -1978,7 +1961,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "ironhead", "suckerpunch", "swordsdance"],
+                "movepool": ["brickbreak", "ironhead", "suckerpunch", "swordsdance"],
                 "abilities": ["Intimidate"]
             },
             {
@@ -2030,7 +2013,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
                 "abilities": ["Plus"],
                 "preferredTypes": ["Ice"]
             },
@@ -2046,7 +2029,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"],
+                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
                 "abilities": ["Minus"],
                 "preferredTypes": ["Ice"]
             },
@@ -2061,18 +2044,8 @@
         "level": 99,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["batonpass", "bugbuzz", "substitute", "tailglow"],
-                "abilities": ["Swarm"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["batonpass", "bugbuzz", "encore", "tailglow"],
-                "abilities": ["Swarm"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["batonpass", "bugbuzz", "roost", "tailglow"],
+                "role": "Staller",
+                "movepool": ["encore", "roost", "seismictoss", "toxic", "uturn"],
                 "abilities": ["Swarm"]
             }
         ]
@@ -2267,7 +2240,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "earthpower", "psychic", "signalbeam", "substitute"],
+                "movepool": ["calmmind", "earthpower", "psychic", "signalbeam", "substitute"],
                 "abilities": ["Levitate"]
             },
             {
@@ -2999,7 +2972,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "rest", "shadowball", "substitute", "thunderbolt"],
+                "movepool": ["calmmind", "hiddenpowerfighting", "rest", "shadowball", "substitute", "thunderbolt"],
                 "abilities": ["Unburden"]
             }
         ]
@@ -3009,7 +2982,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["batonpass", "encore", "return", "substitute", "thunderwave", "toxic"],
+                "movepool": ["encore", "return", "skyuppercut", "thunderwave", "toxic"],
                 "abilities": ["Cute Charm"]
             },
             {
@@ -3309,7 +3282,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["airslash", "aurasphere", "batonpass", "nastyplot", "roost", "thunderwave"],
+                "movepool": ["airslash", "aurasphere", "nastyplot", "roost", "thunderwave"],
                 "abilities": ["Serene Grace"]
             },
             {
@@ -3344,7 +3317,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "doubleedge", "leafblade", "substitute", "swordsdance", "synthesis", "xscissor"],
+                "movepool": ["doubleedge", "leafblade", "substitute", "swordsdance", "synthesis", "xscissor"],
                 "abilities": ["Leaf Guard"],
                 "preferredTypes": ["Normal"]
             }

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -2075,8 +2075,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["hydropump", "icebeam", "selfdestruct", "waterspout"],
-                "abilities": ["Water Veil"],
-                "preferredTypes": ["Ice"]
+                "abilities": ["Water Veil"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1258,8 +1258,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bite", "bodyslam", "earthquake", "roost"],
-                "abilities": ["Serene Grace"],
-                "preferredTypes": ["Dark"]
+                "abilities": ["Serene Grace"]
             }
         ]
     },

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -3417,7 +3417,7 @@
         ]
     },
     "rotomheat": {
-        "level": 77,
+        "level": 79,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3447,7 +3447,7 @@
         ]
     },
     "rotomfrost": {
-        "level": 76,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3462,7 +3462,7 @@
         ]
     },
     "rotomfan": {
-        "level": 76,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -3445,8 +3445,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["overheat", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
-                "abilities": ["Levitate"],
-                "preferredTypes": ["Fire"]
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
@@ -3461,8 +3460,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["hydropump", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
-                "abilities": ["Levitate"],
-                "preferredTypes": ["Water"]
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
@@ -3477,8 +3475,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["blizzard", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
-                "abilities": ["Levitate"],
-                "preferredTypes": ["Ice"]
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",
@@ -3508,8 +3505,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["leafstorm", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
-                "abilities": ["Levitate"],
-                "preferredTypes": ["Grass"]
+                "abilities": ["Levitate"]
             },
             {
                 "role": "Bulky Support",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1002,7 +1002,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["encore", "focusblast", "hiddenpowerflying", "knockoff", "roost", "toxic"],
+                "movepool": ["encore", "focusblast", "hiddenpowerflying", "knockoff", "roost", "toxic", "uturn"],
                 "abilities": ["Early Bird"]
             }
         ]

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -399,7 +399,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		}
 
 		// Enforce a move not on the noSTAB list
-		if (!counter.damagingMoves.size && !(moves.has('uturn') && types.has('Bug'))) {
+		if (!counter.damagingMoves.size) {
 			// Choose an attacking move
 			const attackingMoves = [];
 			for (const moveid of movePool) {

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -355,7 +355,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		// Enforce one of Spikes or Toxic Spikes
 		const hazardMoves = movePool.filter(moveid => ['spikes', 'toxicspikes'].includes(moveid));
 		if (hazardMoves.length) {
-			// Enforce Toxic Spikes if the team has Spikes only
+			// Enforce Toxic Spikes if the team has Spikes already
 			if (teamDetails.spikes && hazardMoves.includes('toxicspikes')) {
 				counter = this.addMove('toxicspikes', moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role);

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -143,10 +143,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			if (movePool.includes('lightscreen')) this.fastPop(movePool, movePool.indexOf('lightscreen'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.stealthRock) {
-			if (movePool.includes('stealthrock')) this.fastPop(movePool, movePool.indexOf('stealthrock'));
-			if (moves.size + movePool.length <= this.maxMoveCount) return;
-		}
 		if (teamDetails.rapidSpin) {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
@@ -186,7 +182,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			['surf', 'hydropump'],
 			[['bodyslam', 'return'], ['bodyslam', 'doubleedge']],
 			[['energyball', 'leafstorm'], ['leafblade', 'leafstorm', 'powerwhip']],
-			['lavaplume', 'fireblast'],
+			['lavaplume', ['fireblast', 'overheat']],
 			['closecombat', 'drainpunch'],
 			['discharge', 'thunderbolt'],
 			['gunkshot', 'poisonjab'],
@@ -278,8 +274,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			}
 		}
 
-		// Enforce hazard removal on Bulky Support and Spinner if the team doesn't already have it
-		if (['Bulky Support', 'Spinner'].includes(role) && !teamDetails.rapidSpin) {
+		// Enforce hazard removal on Bulky Support if the team doesn't already have it
+		if (['Bulky Support'].includes(role) && !teamDetails.rapidSpin) {
 			if (movePool.includes('rapidspin')) {
 				counter = this.addMove('rapidspin', moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role);
@@ -356,14 +352,23 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			}
 		}
 
-		// Enforce Stealth Rock if the team doesn't already have it
-		if (movePool.includes('stealthrock') && !teamDetails.stealthRock) {
-			counter = this.addMove('stealthrock', moves, types, abilities, teamDetails, species, isLead,
-				movePool, preferredType, role);
+		// Enforce one of Spikes or Toxic Spikes
+		const hazardMoves = movePool.filter(moveid => ['spikes', 'toxicspikes'].includes(moveid));
+		if (hazardMoves.length) {
+			// Enforce Toxic Spikes if the team has Spikes only
+			if (teamDetails.spikes && hazardMoves.includes('toxicspikes')) {
+				counter = this.addMove('toxicspikes', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			} else {
+				// Enforce one of the hazards
+				const moveid = this.sample(hazardMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
 		}
 
 		// Enforce recovery
-		if (['Bulky Support', 'Bulky Attacker', 'Bulky Setup', 'Spinner', 'Staller'].includes(role)) {
+		if (['Bulky Support', 'Bulky Attacker', 'Bulky Setup', 'Staller'].includes(role)) {
 			const recoveryMoves = movePool.filter(moveid => RECOVERY_MOVES.includes(moveid));
 			if (recoveryMoves.length) {
 				const moveid = this.sample(recoveryMoves);
@@ -523,10 +528,12 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'marowak') return 'Thick Club';
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
+		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
 		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (species.id === 'ditto' || (species.id === 'rampardos' && role === 'Fast Attacker')) return 'Choice Scarf';
 		if (species.id === 'honchkrow') return 'Life Orb';
+		if (species.id === 'shuckle') return 'Leftovers';
 		if (ability === 'Poison Heal' || moves.has('facade')) return 'Toxic Orb';
 		if (ability === 'Speed Boost' && species.id === 'yanmega') return 'Life Orb';
 		if (['healingwish', 'switcheroo', 'trick'].some(m => moves.has(m))) {
@@ -633,18 +640,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		const forme = this.getForme(species);
 		const sets = this.randomSets[species.id]["sets"];
 		const possibleSets = [];
-		// Check if the Pokemon has a Spinner set
-		let canSpinner = false;
-		for (const set of sets) {
-			if (!teamDetails.rapidSpin && set.role === 'Spinner') canSpinner = true;
-		}
-		for (const set of sets) {
-			// Prevent Spinner if the team already has removal
-			if (teamDetails.rapidSpin && set.role === 'Spinner') continue;
-			// Enforce Spinner if the team does not have removal
-			if (canSpinner && set.role !== 'Spinner') continue;
-			possibleSets.push(set);
-		}
+		for (const set of sets) possibleSets.push(set);
 		const set = this.sampleIfArray(possibleSets);
 		const role = set.role;
 		const movePool: string[] = Array.from(set.movepool);

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -622,7 +622,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			!counter.get('Dragon') && !counter.get('Normal') && !counter.get('Poison') &&
 			noExpertBeltMoves.every(m => !moves.has(m))
 		);
-		if (!counter.get('Status') && expertBeltReqs && (moves.has('uturn') || role === 'Fast Attacker')) return 'Expert Belt';
+		if (!counter.get('Status') && expertBeltReqs && role === 'Fast Attacker') return 'Expert Belt';
 		if (
 			['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) && !moves.has('rapidspin')
 		) return 'Life Orb';

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -210,11 +210,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}
-
-		if (species.id === 'bastiodon') {
-			// Enforces Toxic too, for good measure.
-			this.incompatibleMoves(moves, movePool, ['metalburst', 'protect', 'roar'], ['metalburst', 'protect']);
-		}
 	}
 
 	// Generate random moveset for a given species, role, preferred type.

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -604,8 +604,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (role === 'Fast Support') {
 			return (
 				counter.get('Physical') + counter.get('Special') >= 3 &&
-				['rapidspin', 'uturn'].every(m => !moves.has(m)) &&
-				this.dex.getEffectiveness('Rock', species) < 2
+				['rapidspin', 'uturn'].every(m => !moves.has(m))
 			) ? 'Life Orb' : 'Leftovers';
 		}
 		// noStab moves that should reject Expert Belt
@@ -618,8 +617,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		);
 		if (!counter.get('Status') && expertBeltReqs && (moves.has('uturn') || role === 'Fast Attacker')) return 'Expert Belt';
 		if (
-			['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) &&
-			this.dex.getEffectiveness('Rock', species) < 2 && !moves.has('rapidspin')
+			['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) && !moves.has('rapidspin')
 		) return 'Life Orb';
 		return 'Leftovers';
 	}
@@ -704,8 +702,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		}
 
 		// Prepare optimal HP
-		const srImmunity = ability === 'Magic Guard';
-		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 			if (moves.has('substitute') && item === 'Sitrus Berry') {
@@ -715,12 +711,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				// Belly Drum should activate Sitrus Berry
 				if (hp % 2 === 0) break;
 			} else {
-				// Maximize number of Stealth Rock switch-ins
-				if (srWeakness <= 0) break;
-				if (srWeakness === 1 && ['Black Sludge', 'Leftovers', 'Life Orb'].includes(item)) break;
-				if (item !== 'Sitrus Berry' && hp % (4 / srWeakness) > 0) break;
-				// Minimise number of Stealth Rock switch-ins to activate Sitrus Berry
-				if (item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;
+				break;
 			}
 			evs.hp -= 4;
 		}

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -278,14 +278,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			}
 		}
 
-		// Enforce Substitute on non-Setup sets with Baton Pass
-		if (!role.includes('Setup')) {
-			if (movePool.includes('batonpass') && movePool.includes('substitute')) {
-				counter = this.addMove('substitute', moves, types, abilities, teamDetails, species, isLead,
-					movePool, preferredType, role);
-			}
-		}
-
 		// Enforce hazard removal on Bulky Support and Spinner if the team doesn't already have it
 		if (['Bulky Support', 'Spinner'].includes(role) && !teamDetails.rapidSpin) {
 			if (movePool.includes('rapidspin')) {
@@ -361,12 +353,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				const moveid = this.sample(stabMoves);
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role);
-			} else {
-				// If they have no regular STAB move, enforce U-turn on Bug types.
-				if (movePool.includes('uturn') && types.has('Bug')) {
-					counter = this.addMove('uturn', moves, types, abilities, teamDetails, species, isLead,
-						movePool, preferredType, role);
-				}
 			}
 		}
 
@@ -608,7 +594,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (species.id === 'farfetchd') return 'Stick';
 		if (moves.has('outrage') && counter.get('setup') && !moves.has('sleeptalk')) return 'Lum Berry';
-		if (['batonpass', 'protect', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
+		if (['protect', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (
 			role === 'Fast Support' && isLead && defensiveStatTotal < 255 && !counter.get('recovery') &&
 			(counter.get('hazards') || counter.get('setup')) && (!counter.get('recoil') || ability === 'Rock Head')

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -15,7 +15,7 @@
         ]
     },
     "charizard": {
-        "level": 84,
+        "level": 80,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -50,7 +50,7 @@
         ]
     },
     "butterfree": {
-        "level": 90,
+        "level": 86,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -65,7 +65,7 @@
         ]
     },
     "beedrill": {
-        "level": 99,
+        "level": 97,
         "sets": [
             {
                 "role": "Fast Support",
@@ -75,7 +75,7 @@
         ]
     },
     "pidgeot": {
-        "level": 89,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -101,7 +101,7 @@
         ]
     },
     "fearow": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -210,7 +210,7 @@
         ]
     },
     "ninetales": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -278,7 +278,7 @@
         ]
     },
     "venomoth": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -346,7 +346,7 @@
         ]
     },
     "arcanine": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -440,7 +440,7 @@
         ]
     },
     "rapidash": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -481,7 +481,7 @@
         ]
     },
     "dodrio": {
-        "level": 87,
+        "level": 85,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -491,7 +491,7 @@
         ]
     },
     "dewgong": {
-        "level": 91,
+        "level": 89,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -517,7 +517,7 @@
         ]
     },
     "cloyster": {
-        "level": 79,
+        "level": 77,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -722,7 +722,7 @@
         ]
     },
     "scyther": {
-        "level": 82,
+        "level": 78,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -732,7 +732,7 @@
         ]
     },
     "jynx": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -747,7 +747,7 @@
         ]
     },
     "pinsir": {
-        "level": 87,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -774,7 +774,7 @@
         ]
     },
     "gyarados": {
-        "level": 77,
+        "level": 75,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -784,7 +784,7 @@
         ]
     },
     "lapras": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -834,7 +834,7 @@
         ]
     },
     "flareon": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -879,7 +879,7 @@
         ]
     },
     "aerodactyl": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -915,7 +915,7 @@
         ]
     },
     "articuno": {
-        "level": 83,
+        "level": 79,
         "sets": [
             {
                 "role": "Staller",
@@ -930,7 +930,7 @@
         ]
     },
     "zapdos": {
-        "level": 79,
+        "level": 77,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -940,7 +940,7 @@
         ]
     },
     "moltres": {
-        "level": 82,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -965,7 +965,7 @@
         ]
     },
     "dragonite": {
-        "level": 73,
+        "level": 71,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -1016,7 +1016,7 @@
         ]
     },
     "typhlosion": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1057,7 +1057,7 @@
         ]
     },
     "noctowl": {
-        "level": 97,
+        "level": 95,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1078,7 +1078,7 @@
         ]
     },
     "ariados": {
-        "level": 99,
+        "level": 97,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1088,7 +1088,7 @@
         ]
     },
     "crobat": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1108,7 +1108,7 @@
         ]
     },
     "xatu": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1191,7 +1191,7 @@
         ]
     },
     "jumpluff": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Fast Support",
@@ -1256,7 +1256,7 @@
         ]
     },
     "murkrow": {
-        "level": 89,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1408,7 +1408,7 @@
         ]
     },
     "shuckle": {
-        "level": 89,
+        "level": 98,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1449,7 +1449,7 @@
         ]
     },
     "magcargo": {
-        "level": 98,
+        "level": 96,
         "sets": [
             {
                 "role": "Staller",
@@ -1489,7 +1489,7 @@
         ]
     },
     "mantine": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1519,7 +1519,7 @@
         ]
     },
     "houndoom": {
-        "level": 83,
+        "level": 81,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -1637,7 +1637,7 @@
         ]
     },
     "entei": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -1687,7 +1687,7 @@
         ]
     },
     "lugia": {
-        "level": 72,
+        "level": 70,
         "sets": [
             {
                 "role": "Staller",
@@ -1697,7 +1697,7 @@
         ]
     },
     "hooh": {
-        "level": 72,
+        "level": 68,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1809,7 +1809,7 @@
         ]
     },
     "dustox": {
-        "level": 93,
+        "level": 91,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1849,7 +1849,7 @@
         ]
     },
     "swellow": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1864,7 +1864,7 @@
         ]
     },
     "pelipper": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1891,7 +1891,7 @@
         ]
     },
     "masquerain": {
-        "level": 92,
+        "level": 88,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1936,7 +1936,7 @@
         ]
     },
     "ninjask": {
-        "level": 91,
+        "level": 87,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1951,7 +1951,7 @@
         ]
     },
     "shedinja": {
-        "level": 96,
+        "level": 94,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2107,7 +2107,7 @@
         ]
     },
     "volbeat": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2117,7 +2117,7 @@
         ]
     },
     "illumise": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2173,7 +2173,7 @@
         ]
     },
     "torkoal": {
-        "level": 89,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2239,7 +2239,7 @@
         ]
     },
     "altaria": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2359,7 +2359,7 @@
         ]
     },
     "armaldo": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Spinner",
@@ -2424,7 +2424,7 @@
         ]
     },
     "tropius": {
-        "level": 94,
+        "level": 92,
         "sets": [
             {
                 "role": "Staller",
@@ -2465,7 +2465,7 @@
         ]
     },
     "glalie": {
-        "level": 91,
+        "level": 89,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2476,7 +2476,7 @@
         ]
     },
     "walrein": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2538,7 +2538,7 @@
         ]
     },
     "salamence": {
-        "level": 74,
+        "level": 72,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2586,7 +2586,7 @@
         ]
     },
     "regice": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Staller",
@@ -2677,7 +2677,7 @@
         ]
     },
     "rayquaza": {
-        "level": 72,
+        "level": 70,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -2808,7 +2808,7 @@
         ]
     },
     "staraptor": {
-        "level": 79,
+        "level": 77,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2885,7 +2885,7 @@
         ]
     },
     "bastiodon": {
-        "level": 91,
+        "level": 96,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2920,7 +2920,7 @@
         ]
     },
     "wormadamsandy": {
-        "level": 91,
+        "level": 99,
         "sets": [
             {
                 "role": "Staller",
@@ -2930,7 +2930,7 @@
         ]
     },
     "wormadamtrash": {
-        "level": 87,
+        "level": 95,
         "sets": [
             {
                 "role": "Staller",
@@ -2940,7 +2940,7 @@
         ]
     },
     "mothim": {
-        "level": 95,
+        "level": 91,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2950,7 +2950,7 @@
         ]
     },
     "vespiquen": {
-        "level": 98,
+        "level": 94,
         "sets": [
             {
                 "role": "Staller",
@@ -3027,7 +3027,7 @@
         ]
     },
     "drifblim": {
-        "level": 83,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3067,7 +3067,7 @@
         ]
     },
     "honchkrow": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -3117,7 +3117,7 @@
         ]
     },
     "chatot": {
-        "level": 95,
+        "level": 93,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -3244,7 +3244,7 @@
         ]
     },
     "abomasnow": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3254,7 +3254,7 @@
         ]
     },
     "weavile": {
-        "level": 79,
+        "level": 77,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3331,7 +3331,7 @@
         ]
     },
     "magmortar": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3342,7 +3342,7 @@
         ]
     },
     "togekiss": {
-        "level": 79,
+        "level": 77,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3362,7 +3362,7 @@
         ]
     },
     "yanmega": {
-        "level": 82,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3388,7 +3388,7 @@
         ]
     },
     "glaceon": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3479,7 +3479,7 @@
         ]
     },
     "froslass": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3499,7 +3499,7 @@
         ]
     },
     "rotomheat": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3519,7 +3519,7 @@
         ]
     },
     "rotomfrost": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3529,7 +3529,7 @@
         ]
     },
     "rotomfan": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3734,7 +3734,7 @@
         ]
     },
     "shayminsky": {
-        "level": 72,
+        "level": 70,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3956,7 +3956,7 @@
         ]
     },
     "victini": {
-        "level": 77,
+        "level": 75,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4083,7 +4083,7 @@
         ]
     },
     "simisear": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -4119,7 +4119,7 @@
         ]
     },
     "unfezant": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -4155,7 +4155,7 @@
         ]
     },
     "swoobat": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -4245,7 +4245,7 @@
         ]
     },
     "leavanny": {
-        "level": 91,
+        "level": 89,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -4255,7 +4255,7 @@
         ]
     },
     "scolipede": {
-        "level": 83,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4316,7 +4316,7 @@
         ]
     },
     "darmanitan": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -4341,7 +4341,7 @@
         ]
     },
     "crustle": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -4366,7 +4366,7 @@
         ]
     },
     "sigilyph": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4412,7 +4412,7 @@
         ]
     },
     "archeops": {
-        "level": 77,
+        "level": 75,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4473,7 +4473,7 @@
         ]
     },
     "swanna": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4488,7 +4488,7 @@
         ]
     },
     "vanilluxe": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4510,7 +4510,7 @@
         ]
     },
     "emolga": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4565,7 +4565,7 @@
         ]
     },
     "galvantula": {
-        "level": 81,
+        "level": 79,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -4631,7 +4631,7 @@
         ]
     },
     "chandelure": {
-        "level": 79,
+        "level": 77,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4657,7 +4657,7 @@
         ]
     },
     "beartic": {
-        "level": 93,
+        "level": 91,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -4668,7 +4668,7 @@
         ]
     },
     "cryogonal": {
-        "level": 87,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -4678,7 +4678,7 @@
         ]
     },
     "accelgor": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Support",
@@ -4766,7 +4766,7 @@
         ]
     },
     "braviary": {
-        "level": 83,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4781,7 +4781,7 @@
         ]
     },
     "mandibuzz": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4796,7 +4796,7 @@
         ]
     },
     "heatmor": {
-        "level": 90,
+        "level": 88,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -4828,7 +4828,7 @@
         ]
     },
     "volcarona": {
-        "level": 77,
+        "level": 73,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -4875,7 +4875,7 @@
         ]
     },
     "tornadus": {
-        "level": 78,
+        "level": 76,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -4890,7 +4890,7 @@
         ]
     },
     "tornadustherian": {
-        "level": 75,
+        "level": 73,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4900,7 +4900,7 @@
         ]
     },
     "thundurus": {
-        "level": 77,
+        "level": 75,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -4915,7 +4915,7 @@
         ]
     },
     "thundurustherian": {
-        "level": 76,
+        "level": 74,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4925,7 +4925,7 @@
         ]
     },
     "reshiram": {
-        "level": 72,
+        "level": 70,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4983,7 +4983,7 @@
         ]
     },
     "kyurem": {
-        "level": 76,
+        "level": 74,
         "sets": [
             {
                 "role": "Staller",
@@ -4998,7 +4998,7 @@
         ]
     },
     "kyuremblack": {
-        "level": 74,
+        "level": 72,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -5008,7 +5008,7 @@
         ]
     },
     "kyuremwhite": {
-        "level": 73,
+        "level": 71,
         "sets": [
             {
                 "role": "Fast Attacker",

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -2167,6 +2167,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
                 "abilities": ["Water Veil"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["icebeam", "protect", "scald", "toxic"],
+                "abilities": ["Water Veil"]
             }
         ]
     },
@@ -4445,6 +4450,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["bulletseed", "rockblast", "tailslap", "uturn"],
                 "abilities": ["Skill Link"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["bulletseed", "encore", "tailslap", "uturn"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -4499,9 +4509,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["doubleedge", "hornleech", "naturepower", "return", "substitute", "swordsdance"],
-                "abilities": ["Sap Sipper"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["doubleedge", "hornleech", "naturepower", "return", "swordsdance"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -2962,7 +2962,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "quiverdance", "substitute"],
+                "movepool": ["airslash", "bugbuzz", "quiverdance", "roost", "substitute"],
                 "abilities": ["Tinted Lens"]
             }
         ]

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -38,13 +38,13 @@
         "level": 84,
         "sets": [
             {
-                "role": "Spinner",
+                "role": "Bulky Support",
                 "movepool": ["icebeam", "rapidspin", "roar", "scald", "toxic"],
                 "abilities": ["Torrent"]
             },
             {
                 "role": "Staller",
-                "movepool": ["haze", "icebeam", "protect", "scald", "toxic"],
+                "movepool": ["haze", "icebeam", "protect", "rapidspin", "scald", "toxic"],
                 "abilities": ["Torrent"]
             }
         ]
@@ -70,6 +70,11 @@
             {
                 "role": "Fast Support",
                 "movepool": ["drillrun", "poisonjab", "toxicspikes", "uturn"],
+                "abilities": ["Swarm"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["drillrun", "poisonjab", "swordsdance", "uturn", "xscissor"],
                 "abilities": ["Swarm"]
             }
         ]
@@ -161,8 +166,8 @@
         "level": 88,
         "sets": [
             {
-                "role": "Spinner",
-                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "role": "Bulky Support",
+                "movepool": ["earthquake", "rapidspin", "stoneedge", "toxic"],
                 "abilities": ["Sand Rush"]
             },
             {
@@ -177,7 +182,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
+                "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "toxicspikes"],
                 "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
             }
@@ -191,6 +196,12 @@
                 "movepool": ["earthpower", "fireblast", "icebeam", "sludgewave", "substitute", "superpower"],
                 "abilities": ["Sheer Force"],
                 "preferredTypes": ["Ice"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["earthpower", "icebeam", "sludgewave", "substitute", "toxicspikes"],
+                "abilities": ["Sheer Force"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -199,7 +210,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "doubleedge", "fireblast", "softboiled", "stealthrock", "thunderwave"],
+                "movepool": ["aromatherapy", "doubleedge", "fireblast", "softboiled", "thunderwave"],
                 "abilities": ["Magic Guard"]
             },
             {
@@ -236,7 +247,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "fireblast", "healbell", "protect", "stealthrock", "wish"],
+                "movepool": ["bodyslam", "fireblast", "healbell", "protect", "wish"],
                 "abilities": ["Frisk"]
             },
             {
@@ -297,7 +308,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "honeclaws", "stealthrock", "stoneedge", "suckerpunch"],
+                "movepool": ["earthquake", "honeclaws", "stoneedge", "suckerpunch"],
                 "abilities": ["Arena Trap"]
             },
             {
@@ -350,7 +361,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"],
+                "movepool": ["closecombat", "extremespeed", "flareblitz", "morningsun", "toxic", "wildcharge", "willowisp"],
                 "abilities": ["Intimidate"]
             },
             {
@@ -422,7 +433,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["haze", "icebeam", "rapidspin", "scald", "sludgebomb", "toxicspikes"],
                 "abilities": ["Clear Body", "Liquid Ooze"],
                 "preferredTypes": ["Poison"]
@@ -434,7 +445,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
+                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge", "suckerpunch", "toxic"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -599,7 +610,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "firepunch", "stealthrock", "stoneedge", "swordsdance"],
+                "movepool": ["doubleedge", "earthquake", "firepunch", "stoneedge", "swordsdance"],
                 "abilities": ["Battle Armor", "Rock Head"],
                 "preferredTypes": ["Rock"]
             }
@@ -610,24 +621,21 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "fakeout", "rapidspin", "stoneedge", "suckerpunch"],
-                "abilities": ["Unburden"]
+                "movepool": ["bulkup", "closecombat", "earthquake", "stoneedge", "suckerpunch"],
+                "abilities": ["Unburden"],
+                "preferredTypes": ["Rock"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["earthquake", "highjumpkick", "machpunch", "stoneedge", "suckerpunch"],
-                "abilities": ["Reckless"]
+                "abilities": ["Reckless"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },
     "hitmonchan": {
         "level": 87,
         "sets": [
-            {
-                "role": "Spinner",
-                "movepool": ["drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
-                "abilities": ["Iron Fist"]
-            },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "stoneedge"],
@@ -650,7 +658,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+                "movepool": ["earthquake", "megahorn", "stoneedge", "swordsdance", "toxic"],
                 "abilities": ["Lightning Rod"]
             }
         ]
@@ -660,7 +668,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "thunderwave", "toxic", "wish"],
                 "abilities": ["Natural Cure"]
             }
         ]
@@ -728,6 +736,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["aerialace", "brickbreak", "bugbite", "roost", "swordsdance"],
                 "abilities": ["Technician"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["aerialace", "brickbreak", "pursuit", "uturn"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -751,7 +764,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "movepool": ["closecombat", "earthquake", "stoneedge", "swordsdance", "xscissor"],
                 "abilities": ["Moxie"],
                 "preferredTypes": ["Rock"]
             }
@@ -867,14 +880,14 @@
         "level": 85,
         "sets": [
             {
-                "role": "Spinner",
-                "movepool": ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "waterfall"],
+                "role": "Wallbreaker",
+                "movepool": ["aquajet", "stoneedge", "superpower", "waterfall"],
                 "abilities": ["Battle Armor", "Swift Swim"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["aquajet", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"],
-                "abilities": ["Battle Armor", "Swift Swim"]
+                "role": "Setup Sweeper",
+                "movepool": ["aquajet", "stoneedge", "superpower", "swordsdance", "waterfall"],
+                "abilities": ["Weak Armor"]
             }
         ]
     },
@@ -882,14 +895,9 @@
         "level": 79,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"],
-                "abilities": ["Unnerve"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["aerialace", "aquatail", "earthquake", "roost", "stealthrock", "stoneedge"],
-                "abilities": ["Unnerve"],
+                "role": "Fast Attacker",
+                "movepool": ["aerialace", "aquatail", "earthquake", "honeclaws", "roost", "stoneedge"],
+                "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -994,14 +1002,15 @@
         "level": 79,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"],
+                "role": "Setup Sweeper",
+                "movepool": ["aurasphere", "fireblast", "nastyplot", "psychic", "psyshock", "softboiled"],
                 "abilities": ["Synchronize"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "earthpower", "fireblast", "nastyplot", "psychic", "psyshock", "softboiled"],
-                "abilities": ["Synchronize"]
+                "movepool": ["drainpunch", "suckerpunch", "swordsdance", "xscissor", "zenheadbutt"],
+                "abilities": ["Synchronize"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -1168,7 +1177,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
+                "movepool": ["earthquake", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
                 "abilities": ["Rock Head"],
                 "preferredTypes": ["Grass"]
             }
@@ -1311,12 +1320,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "rapidspin", "spikes", "stealthrock", "toxic"],
-                "abilities": ["Sturdy"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "rapidspin", "stealthrock", "toxicspikes", "voltswitch"],
+                "movepool": ["earthquake", "rapidspin", "spikes", "toxic", "toxicspikes", "voltswitch"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -1341,7 +1345,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+                "movepool": ["earthquake", "roost", "taunt", "toxic", "uturn"],
                 "abilities": ["Immunity"]
             }
         ]
@@ -1351,7 +1355,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "ironhead", "roar", "rockslide", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "ironhead", "roar", "rockslide", "toxic"],
                 "abilities": ["Sheer Force"],
                 "preferredTypes": ["Steel"]
             },
@@ -1362,7 +1366,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "heavyslam", "roar", "toxic"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -1411,8 +1415,8 @@
         "level": 98,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["encore", "knockoff", "stealthrock", "toxic"],
+                "role": "Staller",
+                "movepool": ["encore", "knockoff", "protect", "toxic"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -1453,8 +1457,13 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic"],
+                "movepool": ["earthpower", "hiddenpowerrock", "lavaplume", "recover", "toxic"],
                 "abilities": ["Flame Body"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["fireblast", "hiddenpowergrass", "shellsmash", "stoneedge"],
+                "abilities": ["Weak Armor"]
             }
         ]
     },
@@ -1462,8 +1471,8 @@
         "level": 97,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["powergem", "recover", "scald", "stealthrock", "toxic"],
+                "role": "Staller",
+                "movepool": ["icebeam", "powergem", "recover", "scald", "toxic"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -1482,9 +1491,9 @@
         "level": 100,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"],
-                "abilities": ["Insomnia", "Vital Spirit"]
+                "role": "Staller",
+                "movepool": ["counter", "icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"],
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -1508,12 +1517,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+                "movepool": ["bravebird", "roost", "spikes", "whirlwind"],
                 "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"],
+                "movepool": ["bravebird", "roost", "spikes", "toxic"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -1547,10 +1556,15 @@
         "level": 82,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "iceshard", "rapidspin", "stealthrock", "stoneedge", "toxic"],
+                "role": "Bulky Attacker",
+                "movepool": ["earthquake", "iceshard", "rapidspin", "stoneedge", "toxic"],
                 "abilities": ["Sturdy"],
                 "preferredTypes": ["Rock"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "stoneedge", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1580,7 +1594,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["memento", "spikes", "spore", "stealthrock", "whirlwind"],
+                "movepool": ["memento", "spikes", "spore", "toxicspikes", "whirlwind"],
                 "abilities": ["Own Tempo"]
             }
         ]
@@ -1592,6 +1606,12 @@
                 "role": "Bulky Support",
                 "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
                 "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["bulkup", "closecombat", "earthquake", "stoneedge", "suckerpunch"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },
@@ -1600,7 +1620,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+                "movepool": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "toxic"],
                 "abilities": ["Sap Sipper", "Thick Fat"]
             }
         ]
@@ -1610,7 +1630,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "thunderwave", "toxic"],
                 "abilities": ["Natural Cure"]
             },
             {
@@ -1676,7 +1696,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge", "superpower"],
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stoneedge", "superpower", "thunderwave", "toxic"],
                 "abilities": ["Sand Stream"]
             },
             {
@@ -1714,11 +1734,6 @@
                 "movepool": ["earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "uturn"],
                 "abilities": ["Natural Cure"],
                 "preferredTypes": ["Psychic"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"],
-                "abilities": ["Natural Cure"]
             },
             {
                 "role": "Bulky Setup",
@@ -1767,7 +1782,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icebeam", "roar", "scald", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "icebeam", "scald", "toxic"],
                 "abilities": ["Torrent"]
             },
             {
@@ -1945,7 +1960,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aerialace", "substitute", "swordsdance", "xscissor"],
+                "movepool": ["aerialace", "swordsdance", "uturn", "xscissor"],
                 "abilities": ["Speed Boost"]
             }
         ]
@@ -2026,14 +2041,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["firefang", "ironhead", "suckerpunch", "swordsdance", "thunderpunch"],
-                "abilities": ["Intimidate", "Sheer Force"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["brickbreak", "ironhead", "suckerpunch", "swordsdance"],
+                "abilities": ["Intimidate"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["fireblast", "ironhead", "stealthrock", "suckerpunch", "thunderpunch"],
-                "abilities": ["Intimidate", "Sheer Force"],
+                "role": "Setup Sweeper",
+                "movepool": ["firefang", "ironhead", "suckerpunch", "swordsdance", "thunderpunch"],
+                "abilities": ["Sheer Force"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -2043,14 +2057,9 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["aquatail", "earthquake", "headsmash", "heavyslam", "stealthrock", "thunderwave"],
+                "movepool": ["aquatail", "earthquake", "headsmash", "heavyslam", "rockpolish", "thunderwave"],
                 "abilities": ["Rock Head"],
                 "preferredTypes": ["Ground"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["earthquake", "headsmash", "heavyslam", "rockpolish"],
-                "abilities": ["Rock Head"]
             }
         ]
     },
@@ -2166,8 +2175,13 @@
         "level": 89,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "toxic"],
+                "role": "Staller",
+                "movepool": ["earthquake", "lavaplume", "protect", "toxic"],
+                "abilities": ["Solid Rock"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "fireblast", "hiddenpowergrass", "rockpolish", "stoneedge"],
                 "abilities": ["Solid Rock"]
             }
         ]
@@ -2177,7 +2191,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "lavaplume", "rapidspin", "stealthrock", "yawn"],
+                "movepool": ["earthquake", "lavaplume", "rapidspin", "yawn"],
+                "abilities": ["Shell Armor"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "fireblast", "hiddenpowergrass", "shellsmash"],
                 "abilities": ["Shell Armor"]
             }
         ]
@@ -2187,7 +2206,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"],
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic"],
                 "abilities": ["Thick Fat"]
             },
             {
@@ -2202,9 +2221,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["feintattack", "rapidspin", "return", "suckerpunch", "superpower"],
-                "abilities": ["Contrary"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["feintattack", "return", "suckerpunch", "superpower"],
+                "abilities": ["Contrary"]
             }
         ]
     },
@@ -2285,14 +2303,8 @@
                 "preferredTypes": ["Ground"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["earthpower", "hiddenpowerrock", "moonlight", "psychic", "stealthrock", "toxic"],
-                "abilities": ["Levitate"],
-                "preferredTypes": ["Psychic"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["calmmind", "earthpower", "moonlight", "psychic"],
+                "role": "Bulky Attacker",
+                "movepool": ["calmmind", "earthpower", "moonlight", "psychic", "toxic"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -2302,7 +2314,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "morningsun", "stealthrock", "stoneedge", "willowisp"],
+                "movepool": ["earthquake", "morningsun", "stoneedge", "willowisp"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -2337,7 +2349,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "icebeam", "psychic", "rapidspin", "toxic"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -2352,7 +2364,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "gigadrain", "recover", "stealthrock", "stoneedge", "toxic"],
+                "movepool": ["earthpower", "gigadrain", "recover", "stoneedge", "toxic"],
                 "abilities": ["Storm Drain"],
                 "preferredTypes": ["Grass"]
             }
@@ -2362,14 +2374,16 @@
         "level": 84,
         "sets": [
             {
-                "role": "Spinner",
-                "movepool": ["earthquake", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"],
-                "abilities": ["Battle Armor", "Swift Swim"]
+                "role": "Bulky Support",
+                "movepool": ["earthquake", "rapidspin", "stoneedge", "toxic", "xscissor"],
+                "abilities": ["Battle Armor"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquatail", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
-                "abilities": ["Battle Armor", "Swift Swim"]
+                "movepool": ["aquatail", "earthquake", "rockpolish", "stoneedge", "swordsdance", "xscissor"],
+                "abilities": ["Battle Armor"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2398,7 +2412,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "recover", "stealthrock", "thunderwave", "toxic"],
+                "movepool": ["foulplay", "recover", "seismictoss", "thunderwave", "toxic"],
                 "abilities": ["Color Change"]
             }
         ]
@@ -2479,12 +2493,12 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["encore", "icebeam", "roar", "superfang", "surf", "toxic"],
+                "role": "Staller",
+                "movepool": ["encore", "icebeam", "superfang", "surf", "toxic"],
                 "abilities": ["Thick Fat"]
             },
             {
-                "role": "Staller",
+                "role": "Bulky Support",
                 "movepool": ["icebeam", "protect", "surf", "toxic"],
                 "abilities": ["Thick Fat"]
             }
@@ -2516,7 +2530,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall", "yawn"],
+                "movepool": ["earthquake", "headsmash", "toxic", "waterfall", "yawn"],
                 "abilities": ["Rock Head"]
             },
             {
@@ -2559,7 +2573,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "stealthrock", "thunderpunch", "zenheadbutt"],
+                "movepool": ["bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "thunderpunch", "toxic", "zenheadbutt"],
                 "abilities": ["Clear Body"],
                 "preferredTypes": ["Ground"]
             }
@@ -2575,7 +2589,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "earthquake", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+                "movepool": ["drainpunch", "earthquake", "stoneedge", "thunderwave", "toxic"],
                 "abilities": ["Clear Body"]
             },
             {
@@ -2617,11 +2631,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["rest", "seismictoss", "sleeptalk", "toxic"],
-                "abilities": ["Clear Body"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"],
                 "abilities": ["Clear Body"]
             }
         ]
@@ -2666,7 +2675,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragontail", "earthquake", "lavaplume", "stealthrock", "stoneedge", "thunderwave"],
+                "movepool": ["earthquake", "lavaplume", "overheat", "stoneedge", "thunderwave"],
                 "abilities": ["Drought"]
             },
             {
@@ -2702,7 +2711,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"],
+                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "toxic", "uturn", "wish"],
                 "abilities": ["Serene Grace"]
             }
         ]
@@ -2742,7 +2751,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+                "movepool": ["recover", "seismictoss", "spikes", "taunt", "toxic"],
                 "abilities": ["Pressure"]
             }
         ]
@@ -2752,7 +2761,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+                "movepool": ["psychoboost", "spikes", "superpower", "taunt"],
                 "abilities": ["Pressure"]
             }
         ]
@@ -2762,7 +2771,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+                "movepool": ["earthquake", "stoneedge", "synthesis", "woodhammer"],
                 "abilities": ["Overgrow"]
             },
             {
@@ -2777,7 +2786,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"],
+                "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "uturn"],
                 "abilities": ["Blaze", "Iron Fist"]
             },
             {
@@ -2792,12 +2801,12 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "scald", "stealthrock", "toxic"],
+                "movepool": ["icebeam", "protect", "scald", "toxic"],
                 "abilities": ["Torrent"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "roar", "scald", "stealthrock", "toxic"],
+                "movepool": ["icebeam", "roar", "scald", "toxic"],
                 "abilities": ["Torrent"]
             },
             {
@@ -2889,12 +2898,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["metalburst", "roar", "rockblast", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "metalburst", "roar", "toxic"],
                 "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",
-                "movepool": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "protect", "roar", "toxic"],
                 "abilities": ["Sturdy"]
             }
         ]
@@ -2923,8 +2932,13 @@
         "level": 99,
         "sets": [
             {
+                "role": "Bulky Support",
+                "movepool": ["earthquake", "rest", "sleeptalk", "toxic"],
+                "abilities": ["Anticipation"]
+            },
+                        {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "stealthrock", "suckerpunch", "toxic"],
+                "movepool": ["earthquake", "protect", "rockblast", "toxic"],
                 "abilities": ["Anticipation"]
             }
         ]
@@ -2934,7 +2948,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"],
+                "movepool": ["flashcannon", "rest", "sleeptalk", "toxic"],
                 "abilities": ["Anticipation"]
             }
         ]
@@ -3106,7 +3120,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "hypnosis", "psychic", "stealthrock", "toxic"],
+                "movepool": ["earthquake", "hypnosis", "psychic", "toxic"],
                 "abilities": ["Levitate"]
             },
             {
@@ -3151,7 +3165,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "fireblast", "outrage", "stealthrock", "stoneedge"],
+                "movepool": ["earthquake", "fireblast", "outrage", "stoneedge", "toxic"],
                 "abilities": ["Rough Skin"]
             },
             {
@@ -3182,7 +3196,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
+                "movepool": ["earthquake", "slackoff", "stoneedge", "toxic", "whirlwind"],
                 "abilities": ["Sand Stream"]
             }
         ]
@@ -3412,7 +3426,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "facade", "roost", "stealthrock", "stoneedge", "taunt", "toxic", "uturn"],
+                "movepool": ["earthquake", "facade", "roost", "stoneedge", "taunt", "toxic", "uturn"],
                 "abilities": ["Poison Heal"]
             },
             {
@@ -3427,7 +3441,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "stealthrock", "stoneedge", "superpower"],
+                "movepool": ["earthquake", "iceshard", "iciclecrash", "stoneedge", "superpower", "toxic"],
                 "abilities": ["Thick Fat"]
             }
         ]
@@ -3457,7 +3471,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "powergem", "stealthrock", "thunderwave", "toxic", "voltswitch"],
+                "movepool": ["earthpower", "powergem", "thunderwave", "toxic", "voltswitch"],
                 "abilities": ["Magnet Pull"]
             }
         ]
@@ -3553,7 +3567,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"],
+                "movepool": ["healbell", "psychic", "thunderwave", "uturn", "yawn"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -3568,7 +3582,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfighting", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"],
+                "movepool": ["hiddenpowerfighting", "psychic", "thunderwave", "toxic", "uturn"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -3581,11 +3595,6 @@
                 "movepool": ["fireblast", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "uturn"],
                 "abilities": ["Levitate"],
                 "preferredTypes": ["Fire"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["explosion", "fireblast", "psychic", "stealthrock", "taunt", "uturn"],
-                "abilities": ["Levitate"]
             }
         ]
     },
@@ -3594,7 +3603,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aurasphere", "dracometeor", "dragontail", "fireblast", "stealthrock", "thunderbolt", "toxic"],
+                "movepool": ["aurasphere", "dracometeor", "fireblast", "thunderbolt", "thunderwave", "toxic"],
                 "abilities": ["Pressure"],
                 "preferredTypes": ["Fire"]
             }
@@ -3620,14 +3629,8 @@
                 "abilities": ["Flash Fire"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["earthpower", "fireblast", "hiddenpowerice", "lavaplume", "roar", "stealthrock", "toxic"],
-                "abilities": ["Flash Fire"],
-                "preferredTypes": ["Ground"]
-            },
-            {
                 "role": "Staller",
-                "movepool": ["earthpower", "magmastorm", "protect", "toxic"],
+                "movepool": ["earthpower", "lavaplume", "magmastorm", "protect", "toxic"],
                 "abilities": ["Flash Fire"]
             }
         ]
@@ -3894,12 +3897,6 @@
                 "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"],
                 "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"],
-                "abilities": ["Multitype"],
-                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -4148,9 +4145,14 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower", "toxic"],
+                "movepool": ["earthquake", "explosion", "stoneedge", "superpower", "toxic"],
                 "abilities": ["Sturdy"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "stoneedge", "toxic"],
+                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -4173,12 +4175,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Spinner",
-                "movepool": ["earthquake", "ironhead", "rapidspin", "swordsdance"],
-                "abilities": ["Mold Breaker", "Sand Rush"]
-            },
-            {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["earthquake", "ironhead", "rockslide", "swordsdance"],
                 "abilities": ["Mold Breaker", "Sand Rush"]
             }
@@ -4211,11 +4208,6 @@
                 "role": "Setup Sweeper",
                 "movepool": ["earthquake", "hydropump", "raindance", "sludgewave"],
                 "abilities": ["Swift Swim"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "scald", "sludgebomb", "stealthrock", "toxic"],
-                "abilities": ["Water Absorb"]
             },
             {
                 "role": "Staller",
@@ -4259,9 +4251,14 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "megahorn", "rockslide", "spikes", "swordsdance", "toxicspikes"],
+                "movepool": ["earthquake", "megahorn", "rockslide", "spikes", "toxicspikes"],
                 "abilities": ["Swarm"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "megahorn", "rockslide", "swordsdance"],
+                "abilities": ["Swarm"]
             }
         ]
     },
@@ -4310,7 +4307,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "earthquake", "pursuit", "stealthrock", "stoneedge", "superpower"],
+                "movepool": ["bulkup", "crunch", "earthquake", "pursuit", "stoneedge", "superpower"],
                 "abilities": ["Intimidate"]
             }
         ]
@@ -4416,7 +4413,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["acrobatics", "earthquake", "roost", "stealthrock", "stoneedge", "uturn"],
+                "movepool": ["acrobatics", "earthquake", "roost", "stoneedge", "uturn"],
                 "abilities": ["Defeatist"],
                 "preferredTypes": ["Ground"]
             }
@@ -4584,12 +4581,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gyroball", "leechseed", "powerwhip", "spikes", "stealthrock"],
+                "movepool": ["gyroball", "leechseed", "powerwhip", "spikes", "toxic"],
                 "abilities": ["Iron Barbs"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["powerwhip", "spikes", "stealthrock", "thunderwave", "toxic"],
+                "movepool": ["ironhead", "powerwhip", "spikes", "thunderwave"],
                 "abilities": ["Iron Barbs"]
             }
         ]
@@ -4692,7 +4689,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["discharge", "earthpower", "rest", "scald", "sleeptalk", "stealthrock", "toxic"],
+                "movepool": ["discharge", "earthpower", "rest", "scald", "sleeptalk", "toxic"],
+                "abilities": ["Static"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["discharge", "earthpower", "protect", "toxic"],
                 "abilities": ["Static"]
             }
         ]
@@ -4722,8 +4724,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["dragontail", "earthquake", "glare", "outrage", "stealthrock", "suckerpunch", "superpower"],
+                "role": "Bulky Attacker",
+                "movepool": ["dragontail", "earthquake", "glare", "outrage", "suckerpunch", "superpower"],
                 "abilities": ["Rough Skin"]
             }
         ]
@@ -4733,7 +4735,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dynamicpunch", "earthquake", "icepunch", "rockpolish", "stealthrock", "stoneedge"],
+                "movepool": ["dynamicpunch", "earthquake", "icepunch", "rockpolish", "stoneedge"],
                 "abilities": ["No Guard"],
                 "preferredTypes": ["Fighting"]
             }
@@ -4841,12 +4843,6 @@
         "level": 77,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "taunt", "thunderwave", "toxic"],
-                "abilities": ["Justified"],
-                "preferredTypes": ["Steel"]
-            },
-            {
                 "role": "Bulky Setup",
                 "movepool": ["closecombat", "ironhead", "stoneedge", "swordsdance"],
                 "abilities": ["Justified"]
@@ -4858,7 +4854,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance"],
+                "movepool": ["closecombat", "earthquake", "quickattack", "stoneedge", "swordsdance"],
                 "abilities": ["Justified"],
                 "preferredTypes": ["Ground"]
             }
@@ -4954,7 +4950,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "focusblast", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"],
+                "movepool": ["earthpower", "focusblast", "psychic", "rockpolish", "rockslide", "sludgewave", "uturn"],
                 "abilities": ["Sheer Force"],
                 "preferredTypes": ["Rock"]
             },
@@ -4971,7 +4967,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "stealthrock", "stoneedge", "toxic", "uturn"],
+                "movepool": ["earthquake", "stoneedge", "toxic", "uturn"],
                 "abilities": ["Intimidate"]
             },
             {

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1081,7 +1081,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["acrobatics", "encore", "focusblast", "knockoff", "roost", "toxic"],
+                "movepool": ["acrobatics", "encore", "focusblast", "knockoff", "roost", "toxic", "uturn"],
                 "abilities": ["Early Bird"]
             }
         ]

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1493,7 +1493,7 @@
             {
                 "role": "Staller",
                 "movepool": ["counter", "icebeam", "iceshard", "rapidspin", "seismictoss", "toxic"],
-                "abilities": ["Vital Spirit"]
+                "abilities": ["Insomnia", "Vital Spirit"]
             }
         ]
     },
@@ -2375,13 +2375,13 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "rapidspin", "stoneedge", "toxic", "xscissor"],
-                "abilities": ["Battle Armor"],
+                "abilities": ["Battle Armor", "Swift Swim"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aquatail", "earthquake", "rockpolish", "stoneedge", "swordsdance", "xscissor"],
-                "abilities": ["Battle Armor"],
+                "abilities": ["Battle Armor", "Swift Swim"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -3624,7 +3624,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "eruption", "fireblast", "hiddenpowerice"],
+                "movepool": ["earthpower", "eruption", "fireblast", "hiddenpowergrass", "hiddenpowerice"],
                 "abilities": ["Flash Fire"]
             },
             {
@@ -4362,7 +4362,7 @@
         ]
     },
     "sigilyph": {
-        "level": 80,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -897,7 +897,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["aerialace", "aquatail", "earthquake", "honeclaws", "roost", "stoneedge"],
-                "abilities": ["Pressure"],
+                "abilities": ["Unnerve"],
                 "preferredTypes": ["Ground"]
             }
         ]

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1558,8 +1558,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "iceshard", "rapidspin", "stoneedge", "toxic"],
-                "abilities": ["Sturdy"],
-                "preferredTypes": ["Rock"]
+                "abilities": ["Sturdy"]
             },
             {
                 "role": "Staller",

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -3014,7 +3014,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["gigadrain", "healingwish", "hiddenpowerfire", "hiddenpowerrock", "morningsun", "naturepower"],
+                "movepool": ["gigadrain", "healingwish", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "morningsun", "naturepower"],
                 "abilities": ["Flower Gift"]
             },
             {

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -675,9 +675,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			noExpertBeltMoves.every(m => !moves.has(m))
 		);
 		if (!counter.get('Status') && expertBeltReqs && role === 'Fast Attacker') return 'Expert Belt';
-		if (
-			['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) && ability !== 'Sturdy'
-		) return 'Life Orb';
+		if (['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) && ability !== 'Sturdy') return 'Life Orb';
 		return 'Leftovers';
 	}
 

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -157,10 +157,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			if (movePool.includes('lightscreen')) this.fastPop(movePool, movePool.indexOf('lightscreen'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.stealthRock) {
-			if (movePool.includes('stealthrock')) this.fastPop(movePool, movePool.indexOf('stealthrock'));
-			if (moves.size + movePool.length <= this.maxMoveCount) return;
-		}
 		if (teamDetails.rapidSpin) {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
@@ -194,6 +190,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			[['fakeout', 'uturn'], ['switcheroo', 'trick']],
 			['substitute', PIVOT_MOVES],
 			['rest', 'substitute'],
+			['toxic', 'toxicspikes'],
 
 			// These attacks are redundant with each other
 			['psychic', 'psyshock'],
@@ -210,8 +207,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			['flamethrower', 'overheat'],
 			// Meganium
 			['leechseed', 'dragontail'],
-			// Volcarona and Heatran
-			[['fierydance', 'lavaplume'], 'fireblast'],
+			// Volcarona, Heatran, and Groudon
+			[['fierydance', 'lavaplume'], ['fireblast', 'magmastorm', 'overheat']],
 			// Walrein
 			['encore', 'roar'],
 			// Lunatone
@@ -304,14 +301,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				movePool, preferredType, role);
 		}
 
-		// Enforce Stealth Rock if the team doesn't already have it
-		if (movePool.includes('stealthrock') && !teamDetails.stealthRock) {
-			counter = this.addMove('stealthrock', moves, types, abilities, teamDetails, species, isLead,
-				movePool, preferredType, role);
-		}
-
-		// Enforce hazard removal on Bulky Support and Spinner if the team doesn't already have it
-		if (['Bulky Support', 'Spinner'].includes(role) && !teamDetails.rapidSpin) {
+		// Enforce hazard removal on Bulky Support if the team doesn't already have it
+		if (['Bulky Support'].includes(role) && !teamDetails.rapidSpin) {
 			if (movePool.includes('rapidspin')) {
 				counter = this.addMove('rapidspin', moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role);
@@ -394,8 +385,23 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			}
 		}
 
+		// Enforce one of Spikes or Toxic Spikes
+		const hazardMoves = movePool.filter(moveid => ['spikes', 'toxicspikes'].includes(moveid));
+		if (hazardMoves.length) {
+			// Enforce Toxic Spikes if the team has Spikes only
+			if (teamDetails.spikes && hazardMoves.includes('toxicspikes')) {
+				counter = this.addMove('toxicspikes', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			} else {
+				// Enforce one of the hazards
+				const moveid = this.sample(hazardMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
 		// Enforce recovery
-		if (['Bulky Support', 'Bulky Attacker', 'Bulky Setup', 'Spinner', 'Staller'].includes(role)) {
+		if (['Bulky Support', 'Bulky Attacker', 'Bulky Setup', 'Staller'].includes(role)) {
 			const recoveryMoves = movePool.filter(moveid => RECOVERY_MOVES.includes(moveid));
 			if (recoveryMoves.length) {
 				const moveid = this.sample(recoveryMoves);
@@ -572,6 +578,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'marowak') return 'Thick Club';
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
+		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
 		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (ability === 'Harvest') return 'Sitrus Berry';
@@ -580,7 +587,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'exploud' && role === 'Bulky Attacker') return 'Choice Band';
 		if (ability === 'Poison Heal' || (moves.has('facade') && species.id !== 'stoutland')) return 'Toxic Orb';
 		if (ability === 'Speed Boost' && species.id !== 'ninjask') return 'Life Orb';
-		if (species.nfe) return 'Eviolite';
+		if (species.nfe) return (species.name === 'Scyther' && role === 'Wallbreaker') ? 'Choice Band' : 'Eviolite';
 		if (['healingwish', 'memento', 'switcheroo', 'trick'].some(m => moves.has(m))) {
 			if (
 				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && role !== 'Wallbreaker' && !counter.get('priority')
@@ -592,13 +599,13 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 		if (moves.has('bellydrum')) return 'Sitrus Berry';
 		if (moves.has('waterspout')) return 'Choice Scarf';
-		if (moves.has('shellsmash')) return 'White Herb';
+		if (moves.has('shellsmash') && ability !== 'Weak Armor') return 'White Herb';
 		if (moves.has('psychoshift')) return 'Flame Orb';
 		if (ability === 'Magic Guard') return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (moves.has('acrobatics')) return 'Flying Gem';
-		if (species.id === 'hitmonlee' && ability === 'Unburden') return moves.has('fakeout') ? 'Normal Gem' : 'Fighting Gem';
+		if (species.id === 'hitmonlee' && ability === 'Unburden') return 'Fighting Gem';
 		if (moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
 		if (moves.has('rest') && !moves.has('sleeptalk') && !['Natural Cure', 'Shed Skin'].includes(ability)) {
 			return (moves.has('raindance') && ability === 'Hydration') ? 'Damp Rock' : 'Chesto Berry';
@@ -644,7 +651,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			) ? 'Choice Scarf' : 'Choice Band';
 		}
 
-		if (ability === 'Sturdy' && moves.has('explosion')) return 'Custap Berry';
+		if (ability === 'Sturdy' && moves.has('explosion') && !counter.get('speedsetup')) return 'Custap Berry';
 		if (types.has('Normal') && moves.has('fakeout') && !!counter.get('Normal')) return 'Silk Scarf';
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
@@ -653,12 +660,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				ability === 'Regenerator' && species.baseStats.hp + species.baseStats.def >= 180 && this.randomChance(1, 2))
 		) return 'Rocky Helmet';
 		if (['protect', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
-		if (
-			this.dex.getEffectiveness('Ground', species) >= 2 &&
-			ability !== 'Levitate'
-		) {
-			return 'Air Balloon';
-		}
 		if (
 			role === 'Fast Support' && isLead && defensiveStatTotal < 255 && !counter.get('recovery') &&
 			(counter.get('hazards') || counter.get('setup')) && (!counter.get('recoil') || ability === 'Rock Head')
@@ -700,18 +701,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		const forme = this.getForme(species);
 		const sets = this.randomSets[species.id]["sets"];
 		const possibleSets = [];
-		// Check if the Pokemon has a Spinner set
-		let canSpinner = false;
-		for (const set of sets) {
-			if (!teamDetails.rapidSpin && set.role === 'Spinner') canSpinner = true;
-		}
-		for (const set of sets) {
-			// Prevent Spinner if the team already has removal
-			if (teamDetails.rapidSpin && set.role === 'Spinner') continue;
-			// Enforce Spinner if the team does not have removal
-			if (canSpinner && set.role !== 'Spinner') continue;
-			possibleSets.push(set);
-		}
+		for (const set of sets) possibleSets.push(set);
 		const set = this.sampleIfArray(possibleSets);
 		const role = set.role;
 		const movePool: string[] = Array.from(set.movepool);

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -223,8 +223,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
-		if (species.id === 'dugtrio') this.incompatibleMoves(moves, movePool, statusMoves, 'memento');
-
 		const statusInflictingMoves = ['stunspore', 'thunderwave', 'toxic', 'willowisp', 'yawn'];
 		if (!abilities.includes('Prankster') && role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -668,8 +668,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (role === 'Fast Support') {
 			return (
 				counter.get('Physical') + counter.get('Special') >= 3 &&
-				['rapidspin', 'uturn', 'voltswitch'].every(m => !moves.has(m)) &&
-				this.dex.getEffectiveness('Rock', species) < 2
+				['rapidspin', 'uturn', 'voltswitch'].every(m => !moves.has(m))
 			) ? 'Life Orb' : 'Leftovers';
 		}
 		// noStab moves that should reject Expert Belt
@@ -685,8 +684,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			(moves.has('uturn') || moves.has('voltswitch') || role === 'Fast Attacker')
 		) return 'Expert Belt';
 		if (
-			['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) &&
-			this.dex.getEffectiveness('Rock', species) < 2 && ability !== 'Sturdy'
+			['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) && ability !== 'Sturdy'
 		) return 'Life Orb';
 		return 'Leftovers';
 	}
@@ -771,8 +769,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 
 		// Prepare optimal HP
-		const srImmunity = ability === 'Magic Guard';
-		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 			if (moves.has('substitute') && !['Black Sludge', 'Leftovers'].includes(item)) {
@@ -790,12 +786,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				// Crash damage move users want an odd HP to survive two misses
 				if (hp % 2 > 0) break;
 			} else {
-				// Maximize number of Stealth Rock switch-ins
-				if (srWeakness <= 0 || ability === 'Regenerator') break;
-				if (srWeakness === 1 && ['Black Sludge', 'Leftovers', 'Life Orb'].includes(item)) break;
-				if (item !== 'Sitrus Berry' && hp % (4 / srWeakness) > 0) break;
-				// Minimise number of Stealth Rock switch-ins to activate Sitrus Berry
-				if (item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;
+				break;
 			}
 			evs.hp -= 4;
 		}

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -376,12 +376,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				const moveid = this.sample(stabMoves);
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role);
-			} else {
-				// If they have no regular STAB move, enforce U-turn on Bug types.
-				if (movePool.includes('uturn') && types.has('Bug')) {
-					counter = this.addMove('uturn', moves, types, abilities, teamDetails, species, isLead,
-						movePool, preferredType, role);
-				}
 			}
 		}
 
@@ -441,7 +435,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 
 		// Enforce a move not on the noSTAB list
-		if (!counter.damagingMoves.size && !(moves.has('uturn') && types.has('Bug'))) {
+		if (!counter.damagingMoves.size) {
 			// Choose an attacking move
 			const attackingMoves = [];
 			for (const moveid of movePool) {

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -232,9 +232,9 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		if (abilities.includes('Guts')) this.incompatibleMoves(moves, movePool, 'protect', 'swordsdance');
 
-		// Cull filler moves for otherwise fixed set Stealth Rock users
+		// Ensure Mamoswine has Ice Shard
 		if (species.id === 'mamoswine') {
-			this.incompatibleMoves(moves, movePool, ['stealthrock', 'stoneedge'], ['stoneedge', 'superpower']);
+			this.incompatibleMoves(moves, movePool, ['stoneedge', 'superpower'], ['superpower', 'toxic']);
 		}
 	}
 

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -680,10 +680,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			!counter.get('Dragon') && !counter.get('Normal') && !counter.get('Poison') &&
 			noExpertBeltMoves.every(m => !moves.has(m))
 		);
-		if (
-			!counter.get('Status') && expertBeltReqs &&
-			(moves.has('uturn') || moves.has('voltswitch') || role === 'Fast Attacker')
-		) return 'Expert Belt';
+		if (!counter.get('Status') && expertBeltReqs && role === 'Fast Attacker') return 'Expert Belt';
 		if (
 			['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) && ability !== 'Sturdy'
 		) return 'Life Orb';

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -382,7 +382,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		// Enforce one of Spikes or Toxic Spikes
 		const hazardMoves = movePool.filter(moveid => ['spikes', 'toxicspikes'].includes(moveid));
 		if (hazardMoves.length) {
-			// Enforce Toxic Spikes if the team has Spikes only
+			// Enforce Toxic Spikes if the team has Spikes already
 			if (teamDetails.spikes && hazardMoves.includes('toxicspikes')) {
 				counter = this.addMove('toxicspikes', moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role);

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1837,7 +1837,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge"],
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge", "toxic"],
                 "abilities": ["Sand Stream"]
             },
             {
@@ -4408,6 +4408,11 @@
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
                 "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4417,6 +4422,11 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["defog", "earthquake", "judgment", "recover", "toxic", "willowisp"],
+                "abilities": ["Multitype"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
                 "abilities": ["Multitype"]
             }
         ]
@@ -4933,6 +4943,11 @@
                 "movepool": ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"],
                 "abilities": ["Skill Link"],
                 "preferredTypes": ["Grass"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["bulletseed", "encore", "tailslap", "uturn"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -4988,9 +5003,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hornleech", "jumpkick", "return", "substitute", "swordsdance"],
-                "abilities": ["Sap Sipper"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["hornleech", "jumpkick", "return", "swordsdance"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },
@@ -5702,9 +5716,15 @@
         "level": 84,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["drainpunch", "gunkshot", "icepunch", "knockoff", "superpower"],
+                "role": "Bulky Attacker",
+                "movepool": ["drainpunch", "gunkshot", "icepunch", "knockoff"],
                 "abilities": ["Iron Fist"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["earthquake", "gunkshot", "knockoff", "stoneedge", "superpower"],
+                "abilities": ["Scrappy"],
+                "preferredTypes": ["Poison"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -2425,6 +2425,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
                 "abilities": ["Water Veil"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["icebeam", "protect", "scald", "toxic"],
+                "abilities": ["Water Veil"]
             }
         ]
     },

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -2665,6 +2665,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
                 "abilities": ["Water Veil"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["icebeam", "protect", "scald", "toxic"],
+                "abilities": ["Water Veil"]
             }
         ]
     },

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1846,12 +1846,14 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "scald"],
-                "abilities": ["Sniper"]
+                "abilities": ["Sniper"],
+                "preferredTypes": ["Poison"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["energyball", "fireblast", "gunkshot", "icebeam", "scald", "thunderwave"],
-                "abilities": ["Sniper"]
+                "abilities": ["Sniper"],
+                "preferredTypes": ["Poison"]
             }
         ]
     },
@@ -2057,7 +2059,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge"],
+                "movepool": ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge", "toxic"],
                 "abilities": ["Sand Stream"]
             },
             {
@@ -4760,6 +4762,11 @@
                 "movepool": ["earthquake", "extremespeed", "recover", "stoneedge", "swordsdance"],
                 "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -4776,6 +4783,11 @@
                 "movepool": ["earthquake", "ironhead", "recover", "stoneedge", "swordsdance"],
                 "abilities": ["Multitype"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["calmmind", "earthpower", "judgment", "recover"],
+                "abilities": ["Multitype"]
             }
         ]
     },
@@ -5150,14 +5162,15 @@
         "level": 87,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Fast Attacker",
                 "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "quiverdance", "sleeppowder"],
                 "abilities": ["Chlorophyll"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Z-Move user",
                 "movepool": ["hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"],
-                "abilities": ["Own Tempo"]
+                "abilities": ["Own Tempo"],
+                "preferredTypes": ["Grass"]
             }
         ]
     },
@@ -5318,6 +5331,11 @@
                 "movepool": ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"],
                 "abilities": ["Skill Link"],
                 "preferredTypes": ["Grass"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["bulletseed", "encore", "tailslap", "uturn"],
+                "abilities": ["Skill Link"]
             }
         ]
     },
@@ -5379,9 +5397,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["headbutt", "hornleech", "jumpkick", "return", "substitute", "swordsdance"],
-                "abilities": ["Sap Sipper", "Serene Grace"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["headbutt", "hornleech", "jumpkick", "swordsdance"],
+                "abilities": ["Serene Grace"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["hornleech", "jumpkick", "return", "swordsdance"],
+                "abilities": ["Sap Sipper"]
             }
         ]
     },
@@ -6173,10 +6195,14 @@
         "level": 86,
         "sets": [
             {
+                "role": "Bulky Attacker",
+                "movepool": ["bulletpunch", "drainpunch", "gunkshot", "knockoff"],
+                "abilities": ["Iron Fist"]
+            },
+            {
                 "role": "Wallbreaker",
-                "movepool": ["bulletpunch", "drainpunch", "gunkshot", "icepunch", "knockoff", "superpower"],
-                "abilities": ["Iron Fist"],
-                "preferredTypes": ["Poison"]
+                "movepool": ["bulletpunch", "gunkshot", "knockoff", "superpower"],
+                "abilities": ["Scrappy"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -251,7 +251,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			// These attacks are redundant with each other
 			['psychic', 'psyshock'],
 			[['scald', 'surf'], ['hydropump', 'originpulse', 'waterpulse']],
-			['return', ['bodyslam', 'doubleedge', 'headbutt']],
+			['return', ['bodyslam', 'doubleedge']],
 			[['fierydance', 'firelash', 'lavaplume'], ['fireblast', 'magmastorm']],
 			[['flamethrower', 'flareblitz'], ['fireblast', 'overheat']],
 			['hornleech', 'woodhammer'],
@@ -617,7 +617,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'pangoro' && counter.get('ironfist')) return 'Iron Fist';
 		if (species.id === 'tornadus' && counter.get('Status')) return 'Prankster';
 		if (species.id === 'marowak' && counter.get('recoil')) return 'Rock Head';
-		if (species.id === 'sawsbuck') return moves.has('headbutt') ? 'Serene Grace' : 'Sap Sipper';
 		if (species.id === 'toucannon' && counter.get('skilllink')) return 'Skill Link';
 		if (species.id === 'golduck' && teamDetails.rain) return 'Swift Swim';
 		if (species.id === 'roserade' && counter.get('technician')) return 'Technician';

--- a/data/random-battles/gen8/sets.json
+++ b/data/random-battles/gen8/sets.json
@@ -1318,7 +1318,12 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Brave Bird", "Iron Defense", "Roost", "Spikes", "Stealth Rock", "Toxic"],
+                "movepool": ["Body Press", "Brave Bird", "Roost", "Spikes", "Stealth Rock", "Toxic"],
+                "abilities": ["Sturdy"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Brave Bird", "Iron Defense", "Roost"],
                 "abilities": ["Sturdy"]
             }
         ]

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -49,7 +49,7 @@ const HAZARDS = [
 ];
 // Protect and its variants
 const PROTECT_MOVES = [
-	'banefulbunker', 'protect', 'spikyshield',
+	'banefulbunker', 'kingsshield', 'protect', 'spikyshield',
 ];
 // Moves that switch the user out
 const PIVOT_MOVES = [

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -228,8 +228,7 @@ export class RandomGen8Teams extends RandomTeams {
 			// These attacks are redundant with each other
 			['psychic', 'psyshock'],
 			[['scald', 'surf'], ['hydropump', 'originpulse']],
-			['lavaplume', 'magmastorm'],
-			['flamethrower', ['fireblast', 'overheat']],
+			[['flamethrower', 'lavaplume'], ['fireblast', 'magmastorm', 'overheat']],
 			['hornleech', 'woodhammer'],
 			['gigadrain', 'leafstorm'],
 			['airslash', 'hurricane'],

--- a/data/random-battles/gen9/sets-megainvasion.json
+++ b/data/random-battles/gen9/sets-megainvasion.json
@@ -32,13 +32,19 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Air Slash", "Dragon Pulse", "Fire Blast", "Scorching Sands", "Solar Beam"],
+                "movepool": ["Air Slash", "Dragon Pulse", "Solar Beam", "Weather Ball"],
                 "abilities": ["Blaze"],
-                "teraTypes": ["Grass"]
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Air Slash", "Scorching Sands", "Solar Beam", "Weather Ball"],
+                "abilities": ["Blaze"],
+                "teraTypes": ["Stellar"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Dragon Pulse", "Fire Blast", "Scorching Sands", "Solar Beam"],
+                "movepool": ["Dragon Pulse", "Scorching Sands", "Solar Beam", "Weather Ball"],
                 "abilities": ["Blaze"],
                 "teraTypes": ["Stellar"]
             }
@@ -77,7 +83,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Destiny Bond", "Encore", "Shadow Ball", "Sludge Wave"],
+                "movepool": ["Encore", "Nasty Plot", "Shadow Ball", "Sludge Wave"],
                 "abilities": ["Cursed Body"],
                 "teraTypes": ["Stellar"]
             },

--- a/data/random-battles/gen9/sets-megainvasion.json
+++ b/data/random-battles/gen9/sets-megainvasion.json
@@ -239,7 +239,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Mystical Fire", "Psyshock"],
+                "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Psyshock"],
+                "abilities": ["Trace"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Hyper Voice", "Mystical Fire", "Psyshock"],
                 "abilities": ["Trace"],
                 "teraTypes": ["Stellar"]
             }

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1422,9 +1422,7 @@ export class RandomTeams {
 	): number {
 		if (this.adjustLevel) return this.adjustLevel;
 		// Temporarily modified for Mega Invasion randomized spotlight
-		if (
-			this.gen === 9 && (species.id in this.randomMegaSets)
-		) return this.randomMegaSets[species.id]["level"]!;
+		if (this.gen === 9 && (species.id in this.randomMegaSets)) return this.randomMegaSets[species.id]["level"]!;
 		// doubles levelling
 		if (isDoubles && this.randomDoublesSets[species.id]["level"]) return this.randomDoublesSets[species.id]["level"]!;
 		if (!isDoubles && this.randomSets[species.id]["level"]) return this.randomSets[species.id]["level"]!;

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1423,7 +1423,7 @@ export class RandomTeams {
 		if (this.adjustLevel) return this.adjustLevel;
 		// Temporarily modified for Mega Invasion randomized spotlight
 		if (
-			this.gen === 9 && Object.keys(this.randomMegaSets).includes(species.id)
+			this.gen === 9 && (species.id in this.randomMegaSets)
 		) return this.randomMegaSets[species.id]["level"]!;
 		// doubles levelling
 		if (isDoubles && this.randomDoublesSets[species.id]["level"]) return this.randomDoublesSets[species.id]["level"]!;

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1422,7 +1422,9 @@ export class RandomTeams {
 	): number {
 		if (this.adjustLevel) return this.adjustLevel;
 		// Temporarily modified for Mega Invasion randomized spotlight
-		if (Object.keys(this.randomMegaSets).includes(species.id)) return this.randomMegaSets[species.id]["level"]!;
+		if (
+			this.gen === 9 && Object.keys(this.randomMegaSets).includes(species.id)
+		) return this.randomMegaSets[species.id]["level"]!;
 		// doubles levelling
 		if (isDoubles && this.randomDoublesSets[species.id]["level"]) return this.randomDoublesSets[species.id]["level"]!;
 		if (!isDoubles && this.randomSets[species.id]["level"]) return this.randomSets[species.id]["level"]!;

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1438,7 +1438,7 @@ export class RandomTeams {
 				NU: 73,
 				NUBL: 71,
 				UU: 69,
-				UUBL: 67,
+				UUBL: 67, "(OU)": 67,
 				OU: 65,
 				Uber: 61,
 			};

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -276,8 +276,9 @@ describe("New set format (slow)", () => {
 							const stealthRock = Math.floor(i / 2) % 2;
 							const stickyWeb = Math.floor(i / 4) % 2;
 							const spikes = Math.floor(i / 8) % 2;
+							const toxicSpikes = Math.floor(i / 4) % 2;
 							const screens = Math.floor(i / 2) % 2;
-							const teamDetails = { rapidSpin, stealthRock, stickyWeb, spikes, screens };
+							const teamDetails = { rapidSpin, stealthRock, stickyWeb, spikes, toxicSpikes, screens };
 							// randomMoveset() deletes moves from the movepool, so recreate it every time
 							const movePool = set.movepool.map(m => (m.startsWith('hiddenpower') ? m : dex.moves.get(m).id));
 							let moveSet;


### PR DESCRIPTION
Ready to merge!

This is a large update that implements two [Random Battles development council decisions](https://www.smogon.com/forums/threads/random-battles-development-council-information-council-minutes.3718103/#post-10983069):
- Stat passing has been removed from Gens 3-4 Random Battle.
- Stealth Rock has been removed from Gens 4-5 Random Battle.

Many sets have been modified as a result of these; I will not list them all here. They can be viewed by clicking on "Files changed" near the top. Notable holistic changes include
- Bulky Support still enforces Rapid Spin unless the team has another user, but the Spinner role no longer exists
- Sets with Spikes or Toxic Spikes (or both) will always generate a hazard
- Pokémon 4x weak to Rock are no longer prevented from having Life Orb as their item

In addition, some manual level changes have been made to preserve greater balance in the formats:
- Gen 3 Ninjask: +4 levels
- Gens 4-5: most Pokémon 2x weak to Rock had their levels changed by -2, and those 4x weak to Rock by -4. Exceptions include those already at level 100 since they were probably below average to begin with, Gen 4 Ninjask since we simultaneously removed statpass, and Gen 5 Sigilyph because two-thirds of its sets are immune to Stealth Rock. Shuckle, Bastiodon, Wormadam-Trash, and (in Gen 5) Wormadam-Sandy's levels were drastically buffed because their utility is greatly reduced without Stealth Rock.

Other updates are listed below.

**Mega Invasion Random Battle**:
- Mega Gardevoir will always have Hyper Voice
- Levels no longer affect Gen 6-7 Random Battle
- Mega Gengar replaces Destiny Bond with Nasty Plot on its dual STABs set
- Mega Charizard Y replaces Fire Blast with Weather Ball

**Gen 8 Random Battle (bug fixes)**:
- Fix Torkoal getting Lava Plume + Fire Blast
- Fix Aegislash not always having King's Shield on its Toxic set
- Fix Skarmory not generating hazard + Toxic

**Old Gens Random Battle**:
- Gen 7 Octillery will always have Gunk Shot
- Gens 3-7 Tyranitar: +Toxic
- Gens 6-7: Arceus-Rock and Arceus-Steel now have Calm Mind sets
- Gen 7 Petal Dance Lilligant now holds Grassium Z instead of Life Orb
- Gens 5-7 Wailord now has a Leftovers set with Toxic, Protect, Scald, and Ice Beam.
- Gens 5-7 Cinccino now has a Life Orb Encore set with Tail Slap, Bullet Seed, and U-turn
- Gens 5-7 Sawsbuck no longer runs Substitute, ensuring it always has coverage for Steels
- Gen 5 Cherrim: +HP Ice
- Gens 6-7 Pangoro's Choice Band sets have been split so that Drain Punch is Iron Fist and Superpower is Scrappy. In Gen 6, the Scrappy set runs Earthquake/Stone Edge instead of Ice Punch for its 4th move.
- Gen 3 Mightyena: -Shadow Ball
- Gen 3 Gengar: -Fire Punch
- Gen 3 Shedinja now has Choice Band sometimes
- Gen 3 Manectric now has Leftovers sets that can inflict status
- Gen 3 Beedrill now always has Sludge Bomb, and runs HP Ground instead of Brick Break on sets that don't have HP Bug
- Gen 3 Octillery will always have Thunder Wave
- Gen 2 Ho-Oh now has a Flamethrower/Recover/Toxic/Whirlwind set
- Gen 2 Blissey: -Light Screen
- Porygon2's level is back to 67 in Gen 2 Random Battle. It inadvertently changed to 80 when Porygon2 moved from UUBL to "OU by technicality".
- Gen 1 Parasect: -Slash
- Gen 1 Kangaskhan: +Blizzard