### PR TITLE
Allow /editbattle to be used through a battle rule

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -3179,7 +3179,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 	battleedit: {
 		effectType: 'Rule',
 		name: 'Battle Edit',
-		desc: 'Allows users to edit the battle details using `/editbattle`.<br>Requires: ☆ and Global + * % @ ~'
+		desc: 'Allows users to edit the battle details using `/editbattle`.<br>Requires: ☆ and Global + * % @ ~',
 		// hardcoded in chat-commands/admin.ts
 	},
 	rebalancelevels: {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -3176,6 +3176,12 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 			}
 		},
 	},
+	battleedit: {
+		effectType: 'Rule',
+		name: 'Battle Edit',
+		desc: 'Allows users to edit the battle details using `/editbattle`.<br>Requires: ☆ and Global + * % @ ~'
+		// hardcoded in chat-commands/admin.ts
+	},
 	rebalancelevels: {
 		effectType: 'Rule',
 		name: 'Rebalance Levels',

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -1621,12 +1621,19 @@ export const commands: Chat.ChatCommands = {
 	ebat: 'editbattle',
 	editbattle(target, room, user) {
 		room = this.requireRoom();
-		this.checkCan('forcewin');
 		if (!target) return this.parse('/help editbattle');
 		if (!room.battle) {
 			throw new Chat.ErrorMessage("/editbattle - This is not a battle room.");
 		}
 		const battle = room.battle;
+		const format = Dex.formats.get(battle.format, true);
+		const ruleTable = Dex.formats.getRuleTable(format);
+		if (ruleTable.has('battleedit')) {
+			this.checkCan('editprivacy', null, room);
+			this.checkCan('altsself');
+		} else {
+			this.checkCan('forcewin');
+		};
 		void battle.stream.write(`>editbattle user:${user.name}, ${target}`);
 	},
 	editbattlehelp: [
@@ -1642,6 +1649,7 @@ export const commands: Chat.ChatCommands = {
 		`/editbattle reseed [optional seed]`,
 		`Short forms: /ebat h OR s OR pp OR b OR v OR sc OR fc OR w OR t`,
 		`[player] must be a username or number, [pokemon] must be species name or party slot number (not nickname), [move] must be move name.`,
+		`Requires: Battle Edit rule, ☆ and + % @ ~, or ~`
 	],
 };
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -1649,7 +1649,7 @@ export const commands: Chat.ChatCommands = {
 		`/editbattle reseed [optional seed]`,
 		`Short forms: /ebat h OR s OR pp OR b OR v OR sc OR fc OR w OR t`,
 		`[player] must be a username or number, [pokemon] must be species name or party slot number (not nickname), [move] must be move name.`,
-		`Requires: Battle Edit rule, ☆ and + % @ ~, or ~`
+		`Requires: Battle Edit rule, ☆ and + % @ ~, or ~`,
 	],
 };
 


### PR DESCRIPTION
Adds a battle rule "battleedit" that allows the /editbattle command to be used in battle, if the user is a player and has global auth.

(This pull request was heavily discussed through other channels with @Zarel , @mia-pi-git , and @Slayer95 )