### PR TITLE
[Champions] Fix: Anger Shell / Berserk permanently block healing berries after a Sheer Force hit

### DIFF
--- a/data/mods/champions/abilities.ts
+++ b/data/mods/champions/abilities.ts
@@ -1,92 +1,98 @@
 export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
-	angershell: {
-		inherit: true,
-		onDamage(damage, target, source, effect) {
-			this.effectState.checkedAngerShell = !(effect.effectType === "Move" && !effect.multihit);
-		},
-	},
-	berserk: {
-		inherit: true,
-		onDamage(damage, target, source, effect) {
-			this.effectState.checkedBerserk = !(effect.effectType === "Move" && !effect.multihit);
-		},
-	},
-	disguise: {
-		inherit: true,
-		onEffectiveness(typeMod, target, type, move) {
-			if (!target || move.category === 'Status') return;
+        angershell: {
+                inherit: true,
+                onDamage(damage, target, source, effect) {
+                        this.effectState.checkedAngerShell = !(
+                                effect.effectType === "Move" && !effect.multihit &&
+                                !(effect.hasSheerForce && source.hasAbility('sheerforce'))
+                        );
+                },
+        },
+        berserk: {
+                inherit: true,
+                onDamage(damage, target, source, effect) {
+                        this.effectState.checkedBerserk = !(
+                                effect.effectType === "Move" && !effect.multihit &&
+                                !(effect.hasSheerForce && source.hasAbility('sheerforce'))
+                        );
+                },
+        },
+        disguise: {
+                inherit: true,
+                onEffectiveness(typeMod, target, type, move) {
+                        if (!target || move.category === 'Status') return;
 
-			if (move.hit === 1) delete this.effectState.neutral;
-			if (this.effectState.neutral) return 0;
+                        if (move.hit === 1) delete this.effectState.neutral;
+                        if (!['mimikyu', 'mimikyutotem'].includes(target.species.id)) {
+                                return;
+                        }
 
-			if (!['mimikyu', 'mimikyutotem'].includes(target.species.id)) {
-				return;
-			}
+                        if (this.effectState.neutral) return 0;
 
-			const hitSub = target.volatiles['substitute'] && !move.flags['bypasssub'] && !(move.infiltrates && this.gen >= 6);
-			if (hitSub) return;
+                        const hitSub = target.volatiles['substitute'] && !move.flags['bypasssub'] && !(move.infiltrates && this.gen >= 6);
+                        if (hitSub) return;
 
-			if (!target.runImmunity(move)) return;
-			this.effectState.neutral = true;
-			return 0;
-		},
-	},
-	dragonize: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	healer: {
-		inherit: true,
-		onResidual(pokemon) {
-			for (const allyActive of pokemon.adjacentAllies()) {
-				if (allyActive.status && this.randomChance(1, 2)) {
-					this.add('-activate', pokemon, 'ability: Healer');
-					allyActive.cureStatus();
-				}
-			}
-		},
-		desc: "50% chance this Pokemon's ally has its non-volatile status condition cured at the end of each turn.",
-		shortDesc: "50% chance this Pokemon's ally has its status cured at the end of each turn.",
-	},
-	megasol: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	naturalcure: {
-		inherit: true,
-		onCheckShow: undefined, // no inherit
-		onSwitchOut(pokemon) {
-			if (!pokemon.status || pokemon.status === 'fnt') return;
+                        if (!target.runImmunity(move)) return;
+                        this.effectState.neutral = true;
+                        return 0;
+                },
+        },
+        dragonize: {
+                inherit: true,
+                isNonstandard: null,
+        },
+        healer: {
+                inherit: true,
+                onResidual(pokemon) {
+                        for (const allyActive of pokemon.adjacentAllies()) {
+                                if (allyActive.status && this.randomChance(1, 2)) {
+                                        this.add('-activate', pokemon, 'ability: Healer');
+                                        allyActive.cureStatus();
+                                }
+                        }
+                },
+                desc: "50% chance this Pokemon's ally has its non-volatile status condition cured at the end of each turn.",
+                shortDesc: "50% chance this Pokemon's ally has its status cured at the end of each turn.",
+        },
+        megasol: {
+                inherit: true,
+                isNonstandard: null,
+        },
+        naturalcure: {
+                inherit: true,
+                onCheckShow: undefined, // no inherit
+                onSwitchOut(pokemon) {
+                        if (!pokemon.status || pokemon.status === 'fnt') return;
 
-			this.add('-curestatus', pokemon, pokemon.status, '[from] ability: Natural Cure', '[silent]');
-			pokemon.clearStatus();
-		},
-	},
-	piercingdrill: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	regenerator: {
-		inherit: true,
-		onSwitchOut(pokemon) {
-			if (pokemon.heal(pokemon.baseMaxhp / 3)) {
-				this.add('-heal', pokemon, pokemon.getHealth, '[from] ability: Regenerator', '[silent]');
-			}
-		},
-	},
-	spicyspray: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	unseenfist: {
-		onModifyMove: undefined, // no inherit
-		onHitProtect(source, target, move) {
-			if (move.flags['contact']) {
-				target.getMoveHitData(move).bypassProtect = this.effect;
-				return false;
-			}
-		},
-		inherit: true,
-		shortDesc: "This Pokemon's contact moves ignore a target's protection and deal 1/4 the usual damage.",
-	},
+                        this.add('-curestatus', pokemon, pokemon.status, '[from] ability: Natural Cure', '[silent]');
+                        pokemon.clearStatus();
+                },
+        },
+        piercingdrill: {
+                inherit: true,
+                isNonstandard: null,
+        },
+        regenerator: {
+                inherit: true,
+                onSwitchOut(pokemon) {
+                        if (pokemon.heal(pokemon.baseMaxhp / 3)) {
+                                this.add('-heal', pokemon, pokemon.getHealth, '[from] ability: Regenerator', '[silent]');
+                        }
+                },
+        },
+        spicyspray: {
+                inherit: true,
+                isNonstandard: null,
+        },
+        unseenfist: {
+                onModifyMove: undefined, // no inherit
+                onHitProtect(source, target, move) {
+                        if (move.flags['contact']) {
+                                target.getMoveHitData(move).bypassProtect = this.effect;
+                                return false;
+                        }
+                },
+                inherit: true,
+                shortDesc: "This Pokemon's contact moves ignore a target's protection and deal 1/4 the usual damage.",
+        },
 };


