### PR TITLE
Champions: Fix status collision logging for Dire Claw

### DIFF
--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -204,7 +204,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 					if (target.status === status) {
 						this.add('-fail', target, status);
 					} else {
-						this.add('-fail', source);
+						this.add('-fail', target);
 					}
 					return;
 				}


### PR DESCRIPTION
When Dire Claw rolls a status that is different from the one the target already has, the battle log showed the *attacker* as the failing party (`-fail, source`). The correct semantics are that the *defender* failed to receive the status change (`-fail, target`), matching the convention used everywhere else in the sim.