### PR TITLE
Tools: Add per-battle timeout to the Exhaustive Runner

### DIFF
--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -26,6 +26,7 @@ export interface ExhaustiveRunnerOptions {
 	maxGames?: number;
 	maxFailures?: number;
 	dual?: boolean | 'debug';
+	timeoutMs?: number;
 }
 
 export class ExhaustiveRunner {
@@ -52,6 +53,7 @@ export class ExhaustiveRunner {
 	private readonly maxGames?: number;
 	private readonly maxFailures?: number;
 	private readonly dual: boolean | 'debug';
+	private readonly timeoutMs: number;
 
 	private failures: number;
 	private games: number;
@@ -64,6 +66,7 @@ export class ExhaustiveRunner {
 		this.maxGames = options.maxGames;
 		this.maxFailures = options.maxFailures || ExhaustiveRunner.MAX_FAILURES;
 		this.dual = options.dual || false;
+		this.timeoutMs = options.timeoutMs || 0;
 
 		this.failures = 0;
 		this.games = 0;
@@ -92,6 +95,7 @@ export class ExhaustiveRunner {
 					format: this.format,
 					dual: this.dual,
 					error: true,
+					timeoutMs: this.timeoutMs,
 				}).run();
 
 				if (this.log) this.logProgress(pools);

--- a/sim/tools/runner.ts
+++ b/sim/tools/runner.ts
@@ -35,6 +35,7 @@ export interface RunnerOptions {
 	output?: boolean;
 	error?: boolean;
 	dual?: boolean | 'debug';
+	timeoutMs?: number;
 }
 
 export class Runner {
@@ -54,6 +55,7 @@ export class Runner {
 	private readonly output: boolean;
 	private readonly error: boolean;
 	private readonly dual: boolean | 'debug';
+	private readonly timeoutMs: number;
 
 	constructor(options: RunnerOptions) {
 		this.format = options.format;
@@ -68,13 +70,29 @@ export class Runner {
 		this.output = !!options.output;
 		this.error = !!options.error;
 		this.dual = options.dual || false;
+		this.timeoutMs = options.timeoutMs || 0;
 	}
 
 	async run() {
 		const battleStream = this.dual ?
 			new DualStream(this.input, this.dual === 'debug') :
 			new RawBattleStream(this.input);
-		const game = this.runGame(this.format, battleStream);
+		let game: Promise<unknown> = this.runGame(this.format, battleStream);
+		if (this.timeoutMs) {
+			let timer: NodeJS.Timeout | null = null;
+			const timeout = new Promise<never>((_, reject) => {
+				timer = setTimeout(() => {
+					console.error(
+						`\n\nBattle timed out after ${this.timeoutMs}ms (format=${this.format}):\n` +
+						`${battleStream.rawInputLog.join('\n')}\n`
+					);
+					reject(new Error(`Battle timed out after ${this.timeoutMs}ms`));
+				}, this.timeoutMs);
+			});
+			game = Promise.race([game, timeout]).finally(() => {
+				if (timer) clearTimeout(timer);
+			});
+		}
 		if (!this.error) return game;
 		return game.catch(err => {
 			console.log(`\n${battleStream.rawInputLog.join('\n')}\n`);

--- a/test/sim/tools/runner-timeout.js
+++ b/test/sim/tools/runner-timeout.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const assert = require('assert').strict;
+
+const { Runner } = require('../../../dist/sim/tools/runner');
+
+describe('Runner timeoutMs', () => {
+	it('should reject with a timeout error when a battle exceeds the timeout', async () => {
+		const originalError = console.error;
+		const originalLog = console.log;
+		console.error = () => {};
+		console.log = () => {};
+
+		let caught;
+		try {
+			await new Runner({
+				format: 'gen9customgame',
+				prng: [1, 2, 3, 4],
+				error: true,
+				timeoutMs: 1,
+			}).run();
+		} catch (err) {
+			caught = err;
+		} finally {
+			// eslint-disable-next-line require-atomic-updates
+			console.error = originalError;
+			// eslint-disable-next-line require-atomic-updates
+			console.log = originalLog;
+		}
+
+		assert(caught instanceof Error, 'expected runner.run() to reject');
+		assert.equal(caught.message, 'Battle timed out after 1ms');
+	});
+});


### PR DESCRIPTION
fixes #11901 (requested by @andrebastosdias).

soft-locked battles in CI currently only abort when the whole github action times out, which makes the offending battle impossible to identify or repro. this adds an optional \`timeoutMs\` to \`Runner\`: when set, \`run()\` races the game promise against a \`setTimeout\`, and on timeout \`console.error\`s the format plus the raw input log so the battle can be replayed locally before rejecting with a clear \`Battle timed out after Xms\` error.

\`ExhaustiveRunner\` takes the same option and threads it through. default is \`0\` (no timeout) so existing callers behave the same — opt-in only.

added a regression test that runs a battle with \`timeoutMs: 1\` and asserts the rejection.

## test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run tsc\` — clean
- [x] \`node build\` — clean
- [x] \`npx mocha\` — full suite, 2334 passing
- [x] new \`test/sim/tools/runner-timeout.js\` passes in isolation and in the full suite