### PR DESCRIPTION
## Problem

The Champions overrides for **Anger Shell** and **Berserk** dropped the Sheer Force exception that exists in the base `onDamage` handlers.

**Base (correct):**
```ts
this.effectState.checkedAngerShell = !(
    effect.effectType === "Move" && !effect.multihit &&
    !(effect.hasSheerForce && source.hasAbility("sheerforce"))
);
```

**Champions (missing guard):**
```ts
this.effectState.checkedAngerShell = !(effect.effectType === "Move" && !effect.multihit);
```

## Why this matters

The `checkedAngerShell`/`checkedBerserk` flag controls `onTryEatItem` — it prevents healing berries (Sitrus, Oran, etc.) from restoring HP between the damage step and `onAfterMoveSecondary` (so the berry cannot push the holder back above 50% before the ability activates).

For **Sheer Force** moves, `onAfterMoveSecondary` is suppressed entirely. That handler is responsible for resetting `checked → true`. Without the guard, after being hit by a Sheer Force move:

1. `onDamage` fires → `checked = false` (no exception → same as a normal hit)
2. `onAfterMoveSecondary` is suppressed by Sheer Force → flag is **never** reset to `true`
3. From this point on, every healing berry the Pokémon attempts to eat is permanently blocked

## Fix

Restore the missing Sheer Force exception in both abilities, matching base behaviour exactly.
