### PR TITLE
Champions: Fix Disguise neutral check order for Mimikyu species ID

### DIFF
--- a/data/mods/champions/abilities.ts
+++ b/data/mods/champions/abilities.ts
@@ -17,11 +17,11 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			if (!target || move.category === 'Status') return;
 
 			if (move.hit === 1) delete this.effectState.neutral;
-			if (this.effectState.neutral) return 0;
-
 			if (!['mimikyu', 'mimikyutotem'].includes(target.species.id)) {
 				return;
 			}
+
+			if (this.effectState.neutral) return 0;
 
 			const hitSub = target.volatiles['substitute'] && !move.flags['bypasssub'] && !(move.infiltrates && this.gen >= 6);
 			if (hitSub) return;


### PR DESCRIPTION
The champions disguise `onEffectiveness` override tracks whether the current hit was absorbed by the disguise using `effectState.neutral`. However, the `if (this.effectState.neutral) return 0` early-exit was placed *before* the Mimikyu species ID guard. This meant that after a multihit move pops the disguise on hit 1 (causing a forme change to Mimikyu-Busted), every subsequent hit of that move still returned 0 (neutral type modifier) instead of the real type effectiveness.