### PR TITLE
Add inheritance to abilities and move flags

### DIFF
--- a/data/mods/afd/moves.ts
+++ b/data/mods/afd/moves.ts
@@ -395,7 +395,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	headsmash: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, heal: 1 },
+		flags: { inherit: true, heal: 1 },
 		secondary: {
 			chance: 100,
 			onHit(target, source, move) {

--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -176,7 +176,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	crushclaw: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
+		flags: { inherit: true, slicing: 1 },
 	},
 	crushgrip: {
 		inherit: true,
@@ -204,7 +204,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	direclaw: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
+		flags: { inherit: true, slicing: 1 },
 		secondary: {
 			chance: 30,
 			onHit(target, source) {
@@ -254,11 +254,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	dragoncheer: {
 		inherit: true,
-		flags: { bypasssub: 1, allyanim: 1, metronome: 1, sound: 1 },
+		flags: { inherit: true, sound: 1 },
 	},
 	dragonclaw: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
+		flags: { inherit: true, slicing: 1 },
 	},
 	dragonenergy: {
 		inherit: true,
@@ -635,7 +635,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	metalclaw: {
 		inherit: true,
 		isNonstandard: "Past",
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
+		flags: { inherit: true, slicing: 1 },
 	},
 	metronome: {
 		inherit: true,
@@ -882,7 +882,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	shadowclaw: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
+		flags: { inherit: true, slicing: 1 },
 	},
 	shadowforce: {
 		inherit: true,

--- a/data/mods/chatbats/abilities.ts
+++ b/data/mods/chatbats/abilities.ts
@@ -495,7 +495,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	asoneglastrier: {
 		inherit: true,
 		// removing these flags allows Frozen Armor to correctly set Caly-Ice ability as As One
-		flags: {},
+		flags: { inherit: true, cantsuppress: 0, failroleplay: 0, failskillswap: 0, noentrain: 0, noreceiver: 0, notrace: 0 },
 	},
 	protean: {
 		inherit: true,

--- a/data/mods/chatbats/abilities.ts
+++ b/data/mods/chatbats/abilities.ts
@@ -495,7 +495,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	asoneglastrier: {
 		inherit: true,
 		// removing these flags allows Frozen Armor to correctly set Caly-Ice ability as As One
-		flags: { inherit: true, cantsuppress: 0, failroleplay: 0, failskillswap: 0, noentrain: 0, noreceiver: 0, notrace: 0 },
+		flags: {},
 	},
 	protean: {
 		inherit: true,

--- a/data/mods/chatbats/moves.ts
+++ b/data/mods/chatbats/moves.ts
@@ -1023,7 +1023,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	purify: {
 		inherit: true,
 		pp: 10,
-		flags: { reflectable: 1, heal: 1, metronome: 1 },
+		flags: { inherit: true, protect: 0 },
 		onHit(target, source) {
 			const foe = source.side.foe.active[0];
 			if (foe && !foe.fainted && foe.status) {
@@ -1717,6 +1717,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	superfang: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, bite: 1 },
+		flags: { inherit: true, bite: 1 },
 	},
 };

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -182,7 +182,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 
 			return 2 * this.lastDamage;
 		},
-		flags: { contact: 1, protect: 1, metronome: 1 },
+		flags: { inherit: true, metronome: 1 },
 	},
 	crabhammer: {
 		inherit: true,
@@ -451,7 +451,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mimic: {
 		inherit: true,
-		flags: { protect: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, metronome: 1 },
 		onHit(target, source) {
 			const moveslot = source.side.lastSelectedMoveSlot;
 			const moves = target.moves;

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -153,7 +153,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	explosion: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1, noparentalbond: 1, nosketch: 1 },
+		flags: { inherit: true, nosketch: 1 },
 	},
 	flail: {
 		inherit: true,
@@ -305,16 +305,16 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	meanlook: {
 		inherit: true,
-		flags: { reflectable: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, protect: 0 },
 	},
 	metronome: {
 		inherit: true,
-		flags: { failencore: 1, nosketch: 1 },
+		flags: { inherit: true, failencore: 1, failmimic: 0, nosketch: 1, nosleeptalk: 0 },
 	},
 	mimic: {
 		inherit: true,
 		accuracy: 100,
-		flags: { protect: 1, bypasssub: 1, allyanim: 1, failencore: 1, noassist: 1, nosketch: 1 },
+		flags: { inherit: true, failmimic: 0, nosketch: 1 },
 	},
 	mindreader: {
 		inherit: true,
@@ -341,7 +341,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mirrormove: {
 		inherit: true,
-		flags: { metronome: 1, failencore: 1, nosketch: 1 },
+		flags: { inherit: true, nosketch: 1, nosleeptalk: 0 },
 		onHit(pokemon) {
 			const noMirror = ['metronome', 'mimic', 'mirrormove', 'sketch', 'sleeptalk', 'transform'];
 			const target = pokemon.side.foe.active[0];
@@ -575,11 +575,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	selfdestruct: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1, noparentalbond: 1, nosketch: 1 },
+		flags: { inherit: true, nosketch: 1 },
 	},
 	sketch: {
 		inherit: true,
-		flags: { bypasssub: 1, failencore: 1, noassist: 1, nosketch: 1 },
+		flags: { inherit: true, failmimic: 0 },
 		onHit() {
 			// Sketch always fails in Link Battles
 			this.add('-nothing');
@@ -605,7 +605,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sleeptalk: {
 		inherit: true,
-		flags: { failencore: 1, nosleeptalk: 1, nosketch: 1 },
+		flags: { inherit: true, failencore: 1, nosketch: 1 },
 		onHit(pokemon) {
 			const moves = [];
 			for (const moveSlot of pokemon.moveSlots) {
@@ -631,7 +631,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	spiderweb: {
 		inherit: true,
-		flags: { reflectable: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, protect: 0 },
 	},
 	spikes: {
 		inherit: true,
@@ -752,7 +752,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	transform: {
 		inherit: true,
-		flags: { bypasssub: 1, metronome: 1, failencore: 1, nosketch: 1 },
+		flags: { inherit: true, nosketch: 1 },
 	},
 	triattack: {
 		inherit: true,

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -47,7 +47,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	forecast: {
 		inherit: true,
-		flags: {},
+		flags: { inherit: true, notrace: 0 },
 	},
 	hustle: {
 		inherit: true,
@@ -192,7 +192,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			const ability = target.getAbility();
 			pokemon.setAbility(ability, target);
 		},
-		flags: {},
+		flags: { inherit: true, notrace: 0 },
 	},
 	truant: {
 		inherit: true,

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -18,15 +18,15 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	ancientpower: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, contact: 1 },
 	},
 	assist: {
 		inherit: true,
-		flags: { metronome: 1, noassist: 1, nosleeptalk: 1 },
+		flags: { inherit: true, metronome: 1 },
 	},
 	astonish: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, minimize: 1 },
+		flags: { inherit: true, minimize: 1 },
 	},
 	beatup: {
 		inherit: true,
@@ -183,7 +183,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	covet: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, noassist: 1 },
+		flags: { inherit: true, contact: 0 },
 	},
 	crunch: {
 		inherit: true,
@@ -201,7 +201,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	disable: {
 		inherit: true,
 		accuracy: 55,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
 		condition: {
 			inherit: true,
 			durationCallback() {
@@ -260,15 +259,15 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	extrasensory: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1, minimize: 1 },
+		flags: { inherit: true, minimize: 1 },
 	},
 	fakeout: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, contact: 0 },
 	},
 	feintattack: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, contact: 0 },
 	},
 	flail: {
 		inherit: true,
@@ -402,7 +401,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mimic: {
 		inherit: true,
-		flags: { protect: 1, bypasssub: 1, allyanim: 1, failencore: 1, noassist: 1, failmimic: 1 },
+		flags: { inherit: true, bypasssub: 1 },
 	},
 	mirrorcoat: {
 		inherit: true,
@@ -427,7 +426,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mirrormove: {
 		inherit: true,
-		flags: { metronome: 1, failencore: 1, nosleeptalk: 1, noassist: 1 },
+		flags: { inherit: true, metronome: 1 },
 		onTryHit: undefined, // no inherit
 		onHit(pokemon) {
 			const noMirror = [
@@ -453,7 +452,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	needlearm: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, minimize: 1 },
+		flags: { inherit: true, minimize: 1 },
 	},
 	nightmare: {
 		inherit: true,
@@ -469,7 +468,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	overheat: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, contact: 1 },
 	},
 	petaldance: {
 		inherit: true,
@@ -521,7 +520,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sketch: {
 		inherit: true,
-		flags: { bypasssub: 1, failencore: 1, noassist: 1, failmimic: 1, nosketch: 1 },
+		flags: { inherit: true, allyanim: 0 },
 	},
 	sleeptalk: {
 		inherit: true,
@@ -579,7 +578,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	struggle: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, noassist: 1, failencore: 1, failmimic: 1, nosketch: 1 },
 		accuracy: 100,
 		recoil: [1, 4],
 		struggleRecoil: false,
@@ -590,7 +588,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	taunt: {
 		inherit: true,
-		flags: { protect: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, mirror: 0 },
 		condition: {
 			inherit: true,
 			duration: 2,
@@ -603,11 +601,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	teeterdance: {
 		inherit: true,
-		flags: { protect: 1, metronome: 1 },
+		flags: { inherit: true, mirror: 0 },
 	},
 	tickle: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, allyanim: 0, bypasssub: 1 },
 	},
 	uproar: {
 		inherit: true,

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -145,11 +145,11 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				return this.chainModify(1.5);
 			}
 		},
-		flags: { breakable: 1 },
+		flags: { inherit: true, failroleplay: 0, notrace: 0 },
 	},
 	forecast: {
 		inherit: true,
-		flags: { notrace: 1 },
+		flags: { inherit: true, failroleplay: 0 },
 	},
 	forewarn: {
 		inherit: true,
@@ -521,7 +521,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			if (ability.flags['notrace']) return;
 			pokemon.setAbility(ability, target);
 		},
-		flags: { notrace: 1 },
+		flags: { inherit: true, failroleplay: 0 },
 	},
 	vitalspirit: {
 		inherit: true,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1,7 +1,7 @@
 export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	acupressure: {
 		inherit: true,
-		flags: { snatch: 1, metronome: 1 },
+		flags: { inherit: true, snatch: 1 },
 		onHit(target) {
 			if (target.volatiles['substitute']) {
 				return false;
@@ -35,7 +35,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	aquaring: {
 		inherit: true,
-		flags: { metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 		condition: {
 			inherit: true,
 			onResidualOrder: 10,
@@ -186,7 +186,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	conversion: {
 		inherit: true,
-		flags: { metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 		onHit(target) {
 			const possibleTypes = target.moveSlots.map(moveSlot => {
 				const move = this.dex.moves.get(moveSlot.id);
@@ -267,7 +267,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	curse: {
 		inherit: true,
-		flags: { metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 		onModifyMove(move, source, target) {
 			if (!source.hasType('Ghost')) {
 				delete move.volatileStatus;
@@ -288,7 +288,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	defog: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 	},
 	detect: {
 		inherit: true,
@@ -297,7 +297,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	disable: {
 		inherit: true,
 		accuracy: 80,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 		condition: {
 			inherit: true,
 			duration: undefined, // no inherit
@@ -380,7 +380,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	embargo: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 		onTryHit(pokemon) {
 			if (pokemon.ability === 'multitype' || pokemon.item === 'griseousorb') {
 				return false;
@@ -394,7 +394,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	encore: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1, failencore: 1 },
+		flags: { inherit: true, reflectable: 0 },
 		volatileStatus: 'encore',
 		condition: {
 			inherit: true,
@@ -511,7 +511,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	foresight: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 	},
 	furycutter: {
 		inherit: true,
@@ -611,7 +611,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	healblock: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 		condition: {
 			inherit: true,
 			onResidualOrder: 10,
@@ -625,7 +625,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	healingwish: {
 		inherit: true,
-		flags: { heal: 1, metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 		onAfterMove(pokemon) {
 			pokemon.switchFlag = true;
 		},
@@ -662,7 +662,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	imprison: {
 		inherit: true,
-		flags: { bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, mustpressure: 0, snatch: 0 },
 		onTryHit(pokemon) {
 			for (const target of pokemon.foes()) {
 				for (const move of pokemon.moves) {
@@ -743,7 +743,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	luckychant: {
 		inherit: true,
-		flags: { metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 		condition: {
 			inherit: true,
 			onSideResidualOrder: 6,
@@ -752,7 +752,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	lunardance: {
 		inherit: true,
-		flags: { heal: 1, metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 		onAfterMove(pokemon) {
 			pokemon.switchFlag = true;
 		},
@@ -804,7 +804,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	magnetrise: {
 		inherit: true,
-		flags: { gravity: 1, metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 		volatileStatus: 'magnetrise',
 		condition: {
 			inherit: true,
@@ -828,11 +828,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	metalburst: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, failmefirst: 0 },
 	},
 	metronome: {
 		inherit: true,
-		flags: { noassist: 1, failcopycat: 1, nosleeptalk: 1, failmimic: 1 },
+		flags: { inherit: true, failmimic: 1 },
 		onHit(pokemon) {
 			const moves = this.dex.moves.all().filter(move => (
 				(!move.isNonstandard || move.isNonstandard === 'Unobtainable') &&
@@ -852,9 +852,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mimic: {
 		inherit: true,
-		flags: {
-			protect: 1, allyanim: 1, noassist: 1, failcopycat: 1, failencore: 1, failinstruct: 1, failmimic: 1,
-		},
+		flags: { inherit: true, bypasssub: 0, nosleeptalk: 0 },
 		onHit(target, source) {
 			if (source.transformed || !target.lastMove || target.volatiles['substitute']) {
 				return false;
@@ -885,7 +883,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	miracleeye: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 	},
 	mirrormove: {
 		inherit: true,
@@ -953,7 +951,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	naturepower: {
 		inherit: true,
-		flags: { metronome: 1 },
+		flags: { inherit: true, failcopycat: 0, metronome: 1, noassist: 0, nosleeptalk: 0 },
 		onHit(pokemon) {
 			this.actions.useMove('triattack', pokemon);
 		},
@@ -968,7 +966,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	odorsleuth: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, allyanim: 0, reflectable: 0 },
 	},
 	outrage: {
 		inherit: true,
@@ -1009,7 +1007,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	powertrick: {
 		inherit: true,
-		flags: { metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 	},
 	protect: {
 		inherit: true,
@@ -1032,7 +1030,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	psychup: {
 		inherit: true,
-		flags: { snatch: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, allyanim: 0, snatch: 1 },
 	},
 	pursuit: {
 		inherit: true,
@@ -1101,7 +1099,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	recycle: {
 		inherit: true,
-		flags: { metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 	},
 	reflect: {
 		inherit: true,
@@ -1145,7 +1143,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	roar: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 	},
 	rockblast: {
 		inherit: true,
@@ -1177,10 +1175,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sketch: {
 		inherit: true,
-		flags: {
-			bypasssub: 1, allyanim: 1, failencore: 1, noassist: 1,
-			failcopycat: 1, failinstruct: 1, failmimic: 1, nosketch: 1,
-		},
+		flags: { inherit: true, nosleeptalk: 0 },
 		onHit(target, source) {
 			if (source.transformed || !target.lastMove || target.volatiles['substitute']) {
 				return false;
@@ -1212,7 +1207,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	snatch: {
 		inherit: true,
-		flags: { bypasssub: 1, noassist: 1, failcopycat: 1 },
+		flags: { inherit: true, mustpressure: 0 },
 		condition: {
 			inherit: true,
 			onAnyPrepareHit(source, target, move) {
@@ -1238,11 +1233,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	snore: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, metronome: 1 },
 	},
 	spikes: {
 		inherit: true,
-		flags: { metronome: 1, mustpressure: 1 },
+		flags: { inherit: true, reflectable: 0 },
 		condition: {
 			inherit: true,
 			onSwitchIn: undefined, // no inherit
@@ -1255,11 +1250,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	spite: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 	},
 	stealthrock: {
 		inherit: true,
-		flags: { metronome: 1, mustpressure: 1 },
+		flags: { inherit: true, reflectable: 0 },
 		condition: {
 			inherit: true,
 			onSwitchIn: undefined, // no inherit
@@ -1272,10 +1267,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	struggle: {
 		inherit: true,
-		flags: {
-			contact: 1, protect: 1, failencore: 1, failmefirst: 1,
-			noassist: 1, failcopycat: 1, failinstruct: 1, failmimic: 1, nosketch: 1,
-		},
+		flags: { inherit: true, nosleeptalk: 0 },
 		onModifyMove(move) {
 			move.type = '???';
 		},
@@ -1378,7 +1370,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	taunt: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 		condition: {
 			inherit: true,
 			duration: undefined, // no inherit
@@ -1413,7 +1405,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	torment: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 	},
 	toxic: {
 		inherit: true,
@@ -1421,7 +1413,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	toxicspikes: {
 		inherit: true,
-		flags: { metronome: 1, mustpressure: 1 },
+		flags: { inherit: true, reflectable: 0 },
 		condition: {
 			inherit: true,
 			onSwitchIn: undefined, // no inherit
@@ -1442,7 +1434,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	transform: {
 		inherit: true,
-		flags: { bypasssub: 1, metronome: 1, failencore: 1 },
+		flags: { inherit: true, allyanim: 0, bypasssub: 1, failcopycat: 0, failmimic: 0, metronome: 1, noassist: 0 },
 	},
 	trickroom: {
 		inherit: true,
@@ -1490,11 +1482,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	whirlwind: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, reflectable: 0 },
 	},
 	wish: {
 		inherit: true,
-		flags: { heal: 1, metronome: 1 },
+		flags: { inherit: true, snatch: 0 },
 		slotCondition: 'Wish',
 		condition: {
 			duration: 2,

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -69,7 +69,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			if (type === 'sandstorm' || type === 'hail') return false;
 		},
 		onTryHit: undefined, // no inherit
-		flags: {},
+		flags: { inherit: true, breakable: 0 },
 		rating: 0.5,
 	},
 	sapsipper: {

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -1,7 +1,7 @@
 export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	absorb: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	acidarmor: {
 		inherit: true,
@@ -67,7 +67,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	bestow: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, noassist: 1, failcopycat: 1 },
+		flags: { inherit: true, allyanim: 0, bypasssub: 0, protect: 1 },
 	},
 	blizzard: {
 		inherit: true,
@@ -75,15 +75,15 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	block: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, protect: 1 },
 	},
 	bodyslam: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, nonsky: 1, metronome: 1 },
+		flags: { inherit: true, minimize: 0 },
 	},
 	bounce: {
 		inherit: true,
-		flags: { contact: 1, charge: 1, protect: 1, mirror: 1, gravity: 1, distance: 1, metronome: 1, nosleeptalk: 1 },
+		flags: { inherit: true, noassist: 0 },
 	},
 	bubble: {
 		inherit: true,
@@ -91,7 +91,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	bugbuzz: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	camouflage: {
 		inherit: true,
@@ -117,10 +117,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			chance: 10,
 			volatileStatus: 'confusion',
 		},
-		flags: {
-			protect: 1, sound: 1, distance: 1, noassist: 1, failcopycat: 1,
-			failmefirst: 1, nosleeptalk: 1, failmimic: 1, nosketch: 1,
-		},
+		flags: { inherit: true, bypasssub: 0, mirror: 0 },
 	},
 	conversion: {
 		inherit: true,
@@ -177,11 +174,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	dig: {
 		inherit: true,
-		flags: { contact: 1, charge: 1, protect: 1, mirror: 1, nonsky: 1, metronome: 1, nosleeptalk: 1 },
+		flags: { inherit: true, noassist: 0 },
 	},
 	dive: {
 		inherit: true,
-		flags: { contact: 1, charge: 1, protect: 1, mirror: 1, nonsky: 1, metronome: 1, nosleeptalk: 1 },
+		flags: { inherit: true, noassist: 0 },
 	},
 	dracometeor: {
 		inherit: true,
@@ -193,19 +190,19 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	drainpunch: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, punch: 1, metronome: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	dragonrush: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, minimize: 0 },
 	},
 	dreameater: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	echoedvoice: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	electroball: {
 		inherit: true,
@@ -226,11 +223,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	feint: {
 		inherit: true,
-		flags: { noassist: 1, failcopycat: 1 },
+		flags: { inherit: true, mirror: 0 },
 	},
 	finalgambit: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, metronome: 1 },
+		flags: { inherit: true, contact: 1 },
 	},
 	fireblast: {
 		inherit: true,
@@ -253,7 +250,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	fly: {
 		inherit: true,
-		flags: { contact: 1, charge: 1, protect: 1, mirror: 1, gravity: 1, distance: 1, metronome: 1 },
+		flags: { inherit: true, noassist: 0, nosleeptalk: 0 },
 	},
 	followme: {
 		inherit: true,
@@ -304,7 +301,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	gigadrain: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	glare: {
 		inherit: true,
@@ -312,7 +309,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	grasswhistle: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	grasspledge: {
 		inherit: true,
@@ -327,7 +324,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	growl: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	growth: {
 		inherit: true,
@@ -348,7 +345,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	healbell: {
 		inherit: true,
-		flags: { snatch: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0, distance: 0 },
 		onHit(target, source) {
 			this.add('-activate', source, 'move: Heal Bell');
 			const allies = [...target.side.pokemon, ...target.side.allySide?.pokemon || []];
@@ -369,7 +366,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	heatcrash: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, nonsky: 1, metronome: 1 },
+		flags: { inherit: true, minimize: 0 },
 	},
 	heatwave: {
 		inherit: true,
@@ -454,7 +451,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	hornleech: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	hurricane: {
 		inherit: true,
@@ -466,7 +463,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	hypervoice: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	icebeam: {
 		inherit: true,
@@ -493,7 +490,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	leechlife: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	lick: {
 		inherit: true,
@@ -545,15 +542,15 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	meanlook: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, protect: 1 },
 	},
 	megadrain: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	metalsound: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, allyanim: 0, bypasssub: 0 },
 	},
 	meteormash: {
 		inherit: true,
@@ -608,7 +605,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	perishsong: {
 		inherit: true,
-		flags: { sound: 1, distance: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	pinmissile: {
 		inherit: true,
@@ -685,7 +682,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	ragepowder: {
 		inherit: true,
 		priority: 3,
-		flags: { noassist: 1, failcopycat: 1 },
 		condition: {
 			inherit: true,
 			onFoeRedirectTarget(target, source, source2, move) {
@@ -717,12 +713,12 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	relicsong: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	roar: {
 		inherit: true,
 		accuracy: 100,
-		flags: { protect: 1, reflectable: 1, mirror: 1, sound: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, allyanim: 0, failcopycat: 0, noassist: 0, protect: 1 },
 	},
 	rocktomb: {
 		inherit: true,
@@ -732,7 +728,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	round: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	sacredsword: {
 		inherit: true,
@@ -744,7 +740,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	screech: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, allyanim: 0, bypasssub: 0 },
 	},
 	secretpower: {
 		inherit: true,
@@ -757,11 +753,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	shadowforce: {
 		inherit: true,
-		flags: { contact: 1, charge: 1, mirror: 1, metronome: 1, nosleeptalk: 1 },
+		flags: { inherit: true, minimize: 0, noassist: 0 },
 	},
 	sing: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	skullbash: {
 		inherit: true,
@@ -770,7 +766,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	skydrop: {
 		inherit: true,
-		flags: { contact: 1, charge: 1, protect: 1, mirror: 1, gravity: 1, distance: 1, metronome: 1, nosleeptalk: 1 },
+		flags: { inherit: true, noassist: 0 },
 		onTryHit(target, source, move) {
 			if (target.fainted) return false;
 			if (source.removeVolatile(move.id)) {
@@ -806,12 +802,12 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	snarl: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	snore: {
 		inherit: true,
 		basePower: 40,
-		flags: { protect: 1, mirror: 1, sound: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	soak: {
 		inherit: true,
@@ -890,7 +886,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	supersonic: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, sound: 1, metronome: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	surf: {
 		inherit: true,
@@ -942,7 +938,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	uproar: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, sound: 1, metronome: 1, nosleeptalk: 1 },
+		flags: { inherit: true, bypasssub: 0 },
 	},
 	vinewhip: {
 		inherit: true,
@@ -985,7 +981,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	whirlwind: {
 		inherit: true,
 		accuracy: 100,
-		flags: { protect: 1, reflectable: 1, mirror: 1, bypasssub: 1, metronome: 1 },
+		flags: { inherit: true, allyanim: 0, failcopycat: 0, noassist: 0, protect: 1 },
 	},
 	wideguard: {
 		inherit: true,

--- a/data/mods/gen6/abilities.ts
+++ b/data/mods/gen6/abilities.ts
@@ -122,6 +122,6 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	zenmode: {
 		inherit: true,
-		flags: { failroleplay: 1, noentrain: 1, notrace: 1 },
+		flags: { inherit: true, cantsuppress: 0, failskillswap: 0 },
 	},
 };

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -5,11 +5,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	assist: {
 		inherit: true,
-		flags: { noassist: 1, failcopycat: 1, nosleeptalk: 1 },
+		flags: { inherit: true, failencore: 0 },
 	},
 	copycat: {
 		inherit: true,
-		flags: { noassist: 1, failcopycat: 1, nosleeptalk: 1 },
+		flags: { inherit: true, failencore: 0 },
 	},
 	darkvoid: {
 		inherit: true,
@@ -47,7 +47,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	heavyslam: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, nonsky: 1, metronome: 1 },
+		flags: { inherit: true, minimize: 0 },
 	},
 	leechlife: {
 		inherit: true,
@@ -56,11 +56,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mefirst: {
 		inherit: true,
-		flags: { protect: 1, bypasssub: 1, noassist: 1, failcopycat: 1, failmefirst: 1, nosleeptalk: 1 },
+		flags: { inherit: true, failencore: 0 },
 	},
 	metronome: {
 		inherit: true,
-		flags: { noassist: 1, failcopycat: 1, nosleeptalk: 1 },
+		flags: { inherit: true, failencore: 0 },
 	},
 	mistyterrain: {
 		inherit: true,
@@ -75,7 +75,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	naturepower: {
 		inherit: true,
-		flags: { nosleeptalk: 1, noassist: 1, failcopycat: 1 },
+		flags: { inherit: true, failencore: 0 },
 	},
 	paraboliccharge: {
 		inherit: true,
@@ -89,7 +89,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	phantomforce: {
 		inherit: true,
-		flags: { contact: 1, charge: 1, mirror: 1, metronome: 1, nosleeptalk: 1, noassist: 1, failinstruct: 1, minimize: 1 },
+		flags: { inherit: true, minimize: 1 },
 	},
 	powder: {
 		inherit: true,
@@ -100,11 +100,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	rockblast: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, bullet: 0 },
 	},
 	shadowforce: {
 		inherit: true,
-		flags: { contact: 1, charge: 1, mirror: 1, metronome: 1, nosleeptalk: 1, noassist: 1, failinstruct: 1, minimize: 1 },
+		flags: { inherit: true, minimize: 1 },
 	},
 	sheercold: {
 		inherit: true,
@@ -112,7 +112,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sleeptalk: {
 		inherit: true,
-		flags: { nosleeptalk: 1, noassist: 1, failcopycat: 1 },
+		flags: { inherit: true, failencore: 0 },
 	},
 	stockpile: {
 		inherit: true,

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -25,11 +25,11 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	darkaura: {
 		inherit: true,
-		flags: { breakable: 1 },
+		flags: { inherit: true, breakable: 1 },
 	},
 	fairyaura: {
 		inherit: true,
-		flags: { breakable: 1 },
+		flags: { inherit: true, breakable: 1 },
 	},
 	innerfocus: {
 		inherit: true,

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -151,9 +151,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	dive: {
 		inherit: true,
-		flags: {
-			contact: 1, charge: 1, protect: 1, mirror: 1, nonsky: 1, metronome: 1, nosleeptalk: 1, noassist: 1, failinstruct: 1,
-		},
+		flags: { inherit: true, allyanim: 0 },
 	},
 	dizzypunch: {
 		inherit: true,
@@ -169,7 +167,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	dragonhammer: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, metronome: 1 },
 	},
 	dragonrage: {
 		inherit: true,
@@ -443,7 +441,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	howl: {
 		inherit: true,
-		flags: { snatch: 1, metronome: 1 },
+		flags: { inherit: true, sound: 0 },
 		boosts: {
 			atk: 1,
 		},
@@ -594,7 +592,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	moongeistbeam: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, metronome: 1 },
 	},
 	moonlight: {
 		inherit: true,
@@ -662,7 +660,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	naturesmadness: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, metronome: 1 },
 	},
 	needlearm: {
 		inherit: true,
@@ -690,7 +688,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	pollenpuff: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, metronome: 1, bullet: 1 },
+		flags: { inherit: true, allyanim: 0 },
 		onHit(target, source) {
 			if (source.isAlly(target)) {
 				if (!this.heal(Math.floor(target.baseMaxhp * 0.5))) {
@@ -932,7 +930,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sunsteelstrike: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, metronome: 1 },
 	},
 	supersonicskystrike: {
 		inherit: true,

--- a/data/mods/gen7letsgo/moves.ts
+++ b/data/mods/gen7letsgo/moves.ts
@@ -19,7 +19,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	doubleironbash: {
 		inherit: true,
 		isNonstandard: null,
-		flags: { contact: 1, protect: 1, mirror: 1, punch: 1, minimize: 1 },
+		flags: { inherit: true, minimize: 1 },
 	},
 	floatyfall: {
 		inherit: true,

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -411,7 +411,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	gulpmissile: {
 		inherit: true,
-		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1 },
+		flags: { inherit: true, failroleplay: 1, failskillswap: 1, noentrain: 1, noreceiver: 1, notrace: 1 },
 		rating: 2.5,
 	},
 	guts: {
@@ -483,7 +483,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		inherit: true,
 		onTryBoost: undefined, // no inherit
 		onModifyMove: undefined, // no inherit
-		flags: {},
+		flags: { inherit: true, breakable: 0 },
 		rating: 0,
 	},
 	illusion: {
@@ -1202,7 +1202,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	wonderguard: {
 		inherit: true,
-		flags: { failroleplay: 1, noreceiver: 1, failskillswap: 1, breakable: 1 },
+		flags: { inherit: true, noentrain: 0 },
 		rating: 5,
 	},
 	wonderskin: {

--- a/data/mods/gen8/moves.ts
+++ b/data/mods/gen8/moves.ts
@@ -14,7 +14,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	assist: {
 		inherit: true,
-		flags: { failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	auroraveil: {
 		inherit: true,
@@ -32,7 +32,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	belch: {
 		inherit: true,
-		flags: { protect: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	blizzard: {
 		inherit: true,
@@ -54,7 +54,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	celebrate: {
 		inherit: true,
-		flags: { nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	charge: {
 		inherit: true,
@@ -74,14 +74,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	chatter: {
 		inherit: true,
-		flags: {
-			protect: 1, mirror: 1, sound: 1, distance: 1, bypasssub: 1,
-			noassist: 1, failcopycat: 1, failinstruct: 1, failmefirst: 1, nosleeptalk: 1, failmimic: 1, nosketch: 1,
-		},
+		flags: { inherit: true, failmefirst: 1, nosketch: 1 },
 	},
 	copycat: {
 		inherit: true,
-		flags: { failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	coreenforcer: {
 		inherit: true,
@@ -111,7 +108,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	darkvoid: {
 		inherit: true,
 		isNonstandard: "Past",
-		flags: { protect: 1, reflectable: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, nosketch: 0 },
 	},
 	doubleironbash: {
 		inherit: true,
@@ -119,7 +116,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	dragonhammer: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1 },
+		flags: { inherit: true, metronome: 0 },
 	},
 	dualchop: {
 		inherit: true,
@@ -131,7 +128,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	eternabeam: {
 		inherit: true,
-		flags: { recharge: 1, protect: 1, mirror: 1, failinstruct: 1 },
+		flags: { inherit: true, failinstruct: 1 },
 		isNonstandard: null,
 	},
 	fishiousrend: {
@@ -169,7 +166,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	futuresight: {
 		inherit: true,
-		flags: { metronome: 1, futuremove: 1 },
+		flags: { inherit: true, allyanim: 0 },
 	},
 	geargrind: {
 		inherit: true,
@@ -214,12 +211,12 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	holdhands: {
 		inherit: true,
 		isNonstandard: null,
-		flags: { bypasssub: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	hyperspacefury: {
 		inherit: true,
 		isNonstandard: "Past",
-		flags: { mirror: 1, bypasssub: 1 },
+		flags: { inherit: true, nosketch: 0 },
 	},
 	hyperspacehole: {
 		inherit: true,
@@ -347,9 +344,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mefirst: {
 		inherit: true,
-		flags: {
-			protect: 1, bypasssub: 1, failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1,
-		},
+		flags: { inherit: true, failmimic: 0 },
 	},
 	meteorassault: {
 		inherit: true,
@@ -357,7 +352,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	metronome: {
 		inherit: true,
-		flags: { failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	milkdrink: {
 		inherit: true,
@@ -373,11 +368,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	mirrorcoat: {
 		inherit: true,
-		flags: { protect: 1, failmefirst: 1, noassist: 1, failcopycat: 1 },
+		flags: { inherit: true, failcopycat: 1 },
 	},
 	mirrormove: {
 		inherit: true,
-		flags: { failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	mistball: {
 		inherit: true,
@@ -390,7 +385,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	naturepower: {
 		inherit: true,
 		isNonstandard: null,
-		flags: { failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	naturesmadness: {
 		inherit: true,
@@ -494,7 +489,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	sleeptalk: {
 		inherit: true,
-		flags: { failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failinstruct: 1 },
+		flags: { inherit: true, failmimic: 0 },
 	},
 	snaptrap: {
 		inherit: true,

--- a/data/mods/gen8bdsp/moves.ts
+++ b/data/mods/gen8bdsp/moves.ts
@@ -125,7 +125,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	dragonhammer: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, metronome: 1 },
 	},
 	drumbeating: {
 		inherit: true,

--- a/data/mods/gen9dlc1/abilities.ts
+++ b/data/mods/gen9dlc1/abilities.ts
@@ -1,11 +1,11 @@
 export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	commander: {
 		inherit: true,
-		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1 },
+		flags: { inherit: true, notransform: 1 },
 	},
 	gulpmissile: {
 		inherit: true,
-		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1 },
+		flags: { inherit: true, failroleplay: 1, failskillswap: 1, noentrain: 1, noreceiver: 1, notrace: 1 },
 	},
 	protosynthesis: {
 		inherit: true,
@@ -46,7 +46,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				return this.chainModify(1.5);
 			},
 		},
-		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1, cantsuppress: 1 },
+		flags: { inherit: true, cantsuppress: 1 },
 	},
 	quarkdrive: {
 		inherit: true,
@@ -81,6 +81,6 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				this.add('-end', pokemon, 'Quark Drive');
 			},
 		},
-		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1, cantsuppress: 1 },
+		flags: { inherit: true, cantsuppress: 1 },
 	},
 };

--- a/data/mods/gen9dlc1/moves.ts
+++ b/data/mods/gen9dlc1/moves.ts
@@ -1,7 +1,7 @@
 export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	aeroblast: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, distance: 1, metronome: 1 },
+		flags: { inherit: true, wind: 0 },
 		isNonstandard: "Past",
 	},
 	alluringvoice: {
@@ -14,7 +14,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	bitterblade: {
 		inherit: true,
-		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	blueflare: {
 		inherit: true,
@@ -42,7 +42,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	darkvoid: {
 		inherit: true,
-		flags: { protect: 1, reflectable: 1, mirror: 1, metronome: 1 },
+		flags: { inherit: true, nosketch: 0 },
 	},
 	decorate: {
 		inherit: true,
@@ -90,7 +90,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	hyperspacefury: {
 		inherit: true,
-		flags: { mirror: 1, bypasssub: 1 },
+		flags: { inherit: true, nosketch: 0 },
 	},
 	iceburn: {
 		inherit: true,
@@ -107,7 +107,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	matchagotcha: {
 		inherit: true,
-		flags: { protect: 1, mirror: 1, defrost: 1, metronome: 1 },
+		flags: { inherit: true, heal: 0 },
 	},
 	mightycleave: {
 		inherit: true,
@@ -140,7 +140,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	revivalblessing: {
 		inherit: true,
-		flags: { heal: 1 },
+		flags: { inherit: true, nosketch: 0 },
 	},
 	rockwrecker: {
 		inherit: true,

--- a/data/mods/gen9predlc/abilities.ts
+++ b/data/mods/gen9predlc/abilities.ts
@@ -9,7 +9,10 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	hadronengine: {
 		inherit: true,
-		flags: { inherit: true, cantsuppress: 1, failroleplay: 1, failskillswap: 1, noentrain: 1, noreceiver: 1, notrace: 1, notransform: 1 },
+		flags: {
+			inherit: true,
+			cantsuppress: 1, failroleplay: 1, failskillswap: 1, noentrain: 1, noreceiver: 1, notrace: 1, notransform: 1,
+		},
 	},
 	illuminate: {
 		inherit: true,
@@ -24,7 +27,10 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	orichalcumpulse: {
 		inherit: true,
-		flags: { inherit: true, cantsuppress: 1, failroleplay: 1, failskillswap: 1, noentrain: 1, noreceiver: 1, notrace: 1, notransform: 1 },
+		flags: {
+			inherit: true,
+			cantsuppress: 1, failroleplay: 1, failskillswap: 1, noentrain: 1, noreceiver: 1, notrace: 1, notransform: 1,
+		},
 	},
 	supersweetsyrup: {
 		inherit: true,

--- a/data/mods/gen9predlc/abilities.ts
+++ b/data/mods/gen9predlc/abilities.ts
@@ -1,21 +1,21 @@
 export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	commander: {
 		inherit: true,
-		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1 },
+		flags: { inherit: true, cantsuppress: 1 },
 	},
 	gulpmissile: {
 		inherit: true,
-		flags: { cantsuppress: 1, notransform: 1 },
+		flags: { inherit: true, failroleplay: 0, failskillswap: 0, noentrain: 0, noreceiver: 0, notrace: 0 },
 	},
 	hadronengine: {
 		inherit: true,
-		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1 },
+		flags: { inherit: true, cantsuppress: 1, failroleplay: 1, failskillswap: 1, noentrain: 1, noreceiver: 1, notrace: 1, notransform: 1 },
 	},
 	illuminate: {
 		inherit: true,
 		onTryBoost: undefined, // no inherit
 		onModifyMove: undefined, // no inherit
-		flags: {},
+		flags: { inherit: true, breakable: 0 },
 		rating: 0,
 	},
 	mindseye: {
@@ -24,7 +24,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	orichalcumpulse: {
 		inherit: true,
-		flags: { failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1 },
+		flags: { inherit: true, cantsuppress: 1, failroleplay: 1, failskillswap: 1, noentrain: 1, noreceiver: 1, notrace: 1, notransform: 1 },
 	},
 	supersweetsyrup: {
 		inherit: true,

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -28,7 +28,7 @@ type ModdedAbilityFlags = AbilityFlags | ({
 	[K in keyof AbilityFlags]?: 0 | 1;
 } & { inherit: true });
 
-export type ModdedAbilityData = AbilityData | Partial<Omit<AbilityData, 'condition' | 'flags'>> & {
+export type ModdedAbilityData = AbilityData | Partial<Omit<AbilityData, 'condition' | 'flags' | 'name'>> & {
 	inherit: true,
 	condition?: ModdedConditionData,
 	flags?: ModdedAbilityFlags,

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -24,9 +24,14 @@ export interface AbilityData extends Partial<Ability>, AbilityEventMethods, Poke
 	name: string;
 }
 
-export type ModdedAbilityData = AbilityData | Partial<AbilityData> & {
+type ModdedAbilityFlags = AbilityFlags | ({
+	[K in keyof AbilityFlags]?: 0 | 1;
+} & { inherit: true });
+
+export type ModdedAbilityData = AbilityData | Partial<Omit<AbilityData, 'condition' | 'flags'>> & {
 	inherit: true,
 	condition?: ModdedConditionData,
+	flags?: ModdedAbilityFlags,
 };
 export interface AbilityDataTable { [abilityid: IDEntry]: AbilityData }
 export interface ModdedAbilityDataTable { [abilityid: IDEntry]: ModdedAbilityData }
@@ -46,7 +51,7 @@ export class Ability extends BasicEffect implements Readonly<BasicEffect> {
 		this.fullname = `ability: ${this.name}`;
 		this.effectType = 'Ability';
 		this.suppressWeather = !!data.suppressWeather;
-		this.flags = data.flags || {};
+		this.flags = Object.fromEntries(Object.entries(data.flags || {}).filter(([, v]) => v).map(([f]) => [f, 1]));
 		this.rating = data.rating || 0;
 
 		if (!this.gen) {

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -13,7 +13,7 @@ export interface ItemData extends Partial<Item>, PokemonEventMethods {
 	name: string;
 }
 
-export type ModdedItemData = ItemData | Partial<Omit<ItemData, 'name'>> & {
+export type ModdedItemData = ItemData | Partial<Omit<ItemData, 'condition' | 'name'>> & {
 	inherit: true,
 	onCustap?: (this: Battle, pokemon: Pokemon) => void,
 	onWhiteHerb?: (this: Battle, pokemon: Pokemon) => void,

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -275,7 +275,11 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	baseMove?: ID;
 }
 
-export type ModdedMoveData = MoveData | Partial<Omit<MoveData, 'name'>> & {
+type ModdedMoveFlags = MoveFlags | ({
+	[K in keyof MoveFlags]?: 0 | 1;
+} & { inherit: true });
+
+export type ModdedMoveData = MoveData | Partial<Omit<MoveData, 'condition' | 'flags' | 'name'>> & {
 	inherit: true,
 	igniteBoosted?: boolean,
 	settleBoosted?: boolean,
@@ -283,6 +287,7 @@ export type ModdedMoveData = MoveData | Partial<Omit<MoveData, 'name'>> & {
 	longWhipBoost?: boolean,
 	gen?: number,
 	condition?: ModdedConditionData,
+	flags?: ModdedMoveFlags,
 };
 
 export interface MoveDataTable { [moveid: IDEntry]: MoveData }
@@ -503,7 +508,7 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 		this.noPPBoosts = !!(data.noPPBoosts ?? data.isZ);
 		this.isZ = data.isZ || false;
 		this.isMax = data.isMax || false;
-		this.flags = data.flags || {};
+		this.flags = Object.fromEntries(Object.entries(data.flags || {}).filter(([, v]) => v).map(([f]) => [f, 1]));
 		this.selfSwitch = (typeof data.selfSwitch === 'string' ? (data.selfSwitch as ID) : data.selfSwitch) || undefined;
 		this.nonGhostTarget = data.nonGhostTarget || '';
 		this.ignoreAbility = data.ignoreAbility || false;

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -281,10 +281,6 @@ type ModdedMoveFlags = MoveFlags | ({
 
 export type ModdedMoveData = MoveData | Partial<Omit<MoveData, 'condition' | 'flags' | 'name'>> & {
 	inherit: true,
-	igniteBoosted?: boolean,
-	settleBoosted?: boolean,
-	bodyofwaterBoosted?: boolean,
-	longWhipBoost?: boolean,
 	gen?: number,
 	condition?: ModdedConditionData,
 	flags?: ModdedMoveFlags,

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -655,13 +655,15 @@ export class ModdedDex {
 						// instead of overwriting entirely
 						delete childTypedData[entryId].inherit;
 
-						// {inherit: true} can also be used to inherit parts of conditions
-						if (childTypedData[entryId].condition?.inherit) {
-							delete childTypedData[entryId].condition.inherit;
-							childTypedData[entryId].condition = {
-								...parentTypedData[entryId].condition,
-								...childTypedData[entryId].condition,
-							};
+						// {inherit: true} can also be used to inherit parts of nested objects
+						for (const key of ['condition', 'flags'] as const) {
+							if (childTypedData[entryId][key]?.inherit) {
+								delete childTypedData[entryId][key].inherit;
+								childTypedData[entryId][key] = {
+									...parentTypedData[entryId][key],
+									...childTypedData[entryId][key],
+								};
+							}
 						}
 
 						// Merge parent and child's entry, with child overwriting parent.

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -656,7 +656,7 @@ export class ModdedDex {
 						delete childTypedData[entryId].inherit;
 
 						// {inherit: true} can also be used to inherit parts of nested objects
-						for (const key of ['condition', 'flags'] as const) {
+						for (const key of ['condition', 'flags']) {
 							if (childTypedData[entryId][key]?.inherit) {
 								delete childTypedData[entryId][key].inherit;
 								childTypedData[entryId][key] = {


### PR DESCRIPTION
I didn't add or remove any flags. I have enough PRs doing that.

I used this dictionary to ignore gens where a flag is unused. Please check that the gens are correct.

```typescript
const FLAG_START_GENS = {
    moves: {
        allyanim: 3,
        bypasssub: 1,
        bite: 6,
        bullet: 6,
        cantusetwice: 9,
        charge: 1,
        contact: 3,
        dance: 7,
        defrost: 2,
        distance: 5,
        failcopycat: 4,
        failencore: 2,
        failinstruct: 7,
        failmefirst: 4,
        failmimic: 1,
        futuremove: 2,
        gravity: 4,
        heal: 4,
        metronome: 1,
        minimize: 2,
        mirror: 1,
        mustpressure: 3,
        noassist: 3,
        nonsky: 6,
        noparentalbond: 6,
        nosketch: 2,
        nosleeptalk: 2,
        pledgecombo: 5,
        powder: 6,
        protect: 2,
        pulse: 6,
        punch: 4,
        recharge: 1,
        reflectable: 3,
        slicing: 9,
        snatch: 3,
        sound: 3,
        wind: 9,
    },
    abilities: {
        breakable: 4,
        cantsuppress: 4,
        failroleplay: 3,
        failskillswap: 3,
        noentrain: 5,
        noreceiver: 7,
        notrace: 3,
        notransform: 7,
    },
};
```