### PR TITLE
Champions: Reveal Nature in Open Team Sheets

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3213,7 +3213,7 @@ export class Battle {
 					item: set.item,
 					ability: set.ability,
 					moves: set.moves,
-					nature: '',
+					nature: this.format.mod === 'champions' ? set.nature : '',
 					gender: pokemon.gender,
 					evs: null!,
 					ivs: null!,

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -782,8 +782,8 @@ export class TeamValidator {
 		problem = this.checkAbility(set, ability, setHas);
 		if (problem) problems.push(problem);
 
-		if (!set.nature || dex.gen <= 2) {
-			set.nature = '';
+		if (!set.nature) {
+			set.nature = dex.gen <= 2 ? '' : 'Serious';
 		}
 		nature = dex.natures.get(set.nature);
 		problem = this.checkNature(set, nature, setHas);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -782,8 +782,10 @@ export class TeamValidator {
 		problem = this.checkAbility(set, ability, setHas);
 		if (problem) problems.push(problem);
 
-		if (!set.nature) {
-			set.nature = dex.gen <= 2 ? '' : 'Serious';
+		if (dex.gen <= 2) {
+			set.nature = '';
+		} else if (!set.nature) {
+			set.nature = 'Serious';
 		}
 		nature = dex.natures.get(set.nature);
 		problem = this.checkNature(set, nature, setHas);


### PR DESCRIPTION
Not 100% confirmed yet, but preparing for a potential ruleset change.

https://x.com/playpokemon/status/2057484133727690766

Also fixes a bug with the 0 ev detection for champions, where a blank nature would not cause the detection to go off because it explicitly checked for Serious nature.