### PR TITLE
Use encounter data when checking for underleveled Pokemon

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -854,15 +854,28 @@ export class TeamValidator {
 		let isUnderleveled;
 		let requiredLevel;
 		if (!isFromRBYEncounter && ruleTable.has('obtainablemisc')) {
-			// FIXME: Event pokemon given at a level under what it normally can be attained at gives a false positive
-			let evoSpecies = species;
-			while (evoSpecies.prevo) {
-				if (set.level < (evoSpecies.evoLevel || 0)) {
-					isUnderleveled = evoSpecies.name;
-					requiredLevel = evoSpecies.evoLevel;
+			let minEncounterGen = this.minSourceGen;
+			if (dex.gen >= 3 && minEncounterGen < 3) minEncounterGen = 3;
+			let isWildObtainable = false;
+			for (const encounter of learnsetSpecies.encounters || []) {
+				if (!encounter.level) continue;
+				if (encounter.generation < minEncounterGen || encounter.generation > dex.gen) continue;
+				if (set.level >= encounter.level) {
+					isWildObtainable = true;
 					break;
 				}
-				evoSpecies = dex.species.get(evoSpecies.prevo);
+			}
+			if (!isWildObtainable) {
+				// FIXME: Event pokemon given at a level under what it normally can be attained at gives a false positive
+				let evoSpecies = species;
+				while (evoSpecies.prevo) {
+					if (set.level < (evoSpecies.evoLevel || 0)) {
+						isUnderleveled = evoSpecies.name;
+						requiredLevel = evoSpecies.evoLevel;
+						break;
+					}
+					evoSpecies = dex.species.get(evoSpecies.prevo);
+				}
 			}
 		}
 

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -91,6 +91,38 @@ describe('Team Validator', () => {
 		assert.legalTeam(team, 'gen1ou');
 	});
 
+	it('should allow evolved Pokémon that can be caught underleveled in the wild', () => {
+		// Fearow evolves at level 20 but is catchable at level 7 in Gen 4
+		let team = [
+			{ species: 'fearow', ability: 'keeneye', level: 7, moves: ['drillpeck'], evs: { hp: 1 } },
+		];
+		assert.legalTeam(team, 'gen7ou');
+
+		team[0].level = 6;
+		assert.false.legalTeam(team, 'gen7ou');
+
+		// Pidgeot evolves at level 36 but is catchable at level 29 in Gen 7
+		team = [
+			{ species: 'pidgeot', ability: 'keeneye', level: 29, moves: ['wingattack'], evs: { hp: 1 } },
+		];
+		assert.legalTeam(team, 'gen7ou');
+
+		team[0].level = 28;
+		assert.false.legalTeam(team, 'gen7ou');
+	});
+
+	it('should not let underleveled wild encounters transfer out of Gens 1 and 2', () => {
+		// Granbull evolves at level 23 but is catchable at level 15 in Gen 2,
+		// which can't be transferred to Gen 3 or later
+		const team = [
+			{ species: 'granbull', level: 15, moves: ['bite'], evs: { hp: 1 } },
+		];
+		assert.legalTeam(team, 'gen2ou');
+
+		team[0].ability = 'intimidate';
+		assert.false.legalTeam(team, 'gen7ou');
+	});
+
 	it('should correctly enforce Shell Smash as a sketched move for Necturna prior to Gen 9', () => {
 		const team = [
 			{ species: 'necturna', ability: 'forewarn', moves: ['shellsmash', 'vcreate'], evs: { hp: 1 } },


### PR DESCRIPTION
fixes #8180.

learnsets.ts has an encounters field that records the lowest level a pokemon can be met in the wild, but outside gen 1 the legality checks never read it. so an evolved pokemon that's catchable below its evolution level gets wrongly rejected. fearow evolves at 20 but is catchable at level 7 in gen 4, and right now [Gen 7] OU says "Fearow must be at least level 20 to be evolved".

this checks the encounter data before the underleveled evolution check. if there's a wild encounter at or below the set's level in a generation the format can source from, the pokemon counts as obtainable. the generation filter reuses the existing gen 3+ rule so a gen 1 or 2 encounter can't legalize a pokemon in a gen 3+ format, since those can't be transferred forward.

tests cover fearow and pidgeot becoming legal at their encounter level and still illegal one level below, plus granbull being fine in gen 2 but not gen 7. mamoswine and nidoking stay illegal because neither is catchable in the wild itself.

the original report's level 1 aggron already validates through the pokemon go path, and gen 8 go/raid underleveling has no encounter data behind it, so this covers the wild encounter case the issue notes was never implemented.
