### PR TITLE
Champions: Fix Encore redirect to preserve original target location

### DIFF
--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -314,8 +314,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 						this.dex.moves.get(move.id).priority;
 					this.queue.changeAction(target, {
 						choice: 'move',
-						// target: undefined,
-						// targetLoc: undefined,
+						targetLoc: action.targetLoc,
 						moveid: move.id,
 						order: action.order,
 					});


### PR DESCRIPTION
The encore override, `changeAction` was called without forwarding `action.targetLoc`. In VGC doubles formats (which Champions uses) this meant the encored pokemon re-targeted a random opponent instead of the one it had originally chosen, silently producing wrong battle outcomes. Pass `targetLoc: action.targetLoc` to keep the original target slot.