### PR TITLE
Champions UU - Ban Espathra and Charizard-Mega-X

### DIFF
--- a/data/mods/champions/formats-data.ts
+++ b/data/mods/champions/formats-data.ts
@@ -29,7 +29,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "UU",
 	},
 	charizardmegax: {
-		tier: "UU",
+		tier: "UUBL",
 	},
 	charizardmegay: {
 		tier: "UUBL",
@@ -4693,7 +4693,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 		tier: "Illegal",
 	},
 	espathra: {
-		tier: "UU",
+		tier: "UUBL",
 	},
 	wiglett: {
 		isNonstandard: "Past",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/champions-uu-metagame-discussion-mega-charizard-y-and-mega-alakazam-banned.3781741/post-10991680