### PR TITLE
Champions: Fix Fake Out and First Impression turn count

### DIFF
--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -345,7 +345,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	fakeout: {
 		inherit: true,
 		onDisableMove(pokemon) {
-			if (pokemon.activeMoveActions > 0) {
+			if (pokemon.activeMoveActions) {
 				pokemon.disableMove('fakeout');
 			}
 		},
@@ -379,7 +379,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		basePower: 100,
 		onDisableMove(pokemon) {
-			if (pokemon.activeMoveActions > 0) {
+			if (pokemon.activeMoveActions) {
 				pokemon.disableMove('firstimpression');
 			}
 		},

--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -345,7 +345,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	fakeout: {
 		inherit: true,
 		onDisableMove(pokemon) {
-			if (pokemon.activeMoveActions > 1) {
+			if (pokemon.activeMoveActions > 0) {
 				pokemon.disableMove('fakeout');
 			}
 		},
@@ -379,7 +379,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		basePower: 100,
 		onDisableMove(pokemon) {
-			if (pokemon.activeMoveActions > 1) {
+			if (pokemon.activeMoveActions > 0) {
 				pokemon.disableMove('firstimpression');
 			}
 		},


### PR DESCRIPTION
Right now, Fake Out remains enabled during the second move selection. Since the increment happens at the beginning of `BattleActions.runMove`, the check needs to differ from the base mod.