### PR TITLE
Docs: Document |-fieldactivate| in SIM-PROTOCOL.md

### DIFF
--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -435,6 +435,14 @@ stat boosts are minor actions.
 
 > Indicates that the field condition `CONDITION` has ended.
 
+`|-fieldactivate|CONDITION`
+
+> A field-wide effect `CONDITION` has activated for a single moment, without
+> creating a persistent field condition. Used for one-shot triggers like Perish
+> Song, Fairy Lock, Ion Deluge, or Teatime, and for ability activation messages
+> like Delta Stream. Any actual changes (perish counters set, types converted,
+> berries eaten, etc.) are reported by separate messages.
+
 `|-sidestart|SIDE|CONDITION`
 
 > A side condition `CONDITION` has started on `SIDE`. Side conditions are all


### PR DESCRIPTION
fixes #11394 (reported by @smell-of-curry).

\`|-fieldactivate|\` is emitted in a handful of places (\`data/conditions.ts\` for Delta Stream, \`data/moves.ts\` for Fairy Lock / Ion Deluge / Perish Song / Teatime, gen 4 Pay Day) but wasn't documented in SIM-PROTOCOL.md. it's the one-shot counterpart to \`|-fieldstart|\` / \`|-fieldend|\` — the message itself doesn't create a persistent field condition, it just announces that a field-wide effect activated, with the actual state changes reported by separate messages.

added an entry right after \`|-fieldend|\` for grouping.

## test plan

- [x] \`npm run lint\` (no code changes, but ran anyway) — clean
- [x] visually checked the rendered markdown