### PR TITLE
Allow formats that use Stat Points to bypass the EV check using alternate Natures

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1327,14 +1327,14 @@ export class TeamValidator {
 			if (set.level === 50 && ruleTable.maxLevel !== 50 && !ruleTable.maxTotalLevel && evLimit !== 0 && totalEV % 4 === 0) {
 				problems.push(`${name} is level 50, but this format allows level ${ruleTable.maxLevel} Pokémon. (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
 			}
+		}
 
-			if (evLimit !== null && totalEV > evLimit) {
-				const statName = useStatPoints ? 'Stat Points' : 'EVs';
-				if (!evLimit) {
-					problems.push(`${name} has ${statName}, which is not allowed by this format.`);
-				} else {
-					problems.push(`${name} has ${totalEV} total ${statName}, which is more than this format's limit of ${evLimit}.`);
-				}
+		if (evLimit !== null && totalEV > evLimit) {
+			const statName = useStatPoints ? 'Stat Points' : 'EVs';
+			if (!evLimit) {
+				problems.push(`${name} has ${statName}, which is not allowed by this format.`);
+			} else {
+				problems.push(`${name} has ${totalEV} total ${statName}, which is more than this format's limit of ${evLimit}.`);
 			}
 		}
 

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1312,7 +1312,13 @@ export class TeamValidator {
 		for (const stat in set.evs) totalEV += set.evs[stat as 'hp'];
 		if (!this.format.debug) {
 			if (set.level > 1 && evLimit !== 0 && totalEV === 0) {
-				problems.push(`${name} has exactly 0 EVs - did you forget to EV it? (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
+				if (useStatPoints) {
+					if (set.nature === 'Serious') {
+						problems.push(`${name} has exactly 0 Stat Points - did you forget to invest it? (If this was intentional, change your Nature to a different neutral Nature, which won't change its stats but will tell us that it wasn't a mistake).`);
+					}
+				} else {
+					problems.push(`${name} has exactly 0 EVs - did you forget to EV it? (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
+				}
 			} else if (![508, 510].includes(evLimit!) && [508, 510].includes(totalEV)) {
 				problems.push(`${name} has exactly ${totalEV} EVs, but this format does not restrict you to 510 EVs (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
 			}
@@ -1321,14 +1327,14 @@ export class TeamValidator {
 			if (set.level === 50 && ruleTable.maxLevel !== 50 && !ruleTable.maxTotalLevel && evLimit !== 0 && totalEV % 4 === 0) {
 				problems.push(`${name} is level 50, but this format allows level ${ruleTable.maxLevel} Pokémon. (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
 			}
-		}
 
-		if (evLimit !== null && totalEV > evLimit) {
-			const statName = useStatPoints ? 'Stat Points' : 'EVs';
-			if (!evLimit) {
-				problems.push(`${name} has ${statName}, which is not allowed by this format.`);
-			} else {
-				problems.push(`${name} has ${totalEV} total ${statName}, which is more than this format's limit of ${evLimit}.`);
+			if (evLimit !== null && totalEV > evLimit) {
+				const statName = useStatPoints ? 'Stat Points' : 'EVs';
+				if (!evLimit) {
+					problems.push(`${name} has ${statName}, which is not allowed by this format.`);
+				} else {
+					problems.push(`${name} has ${totalEV} total ${statName}, which is more than this format's limit of ${evLimit}.`);
+				}
 			}
 		}
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/the-validator-shouldnt-reject-0-ev-mons-in-champions.3782129/

Formats that useStatPoints can't invest 1 point without changing stats, so I added an alternate bypass where it will pass as long as the Nature is not the default (Serious).