### PR TITLE
Fix typos in doc comments

### DIFF
--- a/server/chat-formatter.ts
+++ b/server/chat-formatter.ts
@@ -44,7 +44,7 @@ SOURCE FOR LINKREGEX (compile with https://regexfree.k55.io/ )
 					\[ ( [^\s()<>&[\]] | &amp; )* ]
 				)*
 				# URLs usually don't end with punctuation, so don't allow
-				# punctuation symbols that probably arent related to URL.
+				# punctuation symbols that probably aren't related to URL.
 				(
 					[^\s()[\]{}\".,!?;:&<>*`^~\\]
 				|

--- a/server/chat-jsx.tsx
+++ b/server/chat-jsx.tsx
@@ -6,7 +6,7 @@ import preact from 'preact';
 import render from 'preact-render-to-string';
 import { Utils } from '../lib';
 
-/** For easy concenation of Preact nodes with strings */
+/** For easy concatenation of Preact nodes with strings */
 export function html(
 	strings: TemplateStringsArray, ...args: (preact.VNode | string | number | null | undefined)[]
 ) {

--- a/server/ip-tools.ts
+++ b/server/ip-tools.ts
@@ -81,8 +81,7 @@ export const IPTools = new class {
 	/**
 	 * IPTools.queryDnsbl(ip, callback)
 	 *
-	 * Calls callb
-	 * ack(blocklist), where blocklist is the blocklist domain
+	 * Calls callback(blocklist), where blocklist is the blocklist domain
 	 * if the passed IP is in a blocklist, or null if the IP is not in
 	 * any blocklist.
 	 *


### PR DESCRIPTION
## Summary

Three small doc-comment typo fixes:

- **`server/ip-tools.ts`** — the doc comment for `queryDnsbl` had a hard line break in the middle of the word `callback`:
  ```
  * Calls callb
  * ack(blocklist), where blocklist is the blocklist domain
  ```
- **`server/chat-formatter.ts`** — `arent` -> `aren't` in the source-form comment for `linkRegex`.
- **`server/chat-jsx.tsx`** — `concenation` -> `concatenation` on the `html` helper.

No code changes.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run tsc` — clean