### PR TITLE
Utils: Fix uncacheModuleTree skipping children due to splice during iteration

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -327,9 +327,12 @@ export function clearRequireCache(options: { exclude?: string[] } = {}) {
 
 export function uncacheModuleTree(mod: NodeJS.Module, excludes: string[]) {
 	if (!mod.children?.length || excludes.some(p => mod.filename.includes(p))) return;
-	for (const [i, child] of mod.children.entries()) {
+	// iterate backwards: splice() shifts later indices down, so a forward
+	// loop with .entries() silently skips the element after each removed one
+	for (let i = mod.children.length - 1; i >= 0; i--) {
+		const child = mod.children[i];
 		if (excludes.some(p => child.filename.includes(p))) continue;
-		mod.children?.splice(i, 1);
+		mod.children.splice(i, 1);
 		uncacheModuleTree(child, excludes);
 	}
 	delete (mod as any).children;


### PR DESCRIPTION
fixes #11524 (reported by @TurboRx, who was asked by @Slayer95 in #11522 to open a separate issue for this).

`uncacheModuleTree` walks a module's `children` array and splices each entry out as it recurses into it. the loop was a forward `for...of` over `.entries()`, which means `splice(i, 1)` shifts every later element down by one — so the iterator's next step lands on `i+1`, skipping the element that just moved into slot `i`. with four children, only indices 0 and 2 of the original list are visited; the rest never get recursed into and stay in the cache.

verified the skip pattern directly:

```js
const arr = ['A', 'B', 'C', 'D'];
const visited = [];
for (const [i, val] of arr.entries()) {
    visited.push(val);
    arr.splice(i, 1);
}
// visited => ['A', 'C']    (B and D never visited)
// arr     => ['B', 'D']
```

fix is the standard one suggested in the issue: iterate backwards, since splicing at `i` only affects indices `> i`, which a descending loop has already processed. behavior is now correct on any input — every non-excluded child gets recursed into and removed exactly once.

## test plan

- [x] `npm run lint` — clean
- [x] `npm run tsc` — clean
- [x] `npx mocha` — full suite, 2333 passing
- [x] reproduced the original bug with the four-element array snippet above