### PR TITLE
Remove smartTarget in Foresighters

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1797,6 +1797,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 					const moveData = this.dex.getActiveMove(move.id);
 					moveData.flags['futuremove'] = 1;
 					delete moveData.flags['protect'];
+					delete moveData.smartTarget;
 					if (moveData.id === 'beatup') this.singleEvent('ModifyMove', moveData, null, pokemon, null, null, moveData);
 					Object.assign(t.side.slotConditions[t.position]['futuremove'], {
 						duration: 3,


### PR DESCRIPTION
The smart target move Dragon Darts crashes the battle when used as a future move (https://www.smogon.com/forums/threads/foresighters-dragon-darts-crashes-battle.3754596/)

Easiest fix was to just remove smartTarget from moves modified by the format, which is what this does.
Since Foresighters can't be played in any forma where smartTarget is relevant, it doesn't cause any issues.