### PR TITLE
Gen 3-4: Fix all-target moves and fainted Pokémon activating Pressure

### DIFF
--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -662,7 +662,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	imprison: {
 		inherit: true,
-		flags: { bypasssub: 1, metronome: 1 },
+		flags: { bypasssub: 1, metronome: 1, mustpressure: 1 },
 		onTryHit(pokemon) {
 			for (const target of pokemon.foes()) {
 				for (const move of pokemon.moves) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -19221,7 +19221,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		name: "Tera Blast",
 		pp: 10,
 		priority: 0,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { protect: 1, mirror: 1, metronome: 1, mustpressure: 1 },
 		onPrepareHit(target, source, move) {
 			if (source.terastallized) {
 				this.attrLastMove('[anim] Tera Blast ' + source.teraType);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -19221,7 +19221,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		name: "Tera Blast",
 		pp: 10,
 		priority: 0,
-		flags: { protect: 1, mirror: 1, metronome: 1, mustpressure: 1 },
+		flags: { protect: 1, mirror: 1, metronome: 1 },
 		onPrepareHit(target, source, move) {
 			if (source.terastallized) {
 				this.attrLastMove('[anim] Tera Blast ' + source.teraType);

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -863,7 +863,7 @@ export class Pokemon {
 	}
 
 	ignoringAbility() {
-		if (this.battle.gen >= 5 && !this.isActive) return true;
+		if (!this.isActive && (this.battle.gen >= 5 || this.fainted)) return true;
 
 		// Certain Abilities won't activate while Transformed, even if they ordinarily couldn't be suppressed (e.g. Disguise)
 		if (this.getAbility().flags['notransform'] && this.transformed) return true;
@@ -885,7 +885,7 @@ export class Pokemon {
 
 	ignoringItem(isFling = false) {
 		if (this.getItem().isPrimalOrb) return false;
-		if (this.battle.gen >= 5 && !this.isActive) return true;
+		if (!this.isActive && (this.battle.gen >= 5 || this.fainted)) return true;
 		if (this.volatiles['embargo'] || this.battle.field.pseudoWeather['magicroom']) return true;
 		// check Fling first to avoid infinite recursion
 		if (isFling) return this.battle.gen >= 5 && this.hasAbility('klutz');

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -852,7 +852,7 @@ export class Pokemon {
 
 		// Resolve apparent targets for Pressure.
 		let pressureTargets = targets;
-		if (move.target === 'foeSide') {
+		if (move.target === 'foeSide' || (move.target === 'all' && move.id !== 'perishsong' && this.battle.gen <= 3)) {
 			pressureTargets = [];
 		}
 		if (move.flags['mustpressure']) {
@@ -884,8 +884,8 @@ export class Pokemon {
 	}
 
 	ignoringItem(isFling = false) {
-		if (this.getItem().isPrimalOrb) return false;
 		if ((this.battle.gen >= 5 && !this.isActive) || this.fainted) return true;
+		if (this.getItem().isPrimalOrb) return false;
 		if (this.volatiles['embargo'] || this.battle.field.pseudoWeather['magicroom']) return true;
 		// check Fling first to avoid infinite recursion
 		if (isFling) return this.battle.gen >= 5 && this.hasAbility('klutz');

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -863,7 +863,7 @@ export class Pokemon {
 	}
 
 	ignoringAbility() {
-		if (!this.isActive && (this.battle.gen >= 5 || this.fainted)) return true;
+		if ((this.battle.gen >= 5 && !this.isActive) || this.fainted) return true;
 
 		// Certain Abilities won't activate while Transformed, even if they ordinarily couldn't be suppressed (e.g. Disguise)
 		if (this.getAbility().flags['notransform'] && this.transformed) return true;
@@ -885,7 +885,7 @@ export class Pokemon {
 
 	ignoringItem(isFling = false) {
 		if (this.getItem().isPrimalOrb) return false;
-		if (!this.isActive && (this.battle.gen >= 5 || this.fainted)) return true;
+		if ((this.battle.gen >= 5 && !this.isActive) || this.fainted) return true;
 		if (this.volatiles['embargo'] || this.battle.field.pseudoWeather['magicroom']) return true;
 		// check Fling first to avoid infinite recursion
 		if (isFling) return this.battle.gen >= 5 && this.hasAbility('klutz');


### PR DESCRIPTION
Fixes #12024 

In Gen 3, moves like Sunny Day are not affected by Pressure, unlike in later gens. Only two moves manually check for Pressure:

* Imprison: affected by the opponent's Pressure
* Perish Song: affected by all Pokémon hit, including allies