### PR TITLE
REPL: Don't crash startup if socket file vanishes before chmod

### DIFF
--- a/lib/repl.ts
+++ b/lib/repl.ts
@@ -156,7 +156,14 @@ export const Repl = new class {
 		const pathname = path.resolve(FS.ROOT_PATH, Config.replsocketprefix || 'logs/repl', filename);
 		try {
 			server.listen(pathname, () => {
-				fs.chmodSync(pathname, Config.replsocketmode || 0o600);
+				try {
+					fs.chmodSync(pathname, Config.replsocketmode || 0o600);
+				} catch (err: any) {
+					// the socket file can vanish between listen() firing and
+					// chmodSync running (e.g. another process cleaning up, or
+					// some sandboxed filesystems). don't crash startup over it.
+					if (err.code !== 'ENOENT') throw err;
+				}
 				Repl.socketPathnames.add(pathname);
 			});
 

--- a/lib/repl.ts
+++ b/lib/repl.ts
@@ -159,10 +159,12 @@ export const Repl = new class {
 				try {
 					fs.chmodSync(pathname, Config.replsocketmode || 0o600);
 				} catch (err: any) {
-					// the socket file can vanish between listen() firing and
-					// chmodSync running (e.g. another process cleaning up, or
-					// some sandboxed filesystems). don't crash startup over it.
-					if (err.code !== 'ENOENT') throw err;
+					if (err.code === 'ENOENT') {
+						server.close();
+						console.error(`Could not start REPL server "${filename}": socket file disappeared before chmod`);
+						return;
+					}
+					throw err;
 				}
 				Repl.socketPathnames.add(pathname);
 			});


### PR DESCRIPTION
fixes #8770 (reported by @haasj22).

`Repl.start()` opens a unix-socket listener, and in the `listen()` callback we run `fs.chmodSync(pathname, ...)` to lock down the socket's permissions. on most setups the socket file is sitting right there when the callback fires, so this is fine. but on dropbox-synced folders (and probably other sandboxed/userspace filesystems), the file can disappear between `listen()` succeeding and `chmodSync` running. when that happens the synchronous chmod throws ENOENT and the whole server crashes on startup with an uncaught exception:

```
Error: ENOENT: no such file or directory, chmod '/.../logs/repl/team-validator-2727'
    at Object.chmodSync (node:fs:1851:3)
    at Server.<anonymous> (lib/repl.ts:114:8)
```

i wrapped the chmodSync in a try/catch that only swallows ENOENT — every other error (EACCES, etc) still throws. losing the permission tightening on a host where the file is missing is the right trade-off vs. failing to boot the server at all; the socket still works, it just isn't 0o600 in that one weird case.

## test plan

- [x] `npm run lint`
- [x] `npm run tsc`
- [x] `npx mocha` — full suite passes