### PR TITLE
Tera Stellar: Apply <60 BP boost to every target of a spread move's first-use activation

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1661,9 +1661,14 @@ export class BattleActions {
 		}
 
 		const dexMove = this.dex.moves.get(move.id);
+		if (source.terastallized === 'Stellar' && !source.stellarBoostedTypes.includes(move.type)) {
+			move.stellarBoosted = true;
+			if (source.species.name !== 'Terapagos-Stellar') {
+				source.stellarBoostedTypes.push(move.type);
+			}
+		}
 		if (source.terastallized && (source.terastallized === 'Stellar' ?
-			(!source.stellarBoostedTypes.includes(move.type) || move.stellarBoosted) :
-			source.hasType(move.type)) &&
+			move.stellarBoosted : source.hasType(move.type)) &&
 			basePower < 60 && dexMove.priority <= 0 && !dexMove.multihit &&
 			// Hard move.basePower check for moves like Dragon Energy that have variable BP
 			!((move.basePower === 0 || move.basePower === 150) && move.basePowerCallback)
@@ -1780,12 +1785,8 @@ export class BattleActions {
 			// then the Stellar tera type applies a one-time 2x STAB boost for that type,
 			// and then goes back to using the regular 1.5x STAB boost for those types.
 			if (pokemon.terastallized === 'Stellar') {
-				if (!pokemon.stellarBoostedTypes.includes(type) || move.stellarBoosted) {
+				if (move.stellarBoosted) {
 					stab = isSTAB ? 2 : [4915, 4096];
-					move.stellarBoosted = true;
-					if (pokemon.species.name !== 'Terapagos-Stellar') {
-						pokemon.stellarBoostedTypes.push(type);
-					}
 				}
 			} else {
 				if (pokemon.terastallized === type && pokemon.getTypes(false, true).includes(type)) {

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1662,7 +1662,8 @@ export class BattleActions {
 
 		const dexMove = this.dex.moves.get(move.id);
 		if (source.terastallized && (source.terastallized === 'Stellar' ?
-			!source.stellarBoostedTypes.includes(move.type) : source.hasType(move.type)) &&
+			(!source.stellarBoostedTypes.includes(move.type) || move.stellarBoosted) :
+			source.hasType(move.type)) &&
 			basePower < 60 && dexMove.priority <= 0 && !dexMove.multihit &&
 			// Hard move.basePower check for moves like Dragon Energy that have variable BP
 			!((move.basePower === 0 || move.basePower === 150) && move.basePowerCallback)

--- a/test/sim/misc/terastellar.js
+++ b/test/sim/misc/terastellar.js
@@ -172,4 +172,23 @@ describe("Tera Stellar", () => {
 		battle.makeChoices('move absorb', 'auto');
 		assert.bounded(hp - chansey.hp, [12, 15], `Absorb should be a 20 BP with regular damage on its second use`);
 	});
+
+	it(`should boost the base power on every target of a spread move's first-use activation`, () => {
+		battle = common.gen(9).createBattle({ gameType: 'doubles', seed: [2, 3, 4, 5] }, [[
+			{ species: 'Comfey', moves: ['razorleaf'], teraType: 'Stellar' },
+			{ species: 'Wynaut', moves: ['sleeptalk'] },
+		], [
+			{ species: 'Chansey', ability: 'shellarmor', moves: ['sleeptalk'] },
+			{ species: 'Chansey', ability: 'shellarmor', moves: ['sleeptalk'] },
+		]]);
+
+		const t1 = battle.p2.active[0];
+		const t2 = battle.p2.active[1];
+		const s1 = t1.hp, s2 = t2.hp;
+		battle.makeChoices('move razorleaf terastallize, move sleeptalk', 'auto');
+		const d1 = s1 - t1.hp;
+		const d2 = s2 - t2.hp;
+		assert.bounded(d1, [118, 139], `Razor Leaf should hit target 1 at 60 BP with ~1.2x Stellar and 0.75 spread`);
+		assert.bounded(d2, [118, 139], `Razor Leaf should hit target 2 at the same 60 BP because Stellar is still resolving its first use of Grass`);
+	});
 });


### PR DESCRIPTION
\#11455 added the "<60 BP -> 60 BP on first use of a type" bump for Tera Stellar, but the guard it added (`!source.stellarBoostedTypes.includes(move.type)`) goes false as soon as the first target's STAB step pushes the type into the array. On a spread move, the second and later targets then skip the BP bump even though the Stellar boost is still resolving for that move execution — the STAB step itself already handles this via the parallel `move.stellarBoosted` flag, but the basePower guard didn't pick up the same fallback.

Repro on master (gen 9 doubles, Stellar Comfey using Razor Leaf — 55 BP grass spread vs two equal Chanseys):

```
target 1 damage: 136   (60 BP × 1.2 stellar × 0.75 spread)
target 2 damage: 101   (55 BP × 1.2 stellar × 0.75 spread)   <-- BP bump dropped
```

Other affected cases: Stellar + Snarl (55 BP dark spread), Stellar + Twister (40 BP dragon spread), Stellar + Bubble in gen 6 doubles (40 BP water spread), and any parental-bond-style follow-up hit of a <60 BP move. Doesn't affect single-target moves (no target 2) or moves at or above 60 BP.

Per [andrebastosdias's review](https://github.com/smogon/pokemon-showdown/pull/12071#pullrequestreview-tarestellar), refactored to hoist the Stellar activation up: `move.stellarBoosted` is set once in `getDamage` if the move's type hasn't been Stellar-boosted yet, and both the basePower guard and the STAB modifier in `modifyDamage` just read the flag. Push-into-`stellarBoostedTypes` happens in the same upfront block so the once-per-type semantics are preserved (next turn / new move object starts with `stellarBoosted` false, and the type is already in the array so the upfront block doesn't re-activate).

Regression test in `test/sim/misc/terastellar.js` uses a seeded doubles battle that fails on master (target 2 at 55 BP rolls below 118) and passes with the fix. Full mocha suite (2334) and lint/tsc clean.