### PR TITLE
Normalize test code formatting

### DIFF
--- a/test/sim/abilities/battlearmor.js
+++ b/test/sim/abilities/battlearmor.js
@@ -11,10 +11,11 @@ describe('Battle Armor', () => {
 	});
 
 	it('should prevent moves from dealing critical hits', () => {
-		battle = common.createBattle([
-			[{ species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack'] }],
-			[{ species: 'Cryogonal', ability: 'noguard', moves: ['frostbreath'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack'] },
+		], [
+			{ species: 'Cryogonal', ability: 'noguard', moves: ['frostbreath'] },
+		]]);
 		let successfulEvent = false;
 		battle.onEvent('ModifyDamage', battle.format, (damage, attacker, defender, move) => {
 			if (move.id === 'frostbreath') {
@@ -27,10 +28,11 @@ describe('Battle Armor', () => {
 	});
 
 	it('should be suppressed by Mold Breaker', () => {
-		battle = common.createBattle([
-			[{ species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack'] }],
-			[{ species: 'Cryogonal', ability: 'moldbreaker', item: 'zoomlens', moves: ['frostbreath'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Slowbro', ability: 'battlearmor', moves: ['quickattack'] },
+		], [
+			{ species: 'Cryogonal', ability: 'moldbreaker', item: 'zoomlens', moves: ['frostbreath'] },
+		]]);
 		battle.makeChoices('move quickattack', 'move frostbreath');
 		let successfulEvent = false;
 		battle.onEvent('ModifyDamage', battle.format, (damage, attacker, defender, move) => {

--- a/test/sim/abilities/costar.js
+++ b/test/sim/abilities/costar.js
@@ -11,17 +11,15 @@ describe('Costar', () => {
 	});
 
 	it('should copy the teammate\'s crit ratio on activation', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Smeargle', level: 1, moves: ['sleeptalk', 'focusenergy'] },
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
 			{ species: 'Flamigo', level: 1, ability: 'costar', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
 			{ species: 'pikachu', level: 1, moves: ['sleeptalk'] },
 			{ species: 'weezinggalar', level: 1, ability: 'neutralizinggas', moves: ['sleeptalk'] },
-		] });
+		]]);
 
 		battle.makeChoices('move focusenergy, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('move sleeptalk, switch flamigo', 'move sleeptalk, move sleeptalk');
@@ -35,16 +33,14 @@ describe('Costar', () => {
 	});
 
 	it('should copy both positive and negative stat changes', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
 			{ species: 'Smeargle', level: 1, moves: ['sleeptalk', 'shellsmash'] },
 			{ species: 'Flamigo', level: 1, ability: 'costar', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
-		] });
+		]]);
 
 		battle.makeChoices('move sleeptalk, move shellsmash', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('switch flamigo, move sleeptalk', 'move sleeptalk, move sleeptalk');

--- a/test/sim/abilities/dazzling.js
+++ b/test/sim/abilities/dazzling.js
@@ -11,20 +11,22 @@ describe('Dazzling', () => {
 	});
 
 	it('should block moves with positive priority', () => {
-		battle = common.createBattle([
-			[{ species: "Sableye", ability: 'prankster', moves: ['taunt'] }],
-			[{ species: "Bruxish", ability: 'dazzling', moves: ['swordsdance'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Sableye", ability: 'prankster', moves: ['taunt'] },
+		], [
+			{ species: "Bruxish", ability: 'dazzling', moves: ['swordsdance'] },
+		]]);
 
 		battle.makeChoices('move taunt', 'move swordsdance');
 		assert.equal(battle.p2.active[0].boosts.atk, 2);
 	});
 
 	it('should not block moves that target all Pokemon, except Perish Song, Rototiller, and Flower Shield', () => {
-		battle = common.createBattle([
-			[{ species: "Bruxish", ability: 'dazzling', moves: ['swordsdance', 'sleeptalk'] }],
-			[{ species: "Mew", ability: 'prankster', moves: ['perishsong', 'haze'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Bruxish", ability: 'dazzling', moves: ['swordsdance', 'sleeptalk'] },
+		], [
+			{ species: "Mew", ability: 'prankster', moves: ['perishsong', 'haze'] },
+		]]);
 
 		battle.makeChoices('move swordsdance', 'move perishsong');
 		battle.makeChoices('move sleeptalk', 'move haze');

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -26,10 +26,12 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it(`should request switch-out at the end of a multi-hit move`, () => {
-		battle = common.createBattle([
-			[{ species: "Cinccino", ability: 'skilllink', moves: ['bulletseed'] }],
-			[{ species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'] }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Cinccino", ability: 'skilllink', moves: ['bulletseed'] },
+		], [
+			{ species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'] },
+			{ species: "Clefable", ability: 'Unaware', moves: ['metronome'] },
+		]]);
 		battle.makeChoices('move bulletseed', 'move sleeptalk');
 		battle.makeChoices('move bulletseed', 'move sleeptalk');
 		assert.equal(battle.requestState, 'switch');
@@ -98,10 +100,12 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it(`should request switch-out after taking hazard damage`, () => {
-		battle = common.createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', moves: ['uturn', 'sleeptalk'] }, { species: "Magikarp", ability: 'swiftswim', moves: ['splash'] }],
-			[{ species: "Arceus-Flying", ability: 'ironbarbs', moves: ['stealthrock', 'spikes', 'dragonascent'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Golisopod", ability: 'emergencyexit', moves: ['uturn', 'sleeptalk'] },
+			{ species: "Magikarp", ability: 'swiftswim', moves: ['splash'] },
+		], [
+			{ species: "Arceus-Flying", ability: 'ironbarbs', moves: ['stealthrock', 'spikes', 'dragonascent'] },
+		]]);
 		battle.makeChoices('move uturn', 'move stealthrock');
 		battle.makeChoices('switch 2', '');
 		battle.makeChoices('move splash', 'move spikes');
@@ -151,10 +155,12 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it(`should not request switch-out after taking entry hazard damage and getting healed by berry`, () => {
-		battle = common.createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', moves: ['uturn', 'sleeptalk'], item: 'sitrusberry' }, { species: "Magikarp", ability: 'swiftswim', moves: ['splash'] }],
-			[{ species: "Ferrothorn", ability: 'ironbarbs', moves: ['stealthrock', 'spikes', 'protect'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Golisopod", ability: 'emergencyexit', moves: ['uturn', 'sleeptalk'], item: 'sitrusberry' },
+			{ species: "Magikarp", ability: 'swiftswim', moves: ['splash'] },
+		], [
+			{ species: "Ferrothorn", ability: 'ironbarbs', moves: ['stealthrock', 'spikes', 'protect'] },
+		]]);
 		battle.makeChoices('move uturn', 'move stealthrock');
 		battle.makeChoices('switch 2', '');
 		battle.makeChoices('move splash', 'move spikes');
@@ -165,10 +171,12 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it(`should not request switch-out after taking poison damage and getting healed by berry`, () => {
-		battle = common.createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', moves: ['substitute', 'sleeptalk'], item: 'sitrusberry' }, { species: "Magikarp", moves: ['splash'] }],
-			[{ species: "Gengar", moves: ['toxic', 'nightshade', 'protect'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Golisopod", ability: 'emergencyexit', moves: ['substitute', 'sleeptalk'], item: 'sitrusberry' },
+			{ species: "Magikarp", moves: ['splash'] },
+		], [
+			{ species: "Gengar", moves: ['toxic', 'nightshade', 'protect'] },
+		]]);
 		battle.makeChoices('move substitute', 'move toxic');
 		battle.makeChoices('move sleeptalk', 'move nightshade');
 		battle.makeChoices('move sleeptalk', 'move protect');
@@ -176,10 +184,12 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it(`should not request switch-out on usage of Substitute`, () => {
-		battle = common.createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', moves: ['substitute'], ivs: EMPTY_IVS }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-			[{ species: "Deoxys-Attack", ability: 'pressure', item: 'laggingtail', moves: ['thunderbolt'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Golisopod", ability: 'emergencyexit', moves: ['substitute'], ivs: EMPTY_IVS },
+			{ species: "Clefable", ability: 'Unaware', moves: ['metronome'] },
+		], [
+			{ species: "Deoxys-Attack", ability: 'pressure', item: 'laggingtail', moves: ['thunderbolt'] },
+		]]);
 		const eePokemon = battle.p1.active[0];
 		battle.makeChoices('move substitute', 'move thunderbolt');
 		assert.false.atMost(eePokemon.hp, eePokemon.maxhp / 2);
@@ -207,10 +217,13 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it(`should not prevent Red Card's activation`, () => {
-		battle = common.createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', item: 'redcard', moves: ['sleeptalk'], ivs: EMPTY_IVS }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-			[{ species: "Raticate", ability: 'guts', moves: ['superfang'] }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Golisopod", ability: 'emergencyexit', item: 'redcard', moves: ['sleeptalk'], ivs: EMPTY_IVS },
+			{ species: "Clefable", ability: 'Unaware', moves: ['metronome'] },
+		], [
+			{ species: "Raticate", ability: 'guts', moves: ['superfang'] },
+			{ species: "Clefable", ability: 'Unaware', moves: ['metronome'] },
+		]]);
 		const eePokemon = battle.p1.active[0];
 		battle.makeChoices('move sleeptalk', 'move superfang');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
@@ -224,10 +237,13 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it(`should not prevent Eject Button's activation`, () => {
-		battle = common.createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', item: 'ejectbutton', moves: ['sleeptalk'], ivs: EMPTY_IVS }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-			[{ species: "Raticate", ability: 'guts', moves: ['superfang'] }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Golisopod", ability: 'emergencyexit', item: 'ejectbutton', moves: ['sleeptalk'], ivs: EMPTY_IVS },
+			{ species: "Clefable", ability: 'Unaware', moves: ['metronome'] },
+		], [
+			{ species: "Raticate", ability: 'guts', moves: ['superfang'] },
+			{ species: "Clefable", ability: 'Unaware', moves: ['metronome'] },
+		]]);
 		const eePokemon = battle.p1.active[0];
 		battle.makeChoices('auto', 'auto');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
@@ -297,10 +313,12 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it('should request switchout if its HP drops to below 50% while dynamaxed', () => {
-		battle = common.gen(8).createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', moves: ['closecombat'], ivs: EMPTY_IVS, level: 30 }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-			[{ species: "Gengar", ability: 'cursedbody', moves: ['nightshade'] }],
-		]);
+		battle = common.gen(8).createBattle([[
+			{ species: "Golisopod", ability: 'emergencyexit', moves: ['closecombat'], ivs: EMPTY_IVS, level: 30 },
+			{ species: "Clefable", ability: 'Unaware', moves: ['metronome'] },
+		], [
+			{ species: "Gengar", ability: 'cursedbody', moves: ['nightshade'] },
+		]]);
 		const eePokemon = battle.p1.active[0];
 		battle.makeChoices('move maxknuckle dynamax', 'move nightshade');
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
@@ -308,10 +326,12 @@ describe(`Emergency Exit`, () => {
 	});
 
 	it('should not request switchout if its HP is below 50% when its dynamax ends', () => {
-		battle = common.gen(8).createBattle([
-			[{ species: "Golisopod", ability: 'emergencyexit', moves: ['drillrun'], ivs: EMPTY_IVS }, { species: "Clefable", ability: 'Unaware', moves: ['metronome'] }],
-			[{ species: "Landorus", ability: 'sheerforce', moves: ['sludgewave'] }],
-		]);
+		battle = common.gen(8).createBattle([[
+			{ species: "Golisopod", ability: 'emergencyexit', moves: ['drillrun'], ivs: EMPTY_IVS },
+			{ species: "Clefable", ability: 'Unaware', moves: ['metronome'] },
+		], [
+			{ species: "Landorus", ability: 'sheerforce', moves: ['sludgewave'] },
+		]]);
 		const eePokemon = battle.p1.active[0];
 		battle.makeChoices('move maxquake dynamax', 'move sludgewave');
 		battle.makeChoices();

--- a/test/sim/abilities/levitate.js
+++ b/test/sim/abilities/levitate.js
@@ -78,10 +78,12 @@ describe('Levitate [Gen 4]', () => {
 	});
 
 	it('should not have its airborne property suppressed by Mold Breaker if it is forced out by a move', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk'] }, { species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk'] }],
-			[{ species: 'Rampardos', ability: 'moldbreaker', moves: ['roar', 'spikes'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk'] },
+			{ species: 'Cresselia', ability: 'levitate', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Rampardos', ability: 'moldbreaker', moves: ['roar', 'spikes'] },
+		]]);
 		battle.makeChoices('move sleeptalk', 'move spikes');
 		assert.false.hurts(battle.p1.pokemon[1], () => battle.makeChoices('move sleeptalk', 'move roar'));
 	});

--- a/test/sim/abilities/magicbounce.js
+++ b/test/sim/abilities/magicbounce.js
@@ -13,54 +13,58 @@ describe('Magic Bounce', () => {
 	it('should bounce Growl', () => {
 		// Sanity check: if this test fails, the remaining tests for Magic Bounce may not make sense.
 		// Tests for specific moves belong to the respective moves' test suites.
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Bulbasaur", ability: 'overgrow', moves: ['growl'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Espeon", ability: 'magicbounce', moves: ['futuresight'] }] });
+		battle = common.createBattle([[
+			{ species: "Bulbasaur", ability: 'overgrow', moves: ['growl'] },
+		], [
+			{ species: "Espeon", ability: 'magicbounce', moves: ['futuresight'] },
+		]]);
 		battle.makeChoices('move growl', 'move futuresight');
 		assert.statStage(battle.p1.active[0], 'atk', -1);
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 	});
 
 	it('should bounce once when target and source share the ability', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Xatu", ability: 'magicbounce', moves: ['roost'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Espeon", ability: 'magicbounce', moves: ['growl'] }] });
+		battle = common.createBattle([[
+			{ species: "Xatu", ability: 'magicbounce', moves: ['roost'] },
+		], [
+			{ species: "Espeon", ability: 'magicbounce', moves: ['growl'] },
+		]]);
 		assert.doesNotThrow(() => battle.makeChoices('move roost', 'move growl'));
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'atk', -1);
 	});
 
 	it('should not cause a choice-lock', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Spoink", ability: 'thickfat', moves: ['bounce'] },
 			{ species: "Xatu", item: 'choicescarf', ability: 'magicbounce', moves: ['roost', 'growl'] },
-		] });
-		battle.setPlayer('p2', { team: [{ species: "Espeon", ability: 'magicbounce', moves: ['growl', 'recover'] }] });
+		], [
+			{ species: "Espeon", ability: 'magicbounce', moves: ['growl', 'recover'] },
+		]]);
 		battle.makeChoices('switch 2', 'move growl');
 		battle.makeChoices('move roost', 'move recover');
 		assert.notEqual(battle.p1.active[0].lastMove.id, 'growl');
 	});
 
 	it('should be suppressed by Mold Breaker', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Bulbasaur", ability: 'moldbreaker', moves: ['growl'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Espeon", ability: 'magicbounce', moves: ['futuresight'] }] });
+		battle = common.createBattle([[
+			{ species: "Bulbasaur", ability: 'moldbreaker', moves: ['growl'] },
+		], [
+			{ species: "Espeon", ability: 'magicbounce', moves: ['futuresight'] },
+		]]);
 		battle.makeChoices('move growl', 'move futuresight');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'atk', -1);
 	});
 
 	it('should not bounce moves while semi-invulnerable', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Bulbasaur", ability: 'overgrow', moves: ['growl'] },
 			{ species: "Geodude", ability: 'rockhead', moves: ['stealthrock'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Xatu", ability: 'magicbounce', moves: ['fly'] },
 			{ species: "Charmander", ability: 'blaze', moves: ['sleeptalk'] },
-		] });
+		]]);
 		battle.makeChoices('auto', 'auto');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'atk', 0);
@@ -98,15 +102,13 @@ describe('Magic Bounce', () => {
 	});
 
 	it(`[Gen 5] should bounce moves that target the foe's side while semi-invulnerable`, () => {
-		battle = common.gen(5).createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'doubles' }, [[
 			{ species: "Bulbasaur", ability: 'overgrow', moves: ['growl'] },
 			{ species: "Geodude", ability: 'rockhead', moves: ['stealthrock'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Xatu", ability: 'magicbounce', moves: ['fly'] },
 			{ species: "Charmander", ability: 'blaze', moves: ['sleeptalk'] },
-		] });
+		]]);
 		battle.makeChoices('auto', 'auto');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'atk', 0);

--- a/test/sim/abilities/magicguard.js
+++ b/test/sim/abilities/magicguard.js
@@ -27,25 +27,23 @@ describe('Magic Guard', () => {
 	});
 
 	it(`should prevent Leech Seed's healing effect`, () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Clefable', ability: 'magicguard', moves: ['moonblast'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Ferrothorn', ability: 'noguard', moves: ['leechseed'] },
-		] });
+		]]);
 		battle.makeChoices('move moonblast', 'move leechseed');
 		assert.fullHP(battle.p1.active[0]);
 		assert.false.fullHP(battle.p2.active[0]);
 	});
 
 	it('should not be suppressed by Mold Breaker', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Magikarp', ability: 'swiftswim', moves: ['splash'] },
 			{ species: 'Clefable', ability: 'magicguard', moves: ['doubleedge'] },
-		] });
-		battle.setPlayer('p2', { team: [{ species: 'Haxorus', ability: 'moldbreaker', moves: ['stealthrock', 'roar'] }] });
+		], [
+			{ species: 'Haxorus', ability: 'moldbreaker', moves: ['stealthrock', 'roar'] },
+		]]);
 		battle.makeChoices('move splash', 'move stealthrock');
 		battle.makeChoices('move splash', 'move roar');
 		assert.fullHP(battle.p1.active[0]);

--- a/test/sim/abilities/magnetpull.js
+++ b/test/sim/abilities/magnetpull.js
@@ -11,12 +11,12 @@ describe('Magnet Pull', () => {
 	});
 
 	it('should prevent Steel-type Pokemon from switching out normally', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Magnezone", ability: 'magnetpull', moves: ['soak', 'charge'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Magnezone", ability: 'magnetpull', moves: ['soak', 'charge'] },
+		], [
 			{ species: "Heatran", ability: 'flashfire', moves: ['curse'] },
 			{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-		] });
+		]]);
 
 		assert.trapped(() => battle.makeChoices('', 'switch 2'), true);
 		battle.makeChoices('auto', 'auto');
@@ -30,24 +30,24 @@ describe('Magnet Pull', () => {
 	});
 
 	it('should not prevent Steel-type Pokemon from switching out using moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Magnezone", ability: 'magnetpull', moves: ['toxic'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Magnezone", ability: 'magnetpull', moves: ['toxic'] },
+		], [
 			{ species: "Heatran", ability: 'flashfire', moves: ['batonpass'] },
 			{ species: "Tentacruel", ability: 'clearbody', moves: ['rapidspin'] },
-		] });
+		]]);
 		battle.makeChoices('move toxic', 'move batonpass');
 		battle.makeChoices('', 'switch 2');
 		assert.species(battle.p2.active[0], 'Tentacruel');
 	});
 
 	it('should not prevent Pokemon immune to trapping from switching out', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Magnezone", ability: 'magnetpull', moves: ['substitute'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Magnezone", ability: 'magnetpull', moves: ['substitute'] },
+		], [
 			{ species: "Aegislash", ability: 'stancechange', moves: ['swordsdance'] },
 			{ species: "Arcanine", ability: 'flashfire', moves: ['roar'] },
-		] });
+		]]);
 		battle.makeChoices('move substitute', 'switch 2');
 		assert.species(battle.p2.active[0], 'Arcanine');
 	});

--- a/test/sim/abilities/mirrorarmor.js
+++ b/test/sim/abilities/mirrorarmor.js
@@ -11,13 +11,11 @@ describe("Mirror Armor", () => {
 	});
 
 	it("should bounce boosts back to the source", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Corviknight', ability: 'mirrorarmor', moves: ['endure'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Machop', ability: 'noguard', moves: ['rocktomb', 'leer'] },
-		] });
+		]]);
 		battle.makeChoices('auto', 'move rocktomb');
 		const corv = battle.p1.active[0];
 		const machop = battle.p2.active[0];

--- a/test/sim/abilities/moxie.js
+++ b/test/sim/abilities/moxie.js
@@ -11,25 +11,34 @@ describe('Moxie', () => {
 	});
 
 	it('should boost Attack when its user KOs a Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Krookodile", ability: 'moxie', moves: ['crunch'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Shedinja", moves: ['sleeptalk'] }, { species: 'Magikarp', moves: ['splash'] }] });
+		battle = common.createBattle([[
+			{ species: "Krookodile", ability: 'moxie', moves: ['crunch'] },
+		], [
+			{ species: "Shedinja", moves: ['sleeptalk'] },
+			{ species: 'Magikarp', moves: ['splash'] },
+		]]);
 		battle.makeChoices('move crunch', 'move sleeptalk');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
 	});
 
 	it('should not boost Attack when its user KOs the last Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Krookodile", ability: 'moxie', moves: ['crunch'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Shedinja", moves: ['sleeptalk'] }] });
+		battle = common.createBattle([[
+			{ species: "Krookodile", ability: 'moxie', moves: ['crunch'] },
+		], [
+			{ species: "Shedinja", moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices('move crunch', 'move sleeptalk');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 	});
 
 	it('should not boost Attack when its user KOs several last Pokemon', () => {
-		battle = common.createBattle({ gameType: "doubles" });
-		battle.setPlayer('p1', { team: [{ species: "Krookodile", ability: 'moxie', moves: ['earthquake'] }, { species: "Shedinja", moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Shedinja", moves: ['sleeptalk'] }, { species: "Shedinja", moves: ['sleeptalk'] }] });
+		battle = common.createBattle({ gameType: "doubles" }, [[
+			{ species: "Krookodile", ability: 'moxie', moves: ['earthquake'] },
+			{ species: "Shedinja", moves: ['sleeptalk'] },
+		], [
+			{ species: "Shedinja", moves: ['sleeptalk'] },
+			{ species: "Shedinja", moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices('move earthquake, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 	});

--- a/test/sim/abilities/naturalcure.js
+++ b/test/sim/abilities/naturalcure.js
@@ -7,18 +7,12 @@ let battle;
 
 describe('Natural Cure', () => {
 	it('should cure even when phased out by Roar', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {
-			team: [
-				{ species: 'Celebi', ability: 'naturalcure', moves: ['leechseed'] },
-				{ species: 'Swampert', ability: 'torrents', moves: ['surf'] },
-			],
-		});
-		battle.setPlayer('p2', {
-			team: [
-				{ species: 'Zapdos', ability: 'pressure', moves: ['thunderwave', 'roar'] },
-			],
-		});
+		battle = common.createBattle([[
+			{ species: 'Celebi', ability: 'naturalcure', moves: ['leechseed'] },
+			{ species: 'Swampert', ability: 'torrents', moves: ['surf'] },
+		], [
+			{ species: 'Zapdos', ability: 'pressure', moves: ['thunderwave', 'roar'] },
+		]]);
 		battle.makeChoices('move leechseed', 'move thunderwave');
 		battle.makeChoices('move leechseed', 'move roar');
 		assert.notEqual(battle.p1.pokemon[1].status, 'par');

--- a/test/sim/abilities/neutralizinggas.js
+++ b/test/sim/abilities/neutralizinggas.js
@@ -11,51 +11,62 @@ describe('Neutralizing Gas', () => {
 	});
 
 	it('should prevent switch-in abilities from activating', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Gyarados", ability: 'intimidate', moves: ['splash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Weezing", ability: 'neutralizinggas', moves: ['toxicspikes'] }] });
+		battle = common.createBattle([[
+			{ species: "Gyarados", ability: 'intimidate', moves: ['splash'] },
+		], [
+			{ species: "Weezing", ability: 'neutralizinggas', moves: ['toxicspikes'] },
+		]]);
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 	});
 
 	it('should ignore damage-reducing abilities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Weezing", ability: 'neutralizinggas', item: 'expertbelt', moves: ['sludgebomb'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Mr. Mime", ability: 'filter', item: 'laggingtail', moves: ['substitute'] }] });
+		battle = common.createBattle([[
+			{ species: "Weezing", ability: 'neutralizinggas', item: 'expertbelt', moves: ['sludgebomb'] },
+		], [
+			{ species: "Mr. Mime", ability: 'filter', item: 'laggingtail', moves: ['substitute'] },
+		]]);
 		battle.makeChoices('move sludgebomb', 'move substitute');
 		assert(!battle.p1.active[0].volatiles['substitute']);
 	});
 
 	it('should negate self-healing abilities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Weezing", ability: 'neutralizinggas', moves: ['toxic'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Breloom", ability: 'poisonheal', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: "Weezing", ability: 'neutralizinggas', moves: ['toxic'] },
+		], [
+			{ species: "Breloom", ability: 'poisonheal', moves: ['swordsdance'] },
+		]]);
 		battle.makeChoices('move toxic', 'move swordsdance');
 		assert.false.fullHP(battle.p2.active[0]);
 	});
 
 	it('should negate abilities that suppress item effects', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Weezing", ability: 'neutralizinggas', moves: ['reflect'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Reuniclus", ability: 'magicguard', item: 'lifeorb', moves: ['shadowball'] }] });
+		battle = common.createBattle([[
+			{ species: "Weezing", ability: 'neutralizinggas', moves: ['reflect'] },
+		], [
+			{ species: "Reuniclus", ability: 'magicguard', item: 'lifeorb', moves: ['shadowball'] },
+		]]);
 		battle.makeChoices('move reflect', 'move shadowball');
 		assert.false.fullHP(battle.p2.active[0]);
 	});
 
 	it('should negate abilities that modify boosts', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Weezing", ability: 'neutralizinggas', moves: ['spore'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Shuckle", ability: 'contrary', moves: ['sleeptalk', 'superpower'] }] });
+		battle = common.createBattle([[
+			{ species: "Weezing", ability: 'neutralizinggas', moves: ['spore'] },
+		], [
+			{ species: "Shuckle", ability: 'contrary', moves: ['sleeptalk', 'superpower'] },
+		]]);
 		battle.makeChoices('move spore', 'move sleeptalk');
 		assert.statStage(battle.p2.active[0], 'atk', -1);
 	});
 
 	it(`should negate abilities that activate on switch-out`, () => {
-		battle = common.createBattle([
-			[{ species: "Weezing", ability: 'neutralizinggas', moves: ['toxic'] },
-				{ species: "Type: Null", ability: 'battlearmor', moves: ['facade'] }],
-			[{ species: "Corsola", ability: 'naturalcure', moves: ['uturn'] },
-				{ species: "Magikarp", ability: 'rattled', moves: ['splash'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Weezing", ability: 'neutralizinggas', moves: ['toxic'] },
+			{ species: "Type: Null", ability: 'battlearmor', moves: ['facade'] },
+		], [
+			{ species: "Corsola", ability: 'naturalcure', moves: ['uturn'] },
+			{ species: "Magikarp", ability: 'rattled', moves: ['splash'] },
+		]]);
 		battle.makeChoices('move toxic', 'move uturn');
 		battle.makeChoices('', 'switch 2');
 		battle.makeChoices('switch 2', 'switch 2');
@@ -63,21 +74,21 @@ describe('Neutralizing Gas', () => {
 	});
 
 	it('should negate abilities that modify move type', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Gengar", ability: 'neutralizinggas', moves: ['laserfocus'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sylveon", ability: 'pixilate', moves: ['hypervoice'] }] });
+		battle = common.createBattle([[
+			{ species: "Gengar", ability: 'neutralizinggas', moves: ['laserfocus'] },
+		], [
+			{ species: "Sylveon", ability: 'pixilate', moves: ['hypervoice'] },
+		]]);
 		battle.makeChoices('move laserfocus', 'move hypervoice');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
 	it("should negate abilities that damage the attacker", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['payback'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Ferrothorn', ability: 'ironbarbs', moves: ['rockpolish'] },
-		] });
+		]]);
 		battle.makeChoices();
 		assert.fullHP(battle.p1.active[0]);
 	});
@@ -97,14 +108,12 @@ describe('Neutralizing Gas', () => {
 	});
 
 	it('should not activate Imposter if Neutralizing Gas leaves the field', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Weezing", ability: 'neutralizinggas', moves: ['snore'] },
 			{ species: "Greninja", ability: 'torrent', moves: ['teleport'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Ditto", ability: 'imposter', moves: ['sleeptalk'] },
-		] });
+		]]);
 		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);
 		battle.makeChoices('switch greninja', 'move sleeptalk');
 		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);

--- a/test/sim/abilities/normalize.js
+++ b/test/sim/abilities/normalize.js
@@ -11,49 +11,61 @@ describe('Normalize', () => {
 	});
 
 	it('should change most of the user\'s moves to Normal-type', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Delcatty", ability: 'normalize', moves: ['grassknot'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Latias", ability: 'colorchange', moves: ['endure'] }] });
+		battle = common.createBattle([[
+			{ species: "Delcatty", ability: 'normalize', moves: ['grassknot'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move grassknot', 'move endure');
 		assert(battle.p2.active[0].hasType('Normal'));
 	});
 
 	it('should not change Hidden Power to Normal-type', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfighting'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Latias", ability: 'colorchange', moves: ['endure'] }] });
+		battle = common.createBattle([[
+			{ species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfighting'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move hiddenpowerfighting', 'move endure');
 		assert(battle.p2.active[0].hasType('Fighting'));
 	});
 
 	it('should not change Techno Blast to Normal-type if the user is holding a Drive', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Delcatty", ability: 'normalize', item: 'dousedrive', moves: ['technoblast'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Latias", ability: 'colorchange', moves: ['endure'] }] });
+		battle = common.createBattle([[
+			{ species: "Delcatty", ability: 'normalize', item: 'dousedrive', moves: ['technoblast'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move technoblast', 'move endure');
 		assert(battle.p2.active[0].hasType('Water'));
 	});
 
 	it('should not change Judgment to Normal-type if the user is holding a Plate', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Delcatty", ability: 'normalize', item: 'zapplate', moves: ['judgment'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Latias", ability: 'colorchange', moves: ['endure'] }] });
+		battle = common.createBattle([[
+			{ species: "Delcatty", ability: 'normalize', item: 'zapplate', moves: ['judgment'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move judgment', 'move endure');
 		assert(battle.p2.active[0].hasType('Electric'));
 	});
 
 	it('should not change Weather Ball to Normal-type if sun, rain, or hail is an active weather', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Latias", ability: 'colorchange', moves: ['sunnyday'] }] });
+		battle = common.createBattle([[
+			{ species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['sunnyday'] },
+		]]);
 		battle.makeChoices('move weatherball', 'move sunnyday');
 		assert(battle.p2.active[0].hasType('Fire'));
 	});
 
 	it('should not change Natural Gift to Normal-type if the user is holding a Berry', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Delcatty", ability: 'normalize', item: 'chopleberry', moves: ['naturalgift'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Latias", ability: 'colorchange', moves: ['endure'] }] });
+		battle = common.createBattle([[
+			{ species: "Delcatty", ability: 'normalize', item: 'chopleberry', moves: ['naturalgift'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move naturalgift', 'move endure');
 		assert(battle.p2.active[0].hasType('Fighting'));
 	});
@@ -65,37 +77,41 @@ describe('Normalize [Gen 4]', () => {
 	});
 
 	it('should change most of the user\'s moves to Normal-type', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Delcatty", ability: 'normalize', moves: ['grassknot'] }],
-			[{ species: "Latias", ability: 'colorchange', moves: ['endure'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Delcatty", ability: 'normalize', moves: ['grassknot'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move grassknot', 'move endure');
 		assert(battle.p2.active[0].hasType('Normal'));
 	});
 
 	it('should change Hidden Power to Normal-type', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfire'] }],
-			[{ species: "Latias", ability: 'colorchange', moves: ['endure'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfire'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move hiddenpowerfire', 'move endure');
 		assert(battle.p2.active[0].hasType('Normal'));
 	});
 
 	it('should change Judgment to Normal-type even if the user is holding a Plate', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Delcatty", ability: 'normalize', item: 'pixieplate', moves: ['judgment'] }],
-			[{ species: "Latias", ability: 'colorchange', moves: ['endure'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Delcatty", ability: 'normalize', item: 'pixieplate', moves: ['judgment'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move judgment', 'move endure');
 		assert(battle.p2.active[0].hasType('Normal'));
 	});
 
 	it('should change Weather Ball to Normal-type even if sun, rain, or hail is an active weather', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball'] }],
-			[{ species: "Latias", ability: 'colorchange', moves: ['sunnyday'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball'] },
+		], [
+			{ species: "Latias", ability: 'colorchange', moves: ['sunnyday'] },
+		]]);
 		battle.makeChoices('move weatherball', 'move sunnyday');
 		assert(battle.p2.active[0].hasType('Normal'));
 	});

--- a/test/sim/abilities/owntempo.js
+++ b/test/sim/abilities/owntempo.js
@@ -11,9 +11,11 @@ describe('Own Tempo', () => {
 	});
 
 	it('should block Intimidate', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Gyarados', ability: 'intimidate', moves: ['splash'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Smeargle', ability: 'own tempo', item: 'adrenaline orb', moves: ['sleeptalk'] }] });
+		battle = common.createBattle([[
+			{ species: 'Gyarados', ability: 'intimidate', moves: ['splash'] },
+		], [
+			{ species: 'Smeargle', ability: 'own tempo', item: 'adrenaline orb', moves: ['sleeptalk'] },
+		]]);
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 		assert.statStage(battle.p2.active[0], 'spe', 1);
 	});

--- a/test/sim/abilities/pickup.js
+++ b/test/sim/abilities/pickup.js
@@ -11,48 +11,54 @@ describe('Pickup', () => {
 	});
 
 	it('should pick up a consumed item', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Gourgeist', ability: 'pickup', moves: ['flamethrower'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Paras', ability: 'dryskin', item: 'sitrusberry', moves: ['endure'] }] });
+		battle = common.createBattle([[
+			{ species: 'Gourgeist', ability: 'pickup', moves: ['flamethrower'] },
+		], [
+			{ species: 'Paras', ability: 'dryskin', item: 'sitrusberry', moves: ['endure'] },
+		]]);
 		battle.makeChoices('move flamethrower', 'move endure');
 		assert.holdsItem(battle.p1.active[0], "Pick Up should retrieve consumed Sitrus Berry");
 	});
 
 	it('should pick up flung items', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Gourgeist', ability: 'pickup', moves: ['endure'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Clefairy', ability: 'unaware', item: 'airballoon', moves: ['fling'] }] });
+		battle = common.createBattle([[
+			{ species: 'Gourgeist', ability: 'pickup', moves: ['endure'] },
+		], [
+			{ species: 'Clefairy', ability: 'unaware', item: 'airballoon', moves: ['fling'] },
+		]]);
 		battle.makeChoices('move endure', 'move fling');
 		assert.holdsItem(battle.p1.active[0], "Pick Up should retrieve flung Air Balloon");
 	});
 
 	it('should not pick up an item that was knocked off', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Ambipom', ability: 'pickup', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Machamp', ability: 'noguard', item: 'choicescarf', moves: ['bulkup'] }] });
+		battle = common.createBattle([[
+			{ species: 'Ambipom', ability: 'pickup', moves: ['knockoff'] },
+		], [
+			{ species: 'Machamp', ability: 'noguard', item: 'choicescarf', moves: ['bulkup'] },
+		]]);
 		battle.makeChoices('move knockoff', 'move bulkup');
 		assert.false.holdsItem(battle.p1.active[0], "Pick Up should not retrieve knocked off Choice Scarf");
 	});
 
 	it('should not pick up a popped Air Balloon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Ambipom', ability: 'pickup', moves: ['fakeout'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Scizor', ability: 'swarm', item: 'airballoon', moves: ['roost'] }] });
+		battle = common.createBattle([[
+			{ species: 'Ambipom', ability: 'pickup', moves: ['fakeout'] },
+		], [
+			{ species: 'Scizor', ability: 'swarm', item: 'airballoon', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move fakeout', 'move roost');
 		assert.false.holdsItem(battle.p1.active[0], "Pick Up should not retrieve popped Air Balloon");
 	});
 
 	it('should not pick up items from Pokemon that have switched out and back in', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Gourgeist', ability: 'pickup', moves: ['shadowsneak'] },
 			{ species: 'Aggron', ability: 'sturdy', moves: ['rest'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Ambipom', ability: 'swarm', moves: ['uturn'] },
 			{ species: 'Clefable', ability: 'unaware', item: 'ejectbutton', moves: ['followme'] },
 			{ species: 'Magikarp', ability: 'rattled', moves: ['splash'] },
-		] });
+		]]);
 		battle.makeChoices('move shadowsneak 1, move rest', 'move uturn 1, move followme');
 		battle.makeChoices('', 'switch 3'); // Eject Button activated
 		battle.makeChoices('', 'switch 3');
@@ -60,12 +66,12 @@ describe('Pickup', () => {
 	});
 
 	it('should not pick up items from Pokemon that have switched out', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Gourgeist', ability: 'pickup', moves: ['shadowsneak', 'synthesis'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: 'Gourgeist', ability: 'pickup', moves: ['shadowsneak', 'synthesis'] },
+		], [
 			{ species: 'Ambipom', ability: 'swarm', item: 'buggem', moves: ['uturn'] },
 			{ species: 'Dusknoir', ability: 'pressure', item: 'ejectbutton', moves: ['painsplit'] },
-		] });
+		]]);
 		battle.makeChoices('move synthesis', 'move uturn');
 		battle.makeChoices('', 'switch 2');
 		assert.false.holdsItem(battle.p1.active[0]);
@@ -75,34 +81,37 @@ describe('Pickup', () => {
 	});
 
 	it('should not pick up items that were already retrieved', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Ambipom', ability: 'pickup', moves: ['return'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Aron', level: 1, ability: 'sturdy', item: 'berryjuice', moves: ['recycle'] }] });
+		battle = common.createBattle([[
+			{ species: 'Ambipom', ability: 'pickup', moves: ['return'] },
+		], [
+			{ species: 'Aron', level: 1, ability: 'sturdy', item: 'berryjuice', moves: ['recycle'] },
+		]]);
 		battle.makeChoices('move return', 'move recycle');
 		assert.false.holdsItem(battle.p1.active[0]);
 	});
 
 	it('should pick up items from adjacent allies', () => {
-		battle = common.createBattle({ gameType: 'doubles' }, [
-			[{ species: 'Ambipom', ability: 'pickup', moves: ['protect'] }, { species: 'Aron', level: 1, ability: 'sturdy', item: 'berryjuice', moves: ['followme'] }],
-			[{ species: 'Ambipom', ability: 'technician', moves: ['return'] }, { species: 'Arcanine', ability: 'flashfire', moves: ['protect'] }],
-		]);
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: 'Ambipom', ability: 'pickup', moves: ['protect'] },
+			{ species: 'Aron', level: 1, ability: 'sturdy', item: 'berryjuice', moves: ['followme'] },
+		], [
+			{ species: 'Ambipom', ability: 'technician', moves: ['return'] },
+			{ species: 'Arcanine', ability: 'flashfire', moves: ['protect'] },
+		]]);
 		battle.makeChoices('move protect, move followme', 'move return 1, move protect');
 		assert.holdsItem(battle.p1.active[0]);
 	});
 
 	it('should not pick up items from non-adjacent allies and enemies', () => {
-		battle = common.gen(5).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 			{ species: 'Ambipom', ability: 'pickup', moves: ['protect'] },
 			{ species: 'Regirock', ability: 'sturdy', moves: ['curse'] },
 			{ species: 'Arcanine', ability: 'flashfire', item: 'normalgem', moves: ['extremespeed'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Arcanine', ability: 'flashfire', item: 'firegem', moves: ['flamecharge'] },
 			{ species: 'Aggron', ability: 'sturdy', moves: ['rest'] },
 			{ species: 'Magikarp', ability: 'swiftswim', moves: ['splash'] },
-		] });
+		]]);
 		battle.makeChoices('move protect, move curse, move extremespeed 2', 'move flamecharge 2, move rest, move splash');
 		assert.false.holdsItem(battle.p1.active[0]);
 	});

--- a/test/sim/abilities/prankster.js
+++ b/test/sim/abilities/prankster.js
@@ -11,50 +11,52 @@ describe('Prankster', () => {
 	});
 
 	it('should increase the priority of Status moves', () => {
-		battle = common.createBattle([
-			[{ species: "Murkrow", ability: 'prankster', moves: ['taunt'] }],
-			[{ species: "Deoxys-Speed", ability: 'pressure', moves: ['calmmind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Murkrow", ability: 'prankster', moves: ['taunt'] },
+		], [
+			{ species: "Deoxys-Speed", ability: 'pressure', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move taunt', 'move calmmind');
 		assert.statStage(battle.p2.active[0], 'spa', 0);
 	});
 
 	it('should cause Status moves to fail against Dark Pokémon', () => {
-		battle = common.createBattle([
-			[{ species: "Sableye", ability: 'prankster', moves: ['willowisp'] }],
-			[{ species: "Sableye", ability: 'keeneye', moves: ['willowisp'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Sableye", ability: 'prankster', moves: ['willowisp'] },
+		], [
+			{ species: "Sableye", ability: 'keeneye', moves: ['willowisp'] },
+		]]);
 		assert.constant(() => battle.p2.active[0].status, () => battle.makeChoices('move willowisp', 'move willowisp'));
 	});
 
 	it('should cause bounced Status moves to fail against Dark Pokémon', () => {
-		battle = common.createBattle([
-			[{ species: "Klefki", ability: 'prankster', moves: ['magiccoat'] }],
-			[{ species: "Spiritomb", ability: 'pressure', moves: ['willowisp'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Klefki", ability: 'prankster', moves: ['magiccoat'] },
+		], [
+			{ species: "Spiritomb", ability: 'pressure', moves: ['willowisp'] },
+		]]);
 		assert.constant(() => battle.p2.active[0].status, () => battle.makeChoices('move magiccoat', 'move willowisp'));
 	});
 
 	it('should not cause bounced Status moves to fail against Dark Pokémon if it is removed', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Alakazam", ability: 'synchronize', moves: ['skillswap'] },
 			{ species: "Sableye", ability: 'prankster', moves: ['magiccoat'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Pyukumuku", ability: 'unaware', moves: ['curse'] },
 			{ species: "Houndoom", ability: 'flashfire', moves: ['confide'] },
-		] });
+		]]);
 		const darkPokemon = battle.p2.active[1];
 		battle.makeChoices('move skillswap -2, move magiccoat', 'move curse, move confide 2');
 		assert.statStage(darkPokemon, 'spa', -1);
 	});
 
 	it('should not cause Status moves forced by Encore to fail against Dark Pokémon', () => {
-		battle = common.createBattle([
-			[{ species: "Liepard", ability: 'prankster', moves: ['encore'] }],
-			[{ species: "Riolu", ability: 'prankster', moves: ['confide', 'return'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Liepard", ability: 'prankster', moves: ['encore'] },
+		], [
+			{ species: "Riolu", ability: 'prankster', moves: ['confide', 'return'] },
+		]]);
 		battle.makeChoices('move encore', 'move confide');
 		battle.makeChoices('move encore', 'move return');
 		assert.statStage(battle.p1.active[0], 'spa', -1);
@@ -62,10 +64,13 @@ describe('Prankster', () => {
 
 	it('should cause moves forced by Encore to fail against Dark Pokémon if the attacker intended to use a Status move', () => {
 		// https://www.smogon.com/forums/threads/3469932/page-396#post-7736003
-		battle = common.createBattle({ gameType: 'doubles' }, [
-			[{ species: "Liepard", ability: 'prankster', moves: ['encore', 'nastyplot'] }, { species: "Tapu Fini", ability: 'mistysurge', moves: ['calmmind'] }],
-			[{ species: "Meowstic", ability: 'prankster', moves: ['frustration', 'leer'] }, { species: "Lopunny", ability: 'limber', moves: ['agility'] }],
-		]);
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: "Liepard", ability: 'prankster', moves: ['encore', 'nastyplot'] },
+			{ species: "Tapu Fini", ability: 'mistysurge', moves: ['calmmind'] },
+		], [
+			{ species: "Meowstic", ability: 'prankster', moves: ['frustration', 'leer'] },
+			{ species: "Lopunny", ability: 'limber', moves: ['agility'] },
+		]]);
 
 		battle.makeChoices('move encore 1, move calmmind', 'move frustration 2, move agility');
 		battle.makeChoices('move encore 1, move calmmind', 'move leer, move agility');
@@ -74,10 +79,11 @@ describe('Prankster', () => {
 	});
 
 	it('should not leak the ability via hint if the target is immune to the Status move', () => {
-		battle = common.createBattle([
-			[{ species: "Sableye", ability: 'prankster', moves: ['willowisp'] }],
-			[{ species: "Houndoom", ability: 'pressure', moves: ['willowisp'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Sableye", ability: 'prankster', moves: ['willowisp'] },
+		], [
+			{ species: "Houndoom", ability: 'pressure', moves: ['willowisp'] },
+		]]);
 		battle.makeChoices('move willowisp', 'move willowisp');
 		assert.false(battle.log.some(line => line.includes('hint')), `Prankster should not leak the ability via hint`);
 	});

--- a/test/sim/abilities/primordialsea.js
+++ b/test/sim/abilities/primordialsea.js
@@ -11,17 +11,21 @@ describe('Primordial Sea', () => {
 	});
 
 	it('should activate the Primordial Sea weather upon switch-in', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Abra", ability: 'magicguard', moves: ['teleport'] }] });
+		battle = common.createBattle([[
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
+		], [
+			{ species: "Abra", ability: 'magicguard', moves: ['teleport'] },
+		]]);
 		assert(battle.field.isWeather('primordialsea'));
 	});
 
 	it('should increase the damage (not the basePower) of Water-type attacks', () => {
-		battle = common.createBattle();
+		battle = common.createBattle([[
+			{ species: 'Kyogre', ability: 'primordialsea', moves: ['waterpledge'] },
+		], [
+			{ species: 'Blastoise', ability: 'torrent', moves: ['splash'] },
+		]]);
 		battle.randomizer = dmg => dmg; // max damage
-		battle.setPlayer('p1', { team: [{ species: 'Kyogre', ability: 'primordialsea', moves: ['waterpledge'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Blastoise', ability: 'torrent', moves: ['splash'] }] });
 		const attacker = battle.p1.active[0];
 		const defender = battle.p2.active[0];
 		assert.hurtsBy(defender, 104, () => battle.makeChoices('move waterpledge', 'move splash'));
@@ -31,30 +35,34 @@ describe('Primordial Sea', () => {
 	});
 
 	it('should cause Fire-type attacks to fail', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Charizard", ability: 'blaze', moves: ['flamethrower'] }] });
+		battle = common.createBattle([[
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
+		], [
+			{ species: "Charizard", ability: 'blaze', moves: ['flamethrower'] },
+		]]);
 		battle.makeChoices('move helpinghand', 'move flamethrower');
 		assert.fullHP(battle.p1.active[0]);
 	});
 
 	it('should not cause Fire-type Status moves to fail', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Charizard", ability: 'noguard', moves: ['willowisp'] }] });
+		battle = common.createBattle([[
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
+		], [
+			{ species: "Charizard", ability: 'noguard', moves: ['willowisp'] },
+		]]);
 		assert.sets(() => battle.p1.active[0].status, 'brn', () => battle.makeChoices('move helpinghand', 'move willowisp'));
 	});
 
 	it('should prevent moves and abilities from setting the weather to Sunny Day, Rain Dance, Sandstorm, or Hail', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
+		], [
 			{ species: "Abra", ability: 'magicguard', moves: ['teleport'] },
 			{ species: "Kyogre", ability: 'drizzle', moves: ['raindance'] },
 			{ species: "Groudon", ability: 'drought', moves: ['sunnyday'] },
 			{ species: "Tyranitar", ability: 'sandstream', moves: ['sandstorm'] },
 			{ species: "Abomasnow", ability: 'snowwarning', moves: ['hail'] },
-		] });
+		]]);
 		for (let i = 2; i <= 5; i++) {
 			battle.makeChoices('move helpinghand', 'switch ' + i);
 			assert(battle.field.isWeather('primordialsea'));
@@ -64,15 +72,15 @@ describe('Primordial Sea', () => {
 	});
 
 	it('should be treated as Rain Dance for any forme, move or ability that requires it', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['sonicboom'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['sonicboom'] },
+		], [
 			{ species: "Castform", ability: 'forecast', moves: ['weatherball'] },
 			{ species: "Kingdra", ability: 'swiftswim', moves: ['focusenergy'] },
 			{ species: "Ludicolo", ability: 'raindish', moves: ['watersport'] },
 			{ species: "Toxicroak", ability: 'dryskin', moves: ['bulkup'] },
 			{ species: "Manaphy", ability: 'hydration', item: 'laggingtail', moves: ['rest'] },
-		] });
+		]]);
 		battle.onEvent('Hit', battle.format, (target, pokemon, move) => {
 			if (move.id === 'weatherball') {
 				assert.equal(move.type, 'Water');
@@ -93,43 +101,49 @@ describe('Primordial Sea', () => {
 	});
 
 	it('should cause the Primordial Sea weather to fade if it switches out and no other Primordial Sea Pokemon are active', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
 			{ species: "Ho-Oh", ability: 'pressure', moves: ['roost'] },
-		] });
-		battle.setPlayer('p2', { team: [{ species: "Lugia", ability: 'pressure', moves: ['roost'] }] });
+		], [
+			{ species: "Lugia", ability: 'pressure', moves: ['roost'] },
+		]]);
 		assert.sets(() => battle.field.isWeather('primordialsea'), false, () => battle.makeChoices('switch 2', 'move roost'));
 	});
 
 	it('should not cause the Primordial Sea weather to fade if it switches out and another Primordial Sea Pokemon is active', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
 			{ species: "Ho-Oh", ability: 'pressure', moves: ['roost'] },
-		] });
-		battle.setPlayer('p2', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['bulkup'] }] });
+		], [
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['bulkup'] },
+		]]);
 		assert.constant(() => battle.field.isWeather('primordialsea'), () => battle.makeChoices('switch 2', 'move bulkup'));
 	});
 
 	it('should cause the Primordial Sea weather to fade if its ability is suppressed and no other Primordial Sea Pokemon are active', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Lugia", ability: 'pressure', moves: ['gastroacid'] }] });
+		battle = common.createBattle([[
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
+		], [
+			{ species: "Lugia", ability: 'pressure', moves: ['gastroacid'] },
+		]]);
 		assert.sets(() => battle.field.isWeather('primordialsea'), false, () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should not cause the Primordial Sea weather to fade if its ability is suppressed and another Primordial Sea Pokemon is active', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['gastroacid'] }] });
+		battle = common.createBattle([[
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
+		], [
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['gastroacid'] },
+		]]);
 		assert.constant(() => battle.field.isWeather('primordialsea'), () => battle.makeChoices('move helpinghand', 'move gastroacid'));
 	});
 
 	it('should cause the Primordial Sea weather to fade if its ability is changed and no other Primordial Sea Pokemon are active', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Lugia", ability: 'pressure', moves: ['entrainment'] }] });
+		battle = common.createBattle([[
+			{ species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand'] },
+		], [
+			{ species: "Lugia", ability: 'pressure', moves: ['entrainment'] },
+		]]);
 		assert.sets(() => battle.field.isWeather('primordialsea'), false, () => battle.makeChoices('move helpinghand', 'move entrainment'));
 	});
 });

--- a/test/sim/abilities/rockhead.js
+++ b/test/sim/abilities/rockhead.js
@@ -11,31 +11,39 @@ describe('Rock Head', () => {
 	});
 
 	it('should block recoil from most moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Aerodactyl', ability: 'rockhead', moves: ['doubleedge'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Registeel', ability: 'clearbody', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: 'Aerodactyl', ability: 'rockhead', moves: ['doubleedge'] },
+		], [
+			{ species: 'Registeel', ability: 'clearbody', moves: ['rest'] },
+		]]);
 		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move doubleedge', 'move rest'));
 	});
 
 	it('should not block recoil if the ability is disabled/removed mid-attack', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Aerodactyl', ability: 'rockhead', moves: ['doubleedge'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Registeel', ability: 'mummy', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: 'Aerodactyl', ability: 'rockhead', moves: ['doubleedge'] },
+		], [
+			{ species: 'Registeel', ability: 'mummy', moves: ['rest'] },
+		]]);
 		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move doubleedge', 'move rest'));
 	});
 
 	it('should not block recoil from Struggle', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Aerodactyl', ability: 'rockhead', moves: ['roost'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] }] });
+		battle = common.createBattle([[
+			{ species: 'Aerodactyl', ability: 'rockhead', moves: ['roost'] },
+		], [
+			{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] },
+		]]);
 		battle.makeChoices('move roost', 'move taunt');
 		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move 1', 'move taunt'));
 	});
 
 	it('should not block crash damage', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Rampardos', ability: 'rockhead', moves: ['jumpkick'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] }] });
+		battle = common.createBattle([[
+			{ species: 'Rampardos', ability: 'rockhead', moves: ['jumpkick'] },
+		], [
+			{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] },
+		]]);
 		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move jumpkick', 'move taunt'));
 	});
 

--- a/test/sim/abilities/roughskin.js
+++ b/test/sim/abilities/roughskin.js
@@ -12,9 +12,11 @@ describe('Rough Skin', () => {
 
 	// Yes, we really need a test for this
 	it("should not activate twice on moves with secondary effects", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Pachirisu', ability: 'voltabsorb', moves: ['nuzzle'] }] });
+		battle = common.createBattle([[
+			{ species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Pachirisu', ability: 'voltabsorb', moves: ['nuzzle'] },
+		]]);
 		battle.makeChoices('auto', 'move nuzzle');
 		const pachi = battle.p2.active[0];
 		assert.equal(pachi.hp, Math.ceil(pachi.maxhp - pachi.maxhp / 8));

--- a/test/sim/abilities/screencleaner.js
+++ b/test/sim/abilities/screencleaner.js
@@ -11,14 +11,12 @@ describe("Screen Cleaner", () => {
 	});
 
 	it("should remove screens from both sides when sent out", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Mew', ability: 'synchronize', moves: ['reflect'] },
 			{ species: 'Mr. Mime-Galar', ability: 'screencleaner', moves: ['psychic'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Mew', ability: 'synchronize', moves: ['lightscreen', 'reflecttype'] },
-		] });
+		]]);
 		battle.makeChoices('move reflect', 'move lightscreen');
 		battle.makeChoices('switch 2', 'move reflecttype');
 		assert(!battle.p1.sideConditions.reflect);

--- a/test/sim/abilities/shadowtag.js
+++ b/test/sim/abilities/shadowtag.js
@@ -11,43 +11,43 @@ describe('Shadow Tag', () => {
 	});
 
 	it('should prevent most Pokemon from switching out normally', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Wobbuffet", ability: 'shadowtag', moves: ['counter'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Wobbuffet", ability: 'shadowtag', moves: ['counter'] },
+		], [
 			{ species: "Tornadus", ability: 'defiant', moves: ['tailwind'] },
 			{ species: "Heatran", ability: 'flashfire', moves: ['roar'] },
-		] });
+		]]);
 		assert.trapped(() => battle.makeChoices('move counter', 'switch 2'), true);
 	});
 
 	it('should not prevent Pokemon from switching out using moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Wobbuffet", ability: 'shadowtag', moves: ['counter'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Wobbuffet", ability: 'shadowtag', moves: ['counter'] },
+		], [
 			{ species: "Tornadus", ability: 'defiant', moves: ['uturn'] },
 			{ species: "Heatran", ability: 'flashfire', moves: ['roar'] },
-		] });
+		]]);
 		battle.makeChoices('move counter', 'move uturn');
 		assert.doesNotThrow(() => battle.makeChoices('', 'switch 2'));
 	});
 
 	it('should not prevent other Pokemon with Shadow Tag from switching out', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Wobbuffet", ability: 'shadowtag', moves: ['counter'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Wobbuffet", ability: 'shadowtag', moves: ['counter'] },
+		], [
 			{ species: "Gothitelle", ability: 'shadowtag', moves: ['psychic'] },
 			{ species: "Heatran", ability: 'flashfire', moves: ['roar'] },
-		] });
+		]]);
 		assert.doesNotThrow(() => battle.makeChoices('move counter', 'switch 2'));
 	});
 
 	it('should not prevent Pokemon immune to trapping from switching out', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Wobbuffet", ability: 'shadowtag', moves: ['counter'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Wobbuffet", ability: 'shadowtag', moves: ['counter'] },
+		], [
 			{ species: "Gengar", ability: 'levitate', moves: ['curse'] },
 			{ species: "Heatran", ability: 'flashfire', moves: ['roar'] },
-		] });
+		]]);
 		assert.doesNotThrow(() => battle.makeChoices('move counter', 'switch 2'));
 	});
 });

--- a/test/sim/abilities/sheerforce.js
+++ b/test/sim/abilities/sheerforce.js
@@ -11,25 +11,31 @@ describe('Sheer Force', () => {
 	});
 
 	it('should not eliminate Life Orb recoil in a move with no secondary effects', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['earthquake'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Lapras', ability: 'shellarmor', item: 'laggingtail', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['earthquake'] },
+		], [
+			{ species: 'Lapras', ability: 'shellarmor', item: 'laggingtail', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move earthquake', 'move rest');
 		assert.equal(battle.p1.active[0].hp, 262);
 	});
 
 	it('should eliminate secondary effects from moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Tauros', ability: 'sheerforce', moves: ['zapcannon'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Machamp', ability: 'noguard', moves: ['bulkup'] }] });
+		battle = common.createBattle([[
+			{ species: 'Tauros', ability: 'sheerforce', moves: ['zapcannon'] },
+		], [
+			{ species: 'Machamp', ability: 'noguard', moves: ['bulkup'] },
+		]]);
 		battle.makeChoices('move zapcannon', 'move bulkup');
 		assert.equal(battle.p2.active[0].status, '');
 	});
 
 	it('should not eliminate Life Orb recoil if the ability is disabled/removed mid-attack', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['lockon', 'dynamicpunch'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Scyther', ability: 'mummy', moves: ['irondefense'] }] });
+		battle = common.createBattle([[
+			{ species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['lockon', 'dynamicpunch'] },
+		], [
+			{ species: 'Scyther', ability: 'mummy', moves: ['irondefense'] },
+		]]);
 		battle.makeChoices('move lockon', 'move irondefense');
 		battle.makeChoices('move dynamicpunch', 'move irondefense');
 		assert.false(battle.p2.active[0].volatiles['confusion']);
@@ -37,9 +43,11 @@ describe('Sheer Force', () => {
 	});
 
 	it('should eliminate Life Orb recoil in a move with secondary effects', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['bodyslam'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Lapras', ability: 'shellarmor', item: 'laggingtail', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: 'Tauros', ability: 'sheerforce', item: 'lifeorb', moves: ['bodyslam'] },
+		], [
+			{ species: 'Lapras', ability: 'shellarmor', item: 'laggingtail', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move bodyslam', 'move rest');
 		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});

--- a/test/sim/abilities/shellarmor.js
+++ b/test/sim/abilities/shellarmor.js
@@ -11,10 +11,11 @@ describe('Shell Armor', () => {
 	});
 
 	it('should prevent moves from dealing critical hits', () => {
-		battle = common.createBattle([
-			[{ species: 'Slowbro', ability: 'shellarmor', moves: ['quickattack'] }],
-			[{ species: 'Cryogonal', ability: 'noguard', moves: ['frostbreath'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Slowbro', ability: 'shellarmor', moves: ['quickattack'] },
+		], [
+			{ species: 'Cryogonal', ability: 'noguard', moves: ['frostbreath'] },
+		]]);
 		let successfulEvent = false;
 		battle.onEvent('ModifyDamage', battle.format, (damage, attacker, defender, move) => {
 			if (move.id === 'frostbreath') {
@@ -27,10 +28,11 @@ describe('Shell Armor', () => {
 	});
 
 	it('should be suppressed by Mold Breaker', () => {
-		battle = common.createBattle([
-			[{ species: 'Slowbro', ability: 'shellarmor', moves: ['quickattack'] }],
-			[{ species: 'Cryogonal', ability: 'moldbreaker', item: 'zoomlens', moves: ['frostbreath'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Slowbro', ability: 'shellarmor', moves: ['quickattack'] },
+		], [
+			{ species: 'Cryogonal', ability: 'moldbreaker', item: 'zoomlens', moves: ['frostbreath'] },
+		]]);
 		let successfulEvent = false;
 		battle.onEvent('ModifyDamage', battle.format, (damage, attacker, defender, move) => {
 			if (move.id === 'frostbreath') {

--- a/test/sim/abilities/shielddust.js
+++ b/test/sim/abilities/shielddust.js
@@ -11,28 +11,34 @@ describe('Shield Dust', () => {
 	});
 
 	it('should block secondary effects against the user', () => {
-		battle = common.createBattle({ gameType: 'doubles' }, [
-			[{ species: 'Latios', ability: 'noguard', moves: ['snarl'] }, { species: 'Latias', ability: 'levitate', moves: ['roost'] }],
-			[{ species: 'Xerneas', ability: 'shielddust', moves: ['roost'] }, { species: 'Yveltal', ability: 'pressure', moves: ['roost'] }],
-		]);
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: 'Latios', ability: 'noguard', moves: ['snarl'] },
+			{ species: 'Latias', ability: 'levitate', moves: ['roost'] },
+		], [
+			{ species: 'Xerneas', ability: 'shielddust', moves: ['roost'] },
+			{ species: 'Yveltal', ability: 'pressure', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move snarl, move roost', 'move roost, move roost');
 		assert.statStage(battle.p2.active[0], 'spa', 0);
 		assert.statStage(battle.p2.active[1], 'spa', -1);
 	});
 
 	it('should not block secondary effects that affect the user of the move', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Ledian', ability: 'ironfist', moves: ['poweruppunch'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Dustox', ability: 'shielddust', moves: ['roost'] }] });
+		battle = common.createBattle([[
+			{ species: 'Ledian', ability: 'ironfist', moves: ['poweruppunch'] },
+		], [
+			{ species: 'Dustox', ability: 'shielddust', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move poweruppunch', 'move roost');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
 	});
 
 	it('should block added effects from items', () => {
-		battle = common.createBattle({ preview: true }, [
-			[{ species: 'Talonflame', ability: 'flamebody', item: 'kingsrock', moves: ['flamecharge'] }],
-			[{ species: 'Clefable', ability: 'shielddust', moves: ['cottonguard'] }],
-		]);
+		battle = common.createBattle({ preview: true }, [[
+			{ species: 'Talonflame', ability: 'flamebody', item: 'kingsrock', moves: ['flamecharge'] },
+		], [
+			{ species: 'Clefable', ability: 'shielddust', moves: ['cottonguard'] },
+		]]);
 		battle.onEvent('ModifyMove', battle.format, move => {
 			if (move.secondaries) {
 				for (const secondary of move.secondaries) {
@@ -47,17 +53,21 @@ describe('Shield Dust', () => {
 	});
 
 	it('should block added effects from Fling', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Ledian', ability: 'ironfist', item: 'petayaberry', moves: ['fling'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Dustox', ability: 'shielddust', moves: ['roost'] }] });
+		battle = common.createBattle([[
+			{ species: 'Ledian', ability: 'ironfist', item: 'petayaberry', moves: ['fling'] },
+		], [
+			{ species: 'Dustox', ability: 'shielddust', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move fling', 'move roost');
 		assert.statStage(battle.p2.active[0], 'spa', 1);
 	});
 
 	it('should not block secondary effects on attacks used by the Pokemon with the ability', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Ledian', ability: 'shielddust', moves: ['poweruppunch', 'strugglebug'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Clefable', ability: 'unaware', moves: ['softboiled'] }] });
+		battle = common.createBattle([[
+			{ species: 'Ledian', ability: 'shielddust', moves: ['poweruppunch', 'strugglebug'] },
+		], [
+			{ species: 'Clefable', ability: 'unaware', moves: ['softboiled'] },
+		]]);
 		battle.makeChoices('move poweruppunch', 'move softboiled');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
 		battle.makeChoices('move strugglebug', 'move softboiled');
@@ -65,9 +75,11 @@ describe('Shield Dust', () => {
 	});
 
 	it('should be negated by Mold Breaker', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Pinsir', ability: 'moldbreaker', moves: ['strugglebug'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Dustox', ability: 'shielddust', moves: ['roost'] }] });
+		battle = common.createBattle([[
+			{ species: 'Pinsir', ability: 'moldbreaker', moves: ['strugglebug'] },
+		], [
+			{ species: 'Dustox', ability: 'shielddust', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move strugglebug', 'move roost');
 		assert.statStage(battle.p2.active[0], 'spa', -1);
 	});

--- a/test/sim/abilities/simple.js
+++ b/test/sim/abilities/simple.js
@@ -11,9 +11,11 @@ describe('Simple', () => {
 	});
 
 	it('should double all stat boosts', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Bibarel", ability: 'simple', moves: ['curse'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Gyarados", ability: 'moxie', moves: ['splash'] }] });
+		battle = common.createBattle([[
+			{ species: "Bibarel", ability: 'simple', moves: ['curse'] },
+		], [
+			{ species: "Gyarados", ability: 'moxie', moves: ['splash'] },
+		]]);
 		battle.makeChoices('move curse', 'move splash');
 		const target = battle.p1.active[0];
 		assert.statStage(target, 'atk', 2);
@@ -28,20 +30,23 @@ describe('Simple [Gen 4]', () => {
 	});
 
 	it('should double the effect of stat boosts', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Bibarel", ability: 'simple', moves: ['defensecurl'] }],
-			[{ species: "Gyarados", ability: 'moxie', moves: ['splash'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Bibarel", ability: 'simple', moves: ['defensecurl'] },
+		], [
+			{ species: "Gyarados", ability: 'moxie', moves: ['splash'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.sets(() => target.getStat('def'), 2 * target.getStat('def'), () => battle.makeChoices('move defensecurl', 'move splash'));
 		assert.statStage(target, 'def', 1);
 	});
 
 	it('should double the effect of stat boosts passed by Baton Pass', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Sableye", ability: 'prankster', moves: ['batonpass'] }, { species: "Bibarel", ability: 'simple', moves: ['protect'] }],
-			[{ species: "Gyarados", ability: 'intimidate', moves: ['splash'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Sableye", ability: 'prankster', moves: ['batonpass'] },
+			{ species: "Bibarel", ability: 'simple', moves: ['protect'] },
+		], [
+			{ species: "Gyarados", ability: 'intimidate', moves: ['splash'] },
+		]]);
 		battle.makeChoices('move batonpass', 'move splash');
 		battle.makeChoices('switch 2', '');
 		assert.equal(battle.p1.active[0].boosts['atk'], -1);
@@ -49,10 +54,11 @@ describe('Simple [Gen 4]', () => {
 	});
 
 	it('should be suppressed by Mold Breaker', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Bibarel", ability: 'simple', moves: ['defensecurl'] }],
-			[{ species: "Haxorus", ability: 'moldbreaker', item: 'laggingtail', moves: ['earthquake'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Bibarel", ability: 'simple', moves: ['defensecurl'] },
+		], [
+			{ species: "Haxorus", ability: 'moldbreaker', item: 'laggingtail', moves: ['earthquake'] },
+		]]);
 		const target = battle.p1.active[0];
 		battle.makeChoices('move defensecurl', 'move earthquake');
 		assert.bounded(target.maxhp - target.hp, [102, 120]);

--- a/test/sim/abilities/stickyhold.js
+++ b/test/sim/abilities/stickyhold.js
@@ -13,12 +13,12 @@ describe('Sticky Hold', () => {
 	});
 
 	it('should prevent held items from being stolen by most moves or abilities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'stickyhold', item: 'razzberry', moves: ['recover'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: 'Shuckle', ability: 'stickyhold', item: 'razzberry', moves: ['recover'] },
+		], [
 			{ species: 'Fennekin', ability: 'magician', moves: ['grassknot'] },
 			{ species: 'Smeargle', ability: 'synchronize', moves: STEAL_MOVES },
-		] });
+		]]);
 		const itemHolder = battle.p1.active[0];
 		battle.makeChoices('move recover', 'move grassknot');
 		assert.equal(itemHolder.item, 'razzberry', "Shuckle should hold a Razz Berry");
@@ -31,9 +31,11 @@ describe('Sticky Hold', () => {
 	});
 
 	it('should be suppressed by Mold Breaker', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Pangoro', ability: 'moldbreaker', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Shuckle', ability: 'stickyhold', item: 'ironball', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: 'Pangoro', ability: 'moldbreaker', moves: ['knockoff'] },
+		], [
+			{ species: 'Shuckle', ability: 'stickyhold', item: 'ironball', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move knockoff', 'move rest');
 		assert.false.holdsItem(battle.p2.active[0]);
 	});

--- a/test/sim/abilities/stormdrain.js
+++ b/test/sim/abilities/stormdrain.js
@@ -11,41 +11,39 @@ describe('Storm Drain', () => {
 	});
 
 	it('should grant immunity to Water-type moves and boost Special Attack by 1 stage', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] }] });
+		battle = common.createBattle([[
+			{ species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] },
+		]]);
 		battle.makeChoices('move sleeptalk', 'move aquajet');
 		assert.fullHP(battle.p1.active[0]);
 		assert.statStage(battle.p1.active[0], 'spa', 1);
 	});
 
 	it('should redirect Max Geyser', () => {
-		battle = common.gen(8).createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(8).createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Gastrodon', ability: 'stormdrain', moves: ['sleep talk'] },
 			{ species: 'Manaphy', ability: 'hydration', moves: ['scald'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Igglybuff', ability: 'cute charm', moves: ['sleep talk'] },
 			{ species: 'Igglybuff', ability: 'cute charm', moves: ['sleep talk'] },
-		] });
+		]]);
 		battle.makeChoices('move sleeptalk, move scald dynamax 1', 'move sleep talk, move sleep talk');
 		assert.fullHP(battle.p1.active[0]);
 		assert.statStage(battle.p1.active[0], 'spa', 1);
 	});
 
 	it('should redirect single-target Water-type attacks to the user if it is a valid target', () => {
-		battle = common.gen(5).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 			{ species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk'] },
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] },
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] },
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] },
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] },
-		] });
+		]]);
 		battle.makeChoices('move sleeptalk, move aquajet 1, move aquajet 1', 'move aquajet 3, move aquajet 3, move aquajet 2');
 		assert.statStage(battle.p1.active[0], 'spa', 3);
 		assert.false.fullHP(battle.p1.active[2]);
@@ -53,15 +51,13 @@ describe('Storm Drain', () => {
 	});
 
 	it('should redirect to the fastest Pokemon with the ability', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk'] },
 			{ species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['waterfall'] },
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['waterfall'] },
-		] });
+		]]);
 		const [fastGastrodon, slowGastrodon] = battle.p1.active;
 		fastGastrodon.boostBy({ spe: 6 });
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move waterfall 1, move waterfall 2');
@@ -70,15 +66,13 @@ describe('Storm Drain', () => {
 	});
 
 	it('should not redirect if another Pokemon has used Follow Me', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Gastrodon', ability: 'stormdrain', moves: ['sleeptalk'] },
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['followme'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] },
 			{ species: 'Azumarill', ability: 'thickfat', moves: ['aquajet'] },
-		] });
+		]]);
 		const [stormDrainMon, defender] = battle.p1.active;
 		battle.makeChoices('move sleeptalk, move followme', 'move aquajet 2, move aquajet 1');
 		assert.statStage(stormDrainMon, 'spa', 0);
@@ -86,15 +80,13 @@ describe('Storm Drain', () => {
 	});
 
 	it('should have its Water-type immunity and its ability to redirect moves suppressed by Mold Breaker', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Gastrodon', ability: 'stormdrain', moves: ['endure'] },
 			{ species: 'Manaphy', ability: 'hydration', moves: ['tailglow'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Haxorus', ability: 'moldbreaker', moves: ['waterfall'] },
 			{ species: 'Reshiram', ability: 'turboblaze', moves: ['waterpulse'] },
-		] });
+		]]);
 		const [stormDrainMon, ally] = battle.p1.active;
 		battle.makeChoices('move endure, move tailglow', 'move waterfall 1, move waterpulse 2');
 		assert.false.fullHP(stormDrainMon);

--- a/test/sim/abilities/sturdy.js
+++ b/test/sim/abilities/sturdy.js
@@ -11,48 +11,60 @@ describe('Sturdy', () => {
 	});
 
 	it('should give the user an immunity to OHKO moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Aron', level: 1, ability: 'sturdy', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Kyogre', ability: 'noguard', moves: ['sheercold'] }] });
+		battle = common.createBattle([[
+			{ species: 'Aron', level: 1, ability: 'sturdy', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Kyogre', ability: 'noguard', moves: ['sheercold'] },
+		]]);
 		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move sheercold'));
 	});
 
 	it('should allow its user to survive an attack from full HP', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Paras', ability: 'sturdy', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Charizard', ability: 'drought', moves: ['fusionflare'] }] });
+		battle = common.createBattle([[
+			{ species: 'Paras', ability: 'sturdy', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Charizard', ability: 'drought', moves: ['fusionflare'] },
+		]]);
 		battle.makeChoices('move sleeptalk', 'move fusionflare');
 		assert.equal(battle.p1.active[0].hp, 1);
 	});
 
 	it('should allow its user to survive a confusion damage hit from full HP', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shedinja', ability: 'sturdy', moves: ['absorb'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Klefki', ability: 'prankster', moves: ['confuseray'] }] });
+		battle = common.createBattle([[
+			{ species: 'Shedinja', ability: 'sturdy', moves: ['absorb'] },
+		], [
+			{ species: 'Klefki', ability: 'prankster', moves: ['confuseray'] },
+		]]);
 		battle.makeChoices('move absorb', 'move confuseray');
 		assert.equal(battle.p1.active[0].hp, 1);
 	});
 
 	it('should not trigger on recoil damage', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shedinja', ability: 'sturdy', moves: ['doubleedge'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Klefki', ability: 'prankster', moves: ['reflect'] }] });
+		battle = common.createBattle([[
+			{ species: 'Shedinja', ability: 'sturdy', moves: ['doubleedge'] },
+		], [
+			{ species: 'Klefki', ability: 'prankster', moves: ['reflect'] },
+		]]);
 		battle.makeChoices('move doubleedge', 'move reflect');
 		assert.fainted(battle.p1.active[0]);
 	});
 
 	it('should not trigger on residual damage', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shedinja', ability: 'sturdy', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Crobat', ability: 'infiltrator', moves: ['toxic'] }] });
+		battle = common.createBattle([[
+			{ species: 'Shedinja', ability: 'sturdy', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Crobat', ability: 'infiltrator', moves: ['toxic'] },
+		]]);
 		battle.makeChoices('move sleeptalk', 'move toxic');
 		assert.fainted(battle.p1.active[0]);
 	});
 
 	it('should be suppressed by Mold Breaker', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Paras', ability: 'sturdy', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Reshiram', ability: 'turboblaze', moves: ['fusionflare'] }] });
+		battle = common.createBattle([[
+			{ species: 'Paras', ability: 'sturdy', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Reshiram', ability: 'turboblaze', moves: ['fusionflare'] },
+		]]);
 		battle.makeChoices('move sleeptalk', 'move fusionflare');
 		assert.fainted(battle.p1.active[0]);
 	});

--- a/test/sim/abilities/suctioncups.js
+++ b/test/sim/abilities/suctioncups.js
@@ -11,12 +11,12 @@ describe('Suction Cups', () => {
 	});
 
 	it('should prevent the user from being forced out', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Shuckle', ability: 'suctioncups', moves: ['rapidspin'] },
 			{ species: 'Forretress', ability: 'sturdy', moves: ['rapidspin'] },
-		] });
-		battle.setPlayer('p2', { team: [{ species: 'Smeargle', ability: 'noguard', item: 'redcard', moves: ['healpulse', 'dragontail', 'circlethrow', 'roar'] }] });
+		], [
+			{ species: 'Smeargle', ability: 'noguard', item: 'redcard', moves: ['healpulse', 'dragontail', 'circlethrow', 'roar'] },
+		]]);
 		const [cupsMon, redCardHolder] = [battle.p1.active[0], battle.p2.active[0]];
 		battle.makeChoices('move rapidspin', 'move healpulse');
 		assert.false.holdsItem(redCardHolder, "Red Card should activate");

--- a/test/sim/abilities/symbiosis.js
+++ b/test/sim/abilities/symbiosis.js
@@ -24,10 +24,13 @@ describe('Symbiosis', () => {
 	});
 
 	it('should not share an item required to change forme', () => {
-		battle = common.createBattle({ gameType: 'doubles' }, [
-			[{ species: 'Smeargle', ability: 'symbiosis', item: 'latiasite', moves: ['snarl'] }, { species: 'Latias', ability: 'levitate', item: 'weaknesspolicy', moves: ['snarl'] }],
-			[{ species: 'Smeargle', moves: ['snarl'] }, { species: 'Smeargle', moves: ['snarl'] }],
-		]);
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: 'Smeargle', ability: 'symbiosis', item: 'latiasite', moves: ['snarl'] },
+			{ species: 'Latias', ability: 'levitate', item: 'weaknesspolicy', moves: ['snarl'] },
+		], [
+			{ species: 'Smeargle', moves: ['snarl'] },
+			{ species: 'Smeargle', moves: ['snarl'] },
+		]]);
 		battle.makeChoices('move snarl, move snarl', 'move snarl, move snarl');
 		assert.equal(battle.p1.active[0].item, 'latiasite');
 		assert.equal(battle.p1.active[1].item, '');

--- a/test/sim/abilities/technician.js
+++ b/test/sim/abilities/technician.js
@@ -11,15 +11,13 @@ describe('Technician', () => {
 	});
 
 	it('should not apply boost on a move boosted over 60 BP by Battery in Gen 7', () => {
-		battle = common.gen(7).createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(7).createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Toxtricity', ability: 'technician', moves: ['shockwave'] },
 			{ species: 'Charjabug', ability: 'battery', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Marshadow', ability: 'technician', moves: ['sleeptalk'] },
 			{ species: 'Mew', ability: 'synchronize', moves: ['sleeptalk'] },
-		] });
+		]]);
 		battle.makeChoices('move shockwave 2, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		const mew = battle.p2.active[1];
 		const damage = mew.maxhp - mew.hp;

--- a/test/sim/abilities/terashell.js
+++ b/test/sim/abilities/terashell.js
@@ -9,10 +9,11 @@ describe('Tera Shell', () => {
 	afterEach(() => battle.destroy());
 
 	it(`should take not very effective damage when it is at full health`, () => {
-		battle = common.createBattle([
-			[{ species: 'Terapagos-Terastal', ability: 'terashell', moves: ['sleeptalk'] }],
-			[{ species: 'Wynaut', moves: ['wickedblow'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Terapagos-Terastal', ability: 'terashell', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Wynaut', moves: ['wickedblow'] },
+		]]);
 
 		battle.makeChoices();
 		const terapagos = battle.p1.active[0];
@@ -25,10 +26,11 @@ describe('Tera Shell', () => {
 
 	// confirmed here: https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9893603
 	it(`should not take precedence over immunities`, () => {
-		battle = common.createBattle([
-			[{ species: 'Terapagos-Terastal', ability: 'terashell', moves: ['sleeptalk'] }],
-			[{ species: 'Wynaut', moves: ['shadowball'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Terapagos-Terastal', ability: 'terashell', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Wynaut', moves: ['shadowball'] },
+		]]);
 
 		battle.makeChoices();
 		const terapagos = battle.p1.active[0];
@@ -58,10 +60,11 @@ describe('Tera Shell', () => {
 	// kinda confirmed here: https://youtu.be/-nerhfXrmCM?si=hLzfrfzVDdfNFMbv&t=314
 	// confirmed here: https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9893781
 	it('All hits of multi-hit move should be not very effective', () => {
-		battle = common.createBattle([
-			[{ species: 'Terapagos-Terastal', ability: 'terashell', moves: ['sleeptalk'] }],
-			[{ species: 'Wynaut', moves: ['surgingstrikes'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Terapagos-Terastal', ability: 'terashell', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Wynaut', moves: ['surgingstrikes'] },
+		]]);
 
 		battle.makeChoices();
 		const terapagos = battle.p1.active[0];
@@ -71,10 +74,11 @@ describe('Tera Shell', () => {
 
 	// confirmed here: https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9893651
 	it(`should be suppressed by Gastro Acid`, () => {
-		battle = common.createBattle([
-			[{ species: 'Terapagos-Terastal', ability: 'terashell', moves: ['sleeptalk'] }],
-			[{ species: 'Wynaut', moves: ['gastroacid', 'wickedblow'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Terapagos-Terastal', ability: 'terashell', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Wynaut', moves: ['gastroacid', 'wickedblow'] },
+		]]);
 
 		battle.makeChoices('move sleeptalk', 'move gastroacid');
 		battle.makeChoices('move sleeptalk', 'move wickedblow');

--- a/test/sim/abilities/truant.js
+++ b/test/sim/abilities/truant.js
@@ -11,9 +11,11 @@ describe('Truant', () => {
 	});
 
 	it('should prevent the user from acting the turn after using a move', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Slaking", ability: 'truant', moves: ['scratch'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Steelix", ability: 'sturdy', moves: ['endure'] }] });
+		battle = common.createBattle([[
+			{ species: "Slaking", ability: 'truant', moves: ['scratch'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', moves: ['endure'] },
+		]]);
 		const pokemon = battle.p2.active[0];
 
 		assert.hurts(pokemon, () => battle.makeChoices());
@@ -34,9 +36,11 @@ describe('Truant', () => {
 	});
 
 	it('should not allow the user to act the turn it wakes up, if it moved the turn it fell asleep', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Slaking", ability: 'truant', moves: ['scratch', 'rest'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Steelix", ability: 'sturdy', moves: ['endure', 'quickattack'] }] });
+		battle = common.createBattle([[
+			{ species: "Slaking", ability: 'truant', moves: ['scratch', 'rest'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', moves: ['endure', 'quickattack'] },
+		]]);
 		const pokemon = battle.p2.active[0];
 
 		battle.makeChoices('move rest', 'move quickattack');
@@ -46,9 +50,11 @@ describe('Truant', () => {
 	});
 
 	it('should allow the user to act the turn it wakes up, if it was loafing the turn it fell asleep', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Slaking", ability: 'truant', moves: ['scratch', 'irondefense'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Steelix", ability: 'sturdy', moves: ['endure', 'spore'] }] });
+		battle = common.createBattle([[
+			{ species: "Slaking", ability: 'truant', moves: ['scratch', 'irondefense'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', moves: ['endure', 'spore'] },
+		]]);
 		const user = battle.p1.active[0];
 		const pokemon = battle.p2.active[0];
 
@@ -63,9 +69,11 @@ describe('Truant', () => {
 	});
 
 	it('should cause two-turn moves to fail', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Slaking", ability: 'truant', moves: ['razorwind'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Steelix", ability: 'sturdy', moves: ['endure'] }] });
+		battle = common.createBattle([[
+			{ species: "Slaking", ability: 'truant', moves: ['razorwind'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', moves: ['endure'] },
+		]]);
 		const pokemon = battle.p2.active[0];
 
 		assert.false.hurts(pokemon, () => battle.makeChoices());
@@ -73,9 +81,11 @@ describe('Truant', () => {
 	});
 
 	it('should prevent a newly-Mega Evolved Pokemon from acting if given the ability', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Slaking", ability: 'truant', item: 'choicescarf', moves: ['entrainment'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Steelix", ability: 'sturdy', item: 'steelixite', moves: ['heavyslam'] }] });
+		battle = common.createBattle([[
+			{ species: "Slaking", ability: 'truant', item: 'choicescarf', moves: ['entrainment'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', item: 'steelixite', moves: ['heavyslam'] },
+		]]);
 
 		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move entrainment', 'move heavyslam mega'));
 	});

--- a/test/sim/abilities/unburden.js
+++ b/test/sim/abilities/unburden.js
@@ -11,57 +11,71 @@ describe('Unburden', () => {
 	});
 
 	it('should trigger when an item is consumed', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Hitmonlee', ability: 'unburden', item: 'whiteherb', moves: ['closecombat'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: 'Hitmonlee', ability: 'unburden', item: 'whiteherb', moves: ['closecombat'] },
+		], [
+			{ species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move closecombat', 'move swordsdance'));
 	});
 
 	it('should trigger when an item is destroyed', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Drifblim', ability: 'unburden', item: 'airballoon', moves: ['endure'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Machamp', ability: 'noguard', moves: ['stoneedge'] }] });
+		battle = common.createBattle([[
+			{ species: 'Drifblim', ability: 'unburden', item: 'airballoon', moves: ['endure'] },
+		], [
+			{ species: 'Machamp', ability: 'noguard', moves: ['stoneedge'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move endure', 'move stoneedge'));
 	});
 
 	it('should trigger when Natural Gift consumes a berry', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sceptile', ability: 'unburden', item: 'oranberry', moves: ['naturalgift'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sceptile', ability: 'unburden', item: 'oranberry', moves: ['naturalgift'] },
+		], [
+			{ species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move naturalgift', 'move swordsdance'));
 	});
 
 	it('should trigger when an item is flung', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['fling'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['fling'] },
+		], [
+			{ species: 'Scizor', ability: 'swarm', item: 'focussash', moves: ['swordsdance'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move fling', 'move swordsdance'));
 	});
 
 	it('should trigger when an item is forcefully removed', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['leechseed'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Scizor', ability: 'swarm', moves: ['knockoff'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['leechseed'] },
+		], [
+			{ species: 'Scizor', ability: 'swarm', moves: ['knockoff'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move leechseed', 'move knockoff'));
 	});
 
 	it('should not be suppressed by Mold Breaker', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['leechseed'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Scizor', ability: 'moldbreaker', moves: ['knockoff'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sceptile', ability: 'unburden', item: 'whiteherb', moves: ['leechseed'] },
+		], [
+			{ species: 'Scizor', ability: 'moldbreaker', moves: ['knockoff'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.sets(() => target.getStat('spe'), 2 * target.getStat('spe'), () => battle.makeChoices('move leechseed', 'move knockoff'));
 	});
 
 	it('should lose the boost when it gains a new item', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Hitmonlee', ability: 'unburden', item: 'fightinggem', moves: ['machpunch'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Togekiss', ability: 'serenegrace', item: 'laggingtail', moves: ['bestow', 'followme'] }] });
+		battle = common.createBattle([[
+			{ species: 'Hitmonlee', ability: 'unburden', item: 'fightinggem', moves: ['machpunch'] },
+		], [
+			{ species: 'Togekiss', ability: 'serenegrace', item: 'laggingtail', moves: ['bestow', 'followme'] },
+		]]);
 		const originalSpeed = battle.p1.active[0].getStat('spe');
 		battle.makeChoices('move machpunch', 'move followme');
 		assert.equal(battle.p1.active[0].getStat('spe'), 2 * originalSpeed);

--- a/test/sim/abilities/wonderguard.js
+++ b/test/sim/abilities/wonderguard.js
@@ -11,9 +11,11 @@ describe('Wonder Guard', () => {
 	});
 
 	it('should make the user immune to damaging attacks that are not super effective', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Aerodactyl", ability: 'wonderguard', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Smeargle", ability: 'owntempo', moves: ['knockoff', 'flamethrower', 'thousandarrows', 'moonblast'] }] });
+		battle = common.createBattle([[
+			{ species: "Aerodactyl", ability: 'wonderguard', moves: ['sleeptalk'] },
+		], [
+			{ species: "Smeargle", ability: 'owntempo', moves: ['knockoff', 'flamethrower', 'thousandarrows', 'moonblast'] },
+		]]);
 		for (let i = 1; i <= 4; i++) {
 			battle.makeChoices('move sleeptalk', 'move ' + i);
 			assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
@@ -23,9 +25,11 @@ describe('Wonder Guard', () => {
 	});
 
 	it('should not make the user immune to status moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Abra", ability: 'wonderguard', moves: ['teleport'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Smeargle", ability: 'noguard', moves: ['poisongas', 'screech', 'healpulse', 'gastroacid'] }] });
+		battle = common.createBattle([[
+			{ species: "Abra", ability: 'wonderguard', moves: ['teleport'] },
+		], [
+			{ species: "Smeargle", ability: 'noguard', moves: ['poisongas', 'screech', 'healpulse', 'gastroacid'] },
+		]]);
 		const wwTarget = battle.p1.active[0];
 		battle.makeChoices('move teleport', 'move poisongas');
 		assert.equal(wwTarget.status, 'psn');
@@ -38,9 +42,11 @@ describe('Wonder Guard', () => {
 	});
 
 	it('should be suppressed by Mold Breaker', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Zekrom", ability: 'wonderguard', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Reshiram", ability: 'turboblaze', moves: ['fusionflare'] }] });
+		battle = common.createBattle([[
+			{ species: "Zekrom", ability: 'wonderguard', moves: ['sleeptalk'] },
+		], [
+			{ species: "Reshiram", ability: 'turboblaze', moves: ['fusionflare'] },
+		]]);
 		assert.hurts(battle.p1.active[0], () => battle.makeChoices('move sleeptalk', 'move fusionflare'));
 	});
 

--- a/test/sim/choice-parser.js
+++ b/test/sim/choice-parser.js
@@ -9,10 +9,11 @@ describe('Choice parser', () => {
 	afterEach(() => battle.destroy());
 	describe('Team Preview requests', () => {
 		it('should accept only `team` choices', () => {
-			battle = common.createBattle({ preview: true }, [
-				[{ species: "Mew", ability: 'synchronize', moves: ['recover'] }],
-				[{ species: "Rhydon", ability: 'prankster', moves: ['splash'] }],
-			]);
+			battle = common.createBattle({ preview: true }, [[
+				{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
+			], [
+				{ species: "Rhydon", ability: 'prankster', moves: ['splash'] },
+			]]);
 
 			const validChoice = 'team 1';
 			assert(battle.choose('p1', validChoice));
@@ -27,10 +28,11 @@ describe('Choice parser', () => {
 		});
 
 		it('should reject non-numerical choice details', () => {
-			battle = common.createBattle({ preview: true }, [
-				[{ species: "Mew", ability: 'synchronize', moves: ['recover'] }],
-				[{ species: "Rhydon", ability: 'prankster', moves: ['splash'] }],
-			]);
+			battle = common.createBattle({ preview: true }, [[
+				{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
+			], [
+				{ species: "Rhydon", ability: 'prankster', moves: ['splash'] },
+			]]);
 
 			for (const side of battle.sides) {
 				assert.throws(() => battle.choose(side.id, 'team Rhydon'));
@@ -40,10 +42,11 @@ describe('Choice parser', () => {
 		});
 
 		it('should reject zero-based choice details', () => {
-			battle = common.createBattle({ preview: true }, [
-				[{ species: "Mew", ability: 'synchronize', moves: ['recover'] }],
-				[{ species: "Rhydon", ability: 'prankster', moves: ['splash'] }],
-			]);
+			battle = common.createBattle({ preview: true }, [[
+				{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
+			], [
+				{ species: "Rhydon", ability: 'prankster', moves: ['splash'] },
+			]]);
 
 			for (const side of battle.sides) {
 				assert.throws(
@@ -58,12 +61,12 @@ describe('Choice parser', () => {
 	describe('Switch requests', () => {
 		describe('Generic', () => {
 			it('should reject non-numerical input for `switch` choices', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle([[
 					{ species: "Mew", ability: 'synchronize', moves: ['lunardance'] },
 					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] },
-				] });
-				battle.setPlayer('p2', { team: [{ species: "Rhydon", ability: 'prankster', moves: ['splash'] }] });
+				], [
+					{ species: "Rhydon", ability: 'prankster', moves: ['splash'] },
+				]]);
 
 				battle.makeChoices('move lunardance', 'move splash');
 
@@ -74,12 +77,12 @@ describe('Choice parser', () => {
 
 		describe('Singles', () => {
 			it('should accept only `switch` choices', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle([[
 					{ species: "Mew", ability: 'synchronize', moves: ['lunardance'] },
 					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] },
-				] });
-				battle.setPlayer('p2', { team: [{ species: "Rhydon", ability: 'prankster', moves: ['splash'] }] });
+				], [
+					{ species: "Rhydon", ability: 'prankster', moves: ['splash'] },
+				]]);
 
 				battle.makeChoices('move lunardance', 'move splash');
 
@@ -96,17 +99,15 @@ describe('Choice parser', () => {
 
 		describe('Doubles/Triples', () => {
 			it('should accept only `switch` and `pass` choices', () => {
-				battle = common.createBattle({ gameType: 'doubles' });
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle({ gameType: 'doubles' }, [[
 					{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Koffing", ability: 'levitate', moves: ['smog'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 					{ species: "Ekans", ability: 'shedskin', moves: ['wrap'] },
-				] });
+				]]);
 				battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense'); // Both p1 active Pokémon faint
 
 				const badChoices = ['move 1', 'move 2 mega', 'team 1', 'shift'];
@@ -118,17 +119,15 @@ describe('Choice parser', () => {
 			});
 
 			it('should reject choice details for `pass` choices', () => {
-				battle = common.createBattle({ gameType: 'doubles' });
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle({ gameType: 'doubles' }, [[
 					{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Koffing", ability: 'levitate', moves: ['smog'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 					{ species: "Ekans", ability: 'shedskin', moves: ['wrap'] },
-				] });
+				]]);
 				battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense'); // Both p1 active Pokémon faint
 
 				const switchChoice = 'switch 3';
@@ -158,9 +157,11 @@ describe('Choice parser', () => {
 	describe('Move requests', () => {
 		describe('Generic', () => {
 			it('should reject `pass` choices for non-fainted Pokémon', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['recover'] }] });
-				battle.setPlayer('p2', { team: [{ species: "Rhydon", ability: 'prankster', moves: ['splash'] }] });
+				battle = common.createBattle([[
+					{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
+				], [
+					{ species: "Rhydon", ability: 'prankster', moves: ['splash'] },
+				]]);
 
 				for (const side of battle.sides) {
 					assert.throws(() => battle.choose(side.id, 'pass'));
@@ -168,15 +169,13 @@ describe('Choice parser', () => {
 			});
 
 			it('should allow mega evolving and targeting in the same move in either order', () => {
-				battle = common.createBattle({ gameType: 'doubles' });
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle({ gameType: 'doubles' }, [[
 					{ species: "Gengar", ability: 'cursedbody', item: 'gengarite', moves: ['shadowball'] },
 					{ species: "Zigzagoon", ability: 'pickup', moves: ['tackle'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Blaziken", ability: 'blaze', item: 'firiumz', moves: ['blazekick'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
-				] });
+				]]);
 
 				const badChoices = [`move 1 1 2`, `move 1 1 mega ultra`, `move 1 mega zmove 2`];
 				for (const badChoice of badChoices) {
@@ -201,15 +200,13 @@ describe('Choice parser', () => {
 			});
 
 			it('should handle Conversion 2', () => {
-				battle = common.createBattle({ gameType: 'doubles' });
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle({ gameType: 'doubles' }, [[
 					{ species: "Porygon-Z", ability: 'adaptability', item: 'normaliumz', moves: ['conversion', 'conversion2'] },
 					{ species: "Porygon", ability: 'download', moves: ['conversion', 'conversion2'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Gengar", ability: 'cursedbody', moves: ['lick'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
-				] });
+				]]);
 
 				assert(battle.choose('p1', `move 1, move Conversion 2 2`));
 				assert.equal(battle.p1.getChoice(), `move conversion, move conversion2 +2`);
@@ -226,15 +223,13 @@ describe('Choice parser', () => {
 
 		describe('Singles', () => {
 			it('should accept only `move` and `switch` choices', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle([[
 					{ species: "Mew", ability: 'synchronize', moves: ['lunardance', 'recover'] },
 					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Rhydon", ability: 'prankster', moves: ['splash', 'horndrill'] },
 					{ species: "Charmander", ability: 'blaze', moves: ['tackle', 'growl'] },
-				] });
+				]]);
 
 				const validChoices = ['move 1', 'move 2', 'switch 2'];
 				for (const action of validChoices) {
@@ -251,16 +246,14 @@ describe('Choice parser', () => {
 
 		describe('Doubles', () => {
 			it('should enforce `pass` choices for fainted Pokémon', () => {
-				battle = common.createBattle({ gameType: 'doubles' });
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle({ gameType: 'doubles' }, [[
 					{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Koffing", ability: 'levitate', moves: ['smog'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
-				] });
+				]]);
 				const p1 = battle.p1;
 				battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense'); // Both p1 active Pokémon faint
 				battle.makeChoices('pass, switch 3', ''); // Koffing switches in at slot #2
@@ -276,18 +269,16 @@ describe('Choice parser', () => {
 
 		describe('Triples', () => {
 			it('should accept only `move` and `switch` choices for a healthy Pokémon on the center', () => {
-				battle = common.gen(5).createBattle({ gameType: 'triples' });
-				battle.setPlayer('p1', { team: [
+				battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 					{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Gastly", ability: 'levitate', moves: ['lick'] },
 					{ species: "Forretress", ability: 'levitate', moves: ['spikes'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 					{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
-				] });
+				]]);
 
 				const validChoices = ['move 1', 'switch 4'];
 
@@ -305,19 +296,17 @@ describe('Choice parser', () => {
 			});
 
 			it('should accept only `move`, `switch` and `shift` choices for a healthy Pokémon on the left', () => {
-				battle = common.gen(5).createBattle({ gameType: 'triples' });
-				battle.setPlayer('p1', { team: [
+				battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 					{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Gastly", ability: 'levitate', moves: ['lick'] },
 					{ species: "Forretress", ability: 'levitate', moves: ['spikes'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 					{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
 					{ species: "Magnezone", ability: 'magnetpull', moves: ['discharge'] },
-				] });
+				]]);
 
 				const validChoices = ['move 1', 'switch 4', 'shift'];
 
@@ -335,19 +324,17 @@ describe('Choice parser', () => {
 			});
 
 			it('should accept only `move`, `switch` and `shift` choices for a healthy Pokémon on the right', () => {
-				battle = common.gen(5).createBattle({ gameType: 'triples' });
-				battle.setPlayer('p1', { team: [
+				battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 					{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Gastly", ability: 'levitate', moves: ['lick'] },
 					{ species: "Forretress", ability: 'levitate', moves: ['spikes'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 					{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
 					{ species: "Magnezone", ability: 'magnetpull', moves: ['discharge'] },
-				] });
+				]]);
 
 				const validChoices = ['move 1 1', 'switch 4', 'shift'];
 
@@ -365,18 +352,16 @@ describe('Choice parser', () => {
 			});
 
 			it('should enforce `pass` choices for fainted Pokémon', () => {
-				battle = common.gen(5).createBattle({ gameType: 'triples' });
-				battle.setPlayer('p1', { team: [
+				battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 					{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 					{ species: "Gastly", ability: 'levitate', moves: ['lunardance'] },
 					{ species: "Forretress", ability: 'levitate', moves: ['spikes'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 					{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 					{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
-				] });
+				]]);
 				const p1 = battle.p1;
 				battle.makeChoices('move selfdestruct, move selfdestruct, move lunardance', 'move roost, move irondefense, move defensecurl'); // All p1 active Pokémon faint
 

--- a/test/sim/decisions.js
+++ b/test/sim/decisions.js
@@ -105,9 +105,11 @@ describe('Choices', () => {
 
 	describe('Generic', () => {
 		it('should wait for players to send their choices and run them as soon as they are all received', done => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['recover'] }] });
-			battle.setPlayer('p2', { team: [{ species: "Rhydon", ability: 'prankster', moves: ['sketch'] }] });
+			battle = common.createBattle([[
+				{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
+			], [
+				{ species: "Rhydon", ability: 'prankster', moves: ['sketch'] },
+			]]);
 
 			setTimeout(() => {
 				battle.choose('p2', 'move 1');
@@ -123,10 +125,11 @@ describe('Choices', () => {
 	describe('Move requests', () => {
 		it('should allow specifying moves', () => {
 			const MOVES = [['growl', 'tackle'], ['growl', 'scratch']];
-			battle = common.createBattle([
-				[{ species: "Bulbasaur", ability: 'Overgrow', moves: MOVES[0] }],
-				[{ species: "Charmander", ability: 'Blaze', moves: MOVES[1] }],
-			]);
+			battle = common.createBattle([[
+				{ species: "Bulbasaur", ability: 'Overgrow', moves: MOVES[0] },
+			], [
+				{ species: "Charmander", ability: 'Blaze', moves: MOVES[1] },
+			]]);
 
 			const activeMons = battle.sides.map(side => side.active[0]);
 			for (let i = 0; i < 2; i++) {
@@ -175,28 +178,37 @@ describe('Choices', () => {
 		});
 
 		it('should disallow specifying move targets for targetless moves (randomNormal)', () => {
-			battle = common.createBattle({ gameType: 'doubles' }, [
-				[{ species: "Dragonite", ability: 'multiscale', moves: ['outrage'] }, { species: "Blastoise", ability: 'torrent', moves: ['rest'] }],
-				[{ species: "Tyranitar", ability: 'unnerve', moves: ['dragondance'] }, { species: "Zapdos", ability: 'pressure', moves: ['roost'] }],
-			]);
+			battle = common.createBattle({ gameType: 'doubles' }, [[
+				{ species: "Dragonite", ability: 'multiscale', moves: ['outrage'] },
+				{ species: "Blastoise", ability: 'torrent', moves: ['rest'] },
+			], [
+				{ species: "Tyranitar", ability: 'unnerve', moves: ['dragondance'] },
+				{ species: "Zapdos", ability: 'pressure', moves: ['roost'] },
+			]]);
 
 			assert.cantTarget(() => battle.p1.chooseMove('outrage', 1), 'outrage');
 		});
 
 		it('should disallow specifying move targets for targetless moves (scripted)', () => {
-			battle = common.createBattle({ gameType: 'doubles' }, [
-				[{ species: "Dragonite", ability: 'multiscale', moves: ['counter'] }, { species: "Blastoise", ability: 'torrent', moves: ['rest'] }],
-				[{ species: "Tyranitar", ability: 'unnerve', moves: ['bodyslam'] }, { species: "Zapdos", ability: 'pressure', moves: ['drillpeck'] }],
-			]);
+			battle = common.createBattle({ gameType: 'doubles' }, [[
+				{ species: "Dragonite", ability: 'multiscale', moves: ['counter'] },
+				{ species: "Blastoise", ability: 'torrent', moves: ['rest'] },
+			], [
+				{ species: "Tyranitar", ability: 'unnerve', moves: ['bodyslam'] },
+				{ species: "Zapdos", ability: 'pressure', moves: ['drillpeck'] },
+			]]);
 
 			assert.cantTarget(() => battle.p1.chooseMove('counter', 2), 'counter');
 		});
 
 		it('should disallow specifying move targets for targetless moves (self)', () => {
-			battle = common.createBattle({ gameType: 'doubles' }, [
-				[{ species: "Dragonite", ability: 'multiscale', moves: ['roost'] }, { species: "Blastoise", ability: 'torrent', moves: ['rest'] }],
-				[{ species: "Tyranitar", ability: 'unnerve', moves: ['dragondance'] }, { species: "Zapdos", ability: 'pressure', moves: ['roost'] }],
-			]);
+			battle = common.createBattle({ gameType: 'doubles' }, [[
+				{ species: "Dragonite", ability: 'multiscale', moves: ['roost'] },
+				{ species: "Blastoise", ability: 'torrent', moves: ['rest'] },
+			], [
+				{ species: "Tyranitar", ability: 'unnerve', moves: ['dragondance'] },
+				{ species: "Zapdos", ability: 'pressure', moves: ['roost'] },
+			]]);
 
 			assert.cantTarget(() => battle.p1.chooseMove('roost', -2), 'roost');
 		});
@@ -229,17 +241,15 @@ describe('Choices', () => {
 		});
 
 		it('should allow shifting the Pokémon on the left to the center', () => {
-			battle = common.gen(5).createBattle({ gameType: 'triples' });
-			battle.setPlayer('p1', { team: [
+			battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 				{ species: "Pineco", ability: 'sturdy', moves: ['harden'] },
 				{ species: "Geodude", ability: 'sturdy', moves: ['defensecurl'] },
 				{ species: "Gastly", ability: 'levitate', moves: ['spite'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 				{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 				{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
-			] });
+			]]);
 			const [p1, p2] = battle.sides;
 			battle.makeChoices('move harden, move defensecurl, shift', 'move roost, move irondefense, shift');
 
@@ -252,17 +262,15 @@ describe('Choices', () => {
 		});
 
 		it('should allow shifting the Pokémon on the right to the center', () => {
-			battle = common.gen(5).createBattle({ gameType: 'triples' });
-			battle.setPlayer('p1', { team: [
+			battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 				{ species: "Pineco", ability: 'sturdy', moves: ['harden'] },
 				{ species: "Geodude", ability: 'sturdy', moves: ['defensecurl'] },
 				{ species: "Gastly", ability: 'levitate', moves: ['spite'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 				{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 				{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
-			] });
+			]]);
 			battle.makeChoices('shift, default, default', 'shift, default, default');
 
 			for (const [index, species] of ['Geodude', 'Pineco', 'Gastly'].entries()) {
@@ -274,17 +282,15 @@ describe('Choices', () => {
 		});
 
 		it('should shift the Pokémon as a standard priority move action', () => {
-			battle = common.gen(5).createBattle({ gameType: 'triples' });
-			battle.setPlayer('p1', { team: [
+			battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 				{ species: "Pineco", ability: 'sturdy', moves: ['harden'] },
 				{ species: "Geodude", ability: 'sturdy', moves: ['suckerpunch'] },
 				{ species: "Gastly", ability: 'levitate', moves: ['spite'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 				{ species: "Aggron", ability: 'sturdy', moves: ['earthquake'] },
 				{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
-			] });
+			]]);
 			battle.makeChoices('shift, move suckerpunch 2, shift', 'shift, move earthquake, shift');
 
 			for (const [index, species] of ['Gastly', 'Pineco', 'Geodude'].entries()) {
@@ -302,9 +308,11 @@ describe('Choices', () => {
 		});
 
 		it('should force Struggle usage on move attempt for no valid moves', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['recover'] }] });
-			battle.setPlayer('p2', { team: [{ species: "Rhydon", ability: 'prankster', moves: ['sketch'] }] });
+			battle = common.createBattle([[
+				{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
+			], [
+				{ species: "Rhydon", ability: 'prankster', moves: ['sketch'] },
+			]]);
 
 			// First turn
 			battle.makeChoices('move 1', 'move 1');
@@ -318,9 +326,11 @@ describe('Choices', () => {
 		});
 
 		it('should not force Struggle usage on move attempt for valid moves', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['recover'] }] });
-			battle.setPlayer('p2', { team: [{ species: "Rhydon", ability: 'prankster', moves: ['struggle', 'surf'] }] });
+			battle = common.createBattle([[
+				{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
+			], [
+				{ species: "Rhydon", ability: 'prankster', moves: ['struggle', 'surf'] },
+			]]);
 
 			battle.makeChoices('move recover', 'move surf');
 
@@ -329,9 +339,11 @@ describe('Choices', () => {
 		});
 
 		it('should not force Struggle usage on move attempt when choosing a disabled move', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Mew", item: 'assaultvest', ability: 'synchronize', moves: ['recover', 'icebeam'] }] });
-			battle.setPlayer('p2', { team: [{ species: "Rhydon", item: '', ability: 'prankster', moves: ['surf'] }] });
+			battle = common.createBattle([[
+				{ species: "Mew", item: 'assaultvest', ability: 'synchronize', moves: ['recover', 'icebeam'] },
+			], [
+				{ species: "Rhydon", item: '', ability: 'prankster', moves: ['surf'] },
+			]]);
 			const failingAttacker = battle.p1.active[0];
 			battle.p2.chooseMove(1);
 
@@ -345,9 +357,11 @@ describe('Choices', () => {
 		});
 
 		it('should send meaningful feedback to players if they try to use a disabled move', () => {
-			battle = common.createBattle({ strictChoices: false });
-			battle.setPlayer('p1', { team: [{ species: "Skarmory", ability: 'sturdy', moves: ['spikes', 'roost'] }] });
-			battle.setPlayer('p2', { team: [{ species: "Smeargle", ability: 'owntempo', moves: ['imprison', 'spikes'] }] });
+			battle = common.createBattle({ strictChoices: false }, [[
+				{ species: "Skarmory", ability: 'sturdy', moves: ['spikes', 'roost'] },
+			], [
+				{ species: "Smeargle", ability: 'owntempo', moves: ['imprison', 'spikes'] },
+			]]);
 
 			battle.makeChoices('move spikes', 'move imprison');
 
@@ -366,12 +380,12 @@ describe('Choices', () => {
 		});
 
 		it('should send meaningful feedback to players if they try to switch a trapped Pokémon out', () => {
-			battle = common.createBattle({ strictChoices: false });
-			battle.setPlayer('p1', { team: [
+			battle = common.createBattle({ strictChoices: false }, [[
 				{ species: "Scizor", ability: 'swarm', moves: ['bulletpunch'] },
 				{ species: "Azumarill", ability: 'sapsipper', moves: ['aquajet'] },
-			] });
-			battle.setPlayer('p2', { team: [{ species: "Gothitelle", ability: 'shadowtag', moves: ['calmmind'] }] });
+			], [
+				{ species: "Gothitelle", ability: 'shadowtag', moves: ['calmmind'] },
+			]]);
 
 			const buffer = [];
 			battle.send = (type, data) => {
@@ -605,10 +619,11 @@ describe('Choices', () => {
 
 	describe('Logging', () => {
 		it('should privately log the ID of chosen moves', () => {
-			battle = common.createBattle([
-				[{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] }],
-				[{ species: "Charmander", ability: 'blaze', moves: ['scratch', 'growl'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] },
+			], [
+				{ species: "Charmander", ability: 'blaze', moves: ['scratch', 'growl'] },
+			]]);
 			battle.makeChoices('move 1', 'move growl');
 
 			const logText = battle.inputLog.join('\n');
@@ -647,10 +662,11 @@ describe('Choices', () => {
 		});
 
 		it('should privately log the user intention of mega evolving', () => {
-			battle = common.createBattle([
-				[{ species: "Venusaur", item: 'venusaurite', ability: 'overgrow', moves: ['tackle'] }],
-				[{ species: "Blastoise", item: 'blastoisinite', ability: 'blaze', moves: ['tailwhip'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: "Venusaur", item: 'venusaurite', ability: 'overgrow', moves: ['tackle'] },
+			], [
+				{ species: "Blastoise", item: 'blastoisinite', ability: 'blaze', moves: ['tailwhip'] },
+			]]);
 			battle.makeChoices('move tackle mega', 'move tailwhip mega');
 
 			const logText = battle.inputLog.join('\n');
@@ -659,10 +675,11 @@ describe('Choices', () => {
 		});
 
 		it('should privately log the user intention of mega evolving for Mega-X and Mega-Y', () => {
-			battle = common.createBattle([
-				[{ species: "Charizard", item: 'charizarditex', ability: 'blaze', moves: ['scratch'] }],
-				[{ species: "Charizard", item: 'charizarditey', ability: 'blaze', moves: ['ember'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: "Charizard", item: 'charizarditex', ability: 'blaze', moves: ['scratch'] },
+			], [
+				{ species: "Charizard", item: 'charizarditey', ability: 'blaze', moves: ['ember'] },
+			]]);
 			battle.makeChoices('move scratch mega', 'move ember mega');
 
 			const logText = battle.inputLog.join('\n');
@@ -709,17 +726,15 @@ describe('Choices', () => {
 		});
 
 		it('should privately log shifting decisions for the Pokémon on the left', () => {
-			battle = common.gen(5).createBattle({ gameType: 'triples' });
-			battle.setPlayer('p1', { team: [
+			battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 				{ species: "Pineco", ability: 'sturdy', moves: ['harden'] },
 				{ species: "Geodude", ability: 'sturdy', moves: ['defensecurl'] },
 				{ species: "Gastly", ability: 'levitate', moves: ['haze'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 				{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 				{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
-			] });
+			]]);
 			battle.makeChoices('shift, move defensecurl, move haze', 'move roost, move irondefense, move defensecurl');
 
 			const logText = battle.inputLog.join('\n');
@@ -728,17 +743,15 @@ describe('Choices', () => {
 		});
 
 		it('should privately log shifting decisions for the Pokémon on the right', () => {
-			battle = common.gen(5).createBattle({ gameType: 'triples' });
-			battle.setPlayer('p1', { team: [
+			battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 				{ species: "Pineco", ability: 'sturdy', moves: ['harden'] },
 				{ species: "Geodude", ability: 'sturdy', moves: ['defensecurl'] },
 				{ species: "Gastly", ability: 'levitate', moves: ['haze'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 				{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 				{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
-			] });
+			]]);
 
 			battle.makeChoices('move harden, move defensecurl, shift', 'move roost, move irondefense, move defensecurl');
 
@@ -754,9 +767,11 @@ describe('Choice extensions', () => {
 		const MODES = ['revoke', 'override'];
 		for (const mode of MODES) {
 			it(`should disallow to ${mode} decisions after every player has sent an unrevoked action`, () => {
-				battle = common.createBattle({ cancel: true });
-				battle.setPlayer('p1', { team: [{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] }] });
-				battle.setPlayer('p2', { team: [{ species: "Charmander", ability: 'blaze', moves: ['tackle', 'growl'] }] });
+				battle = common.createBattle({ cancel: true }, [[
+					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] },
+				], [
+					{ species: "Charmander", ability: 'blaze', moves: ['tackle', 'growl'] },
+				]]);
 
 				battle.choose('p1', 'move tackle');
 				battle.choose('p2', 'move growl');
@@ -771,9 +786,11 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should support to ${mode} move decisions`, () => {
-				battle = common.createBattle({ cancel: true });
-				battle.setPlayer('p1', { team: [{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] }] });
-				battle.setPlayer('p2', { team: [{ species: "Charmander", ability: 'blaze', moves: ['tackle', 'growl'] }] });
+				battle = common.createBattle({ cancel: true }, [[
+					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] },
+				], [
+					{ species: "Charmander", ability: 'blaze', moves: ['tackle', 'growl'] },
+				]]);
 
 				battle.choose('p1', 'move tackle');
 				assert(!battle.p1.activeRequest.noCancel);
@@ -785,9 +802,11 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should disallow to ${mode} move decisions for maybe-disabled Pokémon`, () => {
-				battle = common.createBattle({ cancel: true });
-				battle.setPlayer('p1', { team: [{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl', 'synthesis'] }] });
-				battle.setPlayer('p2', { team: [{ species: "Charmander", ability: 'blaze', moves: ['scratch'] }] });
+				battle = common.createBattle({ cancel: true }, [[
+					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl', 'synthesis'] },
+				], [
+					{ species: "Charmander", ability: 'blaze', moves: ['scratch'] },
+				]]);
 
 				const target = battle.p1.active[0];
 				target.maybeDisabled = true;
@@ -804,9 +823,11 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should disallow to ${mode} move decisions by default`, () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] }] });
-				battle.setPlayer('p2', { team: [{ species: "Charmander", ability: 'blaze', moves: ['tackle', 'growl'] }] });
+				battle = common.createBattle([[
+					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle', 'growl'] },
+				], [
+					{ species: "Charmander", ability: 'blaze', moves: ['tackle', 'growl'] },
+				]]);
 
 				battle.choose('p1', 'move tackle');
 				assert(battle.p1.activeRequest.noCancel);
@@ -1018,16 +1039,14 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should support to ${mode} switch decisions on double switch requests`, () => {
-				battle = common.createBattle({ cancel: true });
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle({ cancel: true }, [[
 					{ species: "Deoxys-Attack", ability: 'pressure', moves: ['explosion'] },
 					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle'] },
 					{ species: "Chikorita", ability: 'overgrow', moves: ['tackle'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Caterpie", ability: 'shielddust', moves: ['tackle'] },
 					{ species: "Charmander", ability: 'blaze', moves: ['tackle'] },
-				] });
+				]]);
 
 				battle.makeChoices('move explosion', 'move tackle');
 
@@ -1042,17 +1061,15 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should support to ${mode} pass decisions on double switch requests`, () => {
-				battle = common.createBattle({ cancel: true, gameType: 'doubles' });
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle({ cancel: true, gameType: 'doubles' }, [[
 					{ species: "Deoxys-Attack", ability: 'pressure', moves: ['explosion'] },
 					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle'] },
 					{ species: "Chikorita", ability: 'overgrow', moves: ['tackle'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Caterpie", ability: 'shielddust', moves: ['tackle'] },
 					{ species: "Charmander", ability: 'blaze', moves: ['tackle'] },
 					{ species: "Cyndaquil", ability: 'blaze', moves: ['tackle'] },
-				] });
+				]]);
 
 				battle.makeChoices('move explosion, move tackle 1', 'move tackle 1, move tackle 1');
 
@@ -1124,16 +1141,14 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should disallow to ${mode} switch decisions on double switch requests by default`, () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle([[
 					{ species: "Deoxys-Attack", ability: 'pressure', moves: ['explosion'] },
 					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle'] },
 					{ species: "Chikorita", ability: 'overgrow', moves: ['tackle'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Caterpie", ability: 'shielddust', moves: ['tackle'] },
 					{ species: "Charmander", ability: 'blaze', moves: ['tackle'] },
-				] });
+				]]);
 
 				battle.makeChoices('move explosion', 'move tackle');
 
@@ -1148,17 +1163,15 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should disallow to ${mode} pass decisions on double switch requests by default`, () => {
-				battle = common.createBattle({ gameType: 'doubles' });
-				battle.setPlayer('p1', { team: [
+				battle = common.createBattle({ gameType: 'doubles' }, [[
 					{ species: "Deoxys-Attack", ability: 'pressure', moves: ['explosion'] },
 					{ species: "Bulbasaur", ability: 'overgrow', moves: ['tackle'] },
 					{ species: "Chikorita", ability: 'overgrow', moves: ['tackle'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Caterpie", ability: 'shielddust', moves: ['tackle'] },
 					{ species: "Charmander", ability: 'blaze', moves: ['tackle'] },
 					{ species: "Cyndaquil", ability: 'blaze', moves: ['tackle'] },
-				] });
+				]]);
 
 				battle.makeChoices('move explosion, move tackle 1', 'move tackle 1, move tackle 1');
 
@@ -1174,10 +1187,13 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should support to ${mode} team order action on team preview requests`, () => {
-				battle = common.createBattle({ preview: true, cancel: true }, [
-					[{ species: 'Bulbasaur', ability: 'overgrow', moves: ['tackle'] }, { species: 'Ivysaur', ability: 'overgrow', moves: ['tackle'] }],
-					[{ species: 'Charmander', ability: 'blaze', moves: ['scratch'] }, { species: 'Charmeleon', ability: 'blaze', moves: ['scratch'] }],
-				]);
+				battle = common.createBattle({ preview: true, cancel: true }, [[
+					{ species: 'Bulbasaur', ability: 'overgrow', moves: ['tackle'] },
+					{ species: 'Ivysaur', ability: 'overgrow', moves: ['tackle'] },
+				], [
+					{ species: 'Charmander', ability: 'blaze', moves: ['scratch'] },
+					{ species: 'Charmeleon', ability: 'blaze', moves: ['scratch'] },
+				]]);
 
 				battle.choose('p1', 'team 12');
 				assert(!battle.p1.activeRequest.noCancel);
@@ -1189,10 +1205,13 @@ describe('Choice extensions', () => {
 				}
 				battle.destroy();
 
-				battle = common.createBattle({ preview: true, cancel: true }, [
-					[{ species: 'Bulbasaur', ability: 'overgrow', moves: ['tackle'] }, { species: 'Ivysaur', ability: 'overgrow', moves: ['tackle'] }],
-					[{ species: 'Charmander', ability: 'blaze', moves: ['scratch'] }, { species: 'Charmeleon', ability: 'blaze', moves: ['scratch'] }],
-				]);
+				battle = common.createBattle({ preview: true, cancel: true }, [[
+					{ species: 'Bulbasaur', ability: 'overgrow', moves: ['tackle'] },
+					{ species: 'Ivysaur', ability: 'overgrow', moves: ['tackle'] },
+				], [
+					{ species: 'Charmander', ability: 'blaze', moves: ['scratch'] },
+					{ species: 'Charmeleon', ability: 'blaze', moves: ['scratch'] },
+				]]);
 
 				battle.choose('p1', 'team 21');
 				assert(!battle.p1.activeRequest.noCancel);
@@ -1205,10 +1224,13 @@ describe('Choice extensions', () => {
 			});
 
 			it(`should disallow to ${mode} team order action on team preview requests by default`, () => {
-				battle = common.createBattle({ preview: true }, [
-					[{ species: 'Bulbasaur', ability: 'overgrow', moves: ['tackle'] }, { species: 'Ivysaur', ability: 'overgrow', moves: ['tackle'] }],
-					[{ species: 'Charmander', ability: 'blaze', moves: ['scratch'] }, { species: 'Charmeleon', ability: 'blaze', moves: ['scratch'] }],
-				]);
+				battle = common.createBattle({ preview: true }, [[
+					{ species: 'Bulbasaur', ability: 'overgrow', moves: ['tackle'] },
+					{ species: 'Ivysaur', ability: 'overgrow', moves: ['tackle'] },
+				], [
+					{ species: 'Charmander', ability: 'blaze', moves: ['scratch'] },
+					{ species: 'Charmeleon', ability: 'blaze', moves: ['scratch'] },
+				]]);
 
 				battle.choose('p1', 'team 12');
 				assert(battle.p1.activeRequest.noCancel);
@@ -1230,15 +1252,13 @@ describe('Choice internals', () => {
 	});
 
 	it('should allow input of move commands in a per Pokémon basis', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
 			{ species: "Bulbasaur", ability: 'overgrow', moves: ['growl', 'synthesis'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Pupitar", ability: 'shedskin', moves: ['surf'] }, // faster than Bulbasaur
 			{ species: "Arceus", ability: 'multitype', moves: ['calmmind'] },
-		] });
+		]]);
 		const [p1, p2] = battle.sides;
 
 		assert.equal(battle.turn, 1);
@@ -1272,17 +1292,15 @@ describe('Choice internals', () => {
 	});
 
 	it('should allow input of switch commands in a per Pokémon basis', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Mew", ability: 'synchronize', moves: ['selfdestruct'] },
 			{ species: "Bulbasaur", ability: 'overgrow', moves: ['selfdestruct'] },
 			{ species: "Koffing", ability: 'levitate', moves: ['smog'] },
 			{ species: "Ekans", ability: 'shedskin', moves: ['leer'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Deoxys-Defense", ability: 'pressure', moves: ['recover'] },
 			{ species: "Arceus", ability: 'multitype', moves: ['recover'] },
-		] });
+		]]);
 		const [p1, p2] = battle.sides;
 
 		assert.equal(battle.turn, 1);
@@ -1303,17 +1321,15 @@ describe('Choice internals', () => {
 	});
 
 	it('should allow input of move and switch commands in a per Pokémon basis', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Mew", ability: 'synchronize', moves: ['recover'] },
 			{ species: "Bulbasaur", ability: 'overgrow', moves: ['growl', 'synthesis'] },
 			{ species: "Koffing", ability: 'levitate', moves: ['smog'] },
 			{ species: "Ekans", ability: 'shedskin', moves: ['leer'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Deoxys-Defense", ability: 'pressure', moves: ['recover'] },
 			{ species: "Arceus", ability: 'multitype', moves: ['recover'] },
-		] });
+		]]);
 		const [p1, p2] = battle.sides;
 
 		assert.equal(battle.turn, 1);
@@ -1345,16 +1361,14 @@ describe('Choice internals', () => {
 	});
 
 	it('should empty the actions list when undoing a move', () => {
-		battle = common.createBattle({ gameType: 'doubles', cancel: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles', cancel: true }, [[
 			{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 			{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 			{ species: "Koffing", ability: 'levitate', moves: ['smog'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 			{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
-		] });
+		]]);
 		const p1 = battle.p1;
 
 		p1.chooseMove(1);
@@ -1369,16 +1383,14 @@ describe('Choice internals', () => {
 	});
 
 	it('should empty the actions list when undoing a switch', () => {
-		battle = common.createBattle({ gameType: 'doubles', cancel: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles', cancel: true }, [[
 			{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 			{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 			{ species: "Koffing", ability: 'levitate', moves: ['smog'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 			{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
-		] });
+		]]);
 		const p1 = battle.p1;
 
 		battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense');
@@ -1394,16 +1406,14 @@ describe('Choice internals', () => {
 	});
 
 	it('should empty the actions list when undoing a pass', () => {
-		battle = common.createBattle({ gameType: 'doubles', cancel: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles', cancel: true }, [[
 			{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 			{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 			{ species: "Koffing", ability: 'levitate', moves: ['smog'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 			{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
-		] });
+		]]);
 		const p1 = battle.p1;
 
 		battle.makeChoices('move selfdestruct, move selfdestruct', 'move roost, move irondefense');
@@ -1419,18 +1429,16 @@ describe('Choice internals', () => {
 	});
 
 	it('should empty the actions list when undoing a shift', () => {
-		battle = common.gen(5).createBattle({ gameType: 'triples', cancel: true });
-		battle.supportCancel = true;
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples', cancel: true }, [[
 			{ species: "Pineco", ability: 'sturdy', moves: ['selfdestruct'] },
 			{ species: "Geodude", ability: 'sturdy', moves: ['selfdestruct'] },
 			{ species: "Gastly", ability: 'levitate', moves: ['lick'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Skarmory", ability: 'sturdy', moves: ['roost'] },
 			{ species: "Aggron", ability: 'sturdy', moves: ['irondefense'] },
 			{ species: "Golem", ability: 'sturdy', moves: ['defensecurl'] },
-		] });
+		]]);
+		battle.supportCancel = true;
 		const p1 = battle.p1;
 
 		p1.chooseShift();

--- a/test/sim/events.js
+++ b/test/sim/events.js
@@ -11,10 +11,11 @@ describe('Battle#onEvent', () => {
 	});
 
 	it('should allow the addition of one or more event handlers to the battle engine', () => {
-		battle = common.createBattle([
-			[{ species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup'] }],
-			[{ species: 'Talonflame', ability: 'galewings', moves: ['peck'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup'] },
+		], [
+			{ species: 'Talonflame', ability: 'galewings', moves: ['peck'] },
+		]]);
 		let eventCount = 0;
 		let eventCount2 = 0;
 		battle.onEvent('Hit', battle.format, () => {
@@ -34,10 +35,11 @@ describe('Battle#onEvent', () => {
 	});
 
 	it('should support and resolve priorities correctly', () => {
-		battle = common.createBattle([
-			[{ species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup'] }],
-			[{ species: 'Talonflame', ability: 'galewings', moves: ['peck'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup'] },
+		], [
+			{ species: 'Talonflame', ability: 'galewings', moves: ['peck'] },
+		]]);
 		let eventCount = 0;
 		const modHandler = function (count) {
 			return function () {
@@ -53,10 +55,11 @@ describe('Battle#onEvent', () => {
 	});
 
 	it('should throw if a callback is not given for the event handler', () => {
-		battle = common.createBattle([
-			[{ species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup'] }],
-			[{ species: 'Talonflame', ability: 'galewings', moves: ['peck'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Pidgeot', ability: 'keeneye', moves: ['bulkup'] },
+		], [
+			{ species: 'Talonflame', ability: 'galewings', moves: ['peck'] },
+		]]);
 		assert.throws(battle.onEvent, TypeError);
 		assert.throws(() => { battle.onEvent('Hit'); }, TypeError);
 		assert.throws(() => { battle.onEvent('Hit', battle.format); }, TypeError);

--- a/test/sim/items/assaultvest.js
+++ b/test/sim/items/assaultvest.js
@@ -11,16 +11,20 @@ describe('Assault Vest', () => {
 	});
 
 	it('should disable the use of Status moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Abra', ability: 'synchronize', moves: ['teleport'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Abra', ability: 'synchronize', item: 'assaultvest', moves: ['teleport'] }] });
+		battle = common.createBattle([[
+			{ species: 'Abra', ability: 'synchronize', moves: ['teleport'] },
+		], [
+			{ species: 'Abra', ability: 'synchronize', item: 'assaultvest', moves: ['teleport'] },
+		]]);
 		assert.cantMove(() => battle.makeChoices('move teleport', 'move teleport'), 'Abra', 'Teleport');
 	});
 
 	it('should not prevent the use of Status moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Lopunny', ability: 'klutz', item: 'assaultvest', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Abra', ability: 'synchronize', item: 'ironball', moves: ['calmmind'] }] });
+		battle = common.createBattle([[
+			{ species: 'Lopunny', ability: 'klutz', item: 'assaultvest', moves: ['trick'] },
+		], [
+			{ species: 'Abra', ability: 'synchronize', item: 'ironball', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move trick', 'move calmmind');
 		assert.statStage(battle.p2.active[0], 'spa', 1);
 		assert.statStage(battle.p2.active[0], 'spd', 1);

--- a/test/sim/items/drives.js
+++ b/test/sim/items/drives.js
@@ -17,12 +17,12 @@ describe('Drives', () => {
 			});
 
 			it('should not be stolen or removed if held by a Genesect', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: 'Genesect', ability: 'frisk', item: id, moves: ['recover'] }] });
-				battle.setPlayer('p2', { team: [
+				battle = common.createBattle([[
+					{ species: 'Genesect', ability: 'frisk', item: id, moves: ['recover'] },
+				], [
 					{ species: 'Fennekin', ability: 'magician', moves: ['thief', 'mysticalfire'] },
 					{ species: 'Abra', ability: 'synchronize', moves: ['thief', 'trick', 'knockoff'] },
-				] });
+				]]);
 				const holder = battle.p1.active[0];
 				battle.makeChoices('move recover', 'move thief'); // Fennekin's Magician
 				assert.holdsItem(holder);
@@ -35,25 +35,31 @@ describe('Drives', () => {
 			});
 
 			it('should not be removed by Fling if held by a Genesect', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: 'Mawile', ability: 'intimidate', moves: ['swordsdance'] }] });
-				battle.setPlayer('p2', { team: [{ species: 'Genesect', ability: 'frisk', item: id, moves: ['fling'] }] });
+				battle = common.createBattle([[
+					{ species: 'Mawile', ability: 'intimidate', moves: ['swordsdance'] },
+				], [
+					{ species: 'Genesect', ability: 'frisk', item: id, moves: ['fling'] },
+				]]);
 				battle.makeChoices('move swordsdance', 'move fling');
 				assert.holdsItem(battle.p2.active[0]);
 			});
 
 			it('should not be given to a Genesect', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: 'Genesect', ability: 'frisk', moves: ['thief'] }] });
-				battle.setPlayer('p2', { team: [{ species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bestow'] }] });
+				battle = common.createBattle([[
+					{ species: 'Genesect', ability: 'frisk', moves: ['thief'] },
+				], [
+					{ species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bestow'] },
+				]]);
 				battle.makeChoices('move thief', 'move bestow');
 				assert.false.holdsItem(battle.p1.active[0]);
 			});
 
 			it('should be removed if not held by a Genesect', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: 'Genesect', ability: 'frisk', moves: ['knockoff'] }] });
-				battle.setPlayer('p2', { team: [{ species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bulkup'] }] });
+				battle = common.createBattle([[
+					{ species: 'Genesect', ability: 'frisk', moves: ['knockoff'] },
+				], [
+					{ species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bulkup'] },
+				]]);
 				battle.makeChoices('move knockoff', 'move bulkup');
 				assert.false.holdsItem(battle.p2.active[0]);
 			});

--- a/test/sim/items/flameorb.js
+++ b/test/sim/items/flameorb.js
@@ -11,23 +11,23 @@ describe('Flame Orb', () => {
 	});
 
 	it('should not trigger when entering battle', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Magikarp', ability: 'swiftswim', item: 'focussash', moves: ['splash'] },
 			{ species: 'Ursaring', ability: 'guts', item: 'flameorb', moves: ['protect'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Breloom', ability: 'technician', moves: ['bulletseed'] },
-		] });
+		]]);
 		battle.makeChoices('move splash', 'move bulletseed');
 		battle.makeChoices('switch 2', '');
 		assert.notEqual(battle.p1.active[0].status, 'brn');
 	});
 
 	it('should trigger after one turn', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Ursaring', ability: 'guts', item: 'flameorb', moves: ['protect'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Magikarp', ability: 'swiftswim', moves: ['splash'] }] });
+		battle = common.createBattle([[
+			{ species: 'Ursaring', ability: 'guts', item: 'flameorb', moves: ['protect'] },
+		], [
+			{ species: 'Magikarp', ability: 'swiftswim', moves: ['splash'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.sets(() => target.status, 'brn', () => battle.makeChoices('move protect', 'move splash'));
 	});

--- a/test/sim/items/focussash.js
+++ b/test/sim/items/focussash.js
@@ -11,9 +11,11 @@ describe('Focus Sash', () => {
 	});
 
 	it('should be consumed and allow its user to survive an attack from full HP', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Paras', ability: 'dryskin', item: 'focussash', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Delphox', ability: 'magician', moves: ['incinerate'] }] });
+		battle = common.createBattle([[
+			{ species: 'Paras', ability: 'dryskin', item: 'focussash', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Delphox', ability: 'magician', moves: ['incinerate'] },
+		]]);
 		const holder = battle.p1.active[0];
 		battle.makeChoices('move sleeptalk', 'move incinerate');
 		assert.false.holdsItem(holder);
@@ -35,9 +37,11 @@ describe('Focus Sash', () => {
 	});
 
 	it('should not trigger on recoil damage', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['doubleedge'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Klefki', ability: 'prankster', moves: ['reflect'] }] });
+		battle = common.createBattle([[
+			{ species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['doubleedge'] },
+		], [
+			{ species: 'Klefki', ability: 'prankster', moves: ['reflect'] },
+		]]);
 		const holder = battle.p1.active[0];
 		battle.makeChoices('move doubleedge', 'move reflect');
 		assert.holdsItem(holder);
@@ -45,9 +49,11 @@ describe('Focus Sash', () => {
 	});
 
 	it('should not trigger on residual damage', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Crobat', ability: 'infiltrator', moves: ['toxic'] }] });
+		battle = common.createBattle([[
+			{ species: 'Shedinja', ability: 'wonderguard', item: 'focussash', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Crobat', ability: 'infiltrator', moves: ['toxic'] },
+		]]);
 		const holder = battle.p1.active[0];
 		battle.makeChoices('move sleeptalk', 'move toxic');
 		assert.holdsItem(holder);

--- a/test/sim/items/heavydutyboots.js
+++ b/test/sim/items/heavydutyboots.js
@@ -11,14 +11,12 @@ describe("Heavy Duty Boots", () => {
 	});
 
 	it("should prevent entry hazards from affecting the holder", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Magikarp', ability: 'swiftswim', moves: ['splash'] },
 			{ species: 'Magikarp', ability: 'swiftswim', item: 'heavydutyboots', moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Cloyster', ability: 'shellarmor', moves: ['spikes', 'toxicspikes'] },
-		] });
+		]]);
 		battle.makeChoices('auto', 'move spikes');
 		battle.makeChoices('auto', 'move toxicspikes');
 		battle.makeChoices('switch 2', 'auto');

--- a/test/sim/items/ironball.js
+++ b/test/sim/items/ironball.js
@@ -11,20 +11,22 @@ describe('Iron Ball', () => {
 	});
 
 	it('should reduce halve the holder\'s speed', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', item: 'ironball', moves: ['bestow'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Aerodactyl", ability: 'pressure', moves: ['stealthrock'] }] });
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', item: 'ironball', moves: ['bestow'] },
+		], [
+			{ species: "Aerodactyl", ability: 'pressure', moves: ['stealthrock'] },
+		]]);
 		const target = battle.p2.active[0];
 		assert.sets(() => target.getStat('spe'), battle.modify(target.getStat('spe'), 0.5), () => battle.makeChoices('move bestow', 'move stealthrock'));
 	});
 
 	it('should negate Ground immunities and deal neutral type effectiveness to Flying-type Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake'] },
+		], [
 			{ species: "Aerodactyl", ability: 'pressure', item: 'ironball', moves: ['stealthrock'] },
 			{ species: "Tropius", ability: 'harvest', item: 'ironball', moves: ['leechseed'] },
-		] });
+		]]);
 		battle.makeChoices('move earthquake', 'move stealthrock');
 		// Earthquake neutral on Aerodactyl
 		assert(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
@@ -36,12 +38,12 @@ describe('Iron Ball', () => {
 	});
 
 	it('should not deal neutral type effectiveness to Flying-type Pokemon in Gravity', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake', 'gravity'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake', 'gravity'] },
+		], [
 			{ species: "Aerodactyl", ability: 'shellarmor', item: 'ironball', moves: ['stealthrock'] },
 			{ species: "Tropius", ability: 'shellarmor', item: 'ironball', moves: ['leechseed'] },
-		] });
+		]]);
 		// Set up Gravity
 		battle.makeChoices('move gravity', 'move stealthrock');
 
@@ -56,12 +58,12 @@ describe('Iron Ball', () => {
 	});
 
 	it('should negate artificial Ground immunities and deal normal type effectiveness', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['earthquake'] },
+		], [
 			{ species: "Rotom", ability: 'levitate', item: 'ironball', moves: ['rest'] },
 			{ species: "Parasect", ability: 'levitate', item: 'ironball', moves: ['rest'] },
-		] });
+		]]);
 		battle.makeChoices('move earthquake', 'move rest');
 		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
@@ -71,9 +73,11 @@ describe('Iron Ball', () => {
 	});
 
 	it('should ground Pokemon that are airborne', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', moves: ['spore'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Thundurus", ability: 'prankster', item: 'ironball', moves: ['electricterrain'] }] });
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', moves: ['spore'] },
+		], [
+			{ species: "Thundurus", ability: 'prankster', item: 'ironball', moves: ['electricterrain'] },
+		]]);
 		battle.makeChoices('move spore', 'move electricterrain');
 		assert.equal(battle.p2.active[0].status, '');
 	});

--- a/test/sim/items/lansatberry.js
+++ b/test/sim/items/lansatberry.js
@@ -11,9 +11,11 @@ describe('Lansat Berry', () => {
 	});
 
 	it('should apply a Focus Energy effect when consumed', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Aggron', ability: 'sturdy', item: 'lansatberry', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Lucario', ability: 'adaptability', moves: ['aurasphere'] }] });
+		battle = common.createBattle([[
+			{ species: 'Aggron', ability: 'sturdy', item: 'lansatberry', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Lucario', ability: 'adaptability', moves: ['aurasphere'] },
+		]]);
 		const holder = battle.p1.active[0];
 		battle.makeChoices('move sleeptalk', 'move aurasphere');
 		assert.false.holdsItem(holder);
@@ -21,10 +23,11 @@ describe('Lansat Berry', () => {
 	});
 
 	it('should start to apply the effect even in middle of an attack', () => {
-		battle = common.createBattle([
-			[{ species: 'Makuhita', ability: 'guts', item: 'lansatberry', moves: ['triplekick'] }],
-			[{ species: 'Muk', ability: 'noguard', item: 'rockyhelmet', moves: ['acidarmor'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Makuhita', ability: 'guts', item: 'lansatberry', moves: ['triplekick'] },
+		], [
+			{ species: 'Muk', ability: 'noguard', item: 'rockyhelmet', moves: ['acidarmor'] },
+		]]);
 		const holder = battle.p1.active[0];
 
 		let i = 0;

--- a/test/sim/items/leftovers.js
+++ b/test/sim/items/leftovers.js
@@ -11,14 +11,12 @@ describe('Leftovers [Gen 2]', () => {
 	});
 
 	it('should heal after switch', () => {
-		battle = common.gen(2).createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(2).createBattle([[
 			{ species: 'Blissey', item: 'leftovers', moves: ['healbell'] },
 			{ species: 'Magikarp', level: 1, moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Miltank", moves: ['seismictoss'] },
-		] });
+		]]);
 		const holder = battle.p1.active[0];
 		battle.makeChoices('move healbell', 'move seismictoss');
 		assert.equal(holder.hp, 590);

--- a/test/sim/items/leppaberry.js
+++ b/test/sim/items/leppaberry.js
@@ -11,10 +11,11 @@ describe('Leppa Berry', () => {
 	});
 
 	it('should restore PP to the first move with any PP missing when eaten forcibly', () => {
-		battle = common.createBattle([
-			[{ species: 'Gyarados', ability: 'moxie', item: '', moves: ['sleeptalk', 'splash'] }],
-			[{ species: 'Geodude', ability: 'sturdy', item: 'leppaberry', moves: ['sleeptalk', 'fling'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Gyarados', ability: 'moxie', item: '', moves: ['sleeptalk', 'splash'] },
+		], [
+			{ species: 'Geodude', ability: 'sturdy', item: 'leppaberry', moves: ['sleeptalk', 'fling'] },
+		]]);
 
 		const pokemon = battle.p1.active[0];
 

--- a/test/sim/items/lifeorb.js
+++ b/test/sim/items/lifeorb.js
@@ -11,13 +11,11 @@ describe('Life Orb', () => {
 	});
 
 	it('should hurt the user by 1/10 of their max HP after a successful attack', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Scizor', ability: 'technician', item: 'lifeorb', moves: ['uturn'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Primarina', ability: 'torrent', moves: ['sleeptalk'] },
-		] });
+		]]);
 		assert.hurtsBy(battle.p1.active[0], Math.floor(battle.p1.active[0].maxhp / 10), () => battle.makeChoices('move uturn', 'move sleeptalk'));
 	});
 });

--- a/test/sim/items/lumberry.js
+++ b/test/sim/items/lumberry.js
@@ -11,25 +11,31 @@ describe('Lum Berry', () => {
 	});
 
 	it('should heal a non-volatile status condition', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Rapidash', moves: ['inferno'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Machamp', ability: 'noguard', item: 'lumberry', moves: ['sleeptalk'] }] });
+		battle = common.createBattle([[
+			{ species: 'Rapidash', moves: ['inferno'] },
+		], [
+			{ species: 'Machamp', ability: 'noguard', item: 'lumberry', moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices('move inferno', 'move sleeptalk');
 		assert.equal(battle.p2.active[0].status, '');
 	});
 
 	it('should cure confusion', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Golurk', ability: 'noguard', moves: ['dynamicpunch'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Shuckle', item: 'lumberry', moves: ['sleeptalk'] }] });
+		battle = common.createBattle([[
+			{ species: 'Golurk', ability: 'noguard', moves: ['dynamicpunch'] },
+		], [
+			{ species: 'Shuckle', item: 'lumberry', moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices('move dynamicpunch', 'move sleeptalk');
 		assert(!battle.p2.active[0].volatiles['confusion']);
 	});
 
 	it('should be eaten immediately when the holder gains a status condition', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Charizard', item: 'lumberry', moves: ['outrage'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Toxapex', moves: ['recover', 'banefulbunker'] }] });
+		battle = common.createBattle([[
+			{ species: 'Charizard', item: 'lumberry', moves: ['outrage'] },
+		], [
+			{ species: 'Toxapex', moves: ['recover', 'banefulbunker'] },
+		]]);
 		const attacker = battle.p1.active[0];
 		battle.makeChoices('move outrage', 'move recover');
 		attacker.volatiles['lockedmove'].duration = 2;
@@ -52,9 +58,11 @@ describe('Lum Berry', () => {
 	});
 
 	it('should cure Poison and confusion after Poison Puppeteer activation', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Charizard', item: 'lumberry', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Pecharunt', ability: 'poisonpuppeteer', moves: ['toxic'] }] });
+		battle = common.createBattle([[
+			{ species: 'Charizard', item: 'lumberry', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Pecharunt', ability: 'poisonpuppeteer', moves: ['toxic'] },
+		]]);
 		const charizard = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(charizard.status, '');

--- a/test/sim/items/mail.js
+++ b/test/sim/items/mail.js
@@ -11,13 +11,13 @@ describe('Mail', () => {
 	});
 
 	it('should not be stolen by most moves or abilities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Blissey', ability: 'naturalcure', item: 'mail', moves: ['softboiled'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: 'Blissey', ability: 'naturalcure', item: 'mail', moves: ['softboiled'] },
+		], [
 			{ species: 'Fennekin', ability: 'magician', moves: ['grassknot'] },
 			{ species: 'Abra', ability: 'synchronize', moves: ['trick'] },
 			{ species: 'Lopunny', ability: 'klutz', moves: ['switcheroo'] },
-		] });
+		]]);
 		const holder = battle.p1.active[0];
 		assert.constant(() => holder.item, () => battle.makeChoices('move softboiled', 'move grassknot'));
 		battle.makeChoices('move softboiled', 'switch 2');
@@ -27,25 +27,31 @@ describe('Mail', () => {
 	});
 
 	it('should not be removed by Fling', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Pangoro', ability: 'ironfist', moves: ['swordsdance'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Abra', ability: 'synchronize', item: 'mail', moves: ['fling'] }] });
+		battle = common.createBattle([[
+			{ species: 'Pangoro', ability: 'ironfist', moves: ['swordsdance'] },
+		], [
+			{ species: 'Abra', ability: 'synchronize', item: 'mail', moves: ['fling'] },
+		]]);
 		const holder = battle.p2.active[0];
 		assert.constant(() => holder.item, () => battle.makeChoices('move swordsdance', 'move fling'));
 	});
 
 	it('should be removed by Knock Off', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Pangoro', ability: 'ironfist', item: 'mail', moves: ['swordsdance'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Abra', ability: 'synchronize', moves: ['knockoff'] }] });
+		battle = common.createBattle([[
+			{ species: 'Pangoro', ability: 'ironfist', item: 'mail', moves: ['swordsdance'] },
+		], [
+			{ species: 'Abra', ability: 'synchronize', moves: ['knockoff'] },
+		]]);
 		const holder = battle.p1.active[0];
 		assert.false.constant(() => holder.item, () => battle.makeChoices('move swordsdance', 'move knockoff'));
 	});
 
 	it('should be stolen by Thief', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Pangoro', ability: 'ironfist', item: 'mail', moves: ['swordsdance'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Abra', ability: 'synchronize', moves: ['thief'] }] });
+		battle = common.createBattle([[
+			{ species: 'Pangoro', ability: 'ironfist', item: 'mail', moves: ['swordsdance'] },
+		], [
+			{ species: 'Abra', ability: 'synchronize', moves: ['thief'] },
+		]]);
 		const holder = battle.p1.active[0];
 		assert.false.constant(() => holder.item, () => battle.makeChoices('move swordsdance', 'move thief'));
 	});

--- a/test/sim/items/plates.js
+++ b/test/sim/items/plates.js
@@ -20,12 +20,12 @@ describe('Plates', () => {
 			});
 
 			it('should not be stolen or removed if held by an Arceus', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: 'Arceus', ability: 'frisk', item: id, moves: ['recover'] }] });
-				battle.setPlayer('p2', { team: [
+				battle = common.createBattle([[
+					{ species: 'Arceus', ability: 'frisk', item: id, moves: ['recover'] },
+				], [
 					{ species: 'Fennekin', ability: 'magician', moves: ['mysticalfire'] },
 					{ species: 'Abra', ability: 'synchronize', moves: ['thief', 'trick', 'knockoff'] },
-				] });
+				]]);
 				const holder = battle.p1.active[0];
 				battle.makeChoices('move recover', 'move mysticalfire'); // Fennekin's Magician
 				assert.holdsItem(holder);
@@ -38,25 +38,31 @@ describe('Plates', () => {
 			});
 
 			it('should not be removed by Fling if held by an Arceus', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: 'Mawile', ability: 'intimidate', moves: ['swordsdance'] }] });
-				battle.setPlayer('p2', { team: [{ species: 'Arceus', ability: 'frisk', item: id, moves: ['fling'] }] });
+				battle = common.createBattle([[
+					{ species: 'Mawile', ability: 'intimidate', moves: ['swordsdance'] },
+				], [
+					{ species: 'Arceus', ability: 'frisk', item: id, moves: ['fling'] },
+				]]);
 				battle.makeChoices('move swordsdance', 'move fling');
 				assert.holdsItem(battle.p2.active[0]);
 			});
 
 			it('should not be given to an Arceus', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: 'Arceus', ability: 'multitype', moves: ['thief'] }] });
-				battle.setPlayer('p2', { team: [{ species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bestow'] }] });
+				battle = common.createBattle([[
+					{ species: 'Arceus', ability: 'multitype', moves: ['thief'] },
+				], [
+					{ species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bestow'] },
+				]]);
 				battle.makeChoices('move thief', 'move bestow');
 				assert.false.holdsItem(battle.p1.active[0]);
 			});
 
 			it('should be removed if not held by an Arceus', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: 'Arceus', ability: 'multitype', moves: ['knockoff'] }] });
-				battle.setPlayer('p2', { team: [{ species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bulkup'] }] });
+				battle = common.createBattle([[
+					{ species: 'Arceus', ability: 'multitype', moves: ['knockoff'] },
+				], [
+					{ species: 'Azumarill', ability: 'thickfat', item: id, moves: ['bulkup'] },
+				]]);
 				battle.makeChoices('move knockoff', 'move bulkup');
 				assert.false.holdsItem(battle.p2.active[0]);
 			});

--- a/test/sim/items/rockyhelmet.js
+++ b/test/sim/items/rockyhelmet.js
@@ -11,9 +11,11 @@ describe('Rocky Helmet', () => {
 	});
 
 	it("should hurt attackers by 1/6 their max HP when this Pokemon is hit by a contact move", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Haxorus", moves: ['outrage'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Drampa", item: 'rockyhelmet', moves: ['sleeptalk'] }] });
+		battle = common.createBattle([[
+			{ species: "Haxorus", moves: ['outrage'] },
+		], [
+			{ species: "Drampa", item: 'rockyhelmet', moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices('move outrage', 'move sleeptalk');
 		const attacker = battle.p1.active[0];
 		assert.equal(attacker.hp, attacker.maxhp - Math.floor(attacker.maxhp / 6));

--- a/test/sim/items/shedshell.js
+++ b/test/sim/items/shedshell.js
@@ -11,35 +11,35 @@ describe('Shed Shell', () => {
 	});
 
 	it('should allow Pokemon to escape trapping abilities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Gothitelle", ability: 'shadowtag', moves: ['calmmind'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Gothitelle", ability: 'shadowtag', moves: ['calmmind'] },
+		], [
 			{ species: "Starmie", ability: 'naturalcure', item: 'shedshell', moves: ['recover'] },
 			{ species: "Heatran", ability: 'flashfire', moves: ['rest'] },
-		] });
+		]]);
 		battle.makeChoices('move calmmind', 'switch 2');
 		assert.species(battle.p2.active[0], 'Heatran');
 	});
 
 	it('should allow Pokemon to escape from most moves that would trap them', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Gengar", ability: 'levitate', moves: ['meanlook'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Gengar", ability: 'levitate', moves: ['meanlook'] },
+		], [
 			{ species: "Venusaur", ability: 'overgrow', item: 'shedshell', moves: ['ingrain'] },
 			{ species: "Heatran", ability: 'flashfire', moves: ['rest'] },
-		] });
+		]]);
 		battle.makeChoices('move meanlook', 'move ingrain');
 		battle.makeChoices('move meanlook', 'switch 2');
 		assert.species(battle.p2.active[0], 'Heatran');
 	});
 
 	it('should not allow Pokemon to escape from Sky Drop', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Dragonite", ability: 'multiscale', moves: ['skydrop'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Dragonite", ability: 'multiscale', moves: ['skydrop'] },
+		], [
 			{ species: "Magnezone", ability: 'sturdy', item: 'shedshell', moves: ['sleeptalk'] },
 			{ species: "Heatran", ability: 'flashfire', moves: ['rest'] },
-		] });
+		]]);
 		battle.makeChoices('move skydrop', 'move sleeptalk');
 		assert.trapped(() => battle.makeChoices('move skydrop', 'switch 2'));
 		assert.species(battle.p2.active[0], 'Magnezone');

--- a/test/sim/items/sitrusberry.js
+++ b/test/sim/items/sitrusberry.js
@@ -11,9 +11,11 @@ describe('Sitrus Berry', () => {
 	});
 
 	it('should heal 25% hp when consumed', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Aggron', ability: 'sturdy', item: 'sitrusberry', moves: ['sleeptalk'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Lucario', ability: 'adaptability', moves: ['aurasphere'] }] });
+		battle = common.createBattle([[
+			{ species: 'Aggron', ability: 'sturdy', item: 'sitrusberry', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Lucario', ability: 'adaptability', moves: ['aurasphere'] },
+		]]);
 		const holder = battle.p1.active[0];
 		battle.makeChoices('move sleeptalk', 'move aurasphere');
 		assert.false.holdsItem(holder);
@@ -21,10 +23,11 @@ describe('Sitrus Berry', () => {
 	});
 
 	it('should be eaten immediately if (re)gained on low hp', () => {
-		battle = common.createBattle([
-			[{ species: 'Magnemite', ability: 'sturdy', item: 'sitrusberry', moves: ['recycle'] }],
-			[{ species: 'Garchomp', ability: 'roughskin', moves: ['earthquake'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Magnemite', ability: 'sturdy', item: 'sitrusberry', moves: ['recycle'] },
+		], [
+			{ species: 'Garchomp', ability: 'roughskin', moves: ['earthquake'] },
+		]]);
 		const holder = battle.p1.active[0];
 		const hpgain = Math.floor(holder.maxhp / 4);
 		battle.makeChoices('move recycle', 'move earthquake');
@@ -33,10 +36,11 @@ describe('Sitrus Berry', () => {
 	});
 
 	it('should not heal if Knocked Off', () => {
-		battle = common.createBattle([
-			[{ species: 'Deoxys-Attack', ability: 'sturdy', item: 'sitrusberry', moves: ['sleeptalk'] }],
-			[{ species: 'Krookodile', ability: 'intimidate', moves: ['knockoff'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Deoxys-Attack', ability: 'sturdy', item: 'sitrusberry', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Krookodile', ability: 'intimidate', moves: ['knockoff'] },
+		]]);
 		battle.makeChoices('move sleeptalk', 'move knockoff');
 		assert.equal(battle.p1.active[0].hp, 1);
 	});

--- a/test/sim/items/weaknesspolicy.js
+++ b/test/sim/items/weaknesspolicy.js
@@ -11,13 +11,11 @@ describe('Weakness Policy', () => {
 	});
 
 	it('should be triggered by super effective hits', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Lucario", ability: 'justified', moves: ['aurasphere'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Blissey", ability: 'naturalcure', item: 'weaknesspolicy', moves: ['softboiled'] },
-		] });
+		]]);
 		const holder = battle.p2.active[0];
 		battle.makeChoices('move aurasphere', 'move softboiled');
 		assert.false.holdsItem(holder);
@@ -26,15 +24,13 @@ describe('Weakness Policy', () => {
 	});
 
 	it('should respect individual type effectivenesses in doubles', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Stunfisk", ability: 'limber', moves: ['earthquake', 'surf', 'discharge'] },
 			{ species: "Volcarona", ability: 'swarm', item: 'weaknesspolicy', moves: ['roost'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Zekrom", ability: 'teravolt', item: 'weaknesspolicy', moves: ['roost'] },
 			{ species: "Pyukumuku", ability: 'unaware', item: 'weaknesspolicy', moves: ['recover'] },
-		] });
+		]]);
 		const zekrom = battle.p2.active[0];
 		const pyuk = battle.p2.active[1];
 		const volc = battle.p1.active[1];
@@ -80,13 +76,11 @@ describe('Weakness Policy', () => {
 	});
 
 	it('should not be triggered by fixed damage moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Lucario", ability: 'justified', moves: ['seismictoss'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Blissey", ability: 'naturalcure', item: 'weaknesspolicy', moves: ['softboiled'] },
-		] });
+		]]);
 		const holder = battle.p2.active[0];
 		battle.makeChoices('move seismictoss', 'move softboiled');
 		assert.holdsItem(holder);

--- a/test/sim/misc/accuracy.js
+++ b/test/sim/misc/accuracy.js
@@ -11,10 +11,11 @@ describe("Accuracy", () => {
 	});
 
 	it(`should round half down when applying a modifier`, () => {
-		battle = common.createBattle([
-			[{ species: 'Butterfree', ability: 'compoundeyes', moves: ['sleeppowder'] }],
-			[{ species: 'Beldum', moves: ['poltergeist'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Butterfree', ability: 'compoundeyes', moves: ['sleeppowder'] },
+		], [
+			{ species: 'Beldum', moves: ['poltergeist'] },
+		]]);
 
 		battle.onEvent('Accuracy', battle.format, accuracy => {
 			assert.equal(accuracy, 98, 'CompoundEyes Sleep Powder should be 98% accurate');
@@ -22,10 +23,11 @@ describe("Accuracy", () => {
 
 		battle.makeChoices();
 
-		battle = common.createBattle([
-			[{ species: 'Butterfree', ability: 'victorystar', moves: ['fireblast'] }],
-			[{ species: 'Regirock', moves: ['sleeptalk'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Butterfree', ability: 'victorystar', moves: ['fireblast'] },
+		], [
+			{ species: 'Regirock', moves: ['sleeptalk'] },
+		]]);
 
 		battle.onEvent('Accuracy', battle.format, accuracy => {
 			assert.equal(accuracy, 94, 'Victory Star Fire Blast should be 94% accurate');
@@ -33,10 +35,11 @@ describe("Accuracy", () => {
 
 		battle.makeChoices();
 
-		battle = common.createBattle([
-			[{ species: 'Butterfree', item: 'widelens', moves: ['fireblast'] }],
-			[{ species: 'Regirock', moves: ['sleeptalk'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Butterfree', item: 'widelens', moves: ['fireblast'] },
+		], [
+			{ species: 'Regirock', moves: ['sleeptalk'] },
+		]]);
 
 		battle.onEvent('Accuracy', battle.format, accuracy => {
 			assert.equal(accuracy, 93, 'Wide Lens Fire Blast should be 93% accurate');

--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -11,13 +11,11 @@ describe("Dynamax", () => {
 	});
 
 	it('Max Move effects should not be suppressed by Sheer Force', () => {
-		battle = common.gen(8).createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(8).createBattle([[
 			{ species: 'Braviary', ability: 'sheerforce', moves: ['heatwave', 'facade', 'superpower'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Shedinja', ability: 'sturdy', item: 'ringtarget', moves: ['splash'] },
-		] });
+		]]);
 		battle.makeChoices('move heatwave dynamax', 'auto');
 		assert.equal(battle.field.weather, 'sunnyday');
 		battle.makeChoices('move facade', 'auto');

--- a/test/sim/misc/megaevolution.js
+++ b/test/sim/misc/megaevolution.js
@@ -11,13 +11,11 @@ describe('Mega Evolution', () => {
 	});
 
 	it('should overwrite normally immutable abilities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Metagross", ability: 'comatose', item: 'metagrossite', moves: ['metalclaw'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Wishiwashi", ability: 'schooling', moves: ['uturn'] },
-		] });
+		]]);
 		const megaMon = battle.p1.active[0];
 		battle.makeChoices('move metalclaw mega', 'move uturn');
 		assert.equal(megaMon.ability, 'toughclaws');
@@ -102,13 +100,11 @@ describe('Mega Evolution', () => {
 	});
 
 	it('should not break priority', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Metagross", ability: 'quickfeet', item: 'metagrossite', moves: ['protect'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Ninjask", ability: 'quickfeet', moves: ['thunderwave'] },
-		] });
+		]]);
 		const megaMon = battle.p1.active[0];
 		battle.makeChoices('move protect mega', 'auto');
 		assert.equal(megaMon.status, '');

--- a/test/sim/misc/pledgemoves.js
+++ b/test/sim/misc/pledgemoves.js
@@ -6,21 +6,16 @@ const common = require('./../../common');
 let battle;
 
 describe('Pledge Moves', () => {
-	beforeEach(() => {
-		battle = common.createBattle({ gameType: 'doubles' });
-	});
-
 	afterEach(() => battle.destroy());
 
 	it('should not combine if one of the users is forced to use a non-pledge move on its turn', () => {
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Venusaur', level: 90, moves: ['sludge', 'grasspledge'] },
 			{ species: 'Charizard', level: 99, moves: ['sleeptalk', 'firepledge'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Whimsicott', ability: 'prankster', moves: ['encore'] },
 			{ species: 'Blastoise', moves: ['sleeptalk'] },
-		] });
+		]]);
 
 		battle.makeChoices('move sludge 2, move sleeptalk', 'move encore 1, move sleeptalk');
 		battle.makeChoices('move grasspledge 2, move firepledge 2', 'move encore 1, move sleeptalk');

--- a/test/sim/misc/recoil.js
+++ b/test/sim/misc/recoil.js
@@ -11,9 +11,11 @@ describe('Recoil', () => {
 	});
 
 	it('should deal damage to the user after an attack depending on the damage dealt', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Kartana", ability: 'compoundeyes', moves: ['headcharge', 'doubleedge', 'headsmash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Happiny", level: 50, ability: 'sturdy', moves: ['strengthsap'] }] });
+		battle = common.createBattle([[
+			{ species: "Kartana", ability: 'compoundeyes', moves: ['headcharge', 'doubleedge', 'headsmash'] },
+		], [
+			{ species: "Happiny", level: 50, ability: 'sturdy', moves: ['strengthsap'] },
+		]]);
 		const recoilFactors = [0.25, 0.33, 0.5];
 		for (let i = 0; i < 3; i++) {
 			assert.hurtsBy(battle.p1.active[0], Math.round((battle.p2.active[0].maxhp - 1) * recoilFactors[i]), () => battle.makeChoices(`move ${i + 1}`, `move strengthsap`));

--- a/test/sim/misc/silvally.js
+++ b/test/sim/misc/silvally.js
@@ -7,34 +7,38 @@ const unimportantPokemon = { species: 'magikarp', moves: ['splash'] };
 
 describe(`[Hackmons] Silvally`, () => {
 	it(`in untyped forme should change its type to match the memory held`, () => {
-		const battle = common.createBattle([
-			[{ species: 'silvally', ability: 'rkssystem', item: 'firememory', moves: ['rest'] }],
-			[unimportantPokemon],
-		]);
+		const battle = common.createBattle([[
+			{ species: 'silvally', ability: 'rkssystem', item: 'firememory', moves: ['rest'] },
+		], [
+			unimportantPokemon,
+		]]);
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Fire"]);
 	});
 
 	it(`in Steel forme should should be Water-typed to match the held Water Memory`, () => {
-		const battle = common.createBattle([
-			[{ species: 'silvallysteel', ability: 'rkssystem', item: 'watermemory', moves: ['rest'] }],
-			[unimportantPokemon],
-		]);
+		const battle = common.createBattle([[
+			{ species: 'silvallysteel', ability: 'rkssystem', item: 'watermemory', moves: ['rest'] },
+		], [
+			unimportantPokemon,
+		]]);
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Water"]);
 	});
 
 	it(`in a typed forme should be Normal-typed if no memory is held`, () => {
-		const battle = common.createBattle([
-			[{ species: 'silvallyfire', ability: 'rkssystem', item: 'leftovers', moves: ['rest'] }],
-			[unimportantPokemon],
-		]);
+		const battle = common.createBattle([[
+			{ species: 'silvallyfire', ability: 'rkssystem', item: 'leftovers', moves: ['rest'] },
+		], [
+			unimportantPokemon,
+		]]);
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Normal"]);
 	});
 
 	it(`[Gen 7] in a typed forme should be Normal-typed despite holding a memory if Silvally does not have the RKS System ability`, () => {
-		const battle = common.gen(7).createBattle([
-			[{ species: 'silvallyfire', ability: 'truant', item: 'firememory', moves: ['rest'] }],
-			[unimportantPokemon],
-		]);
+		const battle = common.gen(7).createBattle([[
+			{ species: 'silvallyfire', ability: 'truant', item: 'firememory', moves: ['rest'] },
+		], [
+			unimportantPokemon,
+		]]);
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Normal"]);
 	});
 });

--- a/test/sim/misc/statuses.js
+++ b/test/sim/misc/statuses.js
@@ -11,10 +11,11 @@ describe('Burn', () => {
 	});
 
 	it('should inflict 1/16 of max HP at the end of the turn, rounded down', () => {
-		battle = common.createBattle([
-			[{ species: 'Machamp', ability: 'noguard', moves: ['bulkup'] }],
-			[{ species: 'Sableye', ability: 'prankster', moves: ['willowisp'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Machamp', ability: 'noguard', moves: ['bulkup'] },
+		], [
+			{ species: 'Sableye', ability: 'prankster', moves: ['willowisp'] },
+		]]);
 		const target = battle.p1.active[0];
 		assert.hurtsBy(target, Math.floor(target.maxhp / 16), () => battle.makeChoices('move bulkup', 'move willowisp'));
 	});
@@ -45,29 +46,32 @@ describe('Burn', () => {
 	it('should reduce atk to 50% of its original value in Stadium', () => {
 		// I know WoW doesn't exist in Stadium, but the engine supports future gen moves
 		// and this is easier than digging for a seed that makes Flamethrower burn
-		battle = common.createBattle({ formatid: 'gen1stadiumou@@@!teampreview' }, [
-			[{ species: 'Vaporeon', moves: ['growl'] }],
-			[{ species: 'Jolteon', moves: ['willowisp'] }],
-		]);
+		battle = common.createBattle({ formatid: 'gen1stadiumou@@@!teampreview' }, [[
+			{ species: 'Vaporeon', moves: ['growl'] },
+		], [
+			{ species: 'Jolteon', moves: ['willowisp'] },
+		]]);
 		const attack = battle.p1.active[0].getStat('atk');
 		battle.makeChoices('move growl', 'move willowisp');
 		assert.equal(battle.p1.active[0].getStat('atk'), Math.floor(attack * 0.5));
 	});
 
 	it('should not halve damage from moves with set damage', () => {
-		battle = common.createBattle([
-			[{ species: 'Machamp', ability: 'noguard', moves: ['seismictoss'] }],
-			[{ species: 'Talonflame', ability: 'galewings', moves: ['willowisp'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Machamp', ability: 'noguard', moves: ['seismictoss'] },
+		], [
+			{ species: 'Talonflame', ability: 'galewings', moves: ['willowisp'] },
+		]]);
 		assert.hurtsBy(battle.p2.active[0], 100, () => battle.makeChoices('move seismictoss', 'move willowisp'));
 	});
 
 	describe(`[Gen 6]`, () => {
 		it('should inflict 1/8 of max HP at the end of the turn, rounded down', () => {
-			battle = common.gen(6).createBattle([
-				[{ species: 'Machamp', ability: 'noguard', moves: ['bulkup'] }],
-				[{ species: 'Sableye', ability: 'prankster', moves: ['willowisp'] }],
-			]);
+			battle = common.gen(6).createBattle([[
+				{ species: 'Machamp', ability: 'noguard', moves: ['bulkup'] },
+			], [
+				{ species: 'Sableye', ability: 'prankster', moves: ['willowisp'] },
+			]]);
 			const target = battle.p1.active[0];
 			assert.hurtsBy(target, Math.floor(target.maxhp / 8), () => battle.makeChoices('move bulkup', 'move willowisp'));
 		});
@@ -113,38 +117,44 @@ describe('Paralysis', () => {
 	});
 
 	it('should reduce speed to 25% of its original value in Gen 6', () => {
-		battle = common.gen(6).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Vaporeon', ability: 'waterabsorb', moves: ['aquaring'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Jolteon', ability: 'voltabsorb', moves: ['thunderwave'] }] });
+		battle = common.gen(6).createBattle([[
+			{ species: 'Vaporeon', ability: 'waterabsorb', moves: ['aquaring'] },
+		], [
+			{ species: 'Jolteon', ability: 'voltabsorb', moves: ['thunderwave'] },
+		]]);
 		const speed = battle.p1.active[0].getStat('spe');
 		battle.makeChoices('move aquaring', 'move thunderwave');
 		assert.equal(battle.p1.active[0].getStat('spe'), battle.modify(speed, 0.25));
 	});
 
 	it('should reduce speed to 25% of its original value in Gen 2', () => {
-		battle = common.gen(2).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Vaporeon', ability: 'waterabsorb', moves: ['aquaring'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Jolteon', ability: 'voltabsorb', moves: ['thunderwave'] }] });
+		battle = common.gen(2).createBattle([[
+			{ species: 'Vaporeon', ability: 'waterabsorb', moves: ['aquaring'] },
+		], [
+			{ species: 'Jolteon', ability: 'voltabsorb', moves: ['thunderwave'] },
+		]]);
 		const speed = battle.p1.active[0].getStat('spe');
 		battle.makeChoices('move aquaring', 'move thunderwave');
 		assert.equal(battle.p1.active[0].getStat('spe'), battle.modify(speed, 0.25));
 	});
 
 	it('should reduce speed to 25% of its original value in Stadium', () => {
-		battle = common.createBattle({ formatid: 'gen1stadiumou@@@!teampreview' }, [
-			[{ species: 'Vaporeon', moves: ['growl'] }],
-			[{ species: 'Jolteon', moves: ['thunderwave'] }],
-		]);
+		battle = common.createBattle({ formatid: 'gen1stadiumou@@@!teampreview' }, [[
+			{ species: 'Vaporeon', moves: ['growl'] },
+		], [
+			{ species: 'Jolteon', moves: ['thunderwave'] },
+		]]);
 		const speed = battle.p1.active[0].getStat('spe');
 		battle.makeChoices('move growl', 'move thunderwave');
 		assert.equal(battle.p1.active[0].getStat('spe'), Math.floor(speed * 0.25));
 	});
 
 	it('should reapply its speed drop when an opponent uses a stat-altering move in Gen 1', () => {
-		battle = common.gen(1).createBattle([
-			[{ species: 'Electrode', moves: ['rest'] }],
-			[{ species: 'Slowpoke', moves: ['amnesia', 'thunderwave'] }],
-		]);
+		battle = common.gen(1).createBattle([[
+			{ species: 'Electrode', moves: ['rest'] },
+		], [
+			{ species: 'Slowpoke', moves: ['amnesia', 'thunderwave'] },
+		]]);
 		battle.makeChoices('move rest', 'move thunderwave');
 		const speed = battle.p1.active[0].getStat('spe');
 		battle.makeChoices('move rest', 'move amnesia');
@@ -152,10 +162,11 @@ describe('Paralysis', () => {
 	});
 
 	it('should not reapply its speed drop when an opponent uses a failed stat-altering move in Gen 1', () => {
-		battle = common.gen(1).createBattle([
-			[{ species: 'Electrode', moves: ['rest'] }],
-			[{ species: 'Slowpoke', moves: ['amnesia', 'thunderwave'] }],
-		]);
+		battle = common.gen(1).createBattle([[
+			{ species: 'Electrode', moves: ['rest'] },
+		], [
+			{ species: 'Slowpoke', moves: ['amnesia', 'thunderwave'] },
+		]]);
 		battle.makeChoices('move rest', 'move amnesia');
 		battle.makeChoices('move rest', 'move amnesia');
 		battle.makeChoices('move rest', 'move amnesia');
@@ -172,10 +183,11 @@ describe('Toxic Poison', () => {
 	});
 
 	it('should inflict 1/16 of max HP rounded down, times the number of active turns with the status, at the end of the turn', () => {
-		battle = common.createBattle([
-			[{ species: 'Chansey', ability: 'naturalcure', moves: ['softboiled'] }],
-			[{ species: 'Gengar', ability: 'levitate', moves: ['toxic'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Chansey', ability: 'naturalcure', moves: ['softboiled'] },
+		], [
+			{ species: 'Gengar', ability: 'levitate', moves: ['toxic'] },
+		]]);
 		const target = battle.p1.active[0];
 		for (let i = 1; i <= 8; i++) {
 			battle.makeChoices('move softboiled', 'move toxic');
@@ -184,10 +196,12 @@ describe('Toxic Poison', () => {
 	});
 
 	it('should reset the damage counter when the Pokemon switches out', () => {
-		battle = common.createBattle([
-			[{ species: 'Chansey', ability: 'serenegrace', moves: ['counter'] }, { species: 'Snorlax', ability: 'immunity', moves: ['curse'] }],
-			[{ species: 'Crobat', ability: 'infiltrator', moves: ['toxic', 'whirlwind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Chansey', ability: 'serenegrace', moves: ['counter'] },
+			{ species: 'Snorlax', ability: 'immunity', moves: ['curse'] },
+		], [
+			{ species: 'Crobat', ability: 'infiltrator', moves: ['toxic', 'whirlwind'] },
+		]]);
 		for (let i = 0; i < 4; i++) {
 			battle.makeChoices('move counter', 'move toxic');
 		}
@@ -245,13 +259,12 @@ describe('Toxic Poison', () => {
 		});
 
 		it('should revert to regular poison on switch in, even for Poison types', () => {
-			battle = common.gen(2).createBattle([
-				[{ species: 'Smeargle', moves: ['toxic', 'splash'] }],
-				[
-					{ species: 'Qwilfish', moves: ['transform', 'splash'] },
-					{ species: 'Gengar', moves: ['nightshade'] },
-				],
-			]);
+			battle = common.gen(2).createBattle([[
+				{ species: 'Smeargle', moves: ['toxic', 'splash'] },
+			], [
+				{ species: 'Qwilfish', moves: ['transform', 'splash'] },
+				{ species: 'Gengar', moves: ['nightshade'] },
+			]]);
 			battle.makeChoices('move toxic', 'move transform');
 			battle.makeChoices('move splash', 'switch 2');
 			battle.makeChoices('move splash', 'switch 2');
@@ -316,10 +329,11 @@ describe('Freeze', () => {
 	it('should cause an afflicted Shaymin-Sky to revert to its base forme', () => {
 		battle = common.createBattle({
 			customRules: 'guaranteedsecondarymod',
-		}, [
-			[{ species: 'Chansey', ability: 'serenegrace', moves: ['icebeam'] }],
-			[{ species: 'Shaymin-Sky', ability: 'sturdy', moves: ['sleeptalk'] }],
-		]);
+		}, [[
+			{ species: 'Chansey', ability: 'serenegrace', moves: ['icebeam'] },
+		], [
+			{ species: 'Shaymin-Sky', ability: 'sturdy', moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices('move icebeam', 'move sleeptalk');
 		assert.equal(battle.p2.active[0].status, 'frz');
 		assert.equal(battle.p2.active[0].species.name, 'Shaymin');
@@ -328,10 +342,11 @@ describe('Freeze', () => {
 	it('should not cause an afflicted Pokemon transformed into Shaymin-Sky to change to Shaymin', () => {
 		battle = common.createBattle({
 			customRules: 'guaranteedsecondarymod',
-		}, [
-			[{ species: 'Ditto', ability: 'imposter', moves: ['transform'] }],
-			[{ species: 'Shaymin-Sky', ability: 'sturdy', moves: ['icebeam', 'sleeptalk'] }],
-		]);
+		}, [[
+			{ species: 'Ditto', ability: 'imposter', moves: ['transform'] },
+		], [
+			{ species: 'Shaymin-Sky', ability: 'sturdy', moves: ['icebeam', 'sleeptalk'] },
+		]]);
 		battle.makeChoices('move sleeptalk', 'move icebeam');
 		assert.equal(battle.p1.active[0].status, 'frz');
 		assert.equal(battle.p1.active[0].species.name, 'Shaymin-Sky');

--- a/test/sim/misc/statusmoves.js
+++ b/test/sim/misc/statusmoves.js
@@ -11,15 +11,15 @@ describe('Most status moves', () => {
 	});
 
 	it('should ignore natural type immunities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'prankster', item: 'leftovers', moves: ['gastroacid', 'glare', 'confuseray', 'sandattack'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'prankster', item: 'leftovers', moves: ['gastroacid', 'glare', 'confuseray', 'sandattack'] },
+		], [
 			{ species: "Klefki", ability: 'magician', happiness: 0, moves: ['return'] },
 			{ species: "Dusknoir", ability: 'frisk', moves: ['shadowpunch'] },
 			{ species: "Slaking", ability: 'truant', moves: ['shadowclaw'] },
 			{ species: "Tornadus", ability: 'prankster', moves: ['tailwind'] },
 			{ species: "Unown", ability: 'levitate', moves: ['hiddenpower'] },
-		] });
+		]]);
 		battle.makeChoices('move gastroacid', 'move return');
 		assert.false.holdsItem(battle.p2.active[0]); // Klefki's Magician suppressed by Gastro Acid.
 		battle.makeChoices('move glare', 'switch 2'); // Dusknoir
@@ -76,10 +76,11 @@ describe('Poison-inflicting status moves [Gen 2]', () => {
 	});
 
 	it('should not ignore type immunities', () => {
-		battle = common.gen(2).createBattle([
-			[{ species: "Smeargle", moves: POISON_STATUS_MOVES }],
-			[{ species: "Magneton", moves: ['sleeptalk'] }],
-		]);
+		battle = common.gen(2).createBattle([[
+			{ species: "Smeargle", moves: POISON_STATUS_MOVES },
+		], [
+			{ species: "Magneton", moves: ['sleeptalk'] },
+		]]);
 		// Set all moves to perfect accuracy
 		battle.onEvent('Accuracy', battle.format, true);
 

--- a/test/sim/misc/trapmoves.js
+++ b/test/sim/misc/trapmoves.js
@@ -14,68 +14,64 @@ describe('Trapping Moves', () => {
 
 	for (const move of trappers) {
 		it('should prevent Pokemon from switching out normally', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'prankster', moves: [toID(move)] }] });
-			battle.setPlayer('p2', { team: [
+			battle = common.createBattle([[
+				{ species: "Smeargle", ability: 'prankster', moves: [toID(move)] },
+			], [
 				{ species: "Tangrowth", ability: 'leafguard', moves: ['swordsdance'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move swordsdance');
 			assert.trapped(() => battle.makeChoices('move ' + toID(move), 'switch 2'));
 			assert.equal(battle.p2.active[0].species.id, 'tangrowth');
 		});
 
 		it('should not prevent Pokemon from switching out using moves', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'prankster', moves: [toID(move)] }] });
-			battle.setPlayer('p2', { team: [
+			battle = common.createBattle([[
+				{ species: "Smeargle", ability: 'prankster', moves: [toID(move)] },
+			], [
 				{ species: "Tangrowth", ability: 'leafguard', moves: ['batonpass'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move batonpass');
 			battle.makeChoices('', 'switch 2');
 			assert.equal(battle.p2.active[0].species.id, 'starmie');
 		});
 
 		it('should not prevent Pokemon immune to trapping from switching out', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'prankster', moves: [toID(move)] }] });
-			battle.setPlayer('p2', { team: [
+			battle = common.createBattle([[
+				{ species: "Smeargle", ability: 'prankster', moves: [toID(move)] },
+			], [
 				{ species: "Gourgeist", ability: 'insomnia', moves: ['synthesis'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move synthesis');
 			battle.makeChoices('move ' + toID(move), 'switch 2');
 			assert.equal(battle.p2.active[0].species.id, 'starmie');
 		});
 
 		it('should stop trapping the Pokemon if the user is no longer active', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [
+			battle = common.createBattle([[
 				{ species: "Smeargle", ability: 'prankster', moves: [toID(move)] },
 				{ species: "Kyurem", ability: 'pressure', moves: ['rest'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Tangrowth", ability: 'leafguard', moves: ['roar'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move roar');
 			battle.makeChoices('move rest', 'switch 2');
 			assert.equal(battle.p2.active[0].species.id, 'starmie');
 		});
 
 		it('should free all trapped Pokemon if the user is no longer active', () => {
-			battle = common.createBattle({ gameType: 'doubles' });
-			battle.setPlayer('p1', { team: [
+			battle = common.createBattle({ gameType: 'doubles' }, [[
 				{ species: "Smeargle", ability: 'prankster', moves: [toID(move)] },
 				{ species: "Cobalion", ability: 'justified', item: 'laggingtail', moves: ['swordsdance', 'closecombat'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Tangrowth", ability: 'leafguard', moves: ['synthesis'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['recover'] },
 				{ species: "Cradily", ability: 'suctioncups', moves: ['recover'] },
 				{ species: "Hippowdon", ability: 'sandstream', moves: ['slackoff'] },
-			] });
+			]]);
 			if (move !== 'Thousand Waves') {
 				battle.makeChoices('move ' + toID(move) + ' 1, move swordsdance', 'move synthesis, move recover');
 				battle.makeChoices('move ' + toID(move) + ' 2, move closecombat -1', 'move synthesis, move recover');
@@ -90,15 +86,13 @@ describe('Trapping Moves', () => {
 		if (trappers.indexOf(move) < 3) {
 			// Only test on moves that existed in gen 4
 			it('should be passed when the user uses Baton Pass in Gen 4', () => {
-				battle = common.gen(4).createBattle();
-				battle.setPlayer('p1', { team: [
+				battle = common.gen(4).createBattle([[
 					{ species: "Smeargle", ability: 'prankster', moves: [toID(move), 'batonpass'] },
 					{ species: "Shedinja", ability: 'wonderguard', moves: ['rest'] },
-				] });
-				battle.setPlayer('p2', { team: [
+				], [
 					{ species: "Tangrowth", ability: 'leafguard', moves: ['synthesis', 'roar'] },
 					{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-				] });
+				]]);
 				battle.makeChoices('move ' + toID(move), 'move synthesis');
 				battle.makeChoices('move batonpass', 'move synthesis');
 				battle.makeChoices('switch 2', '');
@@ -118,9 +112,11 @@ describe('Partial Trapping Moves', () => {
 
 	for (const move of partialtrappers) {
 		it('should deal 1/8 HP per turn', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'noguard', moves: [toID(move), 'rest'] }] });
-			battle.setPlayer('p2', { team: [{ species: "Blissey", ability: 'naturalcure', moves: ['healbell'] }] });
+			battle = common.createBattle([[
+				{ species: "Smeargle", ability: 'noguard', moves: [toID(move), 'rest'] },
+			], [
+				{ species: "Blissey", ability: 'naturalcure', moves: ['healbell'] },
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move healbell');
 			const pokemon = battle.p2.active[0];
 			pokemon.heal(pokemon.maxhp);
@@ -129,66 +125,62 @@ describe('Partial Trapping Moves', () => {
 		});
 
 		it('should prevent Pokemon from switching out normally', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'noguard', moves: [toID(move)] }] });
-			battle.setPlayer('p2', { team: [
+			battle = common.createBattle([[
+				{ species: "Smeargle", ability: 'noguard', moves: [toID(move)] },
+			], [
 				{ species: "Blissey", ability: 'naturalcure', moves: ['healbell'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move healbell');
 			assert.trapped(() => battle.makeChoices('move ' + toID(move), 'switch 2'));
 			assert.equal(battle.p2.active[0].species.id, 'blissey');
 		});
 
 		it('should not prevent Pokemon from switching out using moves', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'noguard', moves: [toID(move)] }] });
-			battle.setPlayer('p2', { team: [
+			battle = common.createBattle([[
+				{ species: "Smeargle", ability: 'noguard', moves: [toID(move)] },
+			], [
 				{ species: "Blissey", ability: 'naturalcure', moves: ['batonpass'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move batonpass');
 			battle.makeChoices('', 'switch 2');
 			assert.equal(battle.p2.active[0].species.id, 'starmie');
 		});
 
 		it('should not prevent Pokemon immune to trapping from switching out', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'noguard', moves: [toID(move)] }] });
-			battle.setPlayer('p2', { team: [
+			battle = common.createBattle([[
+				{ species: "Smeargle", ability: 'noguard', moves: [toID(move)] },
+			], [
 				{ species: "Dusknoir", ability: 'frisk', moves: ['sleeptalk'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move sleeptalk');
 			battle.makeChoices('move ' + toID(move), 'switch 2');
 			assert.equal(battle.p2.active[0].species.id, 'starmie');
 		});
 
 		it('should stop trapping the Pokemon if the user is no longer active', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [
+			battle = common.createBattle([[
 				{ species: "Smeargle", ability: 'noguard', moves: [toID(move)] },
 				{ species: "Kyurem", ability: 'pressure', moves: ['rest'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Blissey", ability: 'naturalcure', moves: ['roar'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move roar');
 			battle.makeChoices('move rest', 'switch 2');
 			assert.equal(battle.p2.active[0].species.id, 'starmie');
 		});
 
 		it('should stop trapping the Pokemon if the target uses Rapid Spin', () => {
-			battle = common.createBattle();
-			battle.setPlayer('p1', { team: [
+			battle = common.createBattle([[
 				{ species: "Smeargle", ability: 'noguard', moves: [toID(move)] },
 				{ species: "Kyurem", ability: 'pressure', moves: ['rest'] },
-			] });
-			battle.setPlayer('p2', { team: [
+			], [
 				{ species: "Blissey", ability: 'naturalcure', moves: ['rapidspin'] },
 				{ species: "Starmie", ability: 'illuminate', moves: ['reflecttype'] },
-			] });
+			]]);
 			battle.makeChoices('move ' + toID(move), 'move rapidspin');
 			battle.makeChoices('move ' + toID(move), 'switch 2');
 			assert.equal(battle.p2.active[0].species.id, 'starmie');
@@ -202,9 +194,12 @@ describe('Partial Trapping Moves [Gen 1]', () => {
 	});
 
 	it('Wrap ends when wrapped Pokemon dies of residual damage', () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Arbok", moves: ['wrap', 'toxic'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Rhydon", moves: ['splash'] }, { species: "Exeggutor", moves: ['splash'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Arbok", moves: ['wrap', 'toxic'] },
+		], [
+			{ species: "Rhydon", moves: ['splash'] },
+			{ species: "Exeggutor", moves: ['splash'] },
+		]]);
 		battle.makeChoices('move toxic', 'move splash');
 		for (let i = 0; i < 6; i++) {
 			battle.makeChoices();
@@ -213,9 +208,12 @@ describe('Partial Trapping Moves [Gen 1]', () => {
 	});
 
 	it('Wrap ends when wrapped Pokemon switches to a Pokemon that dies of residual damage', () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Dragonite", moves: ['wrap', 'seismictoss', 'toxic'], evs: { hp: 255 } }] });
-		battle.setPlayer('p2', { team: [{ species: "Mewtwo", moves: ['splash'], evs: { hp: 255 } }, { species: "Exeggutor", moves: ['splash'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Dragonite", moves: ['wrap', 'seismictoss', 'toxic'], evs: { hp: 255 } },
+		], [
+			{ species: "Mewtwo", moves: ['splash'], evs: { hp: 255 } },
+			{ species: "Exeggutor", moves: ['splash'] },
+		]]);
 		for (let i = 0; i < 4; i++) {
 			battle.makeChoices('move seismictoss', 'auto');
 		}
@@ -227,9 +225,12 @@ describe('Partial Trapping Moves [Gen 1]', () => {
 	});
 
 	it('Wrap ends when wrapper dies to residual damage', () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Dragonite", moves: ['wrap', 'splash'] }, { species: "Exeggutor", moves: ['splash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Rhydon", moves: ['toxic'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Dragonite", moves: ['wrap', 'splash'] },
+			{ species: "Exeggutor", moves: ['splash'] },
+		], [
+			{ species: "Rhydon", moves: ['toxic'] },
+		]]);
 		battle.makeChoices('move splash', 'move toxic');
 		for (let i = 0; i < 7; i++) {
 			battle.makeChoices();
@@ -238,14 +239,12 @@ describe('Partial Trapping Moves [Gen 1]', () => {
 	});
 
 	it('Wrap ends when wrapper switches to a Pokemon that dies of residual damage', () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(1).createBattle([[
 			{ species: "Rhydon", moves: ['splash'], evs: { hp: 255 } },
 			{ species: "Dragonite", moves: ['wrap'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Slowbro", moves: ['seismictoss', 'toxic'] },
-		] });
+		]]);
 		for (let i = 0; i < 4; i++) {
 			battle.makeChoices();
 		}
@@ -258,9 +257,11 @@ describe('Partial Trapping Moves [Gen 1]', () => {
 	});
 
 	it('Wrap should damage the target\'s substitute', () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "charizard", moves: ['wrap'] }] });
-		battle.setPlayer('p2', { team: [{ species: "alakazam", moves: ['splash', 'substitute'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "charizard", moves: ['wrap'] },
+		], [
+			{ species: "alakazam", moves: ['splash', 'substitute'] },
+		]]);
 		const alakazam = battle.p2.active[0];
 		battle.makeChoices('move wrap', 'move substitute');
 		for (let i = 0; i < 4; i++) {
@@ -275,10 +276,11 @@ describe('Partial Trapping Moves [Gen 1]', () => {
 	});
 
 	it(`Wrap should never miss if the target is already trapped`, () => {
-		battle = common.gen(1).createBattle({ seed: [0, 0, 0, 2] }, [ // 3 turns of Wrap
-			[{ species: 'Dragonite', moves: ['wrap'] }],
-			[{ species: 'Cloyster', moves: ['surf'] }],
-		]);
+		battle = common.gen(1).createBattle({ seed: [0, 0, 0, 2] }, [[
+			{ species: 'Dragonite', moves: ['wrap'] },
+		], [
+			{ species: 'Cloyster', moves: ['surf'] },
+		]]);
 		const cloyster = battle.p2.active[0];
 		assert.hurts(cloyster, () => battle.makeChoices());
 		assert(cloyster.volatiles['partiallytrapped']);

--- a/test/sim/misc/turn-order.js
+++ b/test/sim/misc/turn-order.js
@@ -11,19 +11,24 @@ describe('Mega Evolution', () => {
 	});
 
 	it('should cause mega ability to affect the order of the turn in which it happens', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Banette', ability: 'frisk', item: 'banettite', moves: ['psychup'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind'] }] });
+		battle = common.createBattle([[
+			{ species: 'Banette', ability: 'frisk', item: 'banettite', moves: ['psychup'] },
+		], [
+			{ species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind'] },
+		]]);
 		const pranksterMega = battle.p1.active[0];
 		battle.makeChoices('move psychup mega', 'move calmmind');
 		assert.statStage(pranksterMega, 'spa', 0);
 	});
 
 	it('should cause an ability copied with Trace by a mega to affect the order of the turn in which it happens', () => {
-		battle = common.createBattle([
-			[{ species: "Politoed", ability: 'drizzle', item: '', moves: ['scald'] }, { species: "Kingdra", ability: 'swiftswim', item: '', moves: ['dragondance'] }],
-			[{ species: "Marowak", ability: 'rockhead', item: '', moves: ['earthquake'] }, { species: "Alakazam", ability: 'magicguard', item: 'alakazite', moves: ['psychup'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Politoed", ability: 'drizzle', item: '', moves: ['scald'] },
+			{ species: "Kingdra", ability: 'swiftswim', item: '', moves: ['dragondance'] },
+		], [
+			{ species: "Marowak", ability: 'rockhead', item: '', moves: ['earthquake'] },
+			{ species: "Alakazam", ability: 'magicguard', item: 'alakazite', moves: ['psychup'] },
+		]]);
 		battle.makeChoices('switch 2', 'switch 2');
 		battle.makeChoices('move dragondance', 'move psychup mega');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
@@ -32,27 +37,33 @@ describe('Mega Evolution', () => {
 	});
 
 	it('should cause base ability to not affect the order of the turn in which it happens', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', item: 'sablenite', moves: ['psychup'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sableye', ability: 'prankster', item: 'sablenite', moves: ['psychup'] },
+		], [
+			{ species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind'] },
+		]]);
 		const noPranksterMega = battle.p1.active[0];
 		battle.makeChoices('move psychup mega', 'move calmmind');
 		assert.statStage(noPranksterMega, 'spa', 1);
 	});
 
 	it('should cause mega forme speed to decide turn order', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Beedrill', ability: 'swarm', item: 'beedrillite', moves: ['xscissor'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Hoopa-Unbound', ability: 'magician', moves: ['psyshock'] }] });
+		battle = common.createBattle([[
+			{ species: 'Beedrill', ability: 'swarm', item: 'beedrillite', moves: ['xscissor'] },
+		], [
+			{ species: 'Hoopa-Unbound', ability: 'magician', moves: ['psyshock'] },
+		]]);
 		const fastBase = battle.p2.active[0];
 		battle.makeChoices('move xscissor mega', 'move psyshock');
 		assert.fainted(fastBase);
 	});
 
 	it('should cause ultra forme speed to decide turn order', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Necrozma-Dusk-Mane', ability: 'swarm', item: 'ultranecroziumz', moves: ['xscissor'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Hoopa-Unbound', ability: 'magician', moves: ['darkpulse'] }] });
+		battle = common.createBattle([[
+			{ species: 'Necrozma-Dusk-Mane', ability: 'swarm', item: 'ultranecroziumz', moves: ['xscissor'] },
+		], [
+			{ species: 'Hoopa-Unbound', ability: 'magician', moves: ['darkpulse'] },
+		]]);
 		const fastBase = battle.p2.active[0];
 		battle.makeChoices('move xscissor ultra', 'move darkpulse');
 		assert.equal(fastBase.hp, 0);
@@ -65,19 +76,24 @@ describe('Mega Evolution [Gen 6]', () => {
 	});
 
 	it('should not cause mega ability to affect the order of the turn in which it happens', () => {
-		battle = common.gen(6).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Banette', ability: 'frisk', item: 'banettite', moves: ['psychup'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind'] }] });
+		battle = common.gen(6).createBattle([[
+			{ species: 'Banette', ability: 'frisk', item: 'banettite', moves: ['psychup'] },
+		], [
+			{ species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind'] },
+		]]);
 		const pranksterMega = battle.p1.active[0];
 		battle.makeChoices('move psychup mega', 'move calmmind');
 		assert.statStage(pranksterMega, 'spa', 1);
 	});
 
 	it('should not cause an ability copied with Trace by a mega to affect the order of the turn in which it happens', () => {
-		battle = common.gen(6).createBattle([
-			[{ species: "Politoed", ability: 'drizzle', item: '', moves: ['scald'] }, { species: "Kingdra", ability: 'swiftswim', item: '', moves: ['dragondance'] }],
-			[{ species: "Marowak", ability: 'rockhead', item: '', moves: ['earthquake'] }, { species: "Alakazam", ability: 'magicguard', item: 'alakazite', moves: ['psychup'] }],
-		]);
+		battle = common.gen(6).createBattle([[
+			{ species: "Politoed", ability: 'drizzle', item: '', moves: ['scald'] },
+			{ species: "Kingdra", ability: 'swiftswim', item: '', moves: ['dragondance'] },
+		], [
+			{ species: "Marowak", ability: 'rockhead', item: '', moves: ['earthquake'] },
+			{ species: "Alakazam", ability: 'magicguard', item: 'alakazite', moves: ['psychup'] },
+		]]);
 		battle.makeChoices('switch 2', 'switch 2');
 		battle.makeChoices('move dragondance', 'move psychup mega');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
@@ -86,18 +102,22 @@ describe('Mega Evolution [Gen 6]', () => {
 	});
 
 	it('should cause base ability to affect the order of the turn in which it happens', () => {
-		battle = common.gen(6).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', item: 'sablenite', moves: ['psychup'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind'] }] });
+		battle = common.gen(6).createBattle([[
+			{ species: 'Sableye', ability: 'prankster', item: 'sablenite', moves: ['psychup'] },
+		], [
+			{ species: 'Deoxys-Speed', ability: 'pressure', moves: ['calmmind'] },
+		]]);
 		const noPranksterMega = battle.p1.active[0];
 		battle.makeChoices('move psychup mega', 'move calmmind');
 		assert.statStage(noPranksterMega, 'spa', 0);
 	});
 
 	it('should cause base forme speed to decide turn order', () => {
-		battle = common.gen(6).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Beedrill', ability: 'swarm', item: 'beedrillite', moves: ['xscissor'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Hoopa-Unbound', ability: 'magician', moves: ['psyshock'] }] });
+		battle = common.gen(6).createBattle([[
+			{ species: 'Beedrill', ability: 'swarm', item: 'beedrillite', moves: ['xscissor'] },
+		], [
+			{ species: 'Hoopa-Unbound', ability: 'magician', moves: ['psyshock'] },
+		]]);
 		const fastMega = battle.p1.active[0];
 		battle.makeChoices('move xscissor mega', 'move psyshock');
 		assert.fainted(fastMega);
@@ -110,7 +130,6 @@ describe('Pokemon Speed', () => {
 	});
 
 	it('should update dynamically in Gen 8', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
 		const p1team = [
 			{ species: 'Ludicolo', ability: 'swiftswim', moves: ['scald'], evs: { spe: 100 } }, // 201 Speed
 			{ species: 'Appletun', ability: 'ripen', moves: ['sleeptalk'] }, // To be switched out
@@ -120,8 +139,7 @@ describe('Pokemon Speed', () => {
 			{ species: 'Accelgor', ability: 'hydration', moves: ['bugbuzz'], evs: { spe: 156 }, nature: 'Timid' }, // 401 Speed
 			{ species: 'Aegislash', ability: 'stancechange', moves: ['sleeptalk'] }, // Does nothing but fill a slot
 		];
-		battle.setPlayer('p1', { team: p1team });
-		battle.setPlayer('p2', { team: p2team });
+		battle = common.createBattle({ gameType: 'doubles' }, [p1team, p2team]);
 
 		// Set ludicolo's and accelgor's HP to 1.
 		battle.p1.pokemon[0].sethp(1); // Ludicolo
@@ -132,7 +150,6 @@ describe('Pokemon Speed', () => {
 	});
 
 	it('should NOT update dynamically in Gen 7', () => {
-		battle = common.gen(7).createBattle({ gameType: 'doubles' });
 		const p1team = [
 			{ species: 'Ludicolo', ability: 'swiftswim', moves: ['scald'], evs: { spe: 100 } }, // 201 Speed
 			{ species: 'Appletun', ability: 'ripen', moves: ['sleeptalk'] }, // To be switched out
@@ -142,8 +159,7 @@ describe('Pokemon Speed', () => {
 			{ species: 'Accelgor', ability: 'hydration', moves: ['bugbuzz'], evs: { spe: 156 }, nature: 'Timid' }, // 401 Speed
 			{ species: 'Aegislash', ability: 'stancechange', moves: ['sleeptalk'] }, // Does nothing but fill a slot
 		];
-		battle.setPlayer('p1', { team: p1team });
-		battle.setPlayer('p2', { team: p2team });
+		battle = common.gen(7).createBattle({ gameType: 'doubles' }, [p1team, p2team]);
 
 		// Set ludicolo's and accelgor's HP to 1.
 		battle.p1.pokemon[0].sethp(1); // Ludicolo
@@ -156,7 +172,6 @@ describe('Pokemon Speed', () => {
 
 describe('Switching out', () => {
 	it('should happen in order of switch-out\'s Speed stat', () => {
-		battle = common.createBattle();
 		const p1team = [
 			{ species: 'Accelgor', ability: 'runaway', moves: ['sleeptalk'] },
 			{ species: 'Shuckle', ability: 'intimidate', moves: ['sleeptalk'] },
@@ -165,8 +180,7 @@ describe('Switching out', () => {
 			{ species: 'Durant', ability: 'runaway', moves: ['sleeptalk'] },
 			{ species: 'Barraskewda', ability: 'runaway', moves: ['sleeptalk'] },
 		];
-		battle.setPlayer('p1', { team: p1team });
-		battle.setPlayer('p2', { team: p2team });
+		battle = common.createBattle([p1team, p2team]);
 
 		battle.makeChoices('switch 2', 'switch 2');
 		assert.equal(battle.p2.pokemon[0].boosts.atk, 0);

--- a/test/sim/misc/twoturnmoves.js
+++ b/test/sim/misc/twoturnmoves.js
@@ -11,9 +11,11 @@ describe('Two Turn Moves [Gen 1]', () => {
 	});
 
 	it(`charges the first turn, does damage and uses PP the second turn`, () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Venusaur", moves: ['solarbeam'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Parasect", moves: ['swordsdance'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Venusaur", moves: ['solarbeam'] },
+		], [
+			{ species: "Parasect", moves: ['swordsdance'] },
+		]]);
 		const venusaur = battle.p1.active[0];
 		const parasect = battle.p2.active[0];
 		assert.equal(venusaur.moveSlots[0].pp, 16);
@@ -28,9 +30,11 @@ describe('Two Turn Moves [Gen 1]', () => {
 	});
 
 	it(`move is paused when asleep or frozen`, () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Aerodactyl", moves: ['skyattack'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Parasect", moves: ['spore'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Aerodactyl", moves: ['skyattack'] },
+		], [
+			{ species: "Parasect", moves: ['spore'] },
+		]]);
 		const aerodactyl = battle.p1.active[0];
 		for (let i = 0; i < 10; i++) {
 			battle.makeChoices();
@@ -57,9 +61,11 @@ describe('Two Turn Moves [Gen 1]', () => {
 	});
 
 	it(`if called by Metronome or Mirror Move, the calling move uses PP in the attacking turn`, () => {
-		battle = common.gen(1).createBattle({ seed: [0, 1, 0, 1] });
-		battle.setPlayer('p1', { team: [{ species: 'blastoise', moves: ['metronome', 'skullbash'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'golem', moves: ['defensecurl'] }] });
+		battle = common.gen(1).createBattle({ seed: [0, 1, 0, 1] }, [[
+			{ species: 'blastoise', moves: ['metronome', 'skullbash'] },
+		], [
+			{ species: 'golem', moves: ['defensecurl'] },
+		]]);
 		const blastoise = battle.p1.active[0];
 		battle.makeChoices();
 		assert(battle.log.some(line => line.includes('|move|p1a: Blastoise|Skull Bash||[from] Metronome|[still]')));
@@ -71,9 +77,11 @@ describe('Two Turn Moves [Gen 1]', () => {
 	});
 
 	it(`Dig/Fly dodges all attacks except for Swift, Transform, and Bide`, () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Aerodactyl", moves: ['fly'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Pidgeot", moves: ['gust'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Aerodactyl", moves: ['fly'] },
+		], [
+			{ species: "Pidgeot", moves: ['gust'] },
+		]]);
 		battle.makeChoices();
 		assert(battle.log.some(line => line.includes("Aerodactyl can't be hit")));
 		assert.fullHP(battle.p1.active[0]);
@@ -82,9 +90,11 @@ describe('Two Turn Moves [Gen 1]', () => {
 	});
 
 	it(`Dig/Fly invulnerability glitch`, () => {
-		battle = common.gen(1).createBattle({ seed: [0, 0, 0, 1] });
-		battle.setPlayer('p1', { team: [{ species: "Electrode", moves: ['thunderwave', 'swift', 'thunderbolt'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Pidgeot", moves: ['fly', 'gust'] }] });
+		battle = common.gen(1).createBattle({ seed: [0, 0, 0, 1] }, [[
+			{ species: "Electrode", moves: ['thunderwave', 'swift', 'thunderbolt'] },
+		], [
+			{ species: "Pidgeot", moves: ['fly', 'gust'] },
+		]]);
 		const pidgeot = battle.p2.active[0];
 		battle.makeChoices();
 		assert(pidgeot.volatiles['twoturnmove']);

--- a/test/sim/misc/typechange.js
+++ b/test/sim/misc/typechange.js
@@ -18,25 +18,31 @@ describe('Type addition', () => {
 	for (const moveData of adderMoves) {
 		describe(moveData.name, () => {
 			it('should add ' + moveData.type + ' type to its target', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name] }] });
-				battle.setPlayer('p2', { team: [{ species: "Machamp", ability: 'guts', moves: ['crosschop'] }] });
+				battle = common.createBattle([[
+					{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name] },
+				], [
+					{ species: "Machamp", ability: 'guts', moves: ['crosschop'] },
+				]]);
 				const target = battle.p2.active[0];
 				assert.sets(() => target.getTypes().join('/'), `Fighting/${moveData.type}`, () => battle.makeChoices('move ' + moveData.name, 'move crosschop'));
 			});
 
 			it('should not add ' + moveData.type + ' type to ' + moveData.type + ' targets', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name] }] });
-				battle.setPlayer('p2', { team: [{ species: "Trevenant", ability: 'harvest', moves: ['ingrain'] }] });
+				battle = common.createBattle([[
+					{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name] },
+				], [
+					{ species: "Trevenant", ability: 'harvest', moves: ['ingrain'] },
+				]]);
 				const target = battle.p2.active[0];
 				assert.constant(() => target.getTypes().join('/'), () => battle.makeChoices('move ' + moveData.name, 'move ingrain'));
 			});
 
 			it('should be able to add ' + moveData.type + ' type to Arceus', () => {
-				battle = common.createBattle();
-				battle.setPlayer('p1', { team: [{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name] }] });
-				battle.setPlayer('p2', { team: [{ species: "Arceus", ability: 'multitype', moves: ['extremespeed'] }] });
+				battle = common.createBattle([[
+					{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name] },
+				], [
+					{ species: "Arceus", ability: 'multitype', moves: ['extremespeed'] },
+				]]);
 				const target = battle.p2.active[0];
 				assert.sets(() => target.getTypes().join('/'), `Normal/${moveData.type}`, () => battle.makeChoices('move ' + moveData.name, 'move extremespeed'));
 			});
@@ -44,9 +50,11 @@ describe('Type addition', () => {
 			for (const moveData2 of adderMoves) {
 				if (moveData.name === moveData2.name) {
 					it('should fail on repeated use', () => {
-						battle = common.createBattle();
-						battle.setPlayer('p1', { team: [{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name] }] });
-						battle.setPlayer('p2', { team: [{ species: "Deoxys-Speed", ability: 'pressure', moves: ['spikes'] }] });
+						battle = common.createBattle([[
+							{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name] },
+						], [
+							{ species: "Deoxys-Speed", ability: 'pressure', moves: ['spikes'] },
+						]]);
 						const target = battle.p2.active[0];
 						battle.makeChoices('move ' + moveData.name, 'move spikes');
 						assert.constant(() => target.getTypes().join('/'), () => battle.makeChoices('move ' + moveData.name, 'move spikes'));
@@ -54,9 +62,11 @@ describe('Type addition', () => {
 					});
 				} else {
 					it('should override ' + moveData2.name, () => {
-						battle = common.createBattle();
-						battle.setPlayer('p1', { team: [{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name, moveData2.name] }] });
-						battle.setPlayer('p2', { team: [{ species: "Deoxys-Speed", ability: 'pressure', moves: ['spikes'] }] });
+						battle = common.createBattle([[
+							{ species: "Gourgeist", ability: 'frisk', moves: [moveData.name, moveData2.name] },
+						], [
+							{ species: "Deoxys-Speed", ability: 'pressure', moves: ['spikes'] },
+						]]);
 						const target = battle.p2.active[0];
 						battle.makeChoices('move ' + moveData2.name, 'move spikes');
 						assert.sets(() => target.getTypes().join('/'), `Psychic/${moveData.type}`, () => battle.makeChoices('move ' + moveData.name, 'move spikes'));

--- a/test/sim/misc/weather.js
+++ b/test/sim/misc/weather.js
@@ -11,10 +11,12 @@ describe('Weather damage calculation', () => {
 	});
 
 	it('should multiply the damage (not the basePower) in favorable weather', () => {
-		battle = common.createBattle();
+		battle = common.createBattle([[
+			{ species: 'Ninetales', ability: 'drought', moves: ['incinerate'] },
+		], [
+			{ species: 'Cryogonal', ability: 'levitate', moves: ['splash'] },
+		]]);
 		battle.randomizer = dmg => dmg; // max damage
-		battle.setPlayer('p1', { team: [{ species: 'Ninetales', ability: 'drought', moves: ['incinerate'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Cryogonal', ability: 'levitate', moves: ['splash'] }] });
 		const attacker = battle.p1.active[0];
 		const defender = battle.p2.active[0];
 		assert.hurtsBy(defender, 152, () => battle.makeChoices('move incinerate', 'move splash'));
@@ -24,10 +26,12 @@ describe('Weather damage calculation', () => {
 	});
 
 	it('should reduce the damage (not the basePower) in unfavorable weather', () => {
-		battle = common.createBattle();
+		battle = common.createBattle([[
+			{ species: 'Ninetales', ability: 'drizzle', moves: ['incinerate'] },
+		], [
+			{ species: 'Cryogonal', ability: 'levitate', moves: ['splash'] },
+		]]);
 		battle.randomizer = dmg => dmg; // max damage
-		battle.setPlayer('p1', { team: [{ species: 'Ninetales', ability: 'drizzle', moves: ['incinerate'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Cryogonal', ability: 'levitate', moves: ['splash'] }] });
 		const attacker = battle.p1.active[0];
 		const defender = battle.p2.active[0];
 		assert.hurtsBy(defender, 50, () => battle.makeChoices('move incinerate', 'move splash'));
@@ -37,10 +41,12 @@ describe('Weather damage calculation', () => {
 	});
 
 	it('should make Hail/Sandstorm damage some pokemon but not others', () => {
-		battle = common.gen(8).createBattle();
+		battle = common.gen(8).createBattle([[
+			{ species: 'Abomasnow', ability: 'snowwarning', moves: ['protect'] },
+		], [
+			{ species: 'Sandslash', ability: 'sandveil', moves: ['protect'] },
+		]]);
 		battle.randomizer = dmg => dmg; // max damage
-		battle.setPlayer('p1', { team: [{ species: 'Abomasnow', ability: 'snowwarning', moves: ['protect'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Sandslash', ability: 'sandveil', moves: ['protect'] }] });
 		battle.makeChoices('move protect', 'move protect');
 		const p1active = battle.p1.active[0];
 		const p2active = battle.p2.active[0];

--- a/test/sim/misc/weight.js
+++ b/test/sim/misc/weight.js
@@ -11,10 +11,11 @@ describe('Heavy Metal', () => {
 	});
 
 	it('should double the weight of a Pokemon', () => {
-		battle = common.createBattle([
-			[{ species: "Simisear", ability: 'heavymetal', moves: ['nastyplot'] }],
-			[{ species: "Simisage", ability: 'gluttony', moves: ['grassknot'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Simisear", ability: 'heavymetal', moves: ['nastyplot'] },
+		], [
+			{ species: "Simisage", ability: 'gluttony', moves: ['grassknot'] },
+		]]);
 		let basePower = 0;
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
 			if (move.id === 'grassknot') {
@@ -26,10 +27,11 @@ describe('Heavy Metal', () => {
 	});
 
 	it('should be negated by Mold Breaker', () => {
-		battle = common.createBattle([
-			[{ species: "Simisear", ability: 'heavymetal', moves: ['nastyplot'] }],
-			[{ species: "Simisage", ability: 'moldbreaker', moves: ['grassknot'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Simisear", ability: 'heavymetal', moves: ['nastyplot'] },
+		], [
+			{ species: "Simisage", ability: 'moldbreaker', moves: ['grassknot'] },
+		]]);
 		let basePower = 0;
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
 			if (move.id === 'grassknot') {
@@ -47,10 +49,11 @@ describe('Light Metal', () => {
 	});
 
 	it('should halve the weight of a Pokemon', () => {
-		battle = common.createBattle([
-			[{ species: "Registeel", ability: 'lightmetal', moves: ['curse'] }],
-			[{ species: "Simisage", ability: 'gluttony', moves: ['grassknot'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Registeel", ability: 'lightmetal', moves: ['curse'] },
+		], [
+			{ species: "Simisage", ability: 'gluttony', moves: ['grassknot'] },
+		]]);
 		let basePower = 0;
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
 			if (move.id === 'grassknot') {
@@ -62,10 +65,11 @@ describe('Light Metal', () => {
 	});
 
 	it('should be negated by Mold Breaker', () => {
-		battle = common.createBattle([
-			[{ species: "Registeel", ability: 'lightmetal', moves: ['splash'] }],
-			[{ species: "Simisage", ability: 'moldbreaker', moves: ['grassknot'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Registeel", ability: 'lightmetal', moves: ['splash'] },
+		], [
+			{ species: "Simisage", ability: 'moldbreaker', moves: ['grassknot'] },
+		]]);
 		let basePower = 0;
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
 			if (move.id === 'grassknot') {
@@ -83,10 +87,11 @@ describe('Float Stone', () => {
 	});
 
 	it('should halve the weight of a Pokemon', () => {
-		battle = common.createBattle([
-			[{ species: "Registeel", ability: 'clearbody', item: 'floatstone', moves: ['curse'] }],
-			[{ species: "Simisage", ability: 'gluttony', moves: ['grassknot'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Registeel", ability: 'clearbody', item: 'floatstone', moves: ['curse'] },
+		], [
+			{ species: "Simisage", ability: 'gluttony', moves: ['grassknot'] },
+		]]);
 		let basePower = 0;
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
 			if (move.id === 'grassknot') {
@@ -104,10 +109,11 @@ describe('Autotomize', () => {
 	});
 
 	it('should reduce the weight of a Pokemon by 100 kg with each use', () => {
-		battle = common.createBattle([
-			[{ species: "Registeel", ability: 'clearbody', moves: ['autotomize'] }],
-			[{ species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Registeel", ability: 'clearbody', moves: ['autotomize'] },
+		], [
+			{ species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot'] },
+		]]);
 		let basePower = 0;
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
 			if (move.id === 'grassknot') {
@@ -121,10 +127,11 @@ describe('Autotomize', () => {
 	});
 
 	it('should factor into weight before Heavy Metal does', () => {
-		battle = common.createBattle([
-			[{ species: "Lairon", ability: 'heavymetal', moves: ['autotomize'] }],
-			[{ species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Lairon", ability: 'heavymetal', moves: ['autotomize'] },
+		], [
+			{ species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot'] },
+		]]);
 		let basePower = 0;
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
 			if (move.id === 'grassknot') {
@@ -136,10 +143,11 @@ describe('Autotomize', () => {
 	});
 
 	it('should reset after a forme change', () => {
-		battle = common.createBattle([
-			[{ species: "Aegislash", ability: 'stancechange', moves: ['autotomize', 'shadowsneak'] }],
-			[{ species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Aegislash", ability: 'stancechange', moves: ['autotomize', 'shadowsneak'] },
+		], [
+			{ species: "Simisage", ability: 'gluttony', item: 'laggingtail', moves: ['grassknot'] },
+		]]);
 		let basePower = 0;
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
 			if (move.id === 'grassknot') {

--- a/test/sim/moves/aurawheel.js
+++ b/test/sim/moves/aurawheel.js
@@ -11,10 +11,11 @@ describe('Aura Wheel', () => {
 	});
 
 	it('should change types based on Morpeko forme', () => {
-		battle = common.createBattle([
-			[{ species: 'Morpeko', ability: 'hungerswitch', moves: ['aurawheel'] }],
-			[{ species: 'Rhyperior', ability: 'solidrock', moves: ['stealthrock'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Morpeko', ability: 'hungerswitch', moves: ['aurawheel'] },
+		], [
+			{ species: 'Rhyperior', ability: 'solidrock', moves: ['stealthrock'] },
+		]]);
 		battle.makeChoices('move aurawheel', 'move stealthrock');
 		assert.fullHP(battle.p2.active[0]);
 		battle.makeChoices('move aurawheel', 'move stealthrock');

--- a/test/sim/moves/belch.js
+++ b/test/sim/moves/belch.js
@@ -25,9 +25,11 @@ describe('Belch', () => {
 	});
 
 	it('should count berries as consumed with Bug Bite or Pluck', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Swalot', ability: 'gluttony', item: 'salacberry', moves: ['belch', 'bugbite'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Swalot', ability: 'gluttony', item: 'salacberry', moves: ['belch', 'pluck'] }] });
+		battle = common.createBattle([[
+			{ species: 'Swalot', ability: 'gluttony', item: 'salacberry', moves: ['belch', 'bugbite'] },
+		], [
+			{ species: 'Swalot', ability: 'gluttony', item: 'salacberry', moves: ['belch', 'pluck'] },
+		]]);
 		battle.makeChoices('move Bugbite', 'move Pluck');
 		battle.makeChoices('move Belch', 'move Belch');
 		assert.equal(battle.p1.active[0].lastMove.id, 'belch');
@@ -35,23 +37,25 @@ describe('Belch', () => {
 	});
 
 	it('should count berries as consumed when they are Flung', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Swalot', ability: 'gluttony', moves: ['belch', 'stockpile'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Machamp', ability: 'noguard', item: 'salacberry', moves: ['fling'] }] });
+		battle = common.createBattle([[
+			{ species: 'Swalot', ability: 'gluttony', moves: ['belch', 'stockpile'] },
+		], [
+			{ species: 'Machamp', ability: 'noguard', item: 'salacberry', moves: ['fling'] },
+		]]);
 		battle.makeChoices('move Stockpile', 'move Fling');
 		battle.makeChoices('move Belch', 'move Fling');
 		assert.equal(battle.p1.active[0].lastMove.id, 'belch');
 	});
 
 	it('should still count berries as consumed after switch out', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Swalot', item: 'lumberry', moves: ['belch', 'uturn'] },
 			{ species: 'Swalot', moves: ['toxic'] },
-		] });
-		battle.setPlayer('p2', { team: [{
-			species: 'Rotom', moves: ['rest', 'willowisp'],
-		}] });
+		], [
+			{
+				species: 'Rotom', moves: ['rest', 'willowisp'],
+			},
+		]]);
 		battle.makeChoices('move Uturn', 'move Will-o-Wisp');
 		battle.makeChoices('switch 2', ''); // For U-Turn
 		battle.makeChoices('switch 2', 'move Will-o-Wisp');

--- a/test/sim/moves/bellydrum.js
+++ b/test/sim/moves/bellydrum.js
@@ -9,9 +9,11 @@ describe('Belly Drum', () => {
 	afterEach(() => battle.destroy());
 
 	it("should reduce the user's HP by half of their maximum HP, then boost their Attack to maximum", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Linoone", ability: 'limber', moves: ['bellydrum'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Terrakion", ability: 'justified', moves: ['bulkup'] }] });
+		battle = common.createBattle([[
+			{ species: "Linoone", ability: 'limber', moves: ['bellydrum'] },
+		], [
+			{ species: "Terrakion", ability: 'justified', moves: ['bulkup'] },
+		]]);
 		const user = battle.p1.active[0];
 		battle.makeChoices('move bellydrum', 'move bulkup');
 		assert.equal(user.hp, Math.ceil(user.maxhp / 2));
@@ -19,9 +21,11 @@ describe('Belly Drum', () => {
 	});
 
 	it("should fail if the user's HP is less than half of their maximum HP", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Linoone", ability: 'sturdy', moves: ['bellydrum'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Terrakion", ability: 'justified', moves: ['closecombat'] }] });
+		battle = common.createBattle([[
+			{ species: "Linoone", ability: 'sturdy', moves: ['bellydrum'] },
+		], [
+			{ species: "Terrakion", ability: 'justified', moves: ['closecombat'] },
+		]]);
 		const user = battle.p1.active[0];
 		battle.makeChoices('move bellydrum', 'move closecombat');
 		assert.equal(user.hp, 1);
@@ -33,9 +37,11 @@ describe('Z-Belly Drum', () => {
 	afterEach(() => battle.destroy());
 
 	it("should heal the user, then reduce their HP by half their max HP and boost the user's Attack to maximum", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Linoone", ability: 'limber', item: 'normaliumz', moves: ['bellydrum'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Rattata", ability: 'guts', moves: ['quickattack'] }] });
+		battle = common.createBattle([[
+			{ species: "Linoone", ability: 'limber', item: 'normaliumz', moves: ['bellydrum'] },
+		], [
+			{ species: "Rattata", ability: 'guts', moves: ['quickattack'] },
+		]]);
 		const user = battle.p1.active[0];
 		battle.makeChoices('move bellydrum zmove', 'move quickattack');
 		assert.equal(user.hp, Math.ceil(user.maxhp / 2));
@@ -43,9 +49,11 @@ describe('Z-Belly Drum', () => {
 	});
 
 	it("should not fail even if the user's HP is less than half of their maximum HP", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Linoone", ability: 'sturdy', item: 'normaliumz', moves: ['bellydrum'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Terrakion", ability: 'justified', moves: ['closecombat'] }] });
+		battle = common.createBattle([[
+			{ species: "Linoone", ability: 'sturdy', item: 'normaliumz', moves: ['bellydrum'] },
+		], [
+			{ species: "Terrakion", ability: 'justified', moves: ['closecombat'] },
+		]]);
 		const user = battle.p1.active[0];
 		battle.makeChoices('move bellydrum zmove', 'move closecombat');
 		assert.equal(user.hp, Math.ceil(user.maxhp / 2));

--- a/test/sim/moves/boomburst.js
+++ b/test/sim/moves/boomburst.js
@@ -11,9 +11,11 @@ describe('Boomburst', () => {
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'boomburst'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'boomburst'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move boomburst', 'move rest');
 		assert.equal(battle.p2.active[0].item, '');

--- a/test/sim/moves/bugbuzz.js
+++ b/test/sim/moves/bugbuzz.js
@@ -11,9 +11,11 @@ describe('Bug Buzz', () => {
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'bugbuzz'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'bugbuzz'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move bugbuzz', 'move rest');
 		assert.equal(battle.p2.active[0].item, '');
@@ -26,10 +28,11 @@ describe('Bug Buzz [Gen 5]', () => {
 	});
 
 	it('should not pierce through substitutes', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'bugbuzz'] }],
-			[{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'bugbuzz'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move bugbuzz', 'move rest');
 		assert.equal(battle.p2.active[0].item, 'focussash');

--- a/test/sim/moves/burningbulwark.js
+++ b/test/sim/moves/burningbulwark.js
@@ -9,28 +9,31 @@ describe('Burning Bulwark', () => {
 	afterEach(() => battle.destroy());
 
 	it(`should burn the user of a contact move`, () => {
-		battle = common.createBattle([
-			[{ species: "Gallade", ability: 'justified', moves: ['tackle'] }],
-			[{ species: "Entei", ability: 'innerfocus', moves: ['burningbulwark'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Gallade", ability: 'justified', moves: ['tackle'] },
+		], [
+			{ species: "Entei", ability: 'innerfocus', moves: ['burningbulwark'] },
+		]]);
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].status, 'brn', 'Gallade should be burned when using contact move');
 	});
 
 	it(`should not burn the user of a contact move if user has protective pads`, () => {
-		battle = common.createBattle([
-			[{ species: "Gallade", item: 'protectivepads', ability: 'justified', moves: ['tackle'] }],
-			[{ species: "Entei", ability: 'innerfocus', moves: ['burningbulwark'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Gallade", item: 'protectivepads', ability: 'justified', moves: ['tackle'] },
+		], [
+			{ species: "Entei", ability: 'innerfocus', moves: ['burningbulwark'] },
+		]]);
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].status, '', 'Gallade should not be burned when using contact move due to protective pads');
 	});
 
 	it(`should not burn the user of a non-contact move`, () => {
-		battle = common.createBattle([
-			[{ species: "Ogerpon-Wellspring", ability: 'Water Absorb', moves: ['ivycudgel'] }],
-			[{ species: "Entei", ability: 'innerfocus', moves: ['burningbulwark'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Ogerpon-Wellspring", ability: 'Water Absorb', moves: ['ivycudgel'] },
+		], [
+			{ species: "Entei", ability: 'innerfocus', moves: ['burningbulwark'] },
+		]]);
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].status, '', 'Ogerpon-Wellspring should not be burned when using non-contact move');
 	});

--- a/test/sim/moves/burnup.js
+++ b/test/sim/moves/burnup.js
@@ -14,10 +14,11 @@ describe('Burn Up', () => {
 		battle = common.createBattle({
 			seed: [0, 0, 0, 0],
 			customRules: 'guaranteedsecondarymod',
-		}, [
-			[{ species: 'Moltres', moves: ['burnup'] }],
-			[{ species: 'Piplup', moves: ['icebeam', 'sleeptalk'] }],
-		]);
+		}, [[
+			{ species: 'Moltres', moves: ['burnup'] },
+		], [
+			{ species: 'Piplup', moves: ['icebeam', 'sleeptalk'] },
+		]]);
 		const moltres = battle.p1.active[0];
 		battle.makeChoices('move burnup', 'move icebeam');
 		assert.equal(moltres.status, 'frz');

--- a/test/sim/moves/chatter.js
+++ b/test/sim/moves/chatter.js
@@ -11,9 +11,11 @@ describe('Chatter', () => {
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'chatter'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'chatter'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move chatter', 'move rest');
 		assert.equal(battle.p2.active[0].item, '');
@@ -26,20 +28,22 @@ describe('Chatter [Gen 5]', () => {
 	});
 
 	it('should not pierce through substitutes', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'chatter'] }],
-			[{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'chatter'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move chatter', 'move rest');
 		assert.equal(battle.p2.active[0].item, 'focussash');
 	});
 
 	it('should be boosted by Sheer Force', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Rayquaza", ability: 'sheerforce', moves: ['chatter'] }],
-			[{ species: "Carnivine", ability: 'battlearmor', moves: ['sleeptalk'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Rayquaza", ability: 'sheerforce', moves: ['chatter'] },
+		], [
+			{ species: "Carnivine", ability: 'battlearmor', moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices();
 		assert.fainted(battle.p2.active[0]);
 	});

--- a/test/sim/moves/clangoroussoulblaze.js
+++ b/test/sim/moves/clangoroussoulblaze.js
@@ -11,15 +11,13 @@ describe('Z-Moves', () => {
 	});
 
 	it(`should deal reduced damage to only protected targets`, () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Kommo-o', ability: 'overcoat', item: 'kommoniumz', moves: ['clangingscales'] },
 			{ species: 'Pachirisu', ability: 'voltabsorb', moves: ['protect'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Turtonator', ability: 'shellarmor', moves: ['protect'] },
 			{ species: 'Turtonator', ability: 'shellarmor', moves: ['sleeptalk'] },
-		] });
+		]]);
 		battle.makeChoices("move clangingscales zmove, move protect", "move protect, move sleeptalk");
 		assert.false.fullHP(battle.p2.active[0]);
 		assert.false.fainted(battle.p2.active[0]);
@@ -27,17 +25,21 @@ describe('Z-Moves', () => {
 	});
 
 	it(`should bypass Throat Chop's effect`, () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Kommo-o', ability: 'overcoat', item: 'kommoniumz', moves: ['clangingscales'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Regieleki', moves: ['throatchop'] }] });
+		battle = common.createBattle([[
+			{ species: 'Kommo-o', ability: 'overcoat', item: 'kommoniumz', moves: ['clangingscales'] },
+		], [
+			{ species: 'Regieleki', moves: ['throatchop'] },
+		]]);
 		battle.makeChoices("move clangingscales zmove", "move throatchop");
 		assert.fainted(battle.p2.active[0]);
 	});
 
 	it(`[Hackmons] should not bypass Throat Chop's effect if not boosted by a Z-crystal`, () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Kommo-o', ability: 'overcoat', moves: ['clangoroussoulblaze'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Regieleki', moves: ['throatchop'] }] });
+		battle = common.createBattle([[
+			{ species: 'Kommo-o', ability: 'overcoat', moves: ['clangoroussoulblaze'] },
+		], [
+			{ species: 'Regieleki', moves: ['throatchop'] },
+		]]);
 		battle.makeChoices("move clangoroussoulblaze", "move throatchop");
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});

--- a/test/sim/moves/clearsmog.js
+++ b/test/sim/moves/clearsmog.js
@@ -11,9 +11,11 @@ describe('Clear Smog', () => {
 	});
 
 	it('should remove all stat boosts from the target', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sableye", ability: 'prankster', moves: ['calmmind'] }] });
+		battle = common.createBattle([[
+			{ species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog'] },
+		], [
+			{ species: "Sableye", ability: 'prankster', moves: ['calmmind'] },
+		]]);
 
 		battle.makeChoices('move clearsmog', 'move calmmind');
 
@@ -22,9 +24,11 @@ describe('Clear Smog', () => {
 	});
 
 	it('should not remove stat boosts from a target behind a substitute', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog', 'toxic'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sableye", ability: 'prankster', moves: ['substitute', 'calmmind'] }] });
+		battle = common.createBattle([[
+			{ species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog', 'toxic'] },
+		], [
+			{ species: "Sableye", ability: 'prankster', moves: ['substitute', 'calmmind'] },
+		]]);
 
 		battle.makeChoices('move toxic', 'move substitute');
 		battle.makeChoices('move clearsmog', 'move calmmind');
@@ -34,9 +38,11 @@ describe('Clear Smog', () => {
 	});
 
 	it('should not remove stat boosts if the target is immune to its attack type', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Amoonguss", ability: 'regenerator', item: 'laggingtail', moves: ['clearsmog'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Steelix", ability: 'prankster', moves: ['irondefense'] }] });
+		battle = common.createBattle([[
+			{ species: "Amoonguss", ability: 'regenerator', item: 'laggingtail', moves: ['clearsmog'] },
+		], [
+			{ species: "Steelix", ability: 'prankster', moves: ['irondefense'] },
+		]]);
 
 		battle.makeChoices('move clearsmog', 'move irondefense');
 
@@ -44,9 +50,11 @@ describe('Clear Smog', () => {
 	});
 
 	it('should not remove stat boosts from the user', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Arcanine", ability: 'intimidate', moves: ['morningsun'] }] });
+		battle = common.createBattle([[
+			{ species: "Amoonguss", ability: 'regenerator', moves: ['clearsmog'] },
+		], [
+			{ species: "Arcanine", ability: 'intimidate', moves: ['morningsun'] },
+		]]);
 
 		battle.makeChoices('move clearsmog', 'move morningsun');
 
@@ -54,9 +62,11 @@ describe('Clear Smog', () => {
 	});
 
 	it('should trigger before Anger Point activates during critical hits', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Amoonguss", ability: 'regenerator', item: 'scopelens', moves: ['focusenergy', 'clearsmog'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Primeape", ability: 'angerpoint', moves: ['bulkup'] }] });
+		battle = common.createBattle([[
+			{ species: "Amoonguss", ability: 'regenerator', item: 'scopelens', moves: ['focusenergy', 'clearsmog'] },
+		], [
+			{ species: "Primeape", ability: 'angerpoint', moves: ['bulkup'] },
+		]]);
 
 		battle.makeChoices('move focusenergy', 'move bulkup');
 		assert.equal(battle.p2.pokemon[0].boosts['atk'], 1);

--- a/test/sim/moves/conversion2.js
+++ b/test/sim/moves/conversion2.js
@@ -11,11 +11,12 @@ describe('Conversion2', () => {
 	});
 
 	it('should change users type to resist', () => {
-		battle = common.createBattle([
-			[{ species: 'porygon2', moves: ['sleeptalk', 'conversion2', 'spore'] }],
-			[{ species: 'raticate', moves: ['tackle'] },
-				{ species: 'zapdos', moves: ['thundershock', 'sleeptalk'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'porygon2', moves: ['sleeptalk', 'conversion2', 'spore'] },
+		], [
+			{ species: 'raticate', moves: ['tackle'] },
+			{ species: 'zapdos', moves: ['thundershock', 'sleeptalk'] },
+		]]);
 		battle.makeChoices('move conversion2', 'move tackle');
 		assert(['Rock', 'Ghost', 'Steel'].includes(battle.p1.active[0].getTypes()[0]));
 		battle.makeChoices('move spore', 'switch 2');
@@ -24,40 +25,44 @@ describe('Conversion2', () => {
 	});
 
 	it('should respect the determined type of the last move', () => {
-		battle = common.createBattle([
-			[{ species: 'porygon2', moves: ['electrify', 'conversion2'] }],
-			[{ species: 'shuckle', moves: ['tackle'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'porygon2', moves: ['electrify', 'conversion2'] },
+		], [
+			{ species: 'shuckle', moves: ['tackle'] },
+		]]);
 		battle.makeChoices('move electrify', 'move tackle');
 		battle.makeChoices('move conversion2', 'move tackle');
 		assert(['Electric', 'Grass', 'Ground', 'Dragon'].includes(battle.p1.active[0].getTypes()[0]), 'Tackle should be considered Electric');
 	});
 
 	it('should fail if the last move was typeless', () => {
-		battle = common.createBattle([
-			[{ species: 'porygon2', moves: ['conversion2'] }],
-			[{ species: 'raticate', item: 'assaultvest', moves: ['taunt'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'porygon2', moves: ['conversion2'] },
+		], [
+			{ species: 'raticate', item: 'assaultvest', moves: ['taunt'] },
+		]]);
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].getTypes()[0], 'Normal');
 	});
 
 	it('should fail to change to a type the user already has', () => {
 		// Gen 5 to force Steel-type
-		battle = common.gen(5).createBattle([
-			[{ species: 'forretress', moves: ['conversion2'] }],
-			[{ species: 'salamence', moves: ['dragonrage'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: 'forretress', moves: ['conversion2'] },
+		], [
+			{ species: 'salamence', moves: ['dragonrage'] },
+		]]);
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].getTypes()[0], 'Bug');
 	});
 
 	describe('[Gen 4]', () => {
 		it('should not fail if the last move was Struggle', () => {
-			battle = common.gen(4).createBattle([
-				[{ species: 'porygon2', moves: ['conversion2'] }],
-				[{ species: 'raticate', item: 'assaultvest', moves: ['taunt'] }],
-			]);
+			battle = common.gen(4).createBattle([[
+				{ species: 'porygon2', moves: ['conversion2'] },
+			], [
+				{ species: 'raticate', item: 'assaultvest', moves: ['taunt'] },
+			]]);
 			battle.makeChoices();
 			assert(['Rock', 'Ghost', 'Steel'].includes(battle.p1.active[0].getTypes()[0]));
 		});
@@ -65,10 +70,11 @@ describe('Conversion2', () => {
 
 	describe('[Gen 3]', () => {
 		it('should not fail to change to a type the user already has', () => {
-			battle = common.gen(3).createBattle([
-				[{ species: 'forretress', moves: ['conversion2'] }],
-				[{ species: 'salamence', moves: ['dragonrage'] }],
-			]);
+			battle = common.gen(3).createBattle([[
+				{ species: 'forretress', moves: ['conversion2'] },
+			], [
+				{ species: 'salamence', moves: ['dragonrage'] },
+			]]);
 			battle.makeChoices();
 			assert.equal(battle.p1.active[0].getTypes()[0], 'Steel');
 		});

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -11,16 +11,20 @@ describe('Counter', () => {
 	});
 
 	it('should deal damage equal to twice the damage taken from the last Physical attack', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sawk', ability: 'sturdy', moves: ['seismictoss'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Throh', ability: 'guts', moves: ['counter'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sawk', ability: 'sturdy', moves: ['seismictoss'] },
+		], [
+			{ species: 'Throh', ability: 'guts', moves: ['counter'] },
+		]]);
 		assert.hurtsBy(battle.p1.active[0], 200, () => battle.makeChoices());
 	});
 
 	it('should deal damage based on the last hit from the last Physical attack', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sawk', ability: 'sturdy', moves: ['doublekick'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Throh', ability: 'guts', moves: ['counter'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sawk', ability: 'sturdy', moves: ['doublekick'] },
+		], [
+			{ species: 'Throh', ability: 'guts', moves: ['counter'] },
+		]]);
 		let lastDamage = 0;
 		battle.onEvent('Damage', battle.format, (damage, attacker, defender, move) => {
 			if (move.id === 'doublekick') {
@@ -33,24 +37,24 @@ describe('Counter', () => {
 	});
 
 	it('should fail if user is not damaged by Physical attacks this turn', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sawk', ability: 'sturdy', moves: ['aurasphere'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Throh', ability: 'guts', moves: ['counter'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sawk', ability: 'sturdy', moves: ['aurasphere'] },
+		], [
+			{ species: 'Throh', ability: 'guts', moves: ['counter'] },
+		]]);
 		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 
 	it('should target the opposing Pokemon that hit the user with a Physical attack most recently that turn', () => {
-		battle = common.gen(5).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 			{ species: 'Bastiodon', ability: 'sturdy', moves: ['counter'] },
 			{ species: 'Toucannon', ability: 'keeneye', moves: ['beakblast'] },
 			{ species: 'Kingdra', ability: 'sniper', moves: ['dragonpulse'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Crobat', ability: 'innerfocus', moves: ['acrobatics'] },
 			{ species: 'Avalugg', ability: 'sturdy', moves: ['avalanche'] },
 			{ species: 'Castform', ability: 'forecast', moves: ['weatherball'] },
-		] });
+		]]);
 		battle.makeChoices('move counter, move beakblast -1, move dragonpulse -1', 'move acrobatics 1, move avalanche 1, move weatherball 1');
 		assert.fullHP(battle.p1.active[1]);
 		assert.fullHP(battle.p2.active[0]);
@@ -58,15 +62,13 @@ describe('Counter', () => {
 	});
 
 	it('should respect Follow Me', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Bastiodon', ability: 'sturdy', moves: ['counter'] },
 			{ species: 'Magikarp', ability: 'rattled', moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Crobat', ability: 'innerfocus', moves: ['acrobatics'] },
 			{ species: 'Clefable', ability: 'unaware', moves: ['followme'] },
-		] });
+		]]);
 		battle.makeChoices('move counter, move splash', 'move acrobatics 1, move followme');
 		assert.false.fullHP(battle.p2.active[1]);
 		assert.fullHP(battle.p2.active[0]);
@@ -102,9 +104,11 @@ describe('Mirror Coat', () => {
 	});
 
 	it('should deal damage based on the last hit from the last Special attack', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Espeon', ability: 'synchronize', moves: ['watershuriken'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Umbreon', ability: 'synchronize', moves: ['mirrorcoat'] }] });
+		battle = common.createBattle([[
+			{ species: 'Espeon', ability: 'synchronize', moves: ['watershuriken'] },
+		], [
+			{ species: 'Umbreon', ability: 'synchronize', moves: ['mirrorcoat'] },
+		]]);
 		let lastDamage = 0;
 		battle.onEvent('Damage', battle.format, (damage, attacker, defender, move) => {
 			if (move.id === 'watershuriken') {
@@ -117,22 +121,22 @@ describe('Mirror Coat', () => {
 	});
 
 	it('should fail if user is not damaged by Special attacks this turn', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Espeon', ability: 'synchronize', moves: ['tackle'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Umbreon', ability: 'synchronize', moves: ['mirrorcoat'] }] });
+		battle = common.createBattle([[
+			{ species: 'Espeon', ability: 'synchronize', moves: ['tackle'] },
+		], [
+			{ species: 'Umbreon', ability: 'synchronize', moves: ['mirrorcoat'] },
+		]]);
 		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 
 	it('should target the opposing Pokemon that hit the user with a Special attack most recently that turn', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Mew', ability: 'synchronize', moves: ['mirrorcoat'] },
 			{ species: 'Lucario', ability: 'justified', item: 'laggingtail', moves: ['aurasphere'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Crobat', ability: 'innerfocus', moves: ['venoshock'] },
 			{ species: 'Avalugg', ability: 'sturdy', moves: ['flashcannon'] },
-		] });
+		]]);
 		battle.makeChoices('move mirrorcoat, move aurasphere -1', 'move venoshock 1, move flashcannon 1');
 		assert.fullHP(battle.p1.active[1]);
 		assert.fullHP(battle.p2.active[0]);
@@ -140,15 +144,13 @@ describe('Mirror Coat', () => {
 	});
 
 	it('should respect Follow Me', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Mew', ability: 'synchronize', moves: ['mirrorcoat'] },
 			{ species: 'Magikarp', ability: 'rattled', moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Crobat', ability: 'innerfocus', moves: ['venoshock'] },
 			{ species: 'Clefable', ability: 'unaware', moves: ['followme'] },
-		] });
+		]]);
 		battle.makeChoices('move mirrorcoat, move splash', 'move venoshock 1, move followme');
 		assert.false.fullHP(battle.p2.active[1]);
 		assert.fullHP(battle.p2.active[0]);

--- a/test/sim/moves/destinybond.js
+++ b/test/sim/moves/destinybond.js
@@ -9,20 +9,26 @@ describe(`Destiny Bond`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should fail if used consecutively`, () => {
-		battle = common.createBattle([
-			[{ species: "Gastly", ability: 'levitate', moves: ['destinybond'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-			[{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Gastly", ability: 'levitate', moves: ['destinybond'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		], [
+			{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move destinybond', 'move calmmind');
 		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.false.fainted(battle.p2.active[0]);
 
 		battle.destroy();
-		battle = common.createBattle([
-			[{ species: "Gastly", ability: 'levitate', moves: ['destinybond'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-			[{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Gastly", ability: 'levitate', moves: ['destinybond'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		], [
+			{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move destinybond', 'move calmmind');
 		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
@@ -30,10 +36,13 @@ describe(`Destiny Bond`, () => {
 	});
 
 	it(`should not fail after Protect usage`, () => {
-		battle = common.createBattle([
-			[{ species: "Gastly", ability: 'levitate', moves: ['destinybond', 'protect'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-			[{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Gastly", ability: 'levitate', moves: ['destinybond', 'protect'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		], [
+			{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move protect', 'move calmmind');
 		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
@@ -41,10 +50,13 @@ describe(`Destiny Bond`, () => {
 	});
 
 	it(`should be removed the next turn if a fast user is asleep`, () => {
-		battle = common.createBattle([
-			[{ species: "Gastly", ability: 'levitate', item: '', moves: ['destinybond', 'spite'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-			[{ species: "Hypno", ability: 'insomnia', item: 'laggingtail', moves: ['psychic', 'hypnosis'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Gastly", ability: 'levitate', item: '', moves: ['destinybond', 'spite'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		], [
+			{ species: "Hypno", ability: 'insomnia', item: 'laggingtail', moves: ['psychic', 'hypnosis'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move destinybond', 'move hypnosis');
 		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
@@ -56,20 +68,26 @@ describe(`Destiny Bond [Gen 6]`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should not fail if used consecutively`, () => {
-		battle = common.gen(6).createBattle([
-			[{ species: "Gastly", ability: 'levitate', moves: ['destinybond'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-			[{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-		]);
+		battle = common.gen(6).createBattle([[
+			{ species: "Gastly", ability: 'levitate', moves: ['destinybond'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		], [
+			{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move destinybond', 'move calmmind');
 		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 
 		battle.destroy();
-		battle = common.gen(6).createBattle([
-			[{ species: "Gastly", ability: 'levitate', moves: ['destinybond'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-			[{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] }, { species: "Clefable", ability: 'unaware', moves: ['calmmind'] }],
-		]);
+		battle = common.gen(6).createBattle([[
+			{ species: "Gastly", ability: 'levitate', moves: ['destinybond'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		], [
+			{ species: "Metagross", ability: 'clearbody', moves: ['psychic', 'calmmind'] },
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move destinybond', 'move calmmind');
 		battle.makeChoices('move destinybond', 'move psychic');
 		assert.fainted(battle.p1.active[0]);
@@ -77,10 +95,12 @@ describe(`Destiny Bond [Gen 6]`, () => {
 	});
 
 	it(`should end the effect before the user switches out`, () => {
-		battle = common.gen(6).createBattle([
-			[{ species: "Gastly", level: 50, moves: ['destinybond'] }, { species: "Gengar", moves: ['sleeptalk'] }],
-			[{ species: "Snorlax", moves: ['sleeptalk', 'pursuit'] }],
-		]);
+		battle = common.gen(6).createBattle([[
+			{ species: "Gastly", level: 50, moves: ['destinybond'] },
+			{ species: "Gengar", moves: ['sleeptalk'] },
+		], [
+			{ species: "Snorlax", moves: ['sleeptalk', 'pursuit'] },
+		]]);
 		const gastly = battle.p1.pokemon[0];
 		const snorlax = battle.p2.pokemon[0];
 		battle.makeChoices('move destinybond', 'move sleeptalk');
@@ -94,10 +114,12 @@ describe(`Destiny Bond [Gen 4]`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should not end the effect before the user switches out`, () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Gastly", level: 50, moves: ['destinybond'] }, { species: "Gengar", moves: ['sleeptalk'] }],
-			[{ species: "Snorlax", moves: ['sleeptalk', 'pursuit'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Gastly", level: 50, moves: ['destinybond'] },
+			{ species: "Gengar", moves: ['sleeptalk'] },
+		], [
+			{ species: "Snorlax", moves: ['sleeptalk', 'pursuit'] },
+		]]);
 		const gastly = battle.p1.pokemon[0];
 		const snorlax = battle.p2.pokemon[0];
 		battle.makeChoices('move destinybond', 'move sleeptalk');
@@ -111,10 +133,13 @@ describe(`Destiny Bond [Gen 2]`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should end the effect before the user switches out if it is faster than the Pursuit user`, () => {
-		battle = common.gen(2).createBattle([
-			[{ species: "Gastly", level: 50, moves: ['destinybond'] }, { species: "Haunter", level: 30, moves: ['destinybond'] }, { species: "Gengar", moves: ['sleeptalk'] }],
-			[{ species: "Snorlax", moves: ['sleeptalk', 'pursuit'] }],
-		]);
+		battle = common.gen(2).createBattle([[
+			{ species: "Gastly", level: 50, moves: ['destinybond'] },
+			{ species: "Haunter", level: 30, moves: ['destinybond'] },
+			{ species: "Gengar", moves: ['sleeptalk'] },
+		], [
+			{ species: "Snorlax", moves: ['sleeptalk', 'pursuit'] },
+		]]);
 		const gastly = battle.p1.pokemon[0];
 		const haunter = battle.p1.pokemon[1];
 		const snorlax = battle.p2.pokemon[0];

--- a/test/sim/moves/dragoncheer.js
+++ b/test/sim/moves/dragoncheer.js
@@ -85,10 +85,11 @@ describe('Dragon Cheer', () => {
 	});
 
 	it('should fail in singles or if no ally exists', () => {
-		battle = common.createBattle([
-			[{ species: 'gyarados', moves: ['dragoncheer'] }],
-			[{ species: 'dragapult', moves: ['splash'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'gyarados', moves: ['dragoncheer'] },
+		], [
+			{ species: 'dragapult', moves: ['splash'] },
+		]]);
 
 		battle.makeChoices();
 		assert(battle.log.some(line => !line.startsWith('|-fail')));

--- a/test/sim/moves/dragondarts.js
+++ b/test/sim/moves/dragondarts.js
@@ -133,15 +133,13 @@ describe('Dragon Darts', () => {
 	});
 
 	it('should hit one target twice if the other is protected by an ability', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"] },
 			{ species: "Grimmsnarl", ability: "Prankster", moves: ["electrify"] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Arcanine", ability: "Stamina", moves: ["sleeptalk"] },
 			{ species: "Emolga", ability: "Motor Drive", moves: ["sleeptalk"] },
-		] });
+		]]);
 		battle.makeChoices('move dragondarts 2, move electrify -1', 'move sleeptalk, move sleeptalk');
 
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
@@ -152,15 +150,13 @@ describe('Dragon Darts', () => {
 	});
 
 	it('should hit one target twice if the other is immunue', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"] },
 			{ species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Arcanine", ability: "Stamina", moves: ["sleeptalk"] },
 			{ species: "Clefairy", ability: "Ripen", moves: ["sleeptalk"] },
-		] });
+		]]);
 		battle.makeChoices('move dragondarts 2, move sleeptalk', 'move sleeptalk, move sleeptalk');
 
 		assert.statStage(battle.p2.active[0], 'def', 2);
@@ -168,15 +164,13 @@ describe('Dragon Darts', () => {
 	});
 
 	it('should hit one target twice if the other is semi-invulnerable', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Dragapult", item: "Lagging Tail", ability: "Clear Body", moves: ["dragondarts"] },
 			{ species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Arcanine", ability: "Stamina", moves: ["sleeptalk"] },
 			{ species: "Golurk", ability: "Ripen", moves: ["phantomforce"] },
-		] });
+		]]);
 		battle.makeChoices('move dragondarts 2, move sleeptalk', 'move sleeptalk, move phantomforce 1');
 
 		assert.statStage(battle.p2.active[0], 'def', 2);
@@ -184,15 +178,13 @@ describe('Dragon Darts', () => {
 	});
 
 	it('should hit one target twice if the other is fainted', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"] },
 			{ species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Arcanine", ability: "Stamina", moves: ["sleeptalk"] },
 			{ species: "Snom", ability: "Ripen", moves: ["sleeptalk"] },
-		] });
+		]]);
 
 		battle.p2.active[1].faint();
 		battle.makeChoices('move dragondarts 2, move sleeptalk', 'move sleeptalk, move sleeptalk');
@@ -202,15 +194,13 @@ describe('Dragon Darts', () => {
 	});
 
 	it('should hit one target twice if the other is Dark type and Dragon Darts is Prankster boosted', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Dragapult", ability: "Clear Body", moves: ["sleeptalk", "dragondarts"] },
 			{ species: "Liepard", ability: "Prankster", moves: ["assist"] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Arcanine", ability: "Stamina", moves: ["sleeptalk"] },
 			{ species: "Spiritomb", ability: "Infiltrator", moves: ["sleeptalk"] },
-		] });
+		]]);
 
 		battle.makeChoices();
 
@@ -219,16 +209,14 @@ describe('Dragon Darts', () => {
 	});
 
 	it('should fail if both targets are fainted', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"] },
 			{ species: "Ludicolo", ability: "Dancer", moves: ["celebrate"] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Arcanine", ability: "Flash Fire", moves: ["celebrate"] },
 			{ species: "Arcanine", ability: "Flash Fire", moves: ["celebrate"] },
 			{ species: "Arcanine", ability: "Flash Fire", moves: ["celebrate"] },
-		] });
+		]]);
 
 		battle.p2.active[0].faint();
 		battle.p2.active[1].faint();

--- a/test/sim/moves/echoedvoice.js
+++ b/test/sim/moves/echoedvoice.js
@@ -11,9 +11,11 @@ describe('Echoed Voice', () => {
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'echoedvoice'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'echoedvoice'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move echoedvoice', 'move rest');
 		assert.equal(battle.p2.active[0].item, '');
@@ -34,10 +36,11 @@ describe('Echoed Voice', () => {
 
 	describe('[Gen 5]', () => {
 		it('should not pierce through substitutes', () => {
-			battle = common.gen(5).createBattle([
-				[{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'echoedvoice'] }],
-				[{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }],
-			]);
+			battle = common.gen(5).createBattle([[
+				{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'echoedvoice'] },
+			], [
+				{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+			]]);
 			battle.makeChoices('move splash', 'move substitute');
 			battle.makeChoices('move echoedvoice', 'move rest');
 			assert.equal(battle.p2.active[0].item, 'focussash');

--- a/test/sim/moves/electricterrain.js
+++ b/test/sim/moves/electricterrain.js
@@ -11,9 +11,11 @@ describe('Electric Terrain', () => {
 	});
 
 	it('should change the current terrain to Electric Terrain for five turns', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Florges", ability: 'symbiosis', moves: ['mist', 'electricterrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Florges", ability: 'symbiosis', moves: ['mist'] }] });
+		battle = common.createBattle([[
+			{ species: "Florges", ability: 'symbiosis', moves: ['mist', 'electricterrain'] },
+		], [
+			{ species: "Florges", ability: 'symbiosis', moves: ['mist'] },
+		]]);
 		battle.makeChoices('move electricterrain', 'move mist');
 		assert(battle.field.isTerrain('electricterrain'));
 		battle.makeChoices('move electricterrain', 'move mist');
@@ -27,9 +29,11 @@ describe('Electric Terrain', () => {
 	});
 
 	it('should increase the base power of Electric-type attacks used by grounded Pokemon', () => {
-		battle = common.gen(7).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Thundurus", ability: 'defiant', moves: ['thunderwave'] }] });
+		battle = common.gen(7).createBattle([[
+			{ species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain'] },
+		], [
+			{ species: "Thundurus", ability: 'defiant', moves: ['thunderwave'] },
+		]]);
 		battle.makeChoices('move electricterrain', 'move thunderwave');
 		let basePower;
 		const move = Dex.moves.get('thunderbolt');
@@ -40,9 +44,11 @@ describe('Electric Terrain', () => {
 	});
 
 	it('should prevent moves from putting grounded Pokemon to sleep', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'spore'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Abra", ability: 'magicguard', moves: ['telekinesis', 'spore'] }] });
+		battle = common.createBattle([[
+			{ species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'spore'] },
+		], [
+			{ species: "Abra", ability: 'magicguard', moves: ['telekinesis', 'spore'] },
+		]]);
 		battle.makeChoices('move electricterrain', 'move telekinesis');
 		battle.makeChoices('move spore', 'move spore');
 		assert.equal(battle.p1.active[0].status, 'slp');
@@ -50,17 +56,21 @@ describe('Electric Terrain', () => {
 	});
 
 	it('should not remove active non-volatile statuses from grounded Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Jolteon", ability: 'voltabsorb', moves: ['sleeptalk', 'electricterrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Whimsicott", ability: 'prankster', moves: ['spore'] }] });
+		battle = common.createBattle([[
+			{ species: "Jolteon", ability: 'voltabsorb', moves: ['sleeptalk', 'electricterrain'] },
+		], [
+			{ species: "Whimsicott", ability: 'prankster', moves: ['spore'] },
+		]]);
 		battle.makeChoices('move sleeptalk', 'move spore');
 		assert.equal(battle.p1.active[0].status, 'slp');
 	});
 
 	it('should prevent Yawn from putting grounded Pokemon to sleep, and cause Yawn to fail', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'yawn'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sableye", ability: 'prankster', moves: ['yawn'] }] });
+		battle = common.createBattle([[
+			{ species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain', 'yawn'] },
+		], [
+			{ species: "Sableye", ability: 'prankster', moves: ['yawn'] },
+		]]);
 		battle.makeChoices('move electricterrain', 'move yawn');
 		battle.makeChoices('move yawn', 'move yawn');
 		assert.equal(battle.p1.active[0].status, '');
@@ -68,9 +78,11 @@ describe('Electric Terrain', () => {
 	});
 
 	it('should cause Rest to fail on grounded Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Jolteon", ability: 'shellarmor', moves: ['electricterrain', 'rest'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Jolteon", ability: 'shellarmor', moves: ['electricterrain', 'rest'] },
+		], [
+			{ species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest'] },
+		]]);
 		battle.makeChoices('move electricterrain', 'move doubleedge');
 		battle.makeChoices('move rest', 'move rest');
 		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
@@ -78,9 +90,11 @@ describe('Electric Terrain', () => {
 	});
 
 	it('should not affect Pokemon in a semi-invulnerable state', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', moves: ['yawn', 'skydrop'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sableye", ability: 'prankster', moves: ['yawn', 'electricterrain'] }] });
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', moves: ['yawn', 'skydrop'] },
+		], [
+			{ species: "Sableye", ability: 'prankster', moves: ['yawn', 'electricterrain'] },
+		]]);
 		battle.makeChoices('move yawn', 'move yawn');
 		battle.makeChoices('move skydrop', 'move electricterrain');
 		assert.equal(battle.p1.active[0].status, 'slp');
@@ -88,9 +102,11 @@ describe('Electric Terrain', () => {
 	});
 
 	it('should cause Nature Power to become Thunderbolt', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Shuckle", ability: 'sturdy', moves: ['naturepower'] }] });
+		battle = common.createBattle([[
+			{ species: "Jolteon", ability: 'voltabsorb', moves: ['electricterrain'] },
+		], [
+			{ species: "Shuckle", ability: 'sturdy', moves: ['naturepower'] },
+		]]);
 		battle.makeChoices('move electricterrain', 'move naturepower');
 		const resultMove = toID(battle.log[battle.lastMoveLine].split('|')[3]);
 		assert.equal(resultMove, 'thunderbolt');

--- a/test/sim/moves/embargo.js
+++ b/test/sim/moves/embargo.js
@@ -11,26 +11,32 @@ describe('Embargo', () => {
 	});
 
 	it('should negate residual healing events', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Lopunny", ability: 'limber', item: 'leftovers', moves: ['bellydrum'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Giratina", ability: 'pressure', moves: ['embargo'] }] });
+		battle = common.createBattle([[
+			{ species: "Lopunny", ability: 'limber', item: 'leftovers', moves: ['bellydrum'] },
+		], [
+			{ species: "Giratina", ability: 'pressure', moves: ['embargo'] },
+		]]);
 		battle.makeChoices('move bellydrum', 'move embargo');
 		assert.equal(battle.p1.active[0].hp, Math.ceil(battle.p1.active[0].maxhp / 2));
 	});
 
 	it('should prevent items from being consumed', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Lopunny", ability: 'limber', item: 'chopleberry', moves: ['bulkup'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Golem", ability: 'noguard', moves: ['embargo', 'lowkick'] }] });
+		battle = common.createBattle([[
+			{ species: "Lopunny", ability: 'limber', item: 'chopleberry', moves: ['bulkup'] },
+		], [
+			{ species: "Golem", ability: 'noguard', moves: ['embargo', 'lowkick'] },
+		]]);
 		battle.makeChoices('move bulkup', 'move embargo');
 		battle.makeChoices('move bulkup', 'move lowkick');
 		assert.equal(battle.p1.active[0].item, 'chopleberry');
 	});
 
 	it('should ignore the effects of items that disable moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Lopunny", ability: 'limber', item: 'assaultvest', moves: ['protect'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Golem", ability: 'noguard', moves: ['embargo'] }] });
+		battle = common.createBattle([[
+			{ species: "Lopunny", ability: 'limber', item: 'assaultvest', moves: ['protect'] },
+		], [
+			{ species: "Golem", ability: 'noguard', moves: ['embargo'] },
+		]]);
 		battle.makeChoices('default', 'move embargo');
 		assert.equal(battle.p1.active[0].lastMove.id, 'struggle');
 		battle.makeChoices('default', 'move embargo');
@@ -38,17 +44,21 @@ describe('Embargo', () => {
 	});
 
 	it('should cause Fling to fail', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Lopunny", ability: 'limber', item: 'seaincense', moves: ['fling'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sableye", ability: 'prankster', moves: ['embargo'] }] });
+		battle = common.createBattle([[
+			{ species: "Lopunny", ability: 'limber', item: 'seaincense', moves: ['fling'] },
+		], [
+			{ species: "Sableye", ability: 'prankster', moves: ['embargo'] },
+		]]);
 		battle.makeChoices('move fling', 'move embargo');
 		assert.equal(battle.p1.active[0].item, 'seaincense');
 	});
 
 	it('should not prevent Pokemon from Mega Evolving', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Lopunny", ability: 'limber', item: 'lopunnite', moves: ['bulkup'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Golem", ability: 'noguard', moves: ['embargo', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Lopunny", ability: 'limber', item: 'lopunnite', moves: ['bulkup'] },
+		], [
+			{ species: "Golem", ability: 'noguard', moves: ['embargo', 'rest'] },
+		]]);
 		battle.makeChoices('move bulkup', 'move embargo');
 		battle.makeChoices('move bulkup mega', 'move rest');
 		assert.equal(battle.p1.active[0].species.id, 'lopunnymega');

--- a/test/sim/moves/explosion.js
+++ b/test/sim/moves/explosion.js
@@ -11,9 +11,11 @@ describe('Explosion', () => {
 	});
 
 	it('should not halve defense in current gens', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Metagross", nature: "Adamant", moves: ['explosion'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Hippowdon", nature: "Impish", evs: { hp: 252, def: 252 }, moves: ['splash'] }] });
+		battle = common.createBattle([[
+			{ species: "Metagross", nature: "Adamant", moves: ['explosion'] },
+		], [
+			{ species: "Hippowdon", nature: "Impish", evs: { hp: 252, def: 252 }, moves: ['splash'] },
+		]]);
 		battle.makeChoices('move explosion', 'move splash');
 		const hippo = battle.p2.active[0];
 		const damage = hippo.maxhp - hippo.hp;
@@ -21,9 +23,11 @@ describe('Explosion', () => {
 	});
 
 	it('should halve defense in old gens', () => {
-		battle = common.gen(4).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Metagross", nature: "Adamant", moves: ['explosion'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Hippowdon", nature: "Impish", evs: { hp: 252, def: 252 }, moves: ['splash'] }] });
+		battle = common.gen(4).createBattle([[
+			{ species: "Metagross", nature: "Adamant", moves: ['explosion'] },
+		], [
+			{ species: "Hippowdon", nature: "Impish", evs: { hp: 252, def: 252 }, moves: ['splash'] },
+		]]);
 		battle.makeChoices('move explosion', 'move splash');
 		const hippo = battle.p2.active[0];
 		const damage = hippo.maxhp - hippo.hp;

--- a/test/sim/moves/focuspunch.js
+++ b/test/sim/moves/focuspunch.js
@@ -64,10 +64,13 @@ describe('Focus Punch', () => {
 	});
 
 	it(`should cause the user to lose focus if hit by an attacking move followed by a status move in one turn`, () => {
-		battle = common.createBattle({ gameType: 'doubles' }, [
-			[{ species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch'] }, { species: 'Blissey', ability: 'naturalcure', moves: ['softboiled'] }],
-			[{ species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf'] }, { species: 'Ivysaur', ability: 'overgrow', moves: ['toxic'] }],
-		]);
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch'] },
+			{ species: 'Blissey', ability: 'naturalcure', moves: ['softboiled'] },
+		], [
+			{ species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf'] },
+			{ species: 'Ivysaur', ability: 'overgrow', moves: ['toxic'] },
+		]]);
 		battle.makeChoices('move focuspunch 1, move softboiled', 'move magicalleaf 1, move toxic 1');
 		assert.equal(battle.p1.active[0].status, 'tox');
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);

--- a/test/sim/moves/followme.js
+++ b/test/sim/moves/followme.js
@@ -13,17 +13,15 @@ describe('Follow Me', () => {
 	it('should redirect single-target moves towards it if it is a valid target', function () {
 		this.timeout(5000);
 
-		battle = common.gen(5).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 			{ species: 'Clefable', ability: 'unaware', moves: ['followme'] },
 			{ species: 'Clefairy', ability: 'unaware', moves: ['calmmind'] },
 			{ species: 'Cleffa', ability: 'unaware', moves: ['calmmind'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Abra', ability: 'synchronize', moves: ['lowkick'] },
 			{ species: 'Kadabra', ability: 'synchronize', moves: ['lowkick'] },
 			{ species: 'Alakazam', ability: 'synchronize', moves: ['lowkick'] },
-		] });
+		]]);
 		let hitCount = 0;
 		battle.onEvent('Damage', battle.format, (damage, pokemon) => {
 			if (pokemon.species.id === 'clefable') {
@@ -35,15 +33,13 @@ describe('Follow Me', () => {
 	});
 
 	it('should not redirect self-targeting moves', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Clefable', ability: 'unaware', moves: ['followme'] },
 			{ species: 'Clefairy', ability: 'unaware', moves: ['softboiled'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Alakazam', ability: 'synchronize', moves: ['honeclaws'] },
 			{ species: 'Kadabra', ability: 'synchronize', moves: ['honeclaws'] },
-		] });
+		]]);
 		battle.makeChoices('move followme, move softboiled', 'move honeclaws, move honeclaws');
 		assert.equal(battle.p1.active[0].boosts['atk'], 0);
 		assert.equal(battle.p2.active[0].boosts['atk'], 1);

--- a/test/sim/moves/foresight.js
+++ b/test/sim/moves/foresight.js
@@ -11,9 +11,11 @@ describe('Foresight', () => {
 	});
 
 	it('should negate Normal and Fighting immunities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', moves: ['foresight', 'vitalthrow', 'tackle'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Dusknoir", ability: 'prankster', moves: ['recover'] }] });
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', moves: ['foresight', 'vitalthrow', 'tackle'] },
+		], [
+			{ species: "Dusknoir", ability: 'prankster', moves: ['recover'] },
+		]]);
 		battle.makeChoices('move foresight', 'move recover');
 		battle.makeChoices('move vitalthrow', 'move recover');
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
@@ -22,9 +24,11 @@ describe('Foresight', () => {
 	});
 
 	it('should ignore the effect of positive evasion stat stages', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', moves: ['avalanche', 'foresight'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Forretress", ability: 'sturdy', moves: ['synthesis'] }] });
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', moves: ['avalanche', 'foresight'] },
+		], [
+			{ species: "Forretress", ability: 'sturdy', moves: ['synthesis'] },
+		]]);
 		battle.makeChoices('move foresight', 'move synthesis');
 		battle.boost({ evasion: 6 }, battle.p2.active[0]);
 		for (let i = 0; i < 7; i++) {
@@ -34,9 +38,11 @@ describe('Foresight', () => {
 	});
 
 	it('should not ignore the effect of negative evasion stat stages', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', moves: ['zapcannon', 'dynamicpunch', 'foresight'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Zapdos", ability: 'owntempo', moves: ['roost'] }] });
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', moves: ['zapcannon', 'dynamicpunch', 'foresight'] },
+		], [
+			{ species: "Zapdos", ability: 'owntempo', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move foresight', 'move roost');
 		battle.boost({ spe: 6, evasion: -6 }, battle.p2.active[0]);
 		for (let i = 0; i < 7; i++) {

--- a/test/sim/moves/gearup.js
+++ b/test/sim/moves/gearup.js
@@ -11,17 +11,15 @@ describe('Gear Up', () => {
 	});
 
 	it('should boost the Attack and Special Attack of all active allies with Plus or Minus', () => {
-		battle = common.gen(5).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 			{ species: "Minun", ability: 'minus', moves: ['sleeptalk'] },
 			{ species: "Klinklang", ability: 'plus', moves: ['gearup'] },
 			{ species: "Pyukumuku", ability: 'innardsout', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Plusle", ability: 'plus', moves: ['sleeptalk'] },
 			{ species: "Klinklang", ability: 'minus', moves: ['gearup'] },
 			{ species: "Pyukumuku", ability: 'innardsout', moves: ['sleeptalk'] },
-		] });
+		]]);
 		battle.makeChoices('move sleeptalk, move gearup, move sleeptalk', 'move sleeptalk, move gearup, move sleeptalk');
 		for (const active of battle.getAllActive()) {
 			if (active.name === 'Pyukumuku') continue;

--- a/test/sim/moves/glare.js
+++ b/test/sim/moves/glare.js
@@ -11,9 +11,11 @@ describe('Glare', () => {
 	});
 
 	it('should ignore natural type immunities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Arbok", ability: 'noguard', moves: ['glare'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Gengar", ability: 'blaze', moves: ['bulkup'] }] });
+		battle = common.createBattle([[
+			{ species: "Arbok", ability: 'noguard', moves: ['glare'] },
+		], [
+			{ species: "Gengar", ability: 'blaze', moves: ['bulkup'] },
+		]]);
 		battle.makeChoices('move glare', 'move bulkup');
 		assert.equal(battle.p2.active[0].status, 'par');
 	});
@@ -25,10 +27,11 @@ describe('Glare [Gen 3]', () => {
 	});
 
 	it('should not ignore natural type immunities', () => {
-		battle = common.gen(3).createBattle([
-			[{ species: "Arbok", ability: 'noguard', moves: ['glare'] }],
-			[{ species: "Gengar", ability: 'blaze', moves: ['bulkup'] }],
-		]);
+		battle = common.gen(3).createBattle([[
+			{ species: "Arbok", ability: 'noguard', moves: ['glare'] },
+		], [
+			{ species: "Gengar", ability: 'blaze', moves: ['bulkup'] },
+		]]);
 		battle.makeChoices('move glare', 'move bulkup');
 		assert.equal(battle.p2.active[0].status, '');
 	});

--- a/test/sim/moves/gmaxwildfire.js
+++ b/test/sim/moves/gmaxwildfire.js
@@ -11,29 +11,25 @@ describe('G-Max Wildfire', () => {
 	});
 
 	it('should not damage Fire-types', () => {
-		battle = common.gen(8).createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(8).createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Charizard', moves: ['ember'], gigantamax: true },
 			{ species: 'Wynaut', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Wynaut', moves: ['sleeptalk'] },
 			{ species: 'Flareon', moves: ['sleeptalk'] },
-		] });
+		]]);
 		battle.makeChoices('move ember 1 dynamax, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		assert.fullHP(battle.p2.active[1]);
 	});
 
 	it('should deal damage for four turns, including the fourth turn', () => {
-		battle = common.gen(8).createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(8).createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Charizard', moves: ['ember', 'sleeptalk'], gigantamax: true },
 			{ species: 'Wynaut', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Wynaut', moves: ['sleeptalk'] },
 			{ species: 'Flareon', moves: ['sleeptalk'] },
-		] });
+		]]);
 		battle.makeChoices('move ember 2 dynamax, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');

--- a/test/sim/moves/gravity.js
+++ b/test/sim/moves/gravity.js
@@ -11,25 +11,31 @@ describe('Gravity', () => {
 	});
 
 	it('should ground Flying-type Pokemon and remove their Ground immunity', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Aerodactyl', ability: 'pressure', moves: ['gravity'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Aron', ability: 'sturdy', moves: ['earthpower'] }] });
+		battle = common.createBattle([[
+			{ species: 'Aerodactyl', ability: 'pressure', moves: ['gravity'] },
+		], [
+			{ species: 'Aron', ability: 'sturdy', moves: ['earthpower'] },
+		]]);
 		battle.makeChoices('move gravity', 'move earthpower');
 		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should ground Pokemon with Levitate and remove their Ground immunity', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Rotom', ability: 'levitate', moves: ['gravity'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Aron', ability: 'sturdy', moves: ['earthpower'] }] });
+		battle = common.createBattle([[
+			{ species: 'Rotom', ability: 'levitate', moves: ['gravity'] },
+		], [
+			{ species: 'Aron', ability: 'sturdy', moves: ['earthpower'] },
+		]]);
 		battle.makeChoices('move gravity', 'move earthpower');
 		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should interrupt and disable the use of airborne moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Spiritomb', ability: 'pressure', moves: ['gravity'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Aerodactyl', ability: 'pressure', moves: ['fly'] }] });
+		battle = common.createBattle([[
+			{ species: 'Spiritomb', ability: 'pressure', moves: ['gravity'] },
+		], [
+			{ species: 'Aerodactyl', ability: 'pressure', moves: ['fly'] },
+		]]);
 		battle.makeChoices('move gravity', 'move fly');
 		assert(!battle.p2.active[0].volatiles['twoturnmove']);
 		assert.cantMove(() => battle.makeChoices('move gravity', 'move fly'), 'Aerodactyl', 'Fly');

--- a/test/sim/moves/haze.js
+++ b/test/sim/moves/haze.js
@@ -11,10 +11,11 @@ describe('[Gen 1] Haze', () => {
 	});
 
 	it('should remove stat changes', () => {
-		battle = common.gen(1).createBattle([
-			[{ species: "Mew", moves: ['agility', 'haze'] }],
-			[{ species: "Mewtwo", moves: ['swordsdance', 'splash'] }],
-		]);
+		battle = common.gen(1).createBattle([[
+			{ species: "Mew", moves: ['agility', 'haze'] },
+		], [
+			{ species: "Mewtwo", moves: ['swordsdance', 'splash'] },
+		]]);
 
 		battle.makeChoices('move agility', 'move swordsdance');
 		assert.equal(battle.p1.active[0].boosts.spe, 2);
@@ -54,10 +55,11 @@ describe('[Gen 1] Haze', () => {
 	});
 
 	it('should remove focus energy in gen 1', () => {
-		battle = common.gen(1).createBattle([
-			[{ species: "Mew", moves: ['splash'] }],
-			[{ species: "Mewtwo", moves: ['focusenergy', 'haze'] }],
-		]);
+		battle = common.gen(1).createBattle([[
+			{ species: "Mew", moves: ['splash'] },
+		], [
+			{ species: "Mewtwo", moves: ['focusenergy', 'haze'] },
+		]]);
 
 		battle.makeChoices('move splash', 'move focusenergy');
 		assert(battle.p2.active[0].volatiles['focusenergy']);
@@ -67,10 +69,11 @@ describe('[Gen 1] Haze', () => {
 	});
 
 	it('should remove reflect and light screen', () => {
-		battle = common.gen(1).createBattle([
-			[{ species: "Mew", moves: ['reflect', 'lightscreen', 'haze'] }],
-			[{ species: "Mewtwo", moves: ['splash'] }],
-		]);
+		battle = common.gen(1).createBattle([[
+			{ species: "Mew", moves: ['reflect', 'lightscreen', 'haze'] },
+		], [
+			{ species: "Mewtwo", moves: ['splash'] },
+		]]);
 
 		battle.makeChoices('move reflect', 'move splash');
 		assert(battle.p1.active[0].volatiles['reflect']);
@@ -145,10 +148,11 @@ describe('[Gen 1] Haze', () => {
 	});
 
 	it('should not remove substitute from either side', () => {
-		battle = common.gen(1).createBattle([
-			[{ species: "Mew", moves: ['substitute', 'haze'] }],
-			[{ species: "Muk", moves: ['substitute', 'splash'] }],
-		]);
+		battle = common.gen(1).createBattle([[
+			{ species: "Mew", moves: ['substitute', 'haze'] },
+		], [
+			{ species: "Muk", moves: ['substitute', 'splash'] },
+		]]);
 
 		battle.makeChoices('move substitute', 'move substitute');
 		battle.makeChoices('move haze', 'move splash');
@@ -157,10 +161,11 @@ describe('[Gen 1] Haze', () => {
 	});
 
 	it.skip('should not allow a previously sleeping opponent to move on the same turn', () => {
-		battle = common.gen(1).createBattle([
-			[{ species: "Mew", moves: ['spore', 'haze', 'tackle'] }],
-			[{ species: "Muk", moves: ['splash'] }],
-		]);
+		battle = common.gen(1).createBattle([[
+			{ species: "Mew", moves: ['spore', 'haze', 'tackle'] },
+		], [
+			{ species: "Muk", moves: ['splash'] },
+		]]);
 		battle.makeChoices('move spore', 'auto');
 		battle.makeChoices('move haze', 'auto');
 		assert.equal(battle.lastMove.name, 'Haze');
@@ -170,10 +175,11 @@ describe('[Gen 1] Haze', () => {
 	});
 
 	it.skip('should not allow a previously frozen opponent to move on the same turn', () => {
-		battle = common.gen(1).createBattle([
-			[{ species: "Mew", moves: ['haze', 'icebeam'] }],
-			[{ species: "Muk", moves: ['splash'] }],
-		]);
+		battle = common.gen(1).createBattle([[
+			{ species: "Mew", moves: ['haze', 'icebeam'] },
+		], [
+			{ species: "Muk", moves: ['splash'] },
+		]]);
 		battle.p2.active[0].trySetStatus('frz', battle.p2.active[0]);
 		battle.makeChoices('move icebeam', 'auto');
 		assert.equal(battle.p2.active[0].status, 'frz');
@@ -188,10 +194,11 @@ describe('[Gen 4] Haze', () => {
 	});
 
 	it('should remove focus energy in gen 4', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Mew", moves: ['splash'] }],
-			[{ species: "Mewtwo", moves: ['focusenergy', 'haze'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Mew", moves: ['splash'] },
+		], [
+			{ species: "Mewtwo", moves: ['focusenergy', 'haze'] },
+		]]);
 
 		battle.makeChoices('move splash', 'move focusenergy');
 		assert(battle.p2.active[0].volatiles['focusenergy']);
@@ -200,10 +207,11 @@ describe('[Gen 4] Haze', () => {
 		assert.equal(battle.p2.active[0].volatiles['focusenergy'], undefined);
 	});
 	it('should not remove focus energy in other gens', () => {
-		battle = common.gen(3).createBattle([
-			[{ species: "Mew", moves: ['splash'] }],
-			[{ species: "Mewtwo", moves: ['focusenergy', 'haze'] }],
-		]);
+		battle = common.gen(3).createBattle([[
+			{ species: "Mew", moves: ['splash'] },
+		], [
+			{ species: "Mewtwo", moves: ['focusenergy', 'haze'] },
+		]]);
 
 		battle.makeChoices('move splash', 'move focusenergy');
 		assert(battle.p2.active[0].volatiles['focusenergy']);

--- a/test/sim/moves/healblock.js
+++ b/test/sim/moves/healblock.js
@@ -11,42 +11,52 @@ describe('Heal Block', () => {
 	});
 
 	it('should prevent Pokemon from gaining HP from residual recovery items', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Hippowdon', ability: 'sandstream', moves: ['healblock'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind'] }] });
+		battle = common.createBattle([[
+			{ species: 'Hippowdon', ability: 'sandstream', moves: ['healblock'] },
+		], [
+			{ species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move healblock', 'move calmmind');
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should prevent Pokemon from consuming HP recovery items', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Pansage', ability: 'gluttony', item: 'berryjuice', moves: ['bellydrum'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] },
+		], [
+			{ species: 'Pansage', ability: 'gluttony', item: 'berryjuice', moves: ['bellydrum'] },
+		]]);
 		battle.makeChoices('move healblock', 'move bellydrum');
 		assert.equal(battle.p2.active[0].item, 'berryjuice');
 		assert.equal(battle.p2.active[0].hp, Math.ceil(battle.p2.active[0].maxhp / 2));
 	});
 
 	it('should disable the use of healing moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Cresselia', ability: 'levitate', moves: ['recover'] }] });
+		battle = common.createBattle([[
+			{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock'] },
+		], [
+			{ species: 'Cresselia', ability: 'levitate', moves: ['recover'] },
+		]]);
 		battle.makeChoices('move healblock', 'move recover');
 		assert.cantMove(() => battle.makeChoices('move healblock', 'move recover'), 'Cresselia', 'Recover');
 	});
 
 	it('should prevent Pokemon from using draining moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Venusaur', ability: 'overgrow', moves: ['gigadrain'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] },
+		], [
+			{ species: 'Venusaur', ability: 'overgrow', moves: ['gigadrain'] },
+		]]);
 		battle.makeChoices('move healblock', 'move gigadrain');
 		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should prevent abilities from recovering HP', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['healblock', 'surf'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['healblock', 'surf'] },
+		], [
+			{ species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind'] },
+		]]);
 		battle.makeChoices('move healblock', 'move bellydrum');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move surf', 'move calmmind');
@@ -54,9 +64,11 @@ describe('Heal Block', () => {
 	});
 
 	it('should prevent Leech Seed from healing HP', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Starmie', ability: 'noguard', moves: ['healblock'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed'] }] });
+		battle = common.createBattle([[
+			{ species: 'Starmie', ability: 'noguard', moves: ['healblock'] },
+		], [
+			{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed'] },
+		]]);
 		battle.makeChoices('move healblock', 'move substitute');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move leechseed');
@@ -65,9 +77,11 @@ describe('Heal Block', () => {
 	});
 
 	it('should not prevent the target from using Z-Powered healing status moves or healing from Z Power', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Beheeyem', ability: 'telepathy', item: 'normaliumz', moves: ['psychic', 'healblock', 'recover'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Elgyem', ability: 'telepathy', item: 'psychiumz', moves: ['psychic', 'healblock', 'teleport'] }] });
+		battle = common.createBattle([[
+			{ species: 'Beheeyem', ability: 'telepathy', item: 'normaliumz', moves: ['psychic', 'healblock', 'recover'] },
+		], [
+			{ species: 'Elgyem', ability: 'telepathy', item: 'psychiumz', moves: ['psychic', 'healblock', 'teleport'] },
+		]]);
 		battle.makeChoices('move psychic', 'move psychic');
 		battle.makeChoices('move healblock', 'move healblock');
 		battle.makeChoices('move recover zmove', 'move teleport zmove');
@@ -82,38 +96,42 @@ describe('Heal Block [Gen 5]', () => {
 	});
 
 	it('should prevent Pokemon from gaining HP from residual recovery items', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: 'Hippowdon', ability: 'sandstream', moves: ['healblock'] }],
-			[{ species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: 'Hippowdon', ability: 'sandstream', moves: ['healblock'] },
+		], [
+			{ species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move healblock', 'move calmmind');
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should prevent Pokemon from consuming HP recovery items', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] }],
-			[{ species: 'Pansage', ability: 'gluttony', item: 'sitrusberry', moves: ['bellydrum'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] },
+		], [
+			{ species: 'Pansage', ability: 'gluttony', item: 'sitrusberry', moves: ['bellydrum'] },
+		]]);
 		battle.makeChoices('move healblock', 'move bellydrum');
 		assert.equal(battle.p2.active[0].item, 'sitrusberry');
 		assert.equal(battle.p2.active[0].hp, Math.ceil(battle.p2.active[0].maxhp / 2));
 	});
 
 	it('should disable the use of healing moves', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock'] }],
-			[{ species: 'Cresselia', ability: 'levitate', moves: ['recover'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock'] },
+		], [
+			{ species: 'Cresselia', ability: 'levitate', moves: ['recover'] },
+		]]);
 		battle.makeChoices('move healblock', 'move recover');
 		assert.cantMove(() => battle.makeChoices('move healblock', 'move recover'), 'Cresselia', 'Recover');
 	});
 
 	it('should prevent abilities from recovering HP', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: 'Sableye', ability: 'prankster', moves: ['healblock', 'surf'] }],
-			[{ species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['healblock', 'surf'] },
+		], [
+			{ species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind'] },
+		]]);
 		battle.makeChoices('move healblock', 'move bellydrum');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move surf', 'move calmmind');
@@ -121,10 +139,11 @@ describe('Heal Block [Gen 5]', () => {
 	});
 
 	it('should prevent draining moves from healing HP', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] }],
-			[{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'gigadrain'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] },
+		], [
+			{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'gigadrain'] },
+		]]);
 		battle.makeChoices('move healblock', 'move substitute');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move gigadrain');
@@ -133,10 +152,11 @@ describe('Heal Block [Gen 5]', () => {
 	});
 
 	it('should prevent Leech Seed from healing HP', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: 'Starmie', ability: 'noguard', moves: ['healblock'] }],
-			[{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: 'Starmie', ability: 'noguard', moves: ['healblock'] },
+		], [
+			{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed'] },
+		]]);
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move leechseed');
 		assert.equal(battle.p2.active[0].hp, hp);
@@ -150,28 +170,31 @@ describe('Heal Block [Gen 4]', () => {
 	});
 
 	it('should disable the use of healing moves', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock'] }],
-			[{ species: 'Cresselia', ability: 'levitate', moves: ['recover'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock'] },
+		], [
+			{ species: 'Cresselia', ability: 'levitate', moves: ['recover'] },
+		]]);
 		battle.makeChoices('move healblock', 'move recover');
 		assert.cantMove(() => battle.makeChoices('move healblock', 'move recover'), 'Cresselia', 'Recover');
 	});
 
 	it('should block the effect of Wish', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock'] }],
-			[{ species: 'Deoxys', ability: 'pressure', moves: ['wish'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock'] },
+		], [
+			{ species: 'Deoxys', ability: 'pressure', moves: ['wish'] },
+		]]);
 		battle.makeChoices('move healblock', 'move wish');
 		assert.cantMove(() => battle.makeChoices('move healblock', 'move wish'), 'Deoxys', 'Wish');
 	});
 
 	it('should prevent draining moves from healing HP', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] }],
-			[{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'gigadrain'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['healblock'] },
+		], [
+			{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'gigadrain'] },
+		]]);
 		battle.makeChoices('move healblock', 'move substitute');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move gigadrain');
@@ -180,10 +203,12 @@ describe('Heal Block [Gen 4]', () => {
 	});
 
 	it('should allow HP recovery items to activate', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock', 'shadowball'] }],
-			[{ species: 'Abra', level: 1, ability: 'synchronize', item: 'leftovers', moves: ['celebrate', 'endure'] }, { species: 'Abra', level: 1, ability: 'synchronize', item: 'sitrusberry', moves: ['celebrate', 'endure'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: 'Spiritomb', ability: 'pressure', moves: ['healblock', 'shadowball'] },
+		], [
+			{ species: 'Abra', level: 1, ability: 'synchronize', item: 'leftovers', moves: ['celebrate', 'endure'] },
+			{ species: 'Abra', level: 1, ability: 'synchronize', item: 'sitrusberry', moves: ['celebrate', 'endure'] },
+		]]);
 		battle.makeChoices('move healblock', 'move celebrate');
 		battle.makeChoices('move shadowball', 'move endure');
 		assert.notEqual(battle.p2.active[0].hp, 1);
@@ -194,10 +219,11 @@ describe('Heal Block [Gen 4]', () => {
 	});
 
 	it('should allow abilities that recover HP to activate', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: 'Sableye', ability: 'keeneye', moves: ['healblock', 'surf'] }],
-			[{ species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: 'Sableye', ability: 'keeneye', moves: ['healblock', 'surf'] },
+		], [
+			{ species: 'Quagsire', ability: 'waterabsorb', moves: ['bellydrum', 'calmmind'] },
+		]]);
 		battle.makeChoices('move healblock', 'move bellydrum');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move surf', 'move calmmind');
@@ -205,10 +231,11 @@ describe('Heal Block [Gen 4]', () => {
 	});
 
 	it('should prevent Leech Seed from healing HP', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: 'Starmie', ability: 'noguard', moves: ['healblock'] }],
-			[{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: 'Starmie', ability: 'noguard', moves: ['healblock'] },
+		], [
+			{ species: 'Venusaur', ability: 'overgrow', moves: ['substitute', 'leechseed'] },
+		]]);
 		battle.makeChoices('move healblock', 'move substitute');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move leechseed');

--- a/test/sim/moves/healingwish.js
+++ b/test/sim/moves/healingwish.js
@@ -11,15 +11,13 @@ describe('Healing Wish', () => {
 	});
 
 	it('should heal a switch-in for full before hazards at end of turn', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Caterpie', ability: 'shielddust', moves: ['stringshot'] },
 			{ species: 'Jirachi', ability: 'serenegrace', moves: ['healingwish', 'protect'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Shedinja', ability: 'wonderguard', moves: ['endeavor'] },
 			{ species: 'Tyranitar', ability: 'sandstream', moves: ['seismictoss', 'stealthrock'] },
-		] });
+		]]);
 
 		battle.makeChoices('move stringshot', 'move endeavor'); // set Caterpie to 1hp
 		battle.makeChoices('switch jirachi', 'switch tyranitar'); // set up Sand
@@ -33,14 +31,12 @@ describe('Healing Wish', () => {
 	});
 
 	it('should not be consumed if a switch-in is fully healed already', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Jirachi', ability: 'serenegrace', moves: ['healingwish', 'protect'] },
 			{ species: 'Caterpie', ability: 'shielddust', moves: ['stringshot'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Tyranitar', ability: 'sandstream', moves: ['seismictoss', 'stealthrock'] },
-		] });
+		]]);
 		battle.makeChoices('move protect', 'move stealthrock'); // set up Sand and Stealth Rock
 		battle.makeChoices('move healingwish', 'move seismictoss');
 		assert.equal(battle.requestState, 'switch');
@@ -50,16 +46,14 @@ describe('Healing Wish', () => {
 	});
 
 	it('should heal an ally fully after Ally Switch', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Jirachi', ability: 'serenegrace', moves: ['healingwish'] },
 			{ species: 'Caterpie', ability: 'shielddust', moves: ['stringshot'] },
 			{ species: 'Rotom', ability: 'levitate', moves: ['allyswitch'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Garchomp', ability: 'sandveil', moves: ['sleeptalk'] },
 			{ species: 'Shedinja', ability: 'wonderguard', moves: ['endeavor', 'protect'] },
-		] });
+		]]);
 		// set up Healing Wish, Caterpie is at 1 HP
 		battle.makeChoices('move healingwish, move stringshot', 'move sleeptalk, move endeavor 2');
 		assert.equal(battle.requestState, 'switch');
@@ -110,16 +104,14 @@ describe('Healing Wish', () => {
 	});
 
 	it('[Gen 4] should heal a switch-in for full after hazards mid-turn', () => {
-		battle = common.gen(4).createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(4).createBattle([[
 			{ species: 'Caterpie', ability: 'shielddust', moves: ['stringshot'] },
 			{ species: 'Raichu', ability: 'lightningrod', moves: ['growl'] },
 			{ species: 'Jirachi', ability: 'serenegrace', moves: ['healingwish'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Shedinja', ability: 'wonderguard', moves: ['endeavor'] },
 			{ species: 'Tyranitar', ability: 'sandstream', moves: ['seismictoss', 'stealthrock'] },
-		] });
+		]]);
 
 		battle.makeChoices('move String Shot', 'move Endeavor'); // set Caterpie to 1hp
 

--- a/test/sim/moves/highjumpkick.js
+++ b/test/sim/moves/highjumpkick.js
@@ -11,26 +11,22 @@ describe('High Jump Kick', () => {
 	});
 
 	it('should damage the user if it does not hit the target', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Gastly', ability: 'levitate', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Hitmonlee', ability: 'limber', moves: ['highjumpkick'] },
-		] });
+		]]);
 
 		assert.hurts(battle.p2.active[0], () => battle.makeChoices());
 	});
 
 	it('should not damage the user if there was no target', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Dugtrio', ability: 'sandveil', moves: ['memento'] },
 			{ species: 'Dugtrio', ability: 'sandveil', moves: ['memento'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Hitmonlee', ability: 'limber', moves: ['highjumpkick'] },
-		] });
+		]]);
 
 		assert.false.hurts(battle.p2.active[0], () => battle.makeChoices());
 	});

--- a/test/sim/moves/hypervoice.js
+++ b/test/sim/moves/hypervoice.js
@@ -11,9 +11,11 @@ describe('Hyper Voice', () => {
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'hypervoice'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'hypervoice'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move hypervoice', 'move rest');
 		assert.equal(battle.p2.active[0].item, '');
@@ -26,10 +28,11 @@ describe('Hyper Voice [Gen 5]', () => {
 	});
 
 	it('should not pierce through substitutes', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'hypervoice'] }],
-			[{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'hypervoice'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move hypervoice', 'move rest');
 		assert.equal(battle.p2.active[0].item, 'focussash');

--- a/test/sim/moves/imprison.js
+++ b/test/sim/moves/imprison.js
@@ -11,15 +11,13 @@ describe('Imprison', () => {
 	});
 
 	it(`should prevent foes from using moves that the user knows`, () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Abra', ability: 'prankster', moves: ['imprison', 'calmmind', 'batonpass'] },
 			{ species: 'Kadabra', ability: 'prankster', moves: ['imprison', 'calmmind'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Abra', ability: 'synchronize', moves: ['calmmind', 'gravity'] },
 			{ species: 'Kadabra', ability: 'prankster', moves: ['imprison', 'calmmind'] },
-		] });
+		]]);
 
 		battle.makeChoices('move imprison', 'move calmmind');
 		assert.statStage(battle.p2.active[0], 'spa', 0);
@@ -48,9 +46,11 @@ describe('Imprison', () => {
 	});
 
 	it(`should not prevent foes from using Z-Powered Status moves`, () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['imprison', 'sunnyday'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Charmander', ability: 'blaze', item: 'firiumz', moves: ['sunnyday'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['imprison', 'sunnyday'] },
+		], [
+			{ species: 'Charmander', ability: 'blaze', item: 'firiumz', moves: ['sunnyday'] },
+		]]);
 
 		battle.makeChoices('move imprison', 'move sunnyday zmove');
 		assert.statStage(battle.p2.active[0], 'spe', 1);
@@ -58,13 +58,11 @@ describe('Imprison', () => {
 	});
 
 	it(`should not prevent the user from using moves that a foe knows`, () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Abra', ability: 'prankster', moves: ['imprison', 'calmmind', 'batonpass'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Abra', ability: 'synchronize', moves: ['calmmind', 'gravity'] },
-		] });
+		]]);
 		const imprisonUser = battle.p1.active[0];
 
 		battle.makeChoices('move imprison', 'auto');
@@ -81,20 +79,22 @@ describe('Maybe locked and maybe disabled', () => {
 
 	describe('Singles', () => {
 		it(`should not show Imprisoned moves as disabled`, () => {
-			battle = common.createBattle([
-				[{ species: 'Abra', moves: ['imprison', 'tackle'] }],
-				[{ species: 'Abra', moves: ['sleeptalk', 'tackle'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Abra', moves: ['imprison', 'tackle'] },
+			], [
+				{ species: 'Abra', moves: ['sleeptalk', 'tackle'] },
+			]]);
 			battle.makeChoices();
 			let request = battle.p2.activeRequest.active[0];
 			assert(request.maybeDisabled);
 			assert(request.maybeLocked);
 			assert(request.moves.every(move => !move.disabled));
 
-			battle = common.createBattle([
-				[{ species: 'Abra', moves: ['imprison', 'sleeptalk'] }],
-				[{ species: 'Abra', moves: ['sleeptalk'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Abra', moves: ['imprison', 'sleeptalk'] },
+			], [
+				{ species: 'Abra', moves: ['sleeptalk'] },
+			]]);
 			battle.makeChoices();
 			request = battle.p2.activeRequest.active[0];
 			assert(request.maybeDisabled);
@@ -103,10 +103,11 @@ describe('Maybe locked and maybe disabled', () => {
 		});
 
 		it(`should disable moves as the user uses them`, () => {
-			battle = common.createBattle([
-				[{ species: 'Abra', moves: ['imprison', 'tackle', 'growl'] }],
-				[{ species: 'Abra', moves: ['sleeptalk', 'tackle', 'growl'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Abra', moves: ['imprison', 'tackle', 'growl'] },
+			], [
+				{ species: 'Abra', moves: ['sleeptalk', 'tackle', 'growl'] },
+			]]);
 			battle.makeChoices('move imprison', 'move sleeptalk');
 			let request = battle.p2.activeRequest.active[0];
 			assert(request.maybeDisabled);
@@ -131,10 +132,11 @@ describe('Maybe locked and maybe disabled', () => {
 		});
 
 		it(`should lock the user into Struggle if all moves are Imprisoned`, () => {
-			battle = common.createBattle([
-				[{ species: 'Abra', moves: ['imprison', 'sleeptalk', 'tackle'] }],
-				[{ species: 'Abra', moves: ['sleeptalk', 'tackle'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Abra', moves: ['imprison', 'sleeptalk', 'tackle'] },
+			], [
+				{ species: 'Abra', moves: ['sleeptalk', 'tackle'] },
+			]]);
 			battle.makeChoices('move imprison', 'move sleeptalk');
 			const request = battle.p2.activeRequest.active[0];
 			assert(request.maybeDisabled);
@@ -145,10 +147,11 @@ describe('Maybe locked and maybe disabled', () => {
 		});
 
 		it(`should not allow the user to cancel a move`, () => {
-			battle = common.createBattle({ cancel: true }, [
-				[{ species: 'Abra', moves: ['imprison', 'sleeptalk'] }],
-				[{ species: 'Abra', moves: ['sleeptalk', 'tackle'] }],
-			]);
+			battle = common.createBattle({ cancel: true }, [[
+				{ species: 'Abra', moves: ['imprison', 'sleeptalk'] },
+			], [
+				{ species: 'Abra', moves: ['sleeptalk', 'tackle'] },
+			]]);
 			battle.makeChoices('move imprison', 'move sleeptalk');
 			let request = battle.p2.activeRequest.active[0];
 			assert(request.maybeDisabled);
@@ -161,10 +164,11 @@ describe('Maybe locked and maybe disabled', () => {
 			assert.cantUndo(() => battle.undoChoice('p2'));
 			battle.choose('p1', 'auto');
 
-			battle = common.createBattle([
-				[{ species: 'Abra', moves: ['imprison', 'sleeptalk'] }],
-				[{ species: 'Abra', moves: ['sleeptalk'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Abra', moves: ['imprison', 'sleeptalk'] },
+			], [
+				{ species: 'Abra', moves: ['sleeptalk'] },
+			]]);
 			battle.makeChoices('move imprison', 'move sleeptalk');
 			request = battle.p2.activeRequest.active[0];
 			assert(request.maybeDisabled);

--- a/test/sim/moves/ingrain.js
+++ b/test/sim/moves/ingrain.js
@@ -11,14 +11,12 @@ describe('Ingrain', () => {
 	});
 
 	it('should heal the user by 1/16 of its max HP at the end of each turn', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Cradily', ability: 'prankster', moves: ['ingrain', 'batonpass'] },
 			{ species: 'Lileep', ability: 'stormdrain', moves: ['ingrain', 'uturn'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Miltank', ability: 'thickfat', moves: ['seismictoss', 'protect'] },
-		] });
+		]]);
 		battle.makeChoices('move ingrain', 'move seismictoss');
 		assert.equal(battle.p1.active[0].hp, Math.floor(battle.p1.active[0].maxhp * 17 / 16) - 100);
 
@@ -38,12 +36,12 @@ describe('Ingrain', () => {
 	});
 
 	it('should prevent the user from being forced out or switching out', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Cradily', ability: 'stormdrain', moves: ['ingrain'] },
 			{ species: 'Pikachu', ability: 'static', moves: ['thunder'] },
-		] });
-		battle.setPlayer('p2', { team: [{ species: 'Arcanine', ability: 'flashfire', moves: ['sleeptalk', 'roar'] }] });
+		], [
+			{ species: 'Arcanine', ability: 'flashfire', moves: ['sleeptalk', 'roar'] },
+		]]);
 		battle.makeChoices('move ingrain', 'move roar');
 		assert.equal(battle.p1.active[0].species.id, 'cradily');
 		assert.trapped(() => battle.makeChoices('switch pikachu', 'move sleeptalk'));
@@ -51,9 +49,11 @@ describe('Ingrain', () => {
 	});
 
 	it('should remove the users\' Ground immunities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Tropius', ability: 'harvest', moves: ['earthquake', 'ingrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Carnivine', ability: 'levitate', moves: ['earthquake', 'ingrain'] }] });
+		battle = common.createBattle([[
+			{ species: 'Tropius', ability: 'harvest', moves: ['earthquake', 'ingrain'] },
+		], [
+			{ species: 'Carnivine', ability: 'levitate', moves: ['earthquake', 'ingrain'] },
+		]]);
 		battle.makeChoices('move ingrain', 'move ingrain');
 		battle.makeChoices('move earthquake', 'move earthquake');
 		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);

--- a/test/sim/moves/instruct.js
+++ b/test/sim/moves/instruct.js
@@ -9,19 +9,21 @@ describe(`Instruct`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should make the target reuse its last move`, () => {
-		battle = common.createBattle([
-			[{ species: "Cramorant", moves: ['stockpile'] }],
-			[{ species: "Oranguru", moves: ['instruct'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Cramorant", moves: ['stockpile'] },
+		], [
+			{ species: "Oranguru", moves: ['instruct'] },
+		]]);
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].boosts.def, 2);
 	});
 
 	it(`should not trigger AfterMove effects of the instructed move for the Instruct user`, () => {
-		battle = common.createBattle([
-			[{ species: "Swalot", moves: ['stockpile', 'spitup'] }],
-			[{ species: "Duskull", moves: ['stockpile', 'instruct'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Swalot", moves: ['stockpile', 'spitup'] },
+		], [
+			{ species: "Duskull", moves: ['stockpile', 'instruct'] },
+		]]);
 		battle.makeChoices();
 		battle.makeChoices('move spitup', 'move instruct');
 		assert.equal(battle.p2.active[0].boosts.def, 1);

--- a/test/sim/moves/judgment.js
+++ b/test/sim/moves/judgment.js
@@ -9,18 +9,20 @@ describe(`Judgment`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should adapt its type to a held Plate`, () => {
-		battle = common.createBattle([
-			[{ species: "Arceus", ability: 'Honey Gather', item: 'spookyplate', moves: ['judgment'] }],
-			[{ species: "Spiritomb", ability: 'stancechange', moves: ['calmmind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Arceus", ability: 'Honey Gather', item: 'spookyplate', moves: ['judgment'] },
+		], [
+			{ species: "Spiritomb", ability: 'stancechange', moves: ['calmmind'] },
+		]]);
 		assert.hurts(battle.p2.active[0], () => battle.makeChoices('move judgment', 'move calmmind'));
 	});
 
 	it(`should not adapt its type to a held Z Crystal`, () => {
-		battle = common.createBattle([
-			[{ species: "Arceus", ability: 'Honey Gather', item: 'ghostiumz', moves: ['judgment'] }],
-			[{ species: "Spiritomb", ability: 'stancechange', moves: ['calmmind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Arceus", ability: 'Honey Gather', item: 'ghostiumz', moves: ['judgment'] },
+		], [
+			{ species: "Spiritomb", ability: 'stancechange', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move judgment', 'move calmmind');
 		assert.fullHP(battle.p2.active[0]);
 	});

--- a/test/sim/moves/kingsshield.js
+++ b/test/sim/moves/kingsshield.js
@@ -9,28 +9,31 @@ describe(`King's Shield`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should lower the Atk of a contactor by 2 in Gen 7`, () => {
-		battle = common.gen(7).createBattle([
-			[{ species: "Gallade", ability: 'justified', moves: ['zenheadbutt'] }],
-			[{ species: "Aegislash", ability: 'stancechange', moves: ['kingsshield'] }],
-		]);
+		battle = common.gen(7).createBattle([[
+			{ species: "Gallade", ability: 'justified', moves: ['zenheadbutt'] },
+		], [
+			{ species: "Aegislash", ability: 'stancechange', moves: ['kingsshield'] },
+		]]);
 		battle.makeChoices('move zenheadbutt', 'move kingsshield');
 		assert.statStage(battle.p1.active[0], 'atk', -2);
 	});
 
 	it(`should lower the Atk of a contactor by 1 in Gen 8`, () => {
-		battle = common.createBattle([
-			[{ species: "Gallade", ability: 'justified', moves: ['zenheadbutt'] }],
-			[{ species: "Aegislash", ability: 'stancechange', moves: ['kingsshield'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Gallade", ability: 'justified', moves: ['zenheadbutt'] },
+		], [
+			{ species: "Aegislash", ability: 'stancechange', moves: ['kingsshield'] },
+		]]);
 		battle.makeChoices('move zenheadbutt', 'move kingsshield');
 		assert.statStage(battle.p1.active[0], 'atk', -1);
 	});
 
 	it(`should lower the Atk of a contact-move attacker in 2 levels even if immune`, () => {
-		battle = common.createBattle([
-			[{ species: "Gallade", ability: 'justified', moves: ['drainpunch'] }],
-			[{ species: "Aegislash", ability: 'stancechange', moves: ['kingsshield'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Gallade", ability: 'justified', moves: ['drainpunch'] },
+		], [
+			{ species: "Aegislash", ability: 'stancechange', moves: ['kingsshield'] },
+		]]);
 		battle.makeChoices('move drainpunch', 'move kingsshield');
 		assert.statStage(battle.p1.active[0], 'atk', -1);
 	});
@@ -40,10 +43,11 @@ describe(`King's Shield [Gen 6]`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should not lower the Atk of a contact-move attacker if immune`, () => {
-		battle = common.gen(6).createBattle([
-			[{ species: "Gallade", ability: 'justified', moves: ['drainpunch'] }],
-			[{ species: "Aegislash", ability: 'stancechange', moves: ['kingsshield'] }],
-		]);
+		battle = common.gen(6).createBattle([[
+			{ species: "Gallade", ability: 'justified', moves: ['drainpunch'] },
+		], [
+			{ species: "Aegislash", ability: 'stancechange', moves: ['kingsshield'] },
+		]]);
 		battle.makeChoices('move drainpunch', 'move kingsshield');
 		assert.statStage(battle.p1.active[0], 'atk', 0);
 	});

--- a/test/sim/moves/knockoff.js
+++ b/test/sim/moves/knockoff.js
@@ -11,57 +11,71 @@ describe('Knock Off', () => {
 	});
 
 	it('should remove most items', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] },
+		], [
+			{ species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled'] },
+		]]);
 		battle.makeChoices('move knockoff', 'move softboiled');
 		assert.equal(battle.p2.active[0].item, '');
 	});
 
 	it('should not remove items when hitting Sub', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'noability', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Ninjask", ability: 'noability', item: 'shedshell', moves: ['substitute'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'noability', moves: ['knockoff'] },
+		], [
+			{ species: "Ninjask", ability: 'noability', item: 'shedshell', moves: ['substitute'] },
+		]]);
 		battle.makeChoices();
 		assert.equal(battle.p2.active[0].item, 'shedshell');
 	});
 
 	it('should not remove plates from Arceus', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Arceus", ability: 'download', item: 'flameplate', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] },
+		], [
+			{ species: "Arceus", ability: 'download', item: 'flameplate', moves: ['swordsdance'] },
+		]]);
 		battle.makeChoices('move knockoff', 'move swordsdance');
 		assert.equal(battle.p2.active[0].item, 'flameplate');
 	});
 
 	it('should not remove drives from Genesect', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Genesect", ability: 'download', item: 'dousedrive', moves: ['shiftgear'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] },
+		], [
+			{ species: "Genesect", ability: 'download', item: 'dousedrive', moves: ['shiftgear'] },
+		]]);
 		battle.makeChoices('move knockoff', 'move shiftgear');
 		assert.equal(battle.p2.active[0].item, 'dousedrive');
 	});
 
 	it('should not remove correctly held mega stones', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Scizor", ability: 'technician', item: 'scizorite', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] },
+		], [
+			{ species: "Scizor", ability: 'technician', item: 'scizorite', moves: ['swordsdance'] },
+		]]);
 		battle.makeChoices('move knockoff', 'move swordsdance');
 		assert.equal(battle.p2.active[0].item, 'scizorite');
 	});
 
 	it('should remove wrong mega stones', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Scizor", ability: 'technician', item: 'audinite', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['knockoff'] },
+		], [
+			{ species: "Scizor", ability: 'technician', item: 'audinite', moves: ['swordsdance'] },
+		]]);
 		battle.makeChoices('move knockoff', 'move swordsdance');
 		assert.equal(battle.p2.active[0].item, '');
 	});
 
 	it('should not remove items if the user faints mid-move', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Shedinja", ability: 'wonderguard', moves: ['knockoff'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Ferrothorn", ability: 'ironbarbs', item: 'rockyhelmet', moves: ['curse'] }] });
+		battle = common.createBattle([[
+			{ species: "Shedinja", ability: 'wonderguard', moves: ['knockoff'] },
+		], [
+			{ species: "Ferrothorn", ability: 'ironbarbs', item: 'rockyhelmet', moves: ['curse'] },
+		]]);
 		battle.makeChoices('move knockoff', 'move curse');
 		assert.equal(battle.p2.active[0].item, 'rockyhelmet');
 	});

--- a/test/sim/moves/magneticflux.js
+++ b/test/sim/moves/magneticflux.js
@@ -11,17 +11,15 @@ describe('Magnetic Flux', () => {
 	});
 
 	it('should boost the Defense and Special Defense of all active allies with Plus or Minus', () => {
-		battle = common.gen(5).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 			{ species: "Minun", ability: 'minus', moves: ['sleeptalk'] },
 			{ species: "Klinklang", ability: 'plus', moves: ['magneticflux'] },
 			{ species: "Pyukumuku", ability: 'innardsout', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Plusle", ability: 'plus', moves: ['sleeptalk'] },
 			{ species: "Klinklang", ability: 'minus', moves: ['magneticflux'] },
 			{ species: "Pyukumuku", ability: 'innardsout', moves: ['sleeptalk'] },
-		] });
+		]]);
 		battle.makeChoices('move sleeptalk, move magneticflux, move sleeptalk', 'move sleeptalk, move magneticflux, move sleeptalk');
 		for (const active of battle.getAllActive()) {
 			if (active.name === 'Pyukumuku') continue;

--- a/test/sim/moves/mightycleave.js
+++ b/test/sim/moves/mightycleave.js
@@ -9,10 +9,11 @@ describe('Mighty Cleave', () => {
 	afterEach(() => battle.destroy());
 
 	it(`should go through Protect`, () => {
-		battle = common.createBattle([
-			[{ species: "Terrakion", ability: 'justified', moves: ['mightycleave'] }],
-			[{ species: "Entei", ability: 'innerfocus', moves: ['protect'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Terrakion", ability: 'justified', moves: ['mightycleave'] },
+		], [
+			{ species: "Entei", ability: 'innerfocus', moves: ['protect'] },
+		]]);
 		battle.makeChoices();
 		const damage = battle.p2.active[0].maxhp - battle.p2.active[0].hp;
 		assert.notEqual(damage, 0, `Entei should have taken damage`);

--- a/test/sim/moves/mistyterrain.js
+++ b/test/sim/moves/mistyterrain.js
@@ -11,9 +11,11 @@ describe('Misty Terrain', () => {
 	});
 
 	it('should change the current terrain to Misty Terrain for five turns', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Florges", ability: 'symbiosis', moves: ['mist', 'mistyterrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Florges", ability: 'symbiosis', moves: ['mist'] }] });
+		battle = common.createBattle([[
+			{ species: "Florges", ability: 'symbiosis', moves: ['mist', 'mistyterrain'] },
+		], [
+			{ species: "Florges", ability: 'symbiosis', moves: ['mist'] },
+		]]);
 		battle.makeChoices('move mistyterrain', 'move mist');
 		assert(battle.field.isTerrain('mistyterrain'));
 		battle.makeChoices('move mist', 'move mist');
@@ -27,9 +29,11 @@ describe('Misty Terrain', () => {
 	});
 
 	it('should halve the base power of Dragon-type attacks on grounded Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Shaymin", ability: 'naturalcure', moves: ['mistyterrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Shaymin-Sky", ability: 'serenegrace', moves: ['leechseed'] }] });
+		battle = common.createBattle([[
+			{ species: "Shaymin", ability: 'naturalcure', moves: ['mistyterrain'] },
+		], [
+			{ species: "Shaymin-Sky", ability: 'serenegrace', moves: ['leechseed'] },
+		]]);
 		battle.makeChoices('move mistyterrain', 'move leechseed');
 		let basePower;
 		const move = Dex.moves.get('dragonpulse');
@@ -40,9 +44,11 @@ describe('Misty Terrain', () => {
 	});
 
 	it('should prevent moves from setting non-volatile status on grounded Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'toxic'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Machamp", ability: 'noguard', item: 'airballoon', moves: ['bulkup', 'toxic'] }] });
+		battle = common.createBattle([[
+			{ species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'toxic'] },
+		], [
+			{ species: "Machamp", ability: 'noguard', item: 'airballoon', moves: ['bulkup', 'toxic'] },
+		]]);
 		battle.makeChoices('move mistyterrain', 'move bulkup');
 		battle.makeChoices('move toxic', 'move toxic');
 		assert.equal(battle.p1.active[0].status, '');
@@ -50,17 +56,21 @@ describe('Misty Terrain', () => {
 	});
 
 	it('should not remove active non-volatile statuses from grounded Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Florges", ability: 'symbiosis', moves: ['mistyterrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Crobat", ability: 'infiltrator', moves: ['toxic'] }] });
+		battle = common.createBattle([[
+			{ species: "Florges", ability: 'symbiosis', moves: ['mistyterrain'] },
+		], [
+			{ species: "Crobat", ability: 'infiltrator', moves: ['toxic'] },
+		]]);
 		battle.makeChoices('move mistyterrain', 'move toxic');
 		assert.equal(battle.p1.active[0].status, 'tox');
 	});
 
 	it('should prevent Yawn from putting grounded Pokemon to sleep, but not cause Yawn to fail', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'yawn'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sableye", ability: 'prankster', moves: ['yawn'] }] });
+		battle = common.createBattle([[
+			{ species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'yawn'] },
+		], [
+			{ species: "Sableye", ability: 'prankster', moves: ['yawn'] },
+		]]);
 		battle.makeChoices('move mistyterrain', 'move yawn');
 		battle.makeChoices('move yawn', 'move yawn');
 		assert.equal(battle.p1.active[0].status, '');
@@ -70,9 +80,11 @@ describe('Misty Terrain', () => {
 	});
 
 	it('should cause Rest to fail on grounded Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'rest'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Florges", ability: 'symbiosis', moves: ['mistyterrain', 'rest'] },
+		], [
+			{ species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest'] },
+		]]);
 		battle.makeChoices('move mistyterrain', 'move doubleedge');
 		battle.makeChoices('move rest', 'move rest');
 		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
@@ -80,9 +92,11 @@ describe('Misty Terrain', () => {
 	});
 
 	it('should not affect Pokemon in a semi-invulnerable state', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", ability: 'owntempo', moves: ['yawn', 'skydrop'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sableye", ability: 'prankster', moves: ['yawn', 'mistyterrain'] }] });
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', moves: ['yawn', 'skydrop'] },
+		], [
+			{ species: "Sableye", ability: 'prankster', moves: ['yawn', 'mistyterrain'] },
+		]]);
 		battle.makeChoices('move yawn', 'move yawn');
 		battle.makeChoices('move skydrop', 'move mistyterrain');
 		assert.equal(battle.p1.active[0].status, 'slp');
@@ -90,9 +104,11 @@ describe('Misty Terrain', () => {
 	});
 
 	it('should cause Nature Power to become Moonblast', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Whimsicott", ability: 'prankster', moves: ['mistyterrain'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Shuckle", ability: 'sturdy', moves: ['naturepower'] }] });
+		battle = common.createBattle([[
+			{ species: "Whimsicott", ability: 'prankster', moves: ['mistyterrain'] },
+		], [
+			{ species: "Shuckle", ability: 'sturdy', moves: ['naturepower'] },
+		]]);
 		battle.makeChoices('move mistyterrain', 'move naturepower');
 		const resultMove = toID(battle.log[battle.lastMoveLine].split('|')[3]);
 		assert.equal(resultMove, 'moonblast');

--- a/test/sim/moves/nightmare.js
+++ b/test/sim/moves/nightmare.js
@@ -11,14 +11,12 @@ describe('Nightmare [Gen 2]', () => {
 	});
 
 	it('should not deal damage to the affected if the opponent is KOed', () => {
-		battle = common.gen(2).createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(2).createBattle([[
 			{ species: "Slugma", moves: ['sleeptalk'] },
 			{ species: "Magcargo", moves: ['sleeptalk', 'flamethrower'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Forretress", moves: ['spore', 'nightmare'] },
-		] });
+		]]);
 		battle.makeChoices('switch 2', 'move spore');
 		battle.makeChoices('move sleeptalk', 'move nightmare');
 		assert(battle.p1.active[0].volatiles['nightmare']);
@@ -26,13 +24,11 @@ describe('Nightmare [Gen 2]', () => {
 	});
 
 	it('should continue dealing damage to the affected if it falls asleep while asleep', () => {
-		battle = common.gen(2).createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(2).createBattle([[
 			{ species: "Magcargo", moves: ['sleeptalk', 'rest'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Forretress", moves: ['nightmare', 'pound'] },
-		] });
+		]]);
 		battle.makeChoices('move rest', 'move pound');
 		battle.makeChoices('move rest', 'move nightmare');
 		battle.makeChoices('move sleeptalk', 'move pound');

--- a/test/sim/moves/painsplit.js
+++ b/test/sim/moves/painsplit.js
@@ -11,17 +11,21 @@ describe('Pain Split', () => {
 	});
 
 	it('should reduce the HP of the target to the average of the user and target', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Shedinja', ability: 'wonderguard', moves: ['painsplit'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Arceus', ability: 'multitype', moves: ['judgment'] }] });
+		battle = common.createBattle([[
+			{ species: 'Shedinja', ability: 'wonderguard', moves: ['painsplit'] },
+		], [
+			{ species: 'Arceus', ability: 'multitype', moves: ['judgment'] },
+		]]);
 		battle.makeChoices('move painsplit', 'move judgment');
 		assert.equal(battle.p2.active[0].hp, (battle.p2.active[0].maxhp + 1) / 2);
 	});
 
 	it('should calculate HP changes against a dynamaxed target properly', () => {
-		battle = common.gen(8).createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Drifblim', ability: 'unburden', moves: ['painsplit'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Blissey', ability: 'serenegrace', moves: ['doubleedge'] }] });
+		battle = common.gen(8).createBattle([[
+			{ species: 'Drifblim', ability: 'unburden', moves: ['painsplit'] },
+		], [
+			{ species: 'Blissey', ability: 'serenegrace', moves: ['doubleedge'] },
+		]]);
 
 		battle.makeChoices('move painsplit', 'move doubleedge dynamax');
 

--- a/test/sim/moves/pledge.js
+++ b/test/sim/moves/pledge.js
@@ -11,15 +11,13 @@ describe('Pledge moves', () => {
 	});
 
 	it(`should work`, () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Ninjask', ability: 'noability', moves: ['waterpledge'] },
 			{ species: 'Incineroar', ability: 'noability', moves: ['grasspledge'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Garchomp', ability: 'noability', moves: ['waterpledge'] },
 			{ species: 'Mew', ability: 'noability', moves: ['firepledge'] },
-		] });
+		]]);
 		battle.makeChoices('move 1 1, move 1 1', 'move 1 1, move 1 2');
 
 		// Incineroar should start Grass Pledge first, then faint to Water Pledge

--- a/test/sim/moves/psychup.js
+++ b/test/sim/moves/psychup.js
@@ -11,15 +11,13 @@ describe('Psych Up', () => {
 	});
 
 	it('should copy the opponent\'s crit ratio', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Palkia', level: 100, moves: ['sleeptalk', 'focusenergy', 'psychup', 'laserfocus'] },
 			{ species: 'Smeargle', level: 1, moves: ['laserfocus', 'sleeptalk', 'focusenergy'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
-		] });
+		]]);
 		const palkia = battle.p1.active[0];
 
 		battle.makeChoices('move focusenergy, move sleeptalk', 'move sleeptalk, move sleeptalk');
@@ -40,15 +38,13 @@ describe('Psych Up', () => {
 	});
 
 	it('should copy both positive and negative stat changes', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Palkia', level: 100, moves: ['sleeptalk', 'psychup'] },
 			{ species: 'Smeargle', level: 1, moves: ['sleeptalk', 'swordsdance', 'featherdance'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
-		] });
+		]]);
 		const palkia = battle.p1.active[0];
 
 		battle.makeChoices('move sleeptalk, move swordsdance', 'move sleeptalk, move sleeptalk');
@@ -67,15 +63,13 @@ describe('Psych Up [Gen 5]', () => {
 	});
 
 	it('should not copy the opponent\'s crit ratio', () => {
-		battle = common.gen(5).createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'doubles' }, [[
 			{ species: 'Palkia', level: 100, moves: ['sleeptalk', 'focusenergy', 'psychup'] },
 			{ species: 'Smeargle', level: 1, moves: ['sleeptalk', 'focusenergy'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
 			{ species: 'Suicune', level: 1, moves: ['sleeptalk'] },
-		] });
+		]]);
 		const palkia = battle.p1.active[0];
 
 		battle.makeChoices('move sleeptalk, move focusenergy', 'move sleeptalk, move sleeptalk');

--- a/test/sim/moves/quash.js
+++ b/test/sim/moves/quash.js
@@ -11,32 +11,28 @@ describe('Quash', () => {
 	});
 
 	it('should cause the target to move last if it has not moved yet', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Sableye", ability: 'prankster', moves: ['quash'] },
 			{ species: "Aggron", ability: 'sturdy', moves: ['earthquake'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Arceus", ability: 'multitype', moves: ['voltswitch'] },
 			{ species: "Aerodactyl", ability: 'unnerve', moves: ['swift'] },
 			{ species: "Rotom", ability: 'levitate', moves: ['thunderbolt'] },
-		] });
+		]]);
 		battle.makeChoices('move quash 2, move earthquake', 'move voltswitch 2, move swift');
 		battle.makeChoices('', 'switch 3, pass'); // Volt Switch
 		assert.equal(battle.log[battle.lastMoveLine].split('|')[3], 'Swift');
 	});
 
 	it('should not cause the target to move again if it has already moved', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Sableye", ability: 'prankster', moves: ['quash'] },
 			{ species: "Aggron", ability: 'sturdy', moves: ['earthquake'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Arceus", ability: 'multitype', moves: ['voltswitch'] },
 			{ species: "Aerodactyl", ability: 'unnerve', moves: ['extremespeed'] },
 			{ species: "Rotom", ability: 'levitate', moves: ['thunderbolt'] },
-		] });
+		]]);
 		battle.makeChoices('move quash 2, move earthquake', 'move voltswitch 2, move extremespeed 1');
 		battle.makeChoices('', 'switch 3, pass'); // Volt Switch
 		assert.notEqual(battle.log[battle.lastMoveLine].split('|')[3], 'Extremespeed');

--- a/test/sim/moves/rage.js
+++ b/test/sim/moves/rage.js
@@ -11,9 +11,11 @@ describe('Rage [Gen 1]', () => {
 	});
 
 	it("Rage accuracy bug", () => {
-		battle = common.gen(1).createBattle({ seed: [1, 1, 1, 0] });
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['rage'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Aerodactyl", moves: ['doubleteam'] }] });
+		battle = common.gen(1).createBattle({ seed: [1, 1, 1, 0] }, [[
+			{ species: "Nidoking", moves: ['rage'] },
+		], [
+			{ species: "Aerodactyl", moves: ['doubleteam'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(nidoking.volatiles['rage'].accuracy, 255);

--- a/test/sim/moves/ragepowder.js
+++ b/test/sim/moves/ragepowder.js
@@ -14,17 +14,15 @@ describe('Rage Powder', () => {
 	it('should redirect single-target moves towards it if it is a valid target', function () {
 		this.timeout(5000);
 
-		battle = common.gen(5).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 			{ species: 'Amoonguss', ability: 'overcoat', item: 'safetygoggles', moves: ['ragepowder'] },
 			{ species: 'Venusaur', ability: 'overcoat', moves: ['growth'] },
 			{ species: 'Ivysaur', ability: 'overcoat', moves: ['growth'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Abra', ability: 'synchronize', moves: ['absorb'] },
 			{ species: 'Kadabra', ability: 'synchronize', moves: ['absorb'] },
 			{ species: 'Alakazam', ability: 'synchronize', moves: ['absorb'] },
-		] });
+		]]);
 		const hitCount = [0, 0, 0];
 		battle.p1.active[0].damage = function (...args) {
 			hitCount[0]++;
@@ -45,17 +43,15 @@ describe('Rage Powder', () => {
 	});
 
 	it('should not affect Pokemon with Powder immunities', () => {
-		battle = common.gen(6).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(6).createBattle({ gameType: 'triples' }, [[
 			{ species: 'Amoonguss', ability: 'overcoat', moves: ['growth'] },
 			{ species: 'Venusaur', ability: 'overcoat', moves: ['ragepowder'] },
 			{ species: 'Ivysaur', ability: 'overcoat', moves: ['growth'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Squirtle', ability: 'naturalcure', moves: ['absorb'] },
 			{ species: 'Escavalier', ability: 'overcoat', moves: ['absorb'] },
 			{ species: 'Alakazam', ability: 'synchronize', item: 'safetygoggles', moves: ['absorb'] },
-		] });
+		]]);
 		const hitCount = [0, 0, 0];
 		battle.p1.active[0].damage = function (...args) {
 			hitCount[0]++;
@@ -76,17 +72,15 @@ describe('Rage Powder', () => {
 	});
 
 	it('should have no Powder immunities in Gen 5', () => {
-		battle = common.gen(5).createBattle({ gameType: 'triples' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(5).createBattle({ gameType: 'triples' }, [[
 			{ species: 'Amoonguss', ability: 'overcoat', moves: ['growth'] },
 			{ species: 'Venusaur', ability: 'overcoat', moves: ['ragepowder'] },
 			{ species: 'Ivysaur', ability: 'overcoat', moves: ['growth'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Squirtle', ability: 'naturalcure', moves: ['absorb'] },
 			{ species: 'Escavalier', ability: 'overcoat', moves: ['absorb'] },
 			{ species: 'Ivysaur', ability: 'overcoat', moves: ['absorb'] },
-		] });
+		]]);
 		const hitCount = [0, 0, 0];
 		battle.p1.active[0].damage = function (...args) {
 			hitCount[0]++;

--- a/test/sim/moves/reflecttype.js
+++ b/test/sim/moves/reflecttype.js
@@ -11,16 +11,20 @@ describe('Reflect Type', () => {
 	});
 
 	it('should fail when used against a Pokemon whose type is "???"', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Arcanine', ability: 'intimidate', moves: ['burnup'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype'] }] });
+		battle = common.createBattle([[
+			{ species: 'Arcanine', ability: 'intimidate', moves: ['burnup'] },
+		], [
+			{ species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype'] },
+		]]);
 		assert.constant(() => battle.p2.active[0].getTypes(), () => battle.makeChoices('move burnup', 'move reflecttype'));
 	});
 
 	it('should ignore the "???" type when used against a Pokemon whose type contains "???" and a non-added type', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Moltres', ability: 'pressure', moves: ['burnup'] }] });
+		battle = common.createBattle([[
+			{ species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat'] },
+		], [
+			{ species: 'Moltres', ability: 'pressure', moves: ['burnup'] },
+		]]);
 		battle.makeChoices('move reflecttype', 'move burnup');
 		assert.equal(battle.p1.active[0].getTypes().join('/'), 'Flying');
 		battle.makeChoices('move trickortreat', 'move burnup');
@@ -29,9 +33,11 @@ describe('Reflect Type', () => {
 	});
 
 	it('should turn the "???" type into "Normal" when used against a Pokemon whose type is only "???" and an added type', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Arcanine', ability: 'intimidate', moves: ['burnup'] }] });
+		battle = common.createBattle([[
+			{ species: 'Latias', ability: 'levitate', item: 'laggingtail', moves: ['reflecttype', 'trickortreat'] },
+		], [
+			{ species: 'Arcanine', ability: 'intimidate', moves: ['burnup'] },
+		]]);
 		battle.makeChoices('move trickortreat', 'move burnup');
 		battle.makeChoices('move reflecttype', 'move burnup');
 		assert.equal(battle.p1.active[0].getTypes().join('/'), 'Normal/Ghost');

--- a/test/sim/moves/relicsong.js
+++ b/test/sim/moves/relicsong.js
@@ -11,25 +11,31 @@ describe('Relic Song', () => {
 	});
 
 	it('should transform Meloetta into its Pirouette forme', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Meloetta", ability: 'serenegrace', moves: ['relicsong'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Registeel", ability: 'clearbody', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Meloetta", ability: 'serenegrace', moves: ['relicsong'] },
+		], [
+			{ species: "Registeel", ability: 'clearbody', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move relicsong', 'move rest');
 		assert.equal(battle.p1.active[0].species.id, 'meloettapirouette');
 	});
 
 	it('should transform Meloetta-Pirouette into its Aria forme', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Meloetta-Pirouette", ability: 'serenegrace', moves: ['relicsong'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Registeel", ability: 'clearbody', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Meloetta-Pirouette", ability: 'serenegrace', moves: ['relicsong'] },
+		], [
+			{ species: "Registeel", ability: 'clearbody', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move relicsong', 'move rest');
 		assert.equal(battle.p1.active[0].species.id, 'meloetta');
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'relicsong'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'relicsong'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move relicsong', 'move rest');
 		assert.equal(battle.p2.active[0].item, '');
@@ -42,20 +48,22 @@ describe('Relic Song [Gen 5]', () => {
 	});
 
 	it('should not pierce through substitutes', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'relicsong'] }],
-			[{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'relicsong'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move relicsong', 'move rest');
 		assert.equal(battle.p2.active[0].item, 'focussash');
 	});
 
 	it('should transform Meloetta into its Pirouette forme even if it hits a substitute', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Meloetta", ability: 'serenegrace', moves: ['relicsong'] }],
-			[{ species: "Registeel", ability: 'prankster', moves: ['substitute'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Meloetta", ability: 'serenegrace', moves: ['relicsong'] },
+		], [
+			{ species: "Registeel", ability: 'prankster', moves: ['substitute'] },
+		]]);
 		battle.makeChoices('move relicsong', 'move substitute');
 		assert.equal(battle.p1.active[0].species.id, 'meloettapirouette');
 	});

--- a/test/sim/moves/rollout.js
+++ b/test/sim/moves/rollout.js
@@ -16,10 +16,11 @@ for (const move of moves) {
 		});
 
 		it('should double its Base Power every turn for five turns, then resets to 30 BP', () => {
-			battle = common.createBattle([
-				[{ species: 'Shuckle', ability: 'gluttony', moves: [id] }],
-				[{ species: 'Steelix', ability: 'noguard', moves: ['recover'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Shuckle', ability: 'gluttony', moves: [id] },
+			], [
+				{ species: 'Steelix', ability: 'noguard', moves: ['recover'] },
+			]]);
 
 			let ebp = 30;
 			let count = 0;
@@ -40,10 +41,11 @@ for (const move of moves) {
 		});
 
 		it('should reset its Base Power if the move misses', () => {
-			battle = common.createBattle([
-				[{ species: 'Shuckle', ability: 'gluttony', moves: [id] }],
-				[{ species: 'Steelix', ability: 'furcoat', moves: ['recover'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Shuckle', ability: 'gluttony', moves: [id] },
+			], [
+				{ species: 'Steelix', ability: 'furcoat', moves: ['recover'] },
+			]]);
 
 			let ebp = 30;
 			let count = 0;
@@ -70,10 +72,11 @@ for (const move of moves) {
 		});
 
 		it('should reset its Base Power if the Pokemon is immobilized', () => {
-			battle = common.createBattle([
-				[{ species: 'Shuckle', ability: 'gluttony', moves: [id] }],
-				[{ species: 'Steelix', ability: 'noguard', moves: ['recover'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Shuckle', ability: 'gluttony', moves: [id] },
+			], [
+				{ species: 'Steelix', ability: 'noguard', moves: ['recover'] },
+			]]);
 
 			let ebp = 30;
 			let count = 0;
@@ -98,10 +101,11 @@ for (const move of moves) {
 		});
 
 		it('should have double Base Power if the Pokemon used Defense Curl earlier', () => {
-			battle = common.createBattle([
-				[{ species: 'Shuckle', ability: 'gluttony', moves: [id, 'defensecurl'] }],
-				[{ species: 'Steelix', ability: 'noguard', moves: ['recover'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Shuckle', ability: 'gluttony', moves: [id, 'defensecurl'] },
+			], [
+				{ species: 'Steelix', ability: 'noguard', moves: ['recover'] },
+			]]);
 
 			let runCount = 0;
 			battle.onEvent('BasePower', battle.format, basePower => {
@@ -115,10 +119,11 @@ for (const move of moves) {
 		});
 
 		it('should not be affected by Parental Bond', () => {
-			battle = common.createBattle([
-				[{ species: 'Shuckle', ability: 'parentalbond', moves: [id] }],
-				[{ species: 'Steelix', ability: 'noguard', moves: ['recover'] }],
-			]);
+			battle = common.createBattle([[
+				{ species: 'Shuckle', ability: 'parentalbond', moves: [id] },
+			], [
+				{ species: 'Steelix', ability: 'noguard', moves: ['recover'] },
+			]]);
 
 			let hitCount = 0;
 			battle.onEvent('BasePower', battle.format, basePower => {

--- a/test/sim/moves/roost.js
+++ b/test/sim/moves/roost.js
@@ -12,26 +12,32 @@ describe('Roost', () => {
 	});
 
 	it('should fail if the user is at max HP', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Clefable", item: 'leftovers', ability: 'unaware', moves: ['calmmind'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Dragonite", item: 'laggingtail', ability: 'multiscale', moves: ['roost'] }] });
+		battle = common.createBattle([[
+			{ species: "Clefable", item: 'leftovers', ability: 'unaware', moves: ['calmmind'] },
+		], [
+			{ species: "Dragonite", item: 'laggingtail', ability: 'multiscale', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move calmmind', 'move roost');
 		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
 	});
 
 	it('should heal the user', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Clefable", ability: 'unaware', moves: ['calmmind', 'hiddenpowergrass'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Dragonite", ability: 'multiscale', moves: ['roost', 'dragondance'] }] });
+		battle = common.createBattle([[
+			{ species: "Clefable", ability: 'unaware', moves: ['calmmind', 'hiddenpowergrass'] },
+		], [
+			{ species: "Dragonite", ability: 'multiscale', moves: ['roost', 'dragondance'] },
+		]]);
 		battle.makeChoices('move hiddenpowergrass', 'move dragondance');
 		battle.makeChoices('move calmmind', 'move roost');
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should suppress user\'s current Flying type if successful', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Aggron", item: 'leftovers', ability: 'sturdy', moves: ['mudslap', 'hiddenpowergrass'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Aerodactyl", item: 'focussash', ability: 'wonderguard', moves: ['roost', 'doubleedge'] }] });
+		battle = common.createBattle([[
+			{ species: "Aggron", item: 'leftovers', ability: 'sturdy', moves: ['mudslap', 'hiddenpowergrass'] },
+		], [
+			{ species: "Aerodactyl", item: 'focussash', ability: 'wonderguard', moves: ['roost', 'doubleedge'] },
+		]]);
 
 		battle.makeChoices('move mudslap', 'move roost');
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp); // Immune to Mud Slap
@@ -50,15 +56,13 @@ describe('Roost', () => {
 	});
 
 	it('should suppress Flying type yet to be acquired this turn', () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Pidgeot", item: 'laggingtail', ability: 'victorystar', moves: ['aircutter'] },
 			{ species: "Gligar", item: 'laggingtail', ability: 'immunity', moves: ['earthquake'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Kecleon", ability: 'colorchange', moves: ['roost'] },
 			{ species: "Venusaur", ability: 'chlorophyll', moves: ['earthquake'] },
-		] });
+		]]);
 
 		let hitCount = 0;
 		battle.p2.active[0].damage = function (...args) {
@@ -71,9 +75,11 @@ describe('Roost', () => {
 	});
 
 	it('should treat a pure Flying pokémon as Normal type', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Tornadus", item: 'focussash', ability: 'prankster', moves: ['roost'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Gastly", item: 'laggingtail', ability: 'levitate', moves: ['astonish', 'trickortreat'] }] });
+		battle = common.createBattle([[
+			{ species: "Tornadus", item: 'focussash', ability: 'prankster', moves: ['roost'] },
+		], [
+			{ species: "Gastly", item: 'laggingtail', ability: 'levitate', moves: ['astonish', 'trickortreat'] },
+		]]);
 		battle.makeChoices('move roost', 'move astonish');
 		battle.makeChoices('move roost', 'move astonish');
 		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp); // Immune to Astonish
@@ -103,10 +109,11 @@ describe('Roost - DPP', () => {
 	});
 
 	it('should treat a pure Flying pokémon as `???` type', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Arceus-Flying", item: 'skyplate', ability: 'multitype', moves: ['roost'] }],
-			[{ species: "Gastly", item: 'laggingtail', ability: 'levitate', moves: ['astonish', 'earthpower'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Arceus-Flying", item: 'skyplate', ability: 'multitype', moves: ['roost'] },
+		], [
+			{ species: "Gastly", item: 'laggingtail', ability: 'levitate', moves: ['astonish', 'earthpower'] },
+		]]);
 
 		battle.makeChoices('move roost', 'move astonish');
 		battle.makeChoices('move roost', 'move astonish');

--- a/test/sim/moves/round.js
+++ b/test/sim/moves/round.js
@@ -11,9 +11,11 @@ describe('Round', () => {
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'round'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'round'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move round', 'move rest');
 		assert.equal(battle.p2.active[0].item, '');
@@ -26,10 +28,11 @@ describe('Round [Gen 5]', () => {
 	});
 
 	it('should not pierce through substitutes', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'round'] }],
-			[{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'round'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move round', 'move rest');

--- a/test/sim/moves/sheercold.js
+++ b/test/sim/moves/sheercold.js
@@ -11,10 +11,11 @@ describe('Sheer Cold', () => {
 	});
 
 	it('should not affect Ice-type Pokémon', () => {
-		battle = common.createBattle([
-			[{ species: "Deoxys-Speed", ability: 'noguard', moves: ['sheercold'] }],
-			[{ species: "Arceus-Ice", item: 'icicleplate', ability: 'multitype', moves: ['calmmind'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Deoxys-Speed", ability: 'noguard', moves: ['sheercold'] },
+		], [
+			{ species: "Arceus-Ice", item: 'icicleplate', ability: 'multitype', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move sheercold', 'move calmmind');
 		assert.false.fainted(battle.p2.active[0]);
 	});
@@ -26,10 +27,11 @@ describe('Sheer Cold [Gen 6]', () => {
 	});
 
 	it('should affect Ice-type Pokémon', () => {
-		battle = common.gen(6).createBattle([
-			[{ species: "Deoxys-Speed", ability: 'noguard', moves: ['sheercold'] }],
-			[{ species: "Arceus-Ice", item: 'icicleplate', ability: 'multitype', moves: ['calmmind'] }],
-		]);
+		battle = common.gen(6).createBattle([[
+			{ species: "Deoxys-Speed", ability: 'noguard', moves: ['sheercold'] },
+		], [
+			{ species: "Arceus-Ice", item: 'icicleplate', ability: 'multitype', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move sheercold', 'move calmmind');
 		assert.fainted(battle.p2.active[0]);
 	});

--- a/test/sim/moves/shelltrap.js
+++ b/test/sim/moves/shelltrap.js
@@ -34,19 +34,21 @@ describe('Shell Trap', () => {
 	});
 
 	it('should not Z-power if hit by a Z-move', () => {
-		battle = common.createBattle({}, [
-			[{ species: 'Turtonator', moves: ['shelltrap'] }],
-			[{ species: 'Magikarp', item: 'normaliumz', moves: ['flail'] }],
-		]);
+		battle = common.createBattle({}, [[
+			{ species: 'Turtonator', moves: ['shelltrap'] },
+		], [
+			{ species: 'Magikarp', item: 'normaliumz', moves: ['flail'] },
+		]]);
 		battle.makeChoices('move shelltrap', 'move flail zmove');
 		assert(battle.log.some(line => line.includes('|Shell Trap|')));
 	});
 
 	it('should not Max if hit by a Max move', () => {
-		battle = common.gen(8).createBattle({}, [
-			[{ species: 'Turtonator', moves: ['shelltrap'] }],
-			[{ species: 'Magikarp', moves: ['flail'] }],
-		]);
+		battle = common.gen(8).createBattle({}, [[
+			{ species: 'Turtonator', moves: ['shelltrap'] },
+		], [
+			{ species: 'Magikarp', moves: ['flail'] },
+		]]);
 		battle.makeChoices('move shelltrap', 'move flail dynamax');
 		assert(battle.log.some(line => line.includes('|Shell Trap|')));
 	});

--- a/test/sim/moves/smellingsalts.js
+++ b/test/sim/moves/smellingsalts.js
@@ -11,9 +11,11 @@ describe('Smelling Salts', () => {
 	});
 
 	it('should cure a paralyzed target', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Meloetta", ability: 'serenegrace', moves: ['smellingsalts', 'thunderwave'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Dragonite", ability: 'multiscale', moves: ['roost'] }] });
+		battle = common.createBattle([[
+			{ species: "Meloetta", ability: 'serenegrace', moves: ['smellingsalts', 'thunderwave'] },
+		], [
+			{ species: "Dragonite", ability: 'multiscale', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move thunderwave', 'move roost');
 		battle.makeChoices('move smellingsalts', 'move roost');
 		assert.notEqual(battle.p2.active[0].status, 'par');

--- a/test/sim/moves/snarl.js
+++ b/test/sim/moves/snarl.js
@@ -11,9 +11,11 @@ describe('Snarl', () => {
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'snarl'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'snarl'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 
 		battle.makeChoices('move Splash', 'move Substitute');
 		battle.makeChoices('move Snarl', 'move Rest');
@@ -28,10 +30,11 @@ describe('Snarl [Gen 5]', () => {
 	});
 
 	it('should not pierce through substitutes', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'snarl'] }],
-			[{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'snarl'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 
 		battle.makeChoices('move Splash', 'move Substitute');
 		battle.makeChoices('move Snarl', 'move Rest');

--- a/test/sim/moves/spectralthief.js
+++ b/test/sim/moves/spectralthief.js
@@ -9,10 +9,11 @@ describe(`Spectral Thief`, () => {
 	afterEach(() => battle.destroy());
 
 	it(`should steal the target's boosts before hitting`, () => {
-		battle = common.createBattle([
-			[{ species: "Smeargle", ability: 'technician', moves: ['calmmind', 'spectralthief'] }],
-			[{ species: "Litten", ability: 'intimidate', item: 'focussash', moves: ['swordsdance', 'roar'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'technician', moves: ['calmmind', 'spectralthief'] },
+		], [
+			{ species: "Litten", ability: 'intimidate', item: 'focussash', moves: ['swordsdance', 'roar'] },
+		]]);
 		const [thief, victim] = battle.sides.map(s => s.active[0]);
 
 		battle.makeChoices('move spectralthief', 'move swordsdance');
@@ -32,10 +33,11 @@ describe(`Spectral Thief`, () => {
 	});
 
 	it(`should double the boosts if the user has Simple`, () => {
-		battle = common.createBattle([
-			[{ species: "Smeargle", ability: 'simple', moves: ['calmmind', 'spectralthief'] }],
-			[{ species: "Mew", ability: 'pressure', moves: ['swordsdance', 'roar'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'simple', moves: ['calmmind', 'spectralthief'] },
+		], [
+			{ species: "Mew", ability: 'pressure', moves: ['swordsdance', 'roar'] },
+		]]);
 		const [thief, victim] = battle.sides.map(s => s.active[0]);
 
 		battle.makeChoices('move calmmind', 'move swordsdance');
@@ -48,10 +50,11 @@ describe(`Spectral Thief`, () => {
 	});
 
 	it(`should only steal boosts once if the user has Parental Bond`, () => {
-		battle = common.createBattle([
-			[{ species: "Smeargle", ability: 'parentalbond', moves: ['calmmind', 'spectralthief'] }],
-			[{ species: "Mew", ability: 'pressure', item: 'weaknesspolicy', moves: ['swordsdance', 'roar'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'parentalbond', moves: ['calmmind', 'spectralthief'] },
+		], [
+			{ species: "Mew", ability: 'pressure', item: 'weaknesspolicy', moves: ['swordsdance', 'roar'] },
+		]]);
 		const [thief, victim] = battle.sides.map(s => s.active[0]);
 
 		battle.makeChoices('move calmmind', 'move swordsdance');
@@ -65,10 +68,11 @@ describe(`Spectral Thief`, () => {
 	});
 
 	it(`should not steal boosts if the target is immune to the hit`, () => {
-		battle = common.createBattle([
-			[{ species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['spectralthief'] }],
-			[{ species: "Zangoose", ability: 'immunity', moves: ['swordsdance'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', item: 'laggingtail', moves: ['spectralthief'] },
+		], [
+			{ species: "Zangoose", ability: 'immunity', moves: ['swordsdance'] },
+		]]);
 		const [thief, victim] = battle.sides.map(s => s.active[0]);
 
 		battle.makeChoices('move spectralthief', 'move swordsdance');
@@ -77,10 +81,11 @@ describe(`Spectral Thief`, () => {
 	});
 
 	it(`should zero target's boosts if the target has Contrary`, () => {
-		battle = common.createBattle([
-			[{ species: "Smeargle", ability: 'owntempo', item: 'focussash', moves: ['spectralthief'] }],
-			[{ species: "Serperior", ability: 'contrary', moves: ['leafstorm'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', item: 'focussash', moves: ['spectralthief'] },
+		], [
+			{ species: "Serperior", ability: 'contrary', moves: ['leafstorm'] },
+		]]);
 		const victim = battle.p2.active[0];
 		battle.makeChoices('move spectralthief', 'move leafstorm');
 		assert.statStage(victim, 'spa', 0);
@@ -88,10 +93,11 @@ describe(`Spectral Thief`, () => {
 	});
 
 	it(`should zero target's boosts if the target has Clear Body`, () => {
-		battle = common.createBattle([
-			[{ species: "Smeargle", ability: 'owntempo', moves: ['spectralthief'] }],
-			[{ species: "Tentacruel", ability: 'clearbody', moves: ['swordsdance'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', moves: ['spectralthief'] },
+		], [
+			{ species: "Tentacruel", ability: 'clearbody', moves: ['swordsdance'] },
+		]]);
 		const victim = battle.p2.active[0];
 		battle.makeChoices('move spectralthief', 'move swordsdance');
 		assert.statStage(victim, 'atk', 0);
@@ -99,10 +105,11 @@ describe(`Spectral Thief`, () => {
 	});
 
 	it(`should zero target's boosts if the target has Simple`, () => {
-		battle = common.createBattle([
-			[{ species: "Smeargle", ability: 'owntempo', moves: ['spectralthief'] }],
-			[{ species: "Swoobat", ability: 'simple', moves: ['amnesia'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Smeargle", ability: 'owntempo', moves: ['spectralthief'] },
+		], [
+			{ species: "Swoobat", ability: 'simple', moves: ['amnesia'] },
+		]]);
 		const victim = battle.p2.active[0];
 		battle.makeChoices('move spectralthief', 'move amnesia');
 		assert.statStage(victim, 'spd', 0);

--- a/test/sim/moves/stealthrock.js
+++ b/test/sim/moves/stealthrock.js
@@ -11,24 +11,26 @@ describe('Stealth Rock', () => {
 	});
 
 	it('should succeed against Substitute', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", moves: ['stealthrock'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Ninjask", moves: ['substitute'] }] });
+		battle = common.createBattle([[
+			{ species: "Smeargle", moves: ['stealthrock'] },
+		], [
+			{ species: "Ninjask", moves: ['substitute'] },
+		]]);
 		battle.makeChoices('move stealthrock', 'move substitute');
 		assert(battle.p2.sideConditions['stealthrock']);
 	});
 
 	it('should deal damage to Pokemon switching in based on their type effectiveness against Rock-type', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Smeargle", moves: ['splash', 'stealthrock'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Smeargle", moves: ['splash', 'stealthrock'] },
+		], [
 			{ species: "Ninjask", moves: ['protect'] },
 			{ species: "Volcarona", moves: ['roost'] },
 			{ species: "Staraptor", moves: ['roost'] },
 			{ species: "Chansey", moves: ['wish'] },
 			{ species: "Hitmonchan", moves: ['rest'] },
 			{ species: "Steelix", moves: ['rest'] },
-		] });
+		]]);
 		battle.makeChoices('move stealthrock', 'move protect');
 		let pokemon;
 		for (let i = 2; i <= 6; i++) {

--- a/test/sim/moves/stockpile.js
+++ b/test/sim/moves/stockpile.js
@@ -11,10 +11,11 @@ describe('Stockpile', () => {
 	});
 
 	it('should keep track of how many boosts to each defense stat were successful', () => {
-		battle = common.createBattle([
-			[{ species: 'Seviper', ability: 'shedskin', moves: ['stockpile', 'spitup'] }],
-			[{ species: 'Zangoose', ability: 'immunity', moves: ['sleeptalk'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Seviper', ability: 'shedskin', moves: ['stockpile', 'spitup'] },
+		], [
+			{ species: 'Zangoose', ability: 'immunity', moves: ['sleeptalk'] },
+		]]);
 		battle.boost({ def: 4, spd: 5 }, battle.p1.active[0]);
 
 		battle.makeChoices('move stockpile', 'move sleeptalk');

--- a/test/sim/moves/substitute.js
+++ b/test/sim/moves/substitute.js
@@ -11,18 +11,22 @@ describe('Substitute', () => {
 	});
 
 	it('should deduct 25% of max HP, rounded down', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Mewtwo', ability: 'pressure', moves: ['recover'] }] });
+		battle = common.createBattle([[
+			{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute'] },
+		], [
+			{ species: 'Mewtwo', ability: 'pressure', moves: ['recover'] },
+		]]);
 		battle.makeChoices('move substitute', 'move recover');
 		const pokemon = battle.p1.active[0];
 		assert.equal(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 	});
 
 	it('should not block the user\'s own moves from targeting itself', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute', 'calmmind'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Mewtwo', ability: 'pressure', moves: ['recover'] }] });
+		battle = common.createBattle([[
+			{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute', 'calmmind'] },
+		], [
+			{ species: 'Mewtwo', ability: 'pressure', moves: ['recover'] },
+		]]);
 		battle.makeChoices('move substitute', 'move recover');
 		battle.makeChoices('move calmmind', 'move recover');
 		assert.equal(battle.p1.active[0].boosts['spa'], 1);
@@ -30,18 +34,22 @@ describe('Substitute', () => {
 	});
 
 	it('should block damage from most moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Mewtwo', ability: 'pressure', item: 'laggingtail', moves: ['psystrike'] }] });
+		battle = common.createBattle([[
+			{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute'] },
+		], [
+			{ species: 'Mewtwo', ability: 'pressure', item: 'laggingtail', moves: ['psystrike'] },
+		]]);
 		battle.makeChoices('move substitute', 'move psystrike');
 		const pokemon = battle.p1.active[0];
 		assert.equal(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 	});
 
 	it('should not block recoil damage', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute', 'doubleedge'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Mewtwo', ability: 'pressure', moves: ['nastyplot'] }] });
+		battle = common.createBattle([[
+			{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute', 'doubleedge'] },
+		], [
+			{ species: 'Mewtwo', ability: 'pressure', moves: ['nastyplot'] },
+		]]);
 		battle.makeChoices('move substitute', 'move nastyplot');
 		battle.makeChoices('move doubleedge', 'move nastyplot');
 		const pokemon = battle.p1.active[0];
@@ -88,9 +96,11 @@ describe('Substitute', () => {
 	});
 
 	it('should cause recoil damage from an opponent\'s moves to be based on damage dealt to the substitute', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Mewtwo', ability: 'noguard', moves: ['nastyplot', 'lightofruin'] }] });
+		battle = common.createBattle([[
+			{ species: 'Mewtwo', ability: 'pressure', moves: ['substitute'] },
+		], [
+			{ species: 'Mewtwo', ability: 'noguard', moves: ['nastyplot', 'lightofruin'] },
+		]]);
 		battle.makeChoices('move substitute', 'move nastyplot');
 		battle.makeChoices('move substitute', 'move lightofruin');
 		const pokemon = battle.p2.active[0];
@@ -98,9 +108,11 @@ describe('Substitute', () => {
 	});
 
 	it('should cause recovery from an opponent\'s draining moves to be based on damage dealt to the substitute', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Zangoose', ability: 'pressure', moves: ['substitute'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Zangoose', ability: 'noguard', moves: ['bellydrum', 'drainpunch'] }] });
+		battle = common.createBattle([[
+			{ species: 'Zangoose', ability: 'pressure', moves: ['substitute'] },
+		], [
+			{ species: 'Zangoose', ability: 'noguard', moves: ['bellydrum', 'drainpunch'] },
+		]]);
 		battle.makeChoices('move substitute', 'move bellydrum');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move substitute', 'move drainpunch');
@@ -108,9 +120,11 @@ describe('Substitute', () => {
 	});
 
 	it('should block most status moves targeting the user', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Mewtwo', ability: 'noguard', moves: ['substitute'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Mewtwo', ability: 'pressure', item: 'laggingtail', moves: ['hypnosis', 'toxic', 'poisongas', 'thunderwave', 'willowisp'] }] });
+		battle = common.createBattle([[
+			{ species: 'Mewtwo', ability: 'noguard', moves: ['substitute'] },
+		], [
+			{ species: 'Mewtwo', ability: 'pressure', item: 'laggingtail', moves: ['hypnosis', 'toxic', 'poisongas', 'thunderwave', 'willowisp'] },
+		]]);
 		for (let i = 1; i <= 5; i++) {
 			battle.makeChoices('move substitute', 'move ' + i);
 			assert.equal(battle.p1.active[0].status, '');
@@ -118,9 +132,11 @@ describe('Substitute', () => {
 	});
 
 	it('should allow multi-hit moves to continue after the substitute fades', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Dragonite', ability: 'noguard', item: 'focussash', moves: ['substitute', 'roost'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Dragonite', ability: 'hugepower', item: 'laggingtail', moves: ['roost', 'dualchop'] }] });
+		battle = common.createBattle([[
+			{ species: 'Dragonite', ability: 'noguard', item: 'focussash', moves: ['substitute', 'roost'] },
+		], [
+			{ species: 'Dragonite', ability: 'hugepower', item: 'laggingtail', moves: ['roost', 'dualchop'] },
+		]]);
 		battle.makeChoices('move substitute', 'move roost');
 		battle.makeChoices('move roost', 'move dualchop');
 		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);

--- a/test/sim/moves/synchronoise.js
+++ b/test/sim/moves/synchronoise.js
@@ -11,17 +11,21 @@ describe('Synchronoise', () => {
 	});
 
 	it('should damage Pokemon that share a type with the user', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Gardevoir", moves: ['synchronoise'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Granbull", moves: ['sleeptalk'] }] });
+		battle = common.createBattle([[
+			{ species: "Gardevoir", moves: ['synchronoise'] },
+		], [
+			{ species: "Granbull", moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices();
 		assert.false.fullHP(battle.p2.active[0]);
 	});
 
 	it('should not damage Pokemon that do not share a type with the user', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Gardevoir", moves: ['synchronoise'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", moves: ['sleeptalk'] }] });
+		battle = common.createBattle([[
+			{ species: "Gardevoir", moves: ['synchronoise'] },
+		], [
+			{ species: "Caterpie", moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices();
 		assert.fullHP(battle.p2.active[0]);
 	});

--- a/test/sim/moves/taunt.js
+++ b/test/sim/moves/taunt.js
@@ -11,9 +11,11 @@ describe('Taunt', () => {
 	});
 
 	it('should prevent the target from using Status moves and disable them', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Chansey', ability: 'naturalcure', moves: ['calmmind'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] },
+		], [
+			{ species: 'Chansey', ability: 'naturalcure', moves: ['calmmind'] },
+		]]);
 		battle.makeChoices('move taunt', 'move calmmind');
 		assert.equal(battle.p2.active[0].boosts['spa'], 0);
 		assert.equal(battle.p2.active[0].boosts['spd'], 0);
@@ -21,18 +23,22 @@ describe('Taunt', () => {
 	});
 
 	it('should not prevent the target from using Z-Powered Status moves', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Charmander', ability: 'blaze', item: 'firiumz', moves: ['sunnyday'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] },
+		], [
+			{ species: 'Charmander', ability: 'blaze', item: 'firiumz', moves: ['sunnyday'] },
+		]]);
 		battle.makeChoices('move taunt', 'move sunnyday zmove');
 		assert.statStage(battle.p2.active[0], 'spe', 1);
 		assert(battle.field.isWeather('sunnyday'));
 	});
 
 	it('[Hackmons] should prevent the target from using Z-Powered Status moves if not boosted by a Z-crystal', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] }] });
-		battle.setPlayer('p2', { team: [{ species: 'Eevee', ability: 'runaway', moves: ['extremeevoboost'] }] });
+		battle = common.createBattle([[
+			{ species: 'Sableye', ability: 'prankster', moves: ['taunt'] },
+		], [
+			{ species: 'Eevee', ability: 'runaway', moves: ['extremeevoboost'] },
+		]]);
 		battle.makeChoices();
 		assert.statStage(battle.p2.active[0], 'spe', 0);
 	});

--- a/test/sim/moves/thief.js
+++ b/test/sim/moves/thief.js
@@ -11,25 +11,31 @@ describe('Thief', () => {
 	});
 
 	it('should steal most items', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['thief'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['thief'] },
+		], [
+			{ species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled'] },
+		]]);
 		battle.makeChoices('move thief', 'move softboiled');
 		assert.equal(battle.p1.active[0].item, 'shedshell');
 	});
 
 	it('should not steal items if it is holding an item', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', item: 'focussash', moves: ['thief'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', item: 'focussash', moves: ['thief'] },
+		], [
+			{ species: "Blissey", ability: 'naturalcure', item: 'shedshell', moves: ['softboiled'] },
+		]]);
 		battle.makeChoices('move thief', 'move softboiled');
 		assert.equal(battle.p2.active[0].item, 'shedshell');
 	});
 
 	it('should take Life Orb damage from a stolen Life Orb', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['thief'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Blissey", ability: 'naturalcure', item: 'lifeorb', moves: ['softboiled'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['thief'] },
+		], [
+			{ species: "Blissey", ability: 'naturalcure', item: 'lifeorb', moves: ['softboiled'] },
+		]]);
 		battle.makeChoices('move thief', 'move softboiled');
 		assert.equal(battle.p1.active[0].hp, Math.ceil(9 / 10 * battle.p1.active[0].maxhp));
 	});

--- a/test/sim/moves/thrash.js
+++ b/test/sim/moves/thrash.js
@@ -11,9 +11,11 @@ describe('Thrash [Gen 1]', () => {
 	});
 
 	it("Three turn Thrash", () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['thrash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Golem", moves: ['splash'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Nidoking", moves: ['thrash'] },
+		], [
+			{ species: "Golem", moves: ['splash'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(nidoking.volatiles['lockedmove'].time, 2);
@@ -25,9 +27,11 @@ describe('Thrash [Gen 1]', () => {
 	});
 
 	it("Four turn Thrash", () => {
-		battle = common.gen(1).createBattle({ seed: 'gen5,0001000100010001' });
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['thrash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Golem", moves: ['splash'] }] });
+		battle = common.gen(1).createBattle({ seed: 'gen5,0001000100010001' }, [[
+			{ species: "Nidoking", moves: ['thrash'] },
+		], [
+			{ species: "Golem", moves: ['splash'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(nidoking.volatiles['lockedmove'].time, 3);
@@ -40,27 +44,33 @@ describe('Thrash [Gen 1]', () => {
 	});
 
 	it("Thrash locks the user in, even if it targets a semi-invulnerable foe", () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['thrash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Aerodactyl", moves: ['fly'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Nidoking", moves: ['thrash'] },
+		], [
+			{ species: "Aerodactyl", moves: ['fly'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		battle.makeChoices();
 		assert(nidoking.volatiles['lockedmove']);
 	});
 
 	it("Thrash locks the user in, even if it targets a Ghost type", () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['thrash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Gengar", moves: ['splash'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Nidoking", moves: ['thrash'] },
+		], [
+			{ species: "Gengar", moves: ['splash'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		battle.makeChoices();
 		assert(nidoking.volatiles['lockedmove']);
 	});
 
 	it("Thrash locks the user in, even if it targets and breaks a Substitute", () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['thrash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Alakazam", moves: ['substitute'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Nidoking", moves: ['thrash'] },
+		], [
+			{ species: "Alakazam", moves: ['substitute'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		const alakazam = battle.p2.active[0];
 		battle.makeChoices();
@@ -69,9 +79,11 @@ describe('Thrash [Gen 1]', () => {
 	});
 
 	it("Thrash is paused when asleep or frozen", () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['thrash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Parasect", moves: ['spore'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Nidoking", moves: ['thrash'] },
+		], [
+			{ species: "Parasect", moves: ['spore'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		for (let i = 0; i < 10; i++) {
 			battle.makeChoices();
@@ -80,9 +92,11 @@ describe('Thrash [Gen 1]', () => {
 	});
 
 	it("Thrash is paused when disabled", () => {
-		battle = common.gen(1).createBattle({ seed: [1, 1, 1, 1] });
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['thrash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Golem", moves: ['disable'] }] });
+		battle = common.gen(1).createBattle({ seed: [1, 1, 1, 1] }, [[
+			{ species: "Nidoking", moves: ['thrash'] },
+		], [
+			{ species: "Golem", moves: ['disable'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(nidoking.volatiles['lockedmove'].time, 3);
@@ -92,9 +106,11 @@ describe('Thrash [Gen 1]', () => {
 	});
 
 	it("Thrash accuracy bug", () => {
-		battle = common.gen(1).createBattle({ seed: [1, 1, 1, 1] });
-		battle.setPlayer('p1', { team: [{ species: "Nidoking", moves: ['thrash'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Aerodactyl", moves: ['doubleteam'] }] });
+		battle = common.gen(1).createBattle({ seed: [1, 1, 1, 1] }, [[
+			{ species: "Nidoking", moves: ['thrash'] },
+		], [
+			{ species: "Aerodactyl", moves: ['doubleteam'] },
+		]]);
 		const nidoking = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(nidoking.volatiles['lockedmove'].accuracy, 168);

--- a/test/sim/moves/thunderwave.js
+++ b/test/sim/moves/thunderwave.js
@@ -11,9 +11,11 @@ describe('Thunder Wave', () => {
 	});
 
 	it('should not ignore natural type immunities', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Jolteon", ability: 'quickfeet', moves: ['thunderwave'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Hippowdon", ability: 'sandforce', moves: ['slackoff'] }] });
+		battle = common.createBattle([[
+			{ species: "Jolteon", ability: 'quickfeet', moves: ['thunderwave'] },
+		], [
+			{ species: "Hippowdon", ability: 'sandforce', moves: ['slackoff'] },
+		]]);
 		battle.makeChoices('move thunderwave', 'move slackoff');
 		assert.equal(battle.p2.active[0].status, '');
 	});

--- a/test/sim/moves/toxic.js
+++ b/test/sim/moves/toxic.js
@@ -7,10 +7,11 @@ let battle;
 
 describe('Toxic', () => {
 	it('should always hit when used by a Poison-type', () => {
-		battle = common.createBattle([
-			[{ species: "Naganadel", moves: ['toxic'] }],
-			[{ species: "Sigilyph", ability: 'wonderskin', moves: ['sleeptalk'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Naganadel", moves: ['toxic'] },
+		], [
+			{ species: "Sigilyph", ability: 'wonderskin', moves: ['sleeptalk'] },
+		]]);
 		battle.makeChoices('move toxic', 'move sleeptalk');
 		assert.equal(battle.p2.active[0].status, 'tox');
 	});
@@ -18,15 +19,13 @@ describe('Toxic', () => {
 
 describe('Toxic [Gen 7]', () => {
 	it('should set all moves to sure-hit until the end of the turn', () => {
-		battle = common.gen(7).createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.gen(7).createBattle({ gameType: 'doubles' }, [[
 			{ species: "Nidoking", moves: ['toxic', 'horndrill'] },
 			{ species: "Oranguru", moves: ['trickroom', 'instruct'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Dugtrio", moves: ['dig'] },
 			{ species: "Wynaut", moves: ['splash'] },
-		] });
+		]]);
 		battle.makeChoices('move toxic 1, move trickroom', 'move dig 2, move splash');
 		assert.equal(battle.p2.active[0].status, 'tox');
 		battle.makeChoices('move horndrill 2, move instruct -1', 'move dig 2, move splash');

--- a/test/sim/moves/transform.js
+++ b/test/sim/moves/transform.js
@@ -11,17 +11,21 @@ describe('Transform', () => {
 	});
 
 	it('should copy the Pokemon\'s species', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", ability: 'limber', moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Hoopa-Unbound", ability: 'magician', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Hoopa-Unbound", ability: 'magician', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move transform', 'move rest');
 		assert.equal(battle.p1.active[0].species, battle.p2.active[0].species);
 	});
 
 	it('should copy all stats except HP', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", ability: 'limber', moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Mewtwo", ability: 'pressure', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Mewtwo", ability: 'pressure', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move transform', 'move rest');
 		const p1poke = battle.p1.active[0];
 		const p2poke = battle.p2.active[0];
@@ -33,9 +37,11 @@ describe('Transform', () => {
 	});
 
 	it('should copy all stat changes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', item: 'laggingtail', moves: ['calmmind', 'agility', 'transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Scolipede", ability: 'swarm', moves: ['honeclaws', 'irondefense', 'doubleteam'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', item: 'laggingtail', moves: ['calmmind', 'agility', 'transform'] },
+		], [
+			{ species: "Scolipede", ability: 'swarm', moves: ['honeclaws', 'irondefense', 'doubleteam'] },
+		]]);
 		for (let i = 1; i <= 3; i++) {
 			battle.makeChoices('move ' + i, 'move ' + i);
 		}
@@ -47,17 +53,21 @@ describe('Transform', () => {
 	});
 
 	it("should copy the target's focus energy status", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", ability: 'limber', moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sawk", ability: 'sturdy', moves: ['focusenergy'] }] });
+		battle = common.createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Sawk", ability: 'sturdy', moves: ['focusenergy'] },
+		]]);
 		battle.makeChoices('move transform', 'move focusenergy');
 		assert(battle.p1.active[0].volatiles['focusenergy']);
 	});
 
 	it('should copy the target\'s moves with 5 PP each', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", ability: 'limber', moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Mew", ability: 'synchronize', moves: ['rest', 'psychic', 'energyball', 'hyperbeam'] }] });
+		battle = common.createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Mew", ability: 'synchronize', moves: ['rest', 'psychic', 'energyball', 'hyperbeam'] },
+		]]);
 		const p1poke = battle.p1.active[0];
 		const p2poke = battle.p2.active[0];
 		battle.makeChoices('move transform', 'move rest');
@@ -92,17 +102,21 @@ describe('Transform', () => {
 	});
 
 	it('should not copy speed boosts from Unburden', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", ability: 'limber', moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Hitmonlee", ability: 'unburden', item: 'normalgem', moves: ['feint'] }] });
+		battle = common.createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Hitmonlee", ability: 'unburden', item: 'normalgem', moves: ['feint'] },
+		]]);
 		battle.makeChoices('move transform', 'move feint');
 		assert.notEqual(battle.p1.active[0].getStat('spe'), battle.p2.active[0].getStat('spe'));
 	});
 
 	it('should fail against Pokemon with a Substitute', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", ability: 'limber', moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Mewtwo", ability: 'pressure', moves: ['substitute'] }] });
+		battle = common.createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Mewtwo", ability: 'pressure', moves: ['substitute'] },
+		]]);
 		battle.makeChoices('move transform', 'move substitute');
 		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);
 	});
@@ -120,12 +134,12 @@ describe('Transform', () => {
 	});
 
 	it('should fail against transformed Pokemon', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", ability: 'limber', moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [
+		battle = common.createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
 			{ species: "Magikarp", ability: 'rattled', moves: ['splash'] },
 			{ species: "Mew", ability: 'synchronize', moves: ['transform'] },
-		] });
+		]]);
 		battle.makeChoices('move transform', 'move splash');
 		assert.equal(battle.p1.active[0].species, battle.p2.active[0].species);
 		battle.makeChoices('move splash', 'switch 2');
@@ -134,19 +148,21 @@ describe('Transform', () => {
 	});
 
 	it(`should copy the target's real type, even if the target is an Arceus`, () => {
-		battle = common.createBattle([
-			[{ species: "Ditto", ability: 'limber', item: 'flameplate', moves: ['transform'] }],
-			[{ species: "Arceus-Steel", ability: 'multitype', item: 'ironplate', moves: ['rest'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Ditto", ability: 'limber', item: 'flameplate', moves: ['transform'] },
+		], [
+			{ species: "Arceus-Steel", ability: 'multitype', item: 'ironplate', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move transform', 'move rest');
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Steel"]);
 	});
 
 	it(`should ignore the effects of Roost`, () => {
-		battle = common.createBattle([
-			[{ species: "Mew", ability: 'synchronize', moves: ['seismictoss', 'transform'] }],
-			[{ species: "Talonflame", ability: 'flamebody', moves: ['roost'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['seismictoss', 'transform'] },
+		], [
+			{ species: "Talonflame", ability: 'flamebody', moves: ['roost'] },
+		]]);
 		battle.makeChoices('move seismictoss', 'move roost');
 		battle.makeChoices('move transform', 'move roost');
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Fire", "Flying"]);
@@ -253,9 +269,11 @@ describe('Transform [Gen 5]', () => {
 	});
 
 	it("should not copy the target's focus energy status", () => {
-		battle = common.gen(5).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", ability: 'limber', moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sawk", ability: 'sturdy', moves: ['focusenergy'] }] });
+		battle = common.gen(5).createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Sawk", ability: 'sturdy', moves: ['focusenergy'] },
+		]]);
 		assert.constant(() => battle.p1.active[0].volatiles['focusenergy'], () => battle.makeChoices('move transform', 'move focusenergy'));
 	});
 });
@@ -266,38 +284,42 @@ describe('Transform [Gen 4]', () => {
 	});
 
 	it('should revert Pokemon transformed into Giratina-Origin to Giratina-Alternate if not holding a Griseous Orb', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Ditto", ability: 'limber', moves: ['transform'] }],
-			[{ species: "Giratina-Origin", ability: 'levitate', item: 'griseousorb', moves: ['rest'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Giratina-Origin", ability: 'levitate', item: 'griseousorb', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move transform', 'move rest');
 		assert.equal(battle.p1.active[0].species.name, 'Giratina');
 	});
 
 	it('should cause Pokemon transformed into Giratina-Alternate to become Giratina-Origin if holding a Griseous Orb', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Ditto", ability: 'limber', item: 'griseousorb', moves: ['transform'] }],
-			[{ species: "Giratina", ability: 'pressure', moves: ['rest'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Ditto", ability: 'limber', item: 'griseousorb', moves: ['transform'] },
+		], [
+			{ species: "Giratina", ability: 'pressure', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move transform', 'move rest');
 		assert.equal(battle.p1.active[0].species.name, 'Giratina-Origin');
 	});
 
 	it('should cause Pokemon transformed into Arceus to become an Arceus forme corresponding to its held Plate', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Ditto", ability: 'limber', item: 'flameplate', moves: ['transform'] }],
-			[{ species: "Arceus-Steel", ability: 'multitype', item: 'ironplate', moves: ['rest'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Ditto", ability: 'limber', item: 'flameplate', moves: ['transform'] },
+		], [
+			{ species: "Arceus-Steel", ability: 'multitype', item: 'ironplate', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move transform', 'move rest');
 		assert.equal(battle.p1.active[0].species.name, 'Arceus-Fire');
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Fire"]);
 	});
 
 	it('should succeed against a Substitute', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: "Ditto", ability: 'limber', moves: ['transform'] }],
-			[{ species: "Mewtwo", ability: 'pressure', moves: ['substitute'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: "Ditto", ability: 'limber', moves: ['transform'] },
+		], [
+			{ species: "Mewtwo", ability: 'pressure', moves: ['substitute'] },
+		]]);
 		battle.makeChoices('move transform', 'move substitute');
 		assert.equal(battle.p1.active[0].species, battle.p2.active[0].species);
 	});
@@ -309,9 +331,11 @@ describe('Transform [Gen 1]', () => {
 	});
 
 	it("should not send |-endability|", () => {
-		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Ditto", moves: ['transform'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Gengar", moves: ['lick'] }] });
+		battle = common.gen(1).createBattle([[
+			{ species: "Ditto", moves: ['transform'] },
+		], [
+			{ species: "Gengar", moves: ['lick'] },
+		]]);
 		battle.makeChoices('move transform', 'move lick');
 
 		assert(battle.log.every(line => !line.startsWith('|-endability|')));

--- a/test/sim/moves/trick.js
+++ b/test/sim/moves/trick.js
@@ -9,58 +9,72 @@ describe('Trick', () => {
 	afterEach(() => battle.destroy());
 
 	it("should exchange the items of the user and target", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', item: 'leftovers', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Purugly", ability: 'defiant', item: 'sitrusberry', moves: ['rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', item: 'leftovers', moves: ['trick'] },
+		], [
+			{ species: "Purugly", ability: 'defiant', item: 'sitrusberry', moves: ['rest'] },
+		]]);
 		battle.makeChoices('move trick', 'move rest');
 		assert.equal(battle.p1.active[0].item, 'sitrusberry');
 		assert.equal(battle.p2.active[0].item, 'leftovers');
 	});
 
 	it('should not take plates from Arceus', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Arceus", ability: 'download', item: 'flameplate', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['trick'] },
+		], [
+			{ species: "Arceus", ability: 'download', item: 'flameplate', moves: ['swordsdance'] },
+		]]);
 		battle.makeChoices('move trick', 'move swordsdance');
 		assert.equal(battle.p2.active[0].item, 'flameplate');
 	});
 
 	it('should not cause Arceus to gain a plate', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', item: 'fistplate', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Arceus", ability: 'download', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', item: 'fistplate', moves: ['trick'] },
+		], [
+			{ species: "Arceus", ability: 'download', moves: ['swordsdance'] },
+		]]);
 		battle.makeChoices('move trick', 'move swordsdance');
 		assert.equal(battle.p2.active[0].item, '');
 	});
 
 	it('should not remove drives from Genesect', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Genesect", ability: 'download', item: 'dousedrive', moves: ['shiftgear'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['trick'] },
+		], [
+			{ species: "Genesect", ability: 'download', item: 'dousedrive', moves: ['shiftgear'] },
+		]]);
 		battle.makeChoices('move trick', 'move shiftgear');
 		assert.equal(battle.p2.active[0].item, 'dousedrive');
 	});
 
 	it('should not cause Genesect to gain a drive', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', item: 'shockdrive', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Genesect", ability: 'download', moves: ['shiftgear'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', item: 'shockdrive', moves: ['trick'] },
+		], [
+			{ species: "Genesect", ability: 'download', moves: ['shiftgear'] },
+		]]);
 		battle.makeChoices('move trick', 'move shiftgear');
 		assert.equal(battle.p2.active[0].item, '');
 	});
 
 	it('should not remove correctly held mega stones', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Scizor", ability: 'technician', item: 'scizorite', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['trick'] },
+		], [
+			{ species: "Scizor", ability: 'technician', item: 'scizorite', moves: ['swordsdance'] },
+		]]);
 		battle.makeChoices('move trick', 'move swordsdance');
 		assert.equal(battle.p2.active[0].item, 'scizorite');
 	});
 
 	it('should remove wrong mega stones', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Scizor", ability: 'technician', item: 'audinite', moves: ['swordsdance'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', moves: ['trick'] },
+		], [
+			{ species: "Scizor", ability: 'technician', item: 'audinite', moves: ['swordsdance'] },
+		]]);
 		battle.makeChoices('move trick', 'move swordsdance');
 		assert.equal(battle.p1.active[0].item, 'audinite');
 	});
@@ -70,9 +84,11 @@ describe('Z-Trick', () => {
 	afterEach(() => battle.destroy());
 
 	it("boost the user's Speed by 2 stages, but should fail to exchange the items", () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Mew", ability: 'synchronize', item: 'psychiumz', moves: ['trick'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Rattata", ability: 'guts', item: 'leftovers', moves: ['quickattack'] }] });
+		battle = common.createBattle([[
+			{ species: "Mew", ability: 'synchronize', item: 'psychiumz', moves: ['trick'] },
+		], [
+			{ species: "Rattata", ability: 'guts', item: 'leftovers', moves: ['quickattack'] },
+		]]);
 		const [user, nonTarget] = [battle.p1.active[0], battle.p2.active[0]];
 		battle.makeChoices('move trick zmove', 'move quickattack');
 		assert.statStage(user, 'spe', 2);

--- a/test/sim/moves/trickroom.js
+++ b/test/sim/moves/trickroom.js
@@ -11,10 +11,11 @@ describe('Trick Room', () => {
 	});
 
 	it('should cause slower Pokemon to move before faster Pokemon in a priority bracket', () => {
-		battle = common.createBattle([
-			[{ species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom'] }],
-			[{ species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'spore'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom'] },
+		], [
+			{ species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'spore'] },
+		]]);
 		battle.makeChoices('move trickroom', 'move poisonjab');
 		battle.makeChoices('move spore', 'move spore');
 		assert.equal(battle.p1.active[0].status, '');
@@ -22,10 +23,11 @@ describe('Trick Room', () => {
 	});
 
 	it('should not allow Pokemon using a lower priority move to act before other Pokemon', () => {
-		battle = common.createBattle([
-			[{ species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom'] }],
-			[{ species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'protect'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom'] },
+		], [
+			{ species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'protect'] },
+		]]);
 		battle.makeChoices('move trickroom', 'move poisonjab');
 		battle.makeChoices('move spore', 'move protect');
 		assert.equal(battle.p1.active[0].status, '');
@@ -33,15 +35,13 @@ describe('Trick Room', () => {
 	});
 
 	it('should also affect the activation order for abilities and other non-move actions', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: 'Bronzong', ability: 'heatproof', moves: ['trickroom', 'explosion'] },
 			{ species: 'Hippowdon', ability: 'sandstream', moves: ['protect'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Ninjask', ability: 'speedboost', moves: ['shellsmash'] },
 			{ species: 'Ninetales', ability: 'drought', moves: ['protect'] },
-		] });
+		]]);
 		battle.makeChoices('move trickroom', 'move shellsmash');
 		battle.makeChoices('move explosion', 'move shellsmash');
 		battle.makeChoices('switch hippowdon', 'switch ninetales');
@@ -53,10 +53,11 @@ describe('Trick Room', () => {
 	// The following two tests involve the Trick Room glitch, where turn order changes when a Pokemon goes to 1809 speed.
 
 	it('should roll over and cause Pokemon with 1809 or more speed to outspeed Pokemon with 1808 or less', () => {
-		battle = common.createBattle([
-			[{ species: 'Ninjask', ability: 'swarm', evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 184 }, moves: ['protect', 'spore'] }],
-			[{ species: 'Deoxys-Speed', ability: 'pressure', evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 224 }, moves: ['spore', 'trickroom'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Ninjask', ability: 'swarm', evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 184 }, moves: ['protect', 'spore'] },
+		], [
+			{ species: 'Deoxys-Speed', ability: 'pressure', evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 224 }, moves: ['spore', 'trickroom'] },
+		]]);
 		battle.makeChoices('move protect', 'move trickroom'); // Trick Room is now up.
 
 		// This sets Ninjask to exactly 1809 Speed
@@ -76,10 +77,11 @@ describe('Trick Room', () => {
 	});
 
 	it('should not affect damage dealt by moves whose power is reliant on speed', () => {
-		battle = common.createBattle([
-			[{ species: 'Ninjask', ability: 'swarm', evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 184 }, item: 'choicescarf', moves: ['earthquake'] }],
-			[{ species: 'Deoxys-Speed', ability: 'levitate', evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 224 }, moves: ['gyroball', 'trickroom'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Ninjask', ability: 'swarm', evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 184 }, item: 'choicescarf', moves: ['earthquake'] },
+		], [
+			{ species: 'Deoxys-Speed', ability: 'levitate', evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 224 }, moves: ['gyroball', 'trickroom'] },
+		]]);
 		battle.makeChoices('move earthquake', 'move trickroom');
 
 		battle.p1.active[0].boostBy({ spe: 4 }); // 1809 Speed

--- a/test/sim/moves/trumpcard.js
+++ b/test/sim/moves/trumpcard.js
@@ -11,10 +11,11 @@ describe('Trump Card', () => {
 	});
 
 	it('should power-up the less PP the move has', () => {
-		battle = common.createBattle([
-			[{ species: 'Eevee', ability: 'runaway', moves: ['trumpcard'] }],
-			[{ species: 'Lugia', ability: 'multiscale', moves: ['recover'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Eevee', ability: 'runaway', moves: ['trumpcard'] },
+		], [
+			{ species: 'Lugia', ability: 'multiscale', moves: ['recover'] },
+		]]);
 
 		const basePowers = [];
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
@@ -31,10 +32,11 @@ describe('Trump Card', () => {
 	});
 
 	it('should get its base power calculated from a move calling it', () => {
-		battle = common.createBattle([
-			[{ species: 'Komala', ability: 'comatose', moves: ['sleeptalk', 'trumpcard'] }],
-			[{ species: 'Lugia', ability: 'multiscale', moves: ['recover'] }],
-		]);
+		battle = common.createBattle([[
+			{ species: 'Komala', ability: 'comatose', moves: ['sleeptalk', 'trumpcard'] },
+		], [
+			{ species: 'Lugia', ability: 'multiscale', moves: ['recover'] },
+		]]);
 
 		const basePowers = [];
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {
@@ -53,10 +55,11 @@ describe('Trump Card', () => {
 	});
 
 	it('should work if called via Custap Berry in Gen 4', () => {
-		battle = common.gen(4).createBattle([
-			[{ species: 'Eevee', level: 1, ability: 'runaway', item: 'custapberry', moves: ['trumpcard'] }],
-			[{ species: 'Scizor', ability: 'technician', moves: ['falseswipe'] }],
-		]);
+		battle = common.gen(4).createBattle([[
+			{ species: 'Eevee', level: 1, ability: 'runaway', item: 'custapberry', moves: ['trumpcard'] },
+		], [
+			{ species: 'Scizor', ability: 'technician', moves: ['falseswipe'] },
+		]]);
 
 		const basePowers = [];
 		battle.onEvent('BasePower', battle.format, (bp, attacker, defender, move) => {

--- a/test/sim/moves/uproar.js
+++ b/test/sim/moves/uproar.js
@@ -11,18 +11,22 @@ describe('Uproar', () => {
 	});
 
 	it('should pierce through substitutes', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'uproar'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }] });
+		battle = common.createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'uproar'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move uproar', 'move rest');
 		assert.equal(battle.p2.active[0].item, '');
 	});
 
 	it('should end if the user is under the effect of Throat Chop', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [{ species: "Zoroark", moves: ['uproar'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Corsola", moves: ['throatchop'] }] });
+		battle = common.createBattle([[
+			{ species: "Zoroark", moves: ['uproar'] },
+		], [
+			{ species: "Corsola", moves: ['throatchop'] },
+		]]);
 		battle.makeChoices('move uproar', 'move throatchop');
 		assert.equal(battle.p1.active[0].volatiles['uproar'], undefined);
 	});
@@ -34,10 +38,11 @@ describe('Uproar [Gen 5]', () => {
 	});
 
 	it('should not pierce through substitutes', () => {
-		battle = common.gen(5).createBattle([
-			[{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'uproar'] }],
-			[{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] }],
-		]);
+		battle = common.gen(5).createBattle([[
+			{ species: "Deoxys-Attack", ability: 'victorystar', item: 'laggingtail', moves: ['splash', 'uproar'] },
+		], [
+			{ species: "Caterpie", level: 2, ability: 'naturalcure', item: 'focussash', moves: ['substitute', 'rest'] },
+		]]);
 		battle.makeChoices('move splash', 'move substitute');
 		battle.makeChoices('move uproar', 'move rest');
 		assert.equal(battle.p2.active[0].item, 'focussash');

--- a/test/sim/moves/weatherball.js
+++ b/test/sim/moves/weatherball.js
@@ -11,26 +11,22 @@ describe('Weather Ball', () => {
 	});
 
 	it('should change type when used as a Z-move in weather', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Castform", item: 'normaliumz', moves: ['weatherball'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Gastly", level: 2, ability: 'drought', item: 'focussash', moves: ['splash'] },
-		] });
+		]]);
 		battle.makeChoices('move weatherball zmove', 'move splash');
 		assert.equal(battle.p2.active[0].item, '');
 	});
 
 	it('should not change type when called by a Z-move in weather', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Castform", item: 'normaliumz', moves: ['shadowball', 'assist'] },
 			{ species: "Castform", moves: ['weatherball'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Gastly", level: 2, ability: 'drought', item: 'focussash', moves: ['splash'] },
-		] });
+		]]);
 		battle.makeChoices('move shadowball', 'move splash');
 		battle.makeChoices('move assist zmove', 'move splash');
 		assert(!battle.p2.active[0].fainted);
@@ -48,33 +44,41 @@ describe('Weather Ball', () => {
 
 	describe('[Gen 3]', () => {
 		it('should not trigger counter when it is special', () => {
-			battle = common.gen(3).createBattle();
-			battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'drizzle', moves: ['weatherball'] }] });
-			battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['counter'] }] });
+			battle = common.gen(3).createBattle([[
+				{ species: 'Shuckle', ability: 'drizzle', moves: ['weatherball'] },
+			], [
+				{ species: 'Shuckle', moves: ['counter'] },
+			]]);
 			battle.makeChoices();
 			assert.fullHP(battle.p1.active[0]);
 		});
 
 		it('should trigger mirror coat when it is special', () => {
-			battle = common.gen(3).createBattle();
-			battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'drought', moves: ['weatherball'] }] });
-			battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['mirrorcoat'] }] });
+			battle = common.gen(3).createBattle([[
+				{ species: 'Shuckle', ability: 'drought', moves: ['weatherball'] },
+			], [
+				{ species: 'Shuckle', moves: ['mirrorcoat'] },
+			]]);
 			battle.makeChoices();
 			assert.false.fullHP(battle.p1.active[0]);
 		});
 
 		it('should not trigger mirror coat when it is physical', () => {
-			battle = common.gen(3).createBattle();
-			battle.setPlayer('p1', { team: [{ species: 'Shuckle', moves: ['weatherball'] }] });
-			battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['mirrorcoat'] }] });
+			battle = common.gen(3).createBattle([[
+				{ species: 'Shuckle', moves: ['weatherball'] },
+			], [
+				{ species: 'Shuckle', moves: ['mirrorcoat'] },
+			]]);
 			battle.makeChoices();
 			assert.fullHP(battle.p1.active[0]);
 		});
 
 		it('should trigger counter when it is physical', () => {
-			battle = common.gen(3).createBattle();
-			battle.setPlayer('p1', { team: [{ species: 'Shuckle', ability: 'sandstream', moves: ['weatherball'] }] });
-			battle.setPlayer('p2', { team: [{ species: 'Shuckle', moves: ['counter'] }] });
+			battle = common.gen(3).createBattle([[
+				{ species: 'Shuckle', ability: 'sandstream', moves: ['weatherball'] },
+			], [
+				{ species: 'Shuckle', moves: ['counter'] },
+			]]);
 			battle.makeChoices();
 			assert.false.fullHP(battle.p1.active[0]);
 		});

--- a/test/sim/moves/wish.js
+++ b/test/sim/moves/wish.js
@@ -11,17 +11,15 @@ describe('Wish', () => {
 	});
 
 	it(`should heal the Pokemon in the user's slot by 1/2 of the user's max HP 1 turn after use`, () => {
-		battle = common.createBattle({ gameType: 'doubles' });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ gameType: 'doubles' }, [[
 			{ species: "Chansey", moves: ['wish'] },
 			{ species: "Chansey", moves: ['wish'] },
 			{ species: "Donphan", ability: 'sturdy', moves: ['sleeptalk'] },
 			{ species: "Guzzlord", item: 'focussash', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Kyurem", moves: ['dragonpulse'] },
 			{ species: "Diancie", moves: ['moonblast'] },
-		] });
+		]]);
 		battle.makeChoices('move wish, move wish', 'move dragonpulse 1, move moonblast 2');
 		battle.makeChoices('switch 3, switch 4', 'move dragonpulse 1, move moonblast 2');
 		assert.fullHP(battle.p1.active[0]);
@@ -29,14 +27,12 @@ describe('Wish', () => {
 	});
 
 	it('should progress its duration whether or not the Pokemon in its slot is fainted', () => {
-		battle = common.createBattle();
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle([[
 			{ species: "Pichu", ability: 'prankster', moves: ['wish'] },
 			{ species: "Parasect", ability: 'effectspore', moves: ['sleeptalk'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Zygarde", ability: 'aurabreak', moves: ['thousandarrows'] },
-		] });
+		]]);
 		battle.makeChoices('move wish', 'move thousandarrows');
 		battle.makeChoices('switch 2');
 		battle.makeChoices('auto', 'move thousandarrows');

--- a/test/sim/othermetas/mixandmega.js
+++ b/test/sim/othermetas/mixandmega.js
@@ -6,14 +6,14 @@ const common = require('./../../common');
 let battle;
 
 describe('Mix and Mega', () => {
-	beforeEach(() => {
-		battle = common.createBattle({ formatid: 'gen9mixandmega' });
-	});
 	afterEach(() => battle.destroy());
 
 	it('should overwrite forme-change abilities on Mega Evolution', () => {
-		battle.setPlayer('p1', { team: [{ species: "Mimikyu", ability: 'disguise', item: 'metagrossite', moves: ['shadowclaw'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Palafin", ability: 'zerotohero', item: 'leftovers', moves: ['jetpunch'] }] });
+		battle = common.createBattle({ formatid: 'gen9mixandmega' }, [[
+			{ species: "Mimikyu", ability: 'disguise', item: 'metagrossite', moves: ['shadowclaw'] },
+		], [
+			{ species: "Palafin", ability: 'zerotohero', item: 'leftovers', moves: ['jetpunch'] },
+		]]);
 		battle.makeChoices('default', 'default'); // Switch in
 		battle.makeChoices('move shadowclaw mega', 'move jetpunch');
 		assert.equal(battle.p1.active[0].ability, 'toughclaws');

--- a/test/sim/rulesets/endlessbattleclause.js
+++ b/test/sim/rulesets/endlessbattleclause.js
@@ -9,9 +9,11 @@ describe('Endless Battle Clause (slow)', () => {
 	afterEach(() => battle.destroy());
 
 	it('should trigger on an infinite loop', () => {
-		battle = common.createBattle({ endlessBattleClause: true });
-		battle.setPlayer('p1', { team: [{ species: "Caterpie", moves: ['tackle'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Slowbro", item: 'leppaberry', moves: ['slackoff', 'healpulse', 'recycle'] }] });
+		battle = common.createBattle({ endlessBattleClause: true }, [[
+			{ species: "Caterpie", moves: ['tackle'] },
+		], [
+			{ species: "Slowbro", item: 'leppaberry', moves: ['slackoff', 'healpulse', 'recycle'] },
+		]]);
 		const [victim, memeSlowbro] = [battle.p1.active[0], battle.p2.active[0]];
 		skipTurns(battle, 100);
 		for (let i = 0; i < 100; i++) {
@@ -33,9 +35,11 @@ describe('Endless Battle Clause (slow)', () => {
 	});
 
 	it('should not trigger by both Pokemon eating a Leppa Berry they started with', () => {
-		battle = common.createBattle({ endlessBattleClause: true });
-		battle.setPlayer('p1', { team: [{ species: "Sunkern", item: 'leppaberry', moves: ['synthesis'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Sunkern", item: 'leppaberry', moves: ['synthesis'] }] });
+		battle = common.createBattle({ endlessBattleClause: true }, [[
+			{ species: "Sunkern", item: 'leppaberry', moves: ['synthesis'] },
+		], [
+			{ species: "Sunkern", item: 'leppaberry', moves: ['synthesis'] },
+		]]);
 		skipTurns(battle, 100);
 		for (let i = 0; i < 10; i++) {
 			battle.makeChoices('move synthesis', 'move synthesis');
@@ -44,15 +48,13 @@ describe('Endless Battle Clause (slow)', () => {
 	});
 
 	it('should only cause the battle to end if either side cannot switch to a non-stale Pokemon and at least one staleness is externally inflicted', () => {
-		battle = common.createBattle({ endlessBattleClause: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ endlessBattleClause: true }, [[
 			{ species: "Blissey", level: 1, item: 'leppaberry', moves: ['recycle', 'extremespeed', 'floralhealing', 'block'] },
 			{ species: "Magikarp", moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Magikarp", moves: ['splash'] },
 			{ species: "Sunkern", item: 'leppaberry', moves: ['synthesis'] },
-		] });
+		]]);
 		skipTurns(battle, 100);
 		for (let i = 0; i < 8; i++) {
 			battle.makeChoices('move extremespeed', 'move splash');
@@ -77,15 +79,13 @@ describe('Endless Battle Clause (slow)', () => {
 	});
 
 	it('Fling should cause externally inflicted staleness', () => {
-		battle = common.createBattle({ endlessBattleClause: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ endlessBattleClause: true }, [[
 			{ species: "Blissey", level: 1, item: 'leppaberry', moves: ['recycle', 'extremespeed', 'fling', 'block'] },
 			{ species: "Magikarp", moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Magikarp", moves: ['splash'] },
 			{ species: "Sunkern", item: 'leppaberry', moves: ['synthesis'] },
-		] });
+		]]);
 		skipTurns(battle, 100);
 		// Blissey inflicts external staleness on Magikarp.
 		battle.makeChoices('move fling', 'move splash');
@@ -104,15 +104,13 @@ describe('Endless Battle Clause (slow)', () => {
 	});
 
 	it('Entrainment should cause externally inflicted staleness', () => {
-		battle = common.createBattle({ endlessBattleClause: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ endlessBattleClause: true }, [[
 			{ species: "Blissey", ability: 'Levitate', level: 1, item: 'leppaberry', moves: ['recycle', 'extremespeed', 'entrainment', 'block'] },
 			{ species: "Magikarp", moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Magikarp", ability: 'Illuminate', moves: ['splash'] },
 			{ species: "Sunkern", item: 'leppaberry', moves: ['synthesis'] },
-		] });
+		]]);
 		skipTurns(battle, 100);
 		// Blissey inflicts external staleness on Magikarp.
 		battle.makeChoices('move entrainment', 'move splash');
@@ -138,15 +136,13 @@ describe('Endless Battle Clause (slow)', () => {
 	});
 
 	it('Entrainment\'s externally inflicted staleness should go away on switch', () => {
-		battle = common.createBattle({ endlessBattleClause: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ endlessBattleClause: true }, [[
 			{ species: "Blissey", ability: 'Levitate', level: 1, item: 'leppaberry', moves: ['recycle', 'extremespeed', 'entrainment', 'block'] },
 			{ species: "Magikarp", moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Magikarp", ability: 'Illuminate', moves: ['splash'] },
 			{ species: "Sunkern", item: 'leppaberry', moves: ['synthesis'] },
-		] });
+		]]);
 		skipTurns(battle, 100);
 		// Blissey inflicts external staleness on Magikarp.
 		battle.makeChoices('move entrainment', 'move splash');
@@ -173,15 +169,13 @@ describe('Endless Battle Clause (slow)', () => {
 
 	it('should allow for a maximum of 1000 turns', function () {
 		this.timeout(0);
-		battle = common.createBattle({ endlessBattleClause: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ endlessBattleClause: true }, [[
 			{ species: "Gengar", moves: ['splash'] },
 			{ species: "Clefable", moves: ['splash'] },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: "Blissey", moves: ['splash'] },
 			{ species: "Vaporeon", moves: ['splash'] },
-		] });
+		]]);
 		for (let i = 0; i < 999; i++) {
 			battle.makeChoices('switch 2', 'switch 2');
 		}

--- a/test/sim/rulesets/overflowstatmod.js
+++ b/test/sim/rulesets/overflowstatmod.js
@@ -11,13 +11,11 @@ describe('Overflow Stat Mod', () => {
 	});
 
 	it('should cap stats at 654 after a positive nature', () => {
-		battle = common.createBattle({ overflowStatMod: true });
-		battle.setPlayer('p1', { team: [
+		battle = common.createBattle({ overflowStatMod: true }, [[
 			{ species: 'Eternatus-Eternamax', ability: 'Neutralizing Gas', moves: ['tackle'], nature: 'bold', evs: { def: 252 } },
-		] });
-		battle.setPlayer('p2', { team: [
+		], [
 			{ species: 'Magikarp', ability: 'Damp', moves: ['tackle'], nature: 'bold', evs: { def: 1 } },
-		] });
+		]]);
 		const eternamax = battle.p1.active[0];
 		const def = eternamax.getStat('def');
 

--- a/test/sim/rulesets/sleepclausemod.js
+++ b/test/sim/rulesets/sleepclausemod.js
@@ -9,9 +9,12 @@ describe('Sleep Clause Mod', () => {
 	afterEach(() => battle.destroy());
 
 	it('should prevent players from putting more than one of foe\'s Pokemon to sleep', () => {
-		battle = common.createBattle({ sleepClause: true });
-		battle.setPlayer('p1', { team: [{ species: "Paras", moves: ['spore'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Magikarp", moves: ['splash'] }, { species: "Feebas", moves: ['splash'] }] });
+		battle = common.createBattle({ sleepClause: true }, [[
+			{ species: "Paras", moves: ['spore'] },
+		], [
+			{ species: "Magikarp", moves: ['splash'] },
+			{ species: "Feebas", moves: ['splash'] },
+		]]);
 		battle.makeChoices('move spore', 'switch 2');
 		assert.equal(battle.p2.active[0].status, 'slp');
 		battle.makeChoices('move spore', 'switch 2');
@@ -19,9 +22,12 @@ describe('Sleep Clause Mod', () => {
 	});
 
 	it('should not prevent Rest', () => {
-		battle = common.createBattle({ sleepClause: true });
-		battle.setPlayer('p1', { team: [{ species: "Paras", moves: ['spore', 'tackle'] }] });
-		battle.setPlayer('p2', { team: [{ species: "Feebas", moves: ['rest'] }, { species: "Magikarp", moves: ['splash'] }] });
+		battle = common.createBattle({ sleepClause: true }, [[
+			{ species: "Paras", moves: ['spore', 'tackle'] },
+		], [
+			{ species: "Feebas", moves: ['rest'] },
+			{ species: "Magikarp", moves: ['splash'] },
+		]]);
 		battle.makeChoices('move spore', 'switch 2');
 		assert.equal(battle.p2.active[0].status, 'slp');
 		battle.makeChoices('move tackle', 'switch 2');


### PR DESCRIPTION
This is a bit nitpicky, but I've wanted to do this for some time. Some of the code in the old tests looks weird by today's standards. And when we copy-paste tests like the one below, they require some extra parentheses and bracket formatting to look good when adding more Pokémon to the team.
```typescript
battle = common.createBattle([
	[{ species: 'Bronzong', ability: 'heatproof', moves: ['spore', 'trickroom'] }],
	[{ species: 'Ninjask', ability: 'speedboost', moves: ['poisonjab', 'spore'] }],
]);
```