### PR TITLE
Sim: Clear active flag on bench pokemon during team preview

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1156,8 +1156,6 @@ export class Pokemon {
 			ident: this.fullname,
 			details: this.details,
 			condition: this.getHealth().secret,
-			// during team preview no pokemon is in play, so the first N
-			// pokemon should not report active:true based on team slot
 			active: this.battle.requestState !== 'teampreview' && this.position < this.side.active.length,
 			stats: {
 				atk: this.baseStoredStats['atk'],

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1156,7 +1156,9 @@ export class Pokemon {
 			ident: this.fullname,
 			details: this.details,
 			condition: this.getHealth().secret,
-			active: this.position < this.side.active.length,
+			// during team preview no pokemon is in play, so the first N
+			// pokemon should not report active:true based on team slot
+			active: this.battle.requestState !== 'teampreview' && this.position < this.side.active.length,
 			stats: {
 				atk: this.baseStoredStats['atk'],
 				def: this.baseStoredStats['def'],

--- a/test/sim/misc/teampreview-active.js
+++ b/test/sim/misc/teampreview-active.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Team preview request data', () => {
+	afterEach(() => {
+		battle.destroy();
+	});
+
+	// regression test for issue #11869
+	it('should not mark any pokemon as active=true during team preview', () => {
+		battle = common.gen(9).createBattle({ formatid: 'gen9vgc2026regf' }, [[
+			{ species: 'gyarados', ability: 'intimidate', moves: ['waterfall'], teraType: 'Water', level: 50 },
+			{ species: 'pikachu', ability: 'static', moves: ['thunderbolt'], teraType: 'Electric', level: 50 },
+			{ species: 'charizard', ability: 'blaze', moves: ['flamethrower'], teraType: 'Fire', level: 50 },
+			{ species: 'venusaur', ability: 'overgrow', moves: ['gigadrain'], teraType: 'Grass', level: 50 },
+		], [
+			{ species: 'snorlax', ability: 'thickfat', moves: ['bodyslam'], teraType: 'Normal', level: 50 },
+			{ species: 'gengar', ability: 'levitate', moves: ['shadowball'], teraType: 'Ghost', level: 50 },
+			{ species: 'alakazam', ability: 'synchronize', moves: ['psychic'], teraType: 'Psychic', level: 50 },
+			{ species: 'machamp', ability: 'guts', moves: ['closecombat'], teraType: 'Fighting', level: 50 },
+		]]);
+
+		assert.equal(battle.requestState, 'teampreview');
+		for (const side of battle.sides) {
+			const data = side.getRequestData();
+			for (const mon of data.pokemon) {
+				assert.equal(mon.active, false, `${mon.ident} should not be active during team preview`);
+			}
+		}
+	});
+});


### PR DESCRIPTION
fixes #11869 (reported by @cameronangliss).

`Pokemon#getSwitchRequestData` builds the per-pokemon entry that goes into the `|request|` payload, and it sets `active` to `this.position < this.side.active.length`. that's a reasonable check during an actual battle (positions 0 and 1 are the two slots in doubles, etc), but during team preview no pokemon has been switched in yet — `position` still reflects the team slot the player imported the pokemon in. so in a doubles format like `[Gen 9] VGC 2026 Reg F`, the first two pokemon in `side.pokemon` end up with `active:true` in the team preview request, even though the player hasn't picked their lead.

added a regression test (`test/sim/misc/teampreview-active.js`). i verified locally that stashing this change and rebuilding makes the new test fail with `expected false, got true`; with the change applied it passes. full mocha suite (2334 + the new one) passes.

the fix gates the original `position < active.length` check on `battle.requestState !== 'teampreview'`. behavior is unchanged for every other request state (move, switch, etc).

## test plan

- [x] `npm run lint`
- [x] `npm run tsc`
- [x] `npx mocha` — full suite passes
- [x] new regression test added and verified to fail without the fix