### PR TITLE
Use Champions HP mechanics if HP Percentage Mod is off

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1352,7 +1352,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 	hppercentagemod: {
 		effectType: 'Rule',
 		name: 'HP Percentage Mod',
-		desc: "Shows the HP of Pok&eacute;mon in percentages",
+		desc: "Shows the HP of Pok&eacute;mon in rounded-up percentages",
 		onBegin() {
 			this.add('rule', 'HP Percentage Mod: HP is shown in percentages');
 			this.reportPercentages = true;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -2063,7 +2063,14 @@ export class Pokemon {
 		let shared;
 		if (this.battle.reportExactHP) {
 			shared = secret;
-		} else if (this.battle.dex.currentMod === 'champions') {
+		} else if (this.battle.reportPercentages) {
+			// HP Percentage Mod mechanics
+			let percentage = Math.ceil(100 * this.hp / this.maxhp);
+			if (percentage === 100 && this.hp < this.maxhp) {
+				percentage = 99;
+			}
+			shared = `${percentage}/100`;
+		} else if (this.battle.gen >= 7) {
 			// Pokemon Champions mechanics
 			const percentage = Math.floor(100 * this.hp / this.maxhp) || 1;
 			shared = `${percentage}/100`;
@@ -2072,13 +2079,6 @@ export class Pokemon {
 			} else if (percentage === 50) {
 				shared += this.hp * 2 > this.maxhp ? 'g' : 'y';
 			}
-		} else if (this.battle.reportPercentages || this.battle.gen >= 7) {
-			// HP Percentage Mod mechanics
-			let percentage = Math.ceil(100 * this.hp / this.maxhp);
-			if (percentage === 100 && this.hp < this.maxhp) {
-				percentage = 99;
-			}
-			shared = `${percentage}/100`;
 		} else {
 			/**
 			 * In-game accurate pixel health mechanics


### PR DESCRIPTION
The Champions mechanics are still more accurate to Gen 7, 8 and 9 games:
- Pixels use the floor function.
- You can still determine the exact 20% and 50% HP by using the HP bar color and counting pixels.

This doesn't change the existing Smogon formats that use the ceiling function, current gen still uses the HP Percentage Mod.