### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -570,7 +570,7 @@
         "level": 68,
         "moves": ["blizzard", "psychic", "thunderbolt"],
         "essentialMoves": ["recover", "thunderwave"],
-        "exclusiveMoves": ["hydropump", "psychic", "surf", "surf"]
+        "exclusiveMoves": ["psychic", "surf", "surf"]
     },
     "mrmime": {
         "level": 75,
@@ -604,8 +604,7 @@
     },
     "tauros": {
         "level": 68,
-        "moves": ["bodyslam", "earthquake", "hyperbeam"],
-        "exclusiveMoves": ["blizzard", "blizzard", "blizzard", "thunderbolt"]
+        "moves": ["blizzard", "bodyslam", "earthquake", "hyperbeam"]
     },
     "gyarados": {
         "level": 74,

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -315,7 +315,7 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["hiddenpowerground", "irontail", "return", "shadowball", "substitute"],
+                "movepool": ["hiddenpowerground", "return", "shadowball", "substitute"],
                 "abilities": ["Limber"]
             },
             {
@@ -366,9 +366,8 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "extremespeed", "fireblast", "hiddenpowerrock", "irontail"],
-                "abilities": ["Intimidate"],
-                "preferredTypes": ["Steel"]
+                "movepool": ["extremespeed", "fireblast", "hiddenpowergrass", "toxic"],
+                "abilities": ["Intimidate"]
             },
             {
                 "role": "Staller",
@@ -734,7 +733,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["explosion", "fireblast", "haze", "painsplit", "sludgebomb", "toxic", "willowisp"],
+                "movepool": ["explosion", "fireblast", "haze", "painsplit", "sludgebomb", "willowisp"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -972,7 +971,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "fireblast", "hiddenpowergrass", "hiddenpowerrock", "irontail", "shadowball", "toxic"],
+                "movepool": ["doubleedge", "fireblast", "hiddenpowergrass", "toxic"],
                 "abilities": ["Flash Fire"]
             }
         ]
@@ -1158,7 +1157,7 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowerice", "substitute", "thunderpunch"],
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderpunch"],
                 "abilities": ["Blaze"]
             },
             {
@@ -1528,12 +1527,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerbug", "hiddenpowerfighting"],
+                "movepool": ["hiddenpowerfighting", "hiddenpowerflying", "hiddenpowerghost", "hiddenpowerground", "hiddenpowerpsychic", "hiddenpowerrock"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -1637,11 +1631,6 @@
     "qwilfish": {
         "level": 82,
         "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hydropump", "selfdestruct", "shadowball", "sludgebomb", "swordsdance"],
-                "abilities": ["Poison Point", "Swift Swim"]
-            },
             {
                 "role": "Fast Attacker",
                 "movepool": ["destinybond", "hydropump", "selfdestruct", "sludgebomb", "spikes"],
@@ -2064,12 +2053,12 @@
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["hiddenpowerice", "leafblade", "substitute", "thunderpunch"],
+                "movepool": ["hiddenpowerfire", "hiddenpowerice", "leafblade", "substitute", "thunderpunch"],
                 "abilities": ["Overgrow"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "hiddenpowerice", "leafblade", "thunderpunch", "toxic"],
+                "movepool": ["earthquake", "hiddenpowerfire", "hiddenpowerice", "leafblade", "toxic"],
                 "abilities": ["Overgrow"],
                 "preferredTypes": ["Ground"]
             }
@@ -2222,9 +2211,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "firepunch", "hypnosis", "icepunch", "psychic", "substitute", "thunderbolt"],
-                "abilities": ["Trace"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["calmmind", "firepunch", "hypnosis", "psychic", "substitute", "thunderbolt", "willowisp"],
+                "abilities": ["Trace"]
             }
         ]
     },
@@ -2829,12 +2817,12 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["rest", "seismictoss", "shadowball", "sleeptalk"],
+                "movepool": ["painsplit", "rest", "seismictoss", "shadowball", "sleeptalk", "willowisp"],
                 "abilities": ["Pressure"]
             },
             {
                 "role": "Generalist",
-                "movepool": ["focuspunch", "icebeam", "painsplit", "shadowball", "substitute", "willowisp"],
+                "movepool": ["focuspunch", "painsplit", "shadowball", "substitute", "willowisp"],
                 "abilities": ["Pressure"]
             }
         ]
@@ -3144,12 +3132,6 @@
     "deoxysspeed": {
         "level": 76,
         "sets": [
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["calmmind", "firepunch", "icebeam", "psychic", "recover", "substitute"],
-                "abilities": ["Pressure"],
-                "preferredTypes": ["Fire"]
-            },
             {
                 "role": "Bulky Support",
                 "movepool": ["psychoboost", "recover", "spikes", "superpower", "toxic"],

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -13,7 +13,7 @@ const SETUP = [
 ];
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
-	'eruption', 'explosion', 'fakeout', 'focuspunch', 'futuresight', 'hiddenpowerpsychic', 'icywind', 'knockoff', 'machpunch', 'pursuit',
+	'eruption', 'explosion', 'fakeout', 'focuspunch', 'futuresight', 'icywind', 'knockoff', 'machpunch', 'pursuit',
 	'quickattack', 'rapidspin', 'selfdestruct', 'skyattack', 'waterspout',
 ];
 
@@ -181,7 +181,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			preferredType, role);
 
 		// If there are only four moves, add all moves and return early
-		if (movePool.length <= this.maxMoveCount) {
+		if (movePool.length <= this.maxMoveCount || species.id === 'unown') {
 			// Still need to ensure that multiple Hidden Powers are not added (if maxMoveCount is increased)
 			while (movePool.length) {
 				const moveid = this.sample(movePool);

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -13,7 +13,7 @@ const SETUP = [
 ];
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
-	'eruption', 'explosion', 'fakeout', 'focuspunch', 'futuresight', 'icywind', 'knockoff', 'machpunch', 'pursuit',
+	'eruption', 'explosion', 'fakeout', 'focuspunch', 'futuresight', 'hiddenpowerpsychic', 'icywind', 'knockoff', 'machpunch', 'pursuit',
 	'quickattack', 'rapidspin', 'selfdestruct', 'skyattack', 'waterspout',
 ];
 

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -302,7 +302,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "encore", "stoneedge", "uturn"],
+                "movepool": ["bulkup", "closecombat", "earthquake", "encore", "stoneedge", "uturn"],
                 "abilities": ["Vital Spirit"],
                 "preferredTypes": ["Rock"]
             }
@@ -1121,12 +1121,12 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["encore", "energyball", "sleeppowder", "toxic", "uturn"],
-                "abilities": ["Chlorophyll"]
+                "abilities": ["Chlorophyll", "Leaf Guard"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["hiddenpowerflying", "leechseed", "protect", "sleeppowder", "substitute"],
-                "abilities": ["Chlorophyll"]
+                "abilities": ["Chlorophyll", "Leaf Guard"]
             }
         ]
     },

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -459,7 +459,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		species: Species,
 	): boolean {
 		switch (ability) {
-		case 'Chlorophyll':
+		case 'Chlorophyll': case 'Leaf Guard':
 			return !teamDetails.sun;
 		case 'Swift Swim':
 			return !teamDetails.rain;

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -499,7 +499,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 
 		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
 		if (!abilityAllowed.length) {
-			const weatherAbilities = abilities.filter(a => ['Chlorophyll', 'Swift Swim'].includes(a));
+			const weatherAbilities = abilities.filter(a => ['Chlorophyll', 'Leaf Guard', 'Swift Swim'].includes(a));
 			if (weatherAbilities.length) return this.sample(weatherAbilities);
 		}
 
@@ -526,7 +526,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
 		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
-		if (species.id === 'ditto' || (species.id === 'rampardos' && role === 'Fast Attacker')) return 'Choice Scarf';
+		if (species.id === 'ditto') return this.sample(['Choice Scarf', 'Quick Powder', 'Sitrus Berry']);
+		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (species.id === 'honchkrow') return 'Life Orb';
 		if (species.id === 'shuckle') return 'Leftovers';
 		if (ability === 'Poison Heal' || moves.has('facade')) return 'Toxic Orb';

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -4498,7 +4498,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hurricane", "raindance", "rest", "surf"],
+                "movepool": ["hurricane", "raindance", "rest", "scald"],
                 "abilities": ["Hydration"]
             }
         ]

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -334,13 +334,13 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "encore", "focusblast", "icebeam", "scald", "substitute"],
+                "movepool": ["calmmind", "encore", "hiddenpowergrass", "icebeam", "scald", "substitute"],
                 "abilities": ["Cloud Nine", "Swift Swim"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "encore", "focusblast", "hydropump", "icebeam"],
+                "movepool": ["calmmind", "encore", "hiddenpowergrass", "hydropump", "icebeam"],
                 "abilities": ["Cloud Nine", "Swift Swim"],
                 "preferredTypes": ["Ice"]
             }
@@ -1205,12 +1205,12 @@
             {
                 "role": "Fast Support",
                 "movepool": ["acrobatics", "encore", "sleeppowder", "uturn"],
-                "abilities": ["Chlorophyll"]
+                "abilities": ["Chlorophyll", "Leaf Guard"]
             },
             {
                 "role": "Staller",
                 "movepool": ["acrobatics", "leechseed", "sleeppowder", "substitute"],
-                "abilities": ["Chlorophyll"]
+                "abilities": ["Chlorophyll", "Leaf Guard"]
             }
         ]
     },
@@ -1509,6 +1509,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["airslash", "hydropump", "icebeam", "raindance"],
                 "abilities": ["Swift Swim"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["airslash", "protect", "scald", "toxic"],
+                "abilities": ["Water Absorb"]
             }
         ]
     },
@@ -4064,6 +4069,11 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["darkpulse", "encore", "hiddenpowerfighting", "nastyplot", "thunderwave"],
+                "abilities": ["Prankster"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["encore", "foulplay", "thunderwave", "uturn"],
                 "abilities": ["Prankster"]
             }
         ]

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -498,7 +498,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		species: Species,
 	): boolean {
 		switch (ability) {
-		case 'Chlorophyll': case 'Solar Power':
+		case 'Chlorophyll': case 'Leaf Guard': case 'Solar Power':
 			return !teamDetails.sun;
 		case 'Hydration': case 'Swift Swim':
 			return !teamDetails.rain;

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -544,7 +544,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
 		if (!abilityAllowed.length) {
 			const weatherAbilities = abilities.filter(
-				a => ['Chlorophyll', 'Hydration', 'Sand Force', 'Sand Rush', 'Solar Power', 'Swift Swim'].includes(a)
+				a => ['Chlorophyll', 'Hydration', 'Leaf Guard', 'Sand Force', 'Sand Rush', 'Solar Power', 'Swift Swim'].includes(a)
 			);
 			if (weatherAbilities.length) return this.sample(weatherAbilities);
 		}

--- a/data/random-battles/gen8/sets.json
+++ b/data/random-battles/gen8/sets.json
@@ -661,7 +661,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Focus Blast", "Freeze-Dry", "Nasty Plot", "Psychic", "Rapid Spin"],
-                "abilities": ["Screen Cleaner"]
+                "abilities": ["Vital Spirit"]
             }
         ]
     },
@@ -1304,7 +1304,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defog", "Hurricane", "Roost", "Scald", "Toxic"],
-                "abilities": ["Water Absorb"]
+                "abilities": ["Swift Swim", "Water Absorb"]
             }
         ]
     },
@@ -2771,11 +2771,6 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Air Slash", "Calm Mind", "Heat Wave", "Roost", "Stored Power"],
                 "abilities": ["Simple"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Heat Wave", "Roost", "Stored Power"],
-                "abilities": ["Simple"]
             }
         ]
     },
@@ -2929,7 +2924,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Close Combat", "Earthquake", "Knock Off", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Knock Off", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Intimidate"]
             }
         ]
@@ -4522,11 +4517,6 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Explosion", "Multi-Attack", "Swords Dance", "U-turn"],
-                "abilities": ["RKS System"]
-            },
-            {
                 "role": "Setup Sweeper",
                 "movepool": ["Explosion", "Flame Charge", "Multi-Attack", "Swords Dance", "X-Scissor"],
                 "abilities": ["RKS System"]
@@ -5149,7 +5139,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Brave Bird", "Bulk Up", "Defog", "Roost"],
-                "abilities": ["Mirror Armor"]
+                "abilities": ["Mirror Armor", "Pressure"]
             }
         ]
     },
@@ -5352,6 +5342,11 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Draining Kiss", "Mystical Fire", "Nuzzle", "Psychic", "Psyshock"],
+                "abilities": ["Magic Bounce"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Dazzling Gleam", "Mystical Fire", "Psychic", "Psyshock", "Trick Room"],
                 "abilities": ["Magic Bounce"]
             }
         ]
@@ -5616,6 +5611,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
+                "movepool": ["Crunch", "Fishious Rend", "Low Kick", "Outrage", "Psychic Fangs"],
+                "abilities": ["Strong Jaw"]
+            },
+            {
+                "role": "Wallbreaker",
                 "movepool": ["Crunch", "Fishious Rend", "Low Kick", "Outrage", "Psychic Fangs"],
                 "abilities": ["Strong Jaw"]
             }

--- a/data/random-battles/gen8/sets.json
+++ b/data/random-battles/gen8/sets.json
@@ -2641,16 +2641,6 @@
         "level": 71,
         "sets": [
             {
-                "role": "Dynamax User",
-                "movepool": ["Dual Wingbeat", "Hone Claws", "Outrage", "Poltergeist"],
-                "abilities": ["Levitate"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Hone Claws", "Outrage", "Poltergeist", "Shadow Sneak"],
-                "abilities": ["Levitate"]
-            },
-            {
                 "role": "Fast Attacker",
                 "movepool": ["Defog", "Draco Meteor", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "abilities": ["Levitate"]

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -61,6 +61,7 @@ const MOVE_PAIRS = [
 	['lightscreen', 'reflect'],
 	['sleeptalk', 'rest'],
 	['protect', 'wish'],
+	['spikyshield', 'wish'],
 	['leechseed', 'substitute'],
 	['focuspunch', 'substitute'],
 ];
@@ -259,7 +260,7 @@ export class RandomGen8Teams extends RandomTeams {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}
 
-		// This space reserved for assorted hardcodes that otherwise make little sense out of context:
+		// This space reserved for assorted hardcodes that make little sense out of context and can't fit in the const:
 		// To force Will-O-Wisp on Corsola-Galar
 		if (species.id === 'corsolagalar') this.incompatibleMoves(moves, movePool, 'haze', 'stealthrock');
 	}
@@ -658,12 +659,10 @@ export class RandomGen8Teams extends RandomTeams {
 				return 'Sitrus Berry';
 			}
 		}
-		if (['boltbeak', 'dragonenergy', 'fishiousrend', 'waterspout'].some(m => moves.has(m))) {
-			if (counter.get('Flying')) {
-				return 'Choice Band';
-			}
-			return 'Choice Scarf';
-		}
+		if (moves.has('dragonenergy') || moves.has('waterspout')) return 'Choice Scarf';
+		if (
+			moves.has('boltbeak') || moves.has('fishiousrend')
+		) return (role === 'Fast Attacker') ? 'Choice Scarf' : 'Choice Band';
 		if (moves.has('geomancy') || moves.has('meteorbeam')) return 'Power Herb';
 		if (moves.has('shellsmash')) return (ability === 'Sturdy') ? 'Heavy-Duty Boots' : 'White Herb';
 		if (ability === 'Guts' && moves.has('facade')) return types.has('Fire') ? 'Toxic Orb' : 'Flame Orb';
@@ -950,6 +949,8 @@ export class RandomGen8Teams extends RandomTeams {
 			[screenSetters, screenSetters],
 
 			// These Pokemon are incompatible because the presence of one actively harms the other.
+			// Screen Cleaner is a bad ability
+			['mrrime', screenSetters],
 			// Prevent Dry Skin + sun setting ability
 			[['jynx', 'toxicroak', 'heliolisk'], sunSetters],
 			// Prevent Shedinja + sand/hail setting ability

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -240,9 +240,15 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Helping Hand", "Protect", "Rock Slide", "Stomping Tantrum", "Sucker Punch"],
+                "movepool": ["Protect", "Rock Slide", "Stomping Tantrum", "Sucker Punch"],
                 "abilities": ["Arena Trap"],
-                "teraTypes": ["Fire", "Ghost", "Ground"]
+                "teraTypes": ["Ghost", "Ground"]
+            },
+            {
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Endeavor", "Protect", "Rock Slide", "Stomping Tantrum"],
+                "abilities": ["Arena Trap"],
+                "teraTypes": ["Ghost", "Ground"]
             }
         ]
     },
@@ -1096,7 +1102,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Dragon Tail", "Electroweb", "Focus Blast", "Helping Hand", "Thunder Wave", "Thunderbolt"],
+                "movepool": ["Dragon Tail", "Electroweb", "Focus Blast", "Helping Hand", "Thunderbolt"],
                 "abilities": ["Static"],
                 "teraTypes": ["Flying"]
             }
@@ -1174,9 +1180,15 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Dazzling Gleam", "Earth Power", "Leaf Storm", "Protect", "Sludge Bomb"],
+                "movepool": ["Earth Power", "Leaf Storm", "Protect", "Sludge Bomb"],
                 "abilities": ["Chlorophyll"],
-                "teraTypes": ["Fairy", "Ground", "Poison"]
+                "teraTypes": ["Ground", "Poison"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Dazzling Gleam", "Earth Power", "Leaf Storm", "Protect"],
+                "abilities": ["Chlorophyll"],
+                "teraTypes": ["Fairy", "Ground"]
             }
         ]
     },
@@ -1677,7 +1689,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Doubles Wallbreaker",
+                "role": "Doubles Fast Attacker",
                 "movepool": ["Fake Out", "Knock Off", "Leaf Blade", "Tailwind"],
                 "abilities": ["Wind Rider"],
                 "teraTypes": ["Ghost"]
@@ -1723,7 +1735,7 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Baton Pass", "Bug Buzz", "Hurricane", "Hydro Pump", "Quiver Dance"],
+                "movepool": ["Bug Buzz", "Hurricane", "Hydro Pump", "Quiver Dance"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Water"]
             },
@@ -2294,7 +2306,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Icy Wind", "Knock Off", "Night Shade", "Spikes", "Thunder Wave"],
+                "movepool": ["Icy Wind", "Knock Off", "Night Shade", "Spikes", "Stealth Rock", "Thunder Wave"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Fairy", "Steel"]
             }
@@ -2657,9 +2669,21 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Fake Out", "Ice Shard", "Knock Off", "Low Kick", "Protect", "Triple Axel"],
+                "movepool": ["Ice Shard", "Knock Off", "Low Kick", "Triple Axel"],
                 "abilities": ["Pickpocket"],
-                "teraTypes": ["Dark", "Fighting", "Ghost", "Ice"]
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Fake Out", "Knock Off", "Protect", "Triple Axel"],
+                "abilities": ["Pickpocket"],
+                "teraTypes": ["Dark", "Ghost", "Ice"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Ice Shard", "Knock Off", "Protect", "Triple Axel"],
+                "abilities": ["Pickpocket"],
+                "teraTypes": ["Dark", "Ghost", "Ice"]
             }
         ]
     },
@@ -3401,7 +3425,7 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Calm Mind", "Earth Power", "Fire Blast", "Judgment", "Recover"],
+                "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover"],
                 "abilities": ["Multitype"],
                 "teraTypes": ["Ground"]
             }
@@ -3605,6 +3629,12 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Leaf Blade", "Protect", "Sleep Powder", "Victory Dance"],
+                "abilities": ["Hustle"],
+                "teraTypes": ["Fighting", "Steel"]
+            },
+            {
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Close Combat", "Leaf Blade", "Protect", "Victory Dance"],
                 "abilities": ["Hustle"],
                 "teraTypes": ["Fighting", "Steel"]
             }
@@ -4424,7 +4454,7 @@
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Brave Bird", "Close Combat", "Protect", "Swords Dance"],
                 "abilities": ["Unburden"],
-                "teraTypes": ["Fighting", "Fire", "Flying"]
+                "teraTypes": ["Fighting", "Fire", "Steel"]
             }
         ]
     },
@@ -4483,7 +4513,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Dazzling Gleam", "Foul Play", "Light Screen", "Reflect", "Spikes", "Thunder Wave"],
+                "movepool": ["Dazzling Gleam", "Light Screen", "Reflect", "Thunder Wave"],
                 "abilities": ["Prankster"],
                 "teraTypes": ["Flying", "Water"]
             }
@@ -4689,9 +4719,9 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Drain Punch", "Gunk Shot", "Ice Hammer", "Protect"],
+                "movepool": ["Drain Punch", "Ice Hammer", "Knock Off", "Protect"],
                 "abilities": ["Iron Fist"],
-                "teraTypes": ["Fire", "Poison"]
+                "teraTypes": ["Dark", "Fire", "Poison"]
             }
         ]
     },
@@ -5165,6 +5195,18 @@
                 "movepool": ["Court Change", "Gunk Shot", "High Jump Kick", "Protect", "Pyro Ball", "Sucker Punch", "U-turn"],
                 "abilities": ["Blaze"],
                 "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Doubles Fast Attacker",
+                "movepool": ["High Jump Kick", "Protect", "Pyro Ball", "U-turn"],
+                "abilities": ["Blaze"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Choice Item user",
+                "movepool": ["Gunk Shot", "High Jump Kick", "Pyro Ball", "U-turn"],
+                "abilities": ["Libero"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -5369,13 +5411,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Fake Out", "Light Screen", "Parting Shot", "Reflect", "Spirit Break", "Thunder Wave"],
-                "abilities": ["Prankster"],
-                "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Doubles Support",
-                "movepool": ["Fake Out", "Parting Shot", "Spirit Break", "Sucker Punch", "Taunt", "Thunder Wave"],
+                "movepool": ["Light Screen", "Parting Shot", "Reflect", "Spirit Break", "Thunder Wave"],
                 "abilities": ["Prankster"],
                 "teraTypes": ["Steel"]
             }
@@ -5681,7 +5717,7 @@
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aqua Jet", "Close Combat", "Ice Spinner", "Protect", "Surging Strikes", "U-turn"],
                 "abilities": ["Unseen Fist"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Fire", "Steel", "Water"]
             }
         ]
     },
@@ -5771,6 +5807,12 @@
                 "movepool": ["Glacial Lance", "High Horsepower", "Protect", "Trick Room"],
                 "abilities": ["As One (Glastrier)"],
                 "teraTypes": ["Ground", "Ice"]
+            },
+            {
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Close Combat", "Glacial Lance", "Protect", "Trick Room"],
+                "abilities": ["As One (Glastrier)"],
+                "teraTypes": ["Fighting", "Ice"]
             }
         ]
     },
@@ -6648,10 +6690,10 @@
                 "teraTypes": ["Fire", "Grass"]
             },
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Acid Spray", "Energy Ball", "Heat Wave", "Protect"],
+                "role": "Doubles Setup Sweeper",
+                "movepool": ["Energy Ball", "Heat Wave", "Meteor Beam", "Protect"],
                 "abilities": ["Quark Drive"],
-                "teraTypes": ["Poison"]
+                "teraTypes": ["Fire", "Grass"]
             }
         ]
     },
@@ -6882,13 +6924,13 @@
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "Leaf Blade", "Protect", "Psyblade"],
                 "abilities": ["Quark Drive"],
-                "teraTypes": ["Fighting", "Fire", "Psychic"]
+                "teraTypes": ["Fighting", "Fire"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Leaf Blade", "Psyblade", "Wild Charge"],
                 "abilities": ["Quark Drive"],
-                "teraTypes": ["Fighting", "Fire", "Psychic"]
+                "teraTypes": ["Fighting", "Fire"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -3103,7 +3103,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Ice Punch", "Knock Off", "Supercell Slam", "Volt Switch"],
                 "abilities": ["Motor Drive"],
-                "teraTypes": ["Dark", "Electric", "Ground"]
+                "teraTypes": ["Dark", "Flying", "Ice", "Ground"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -77,7 +77,7 @@
         "level": 93,
         "sets": [
             {
-                "role": "AV Pivot",
+                "role": "Fast Attacker",
                 "movepool": ["Fake Out", "Knock Off", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
                 "abilities": ["Lightning Rod"],
                 "teraTypes": ["Water"]
@@ -274,9 +274,9 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Dark Pulse", "Hypnosis", "Nasty Plot", "Power Gem", "Thunderbolt"],
+                "movepool": ["Burning Jealousy", "Dark Pulse", "Hypnosis", "Nasty Plot", "Thunderbolt"],
                 "abilities": ["Fur Coat"],
-                "teraTypes": ["Dark", "Electric"]
+                "teraTypes": ["Electric"]
             },
             {
                 "role": "Tera Blast user",
@@ -537,7 +537,7 @@
                 "role": "AV Pivot",
                 "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak"],
                 "abilities": ["Poison Touch"],
-                "teraTypes": ["Dark"]
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -1042,7 +1042,7 @@
         "level": 72,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Fire Blast", "Nasty Plot", "Psystrike", "Recover"],
                 "abilities": ["Pressure", "Unnerve"],
                 "teraTypes": ["Dark", "Fighting", "Fire", "Psychic"]
@@ -1371,13 +1371,13 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Chilly Reception", "Fire Blast", "Psychic Noise", "Psyshock", "Slack Off", "Sludge Bomb", "Thunder Wave", "Toxic Spikes"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Dark", "Poison"]
+                "teraTypes": ["Dark", "Fairy"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Fire Blast", "Future Sight", "Psychic Noise", "Sludge Bomb", "Surf"],
                 "abilities": ["Regenerator"],
-                "teraTypes": ["Poison", "Psychic", "Water"]
+                "teraTypes": ["Dark", "Fairy", "Water"]
             }
         ]
     },
@@ -2075,7 +2075,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Bullet Punch", "Close Combat", "Ice Punch", "Poison Jab", "Zen Headbutt"],
+                "movepool": ["Bullet Punch", "Close Combat", "Ice Punch", "Poison Jab", "Trick", "Zen Headbutt"],
                 "abilities": ["Pure Power"],
                 "teraTypes": ["Fighting"]
             }
@@ -2227,7 +2227,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Drain Punch", "Knock Off", "Seed Bomb", "Sucker Punch", "Swords Dance"],
+                "movepool": ["Knock Off", "Seed Bomb", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Water Absorb"],
                 "teraTypes": ["Dark", "Poison"]
             }
@@ -2273,7 +2273,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Gunk Shot", "Swords Dance", "Trailblaze"],
-                "abilities": ["Infiltrator"],
+                "abilities": ["Infiltrator", "Shed Skin"],
                 "teraTypes": ["Grass", "Ground"]
             }
         ]
@@ -2849,7 +2849,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Calm Mind", "Defog", "Shadow Ball", "Strength Sap"],
                 "abilities": ["Aftermath", "Unburden"],
-                "teraTypes": ["Fairy", "Ghost"]
+                "teraTypes": ["Dark", "Fairy", "Steel"]
             }
         ]
     },
@@ -3024,7 +3024,7 @@
                 "role": "Bulky Support",
                 "movepool": ["Aurora Veil", "Blizzard", "Earthquake", "Ice Shard", "Wood Hammer"],
                 "abilities": ["Snow Warning"],
-                "teraTypes": ["Ice", "Water"]
+                "teraTypes": ["Ghost", "Water"]
             }
         ]
     },
@@ -3609,7 +3609,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Air Slash", "Dazzling Gleam", "Earth Power", "Seed Flare"],
                 "abilities": ["Serene Grace"],
-                "teraTypes": ["Flying", "Grass"]
+                "teraTypes": ["Flying", "Grass", "Ground"]
             },
             {
                 "role": "Bulky Support",
@@ -4738,7 +4738,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Psyshock", "U-turn"],
                 "abilities": ["Serene Grace"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
@@ -5312,7 +5312,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
                 "abilities": ["Dancer"],
-                "teraTypes": ["Fighting", "Ghost"]
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -5567,7 +5567,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Boomburst", "Clanging Scales", "Clangorous Soul", "Close Combat", "Drain Punch", "Iron Head"],
+                "movepool": ["Boomburst", "Clanging Scales", "Clangorous Soul", "Drain Punch", "Iron Head"],
                 "abilities": ["Soundproof"],
                 "teraTypes": ["Normal", "Steel"]
             },
@@ -5895,9 +5895,9 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Giga Drain", "Shadow Ball", "Shell Smash", "Stored Power", "Strength Sap"],
+                "movepool": ["Shadow Ball", "Shell Smash", "Stored Power", "Strength Sap"],
                 "abilities": ["Cursed Body"],
-                "teraTypes": ["Psychic"]
+                "teraTypes": ["Dark", "Psychic"]
             }
         ]
     },
@@ -5943,12 +5943,6 @@
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
                 "abilities": ["Tough Claws"],
                 "teraTypes": ["Fighting"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
-                "abilities": ["Steely Spirit"],
-                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -5957,7 +5951,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Alluring Voice", "Calm Mind", "Psychic", "Psyshock", "Recover"],
+                "movepool": ["Alluring Voice", "Calm Mind", "Psyshock", "Recover"],
                 "abilities": ["Aroma Veil"],
                 "teraTypes": ["Poison", "Steel"]
             },
@@ -6094,7 +6088,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Heat Crash", "Heavy Slam", "Knock Off", "Stone Edge", "Supercell Slam", "Superpower"],
                 "abilities": ["Heavy Metal"],
-                "teraTypes": ["Fire", "Steel"]
+                "teraTypes": ["Fire", "Flying"]
             }
         ]
     },
@@ -7061,13 +7055,13 @@
                 "role": "Fast Support",
                 "movepool": ["Draco Meteor", "Nasty Plot", "Rapid Spin", "Surf"],
                 "abilities": ["Storm Drain"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["Draco Meteor", "Hydro Pump", "Nasty Plot", "Rapid Spin"],
                 "abilities": ["Storm Drain"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -7092,16 +7086,16 @@
                 "teraTypes": ["Ghost", "Ground"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost"],
+                "role": "Bulky Setup",
+                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost", "Shadow Ball"],
                 "abilities": ["Rattled"],
-                "teraTypes": ["Fairy", "Ghost"]
+                "teraTypes": ["Ghost", "Poison"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["Boomburst", "Calm Mind", "Roost", "Shadow Ball"],
+                "role": "Bulky Attacker",
+                "movepool": ["Boomburst", "Earthquake", "Roost", "Toxic"],
                 "abilities": ["Rattled"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Ghost", "Ground", "Poison"]
             }
         ]
     },
@@ -7450,7 +7444,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
+                "movepool": ["Ice Shard", "Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
                 "abilities": ["Sword of Ruin"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
@@ -7577,12 +7571,6 @@
     "fezandipiti": {
         "level": 82,
         "sets": [
-            {
-                "role": "AV Pivot",
-                "movepool": ["Beat Up", "Gunk Shot", "Heat Wave", "Moonblast", "U-turn"],
-                "abilities": ["Toxic Chain"],
-                "teraTypes": ["Dark", "Steel", "Water"]
-            },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Beat Up", "Gunk Shot", "Moonblast", "Roost", "U-turn"],

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -3103,7 +3103,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Ice Punch", "Knock Off", "Supercell Slam", "Volt Switch"],
                 "abilities": ["Motor Drive"],
-                "teraTypes": ["Dark", "Flying", "Ice", "Ground"]
+                "teraTypes": ["Dark", "Flying", "Ground", "Ice"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1286,6 +1286,9 @@ export class RandomTeams {
 			(!types.has('Flying') || this.dex.getEffectiveness('Rock', species) >= 2)
 		) return 'Heavy-Duty Boots';
 		if (
+			role === 'Doubles Support' && ability === 'Prankster' && moves.has('tailwind') && this.randomChance(3, 4)
+		) return 'Covert Cloak';
+		if (
 			(role === 'Bulky Protect' && counter.get('setup')) ||
 			['irondefense', 'coil', 'acidarmor', 'wish'].some(m => moves.has(m)) ||
 			(counter.get('recovery') && !moves.has('strengthsap') && !counter.get('speedcontrol') && !offensiveRole) ||

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -135,7 +135,7 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'breloom', 'brutebonnet', 'cacturne', 'honchkrow', 'mimikyu', 'ragingbolt', 'scizor',
+	'breloom', 'brutebonnet', 'cacturne', 'honchkrow', 'mimikyu', 'ragingbolt', 'scizor', 'scizormega',
 ];
 
 /** Pokemon who should never be in the lead slot */

--- a/data/random-battles/gen9cap/sets.json
+++ b/data/random-battles/gen9cap/sets.json
@@ -60,7 +60,7 @@
         "level": 85,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Earth Power", "Encore", "Rapid Spin", "Sludge Bomb", "Spikes", "Stealth Rock", "Tailwind", "Toxic Spikes", "U-turn"],
                 "abilities": ["Frisk", "Persistent"],
                 "teraTypes": ["Flying", "Steel"]
@@ -431,6 +431,12 @@
                 "movepool": ["Liquidation", "Recover", "Spiky Shield", "Toxic"],
                 "abilities": ["Poison Heal"],
                 "teraTypes": ["Electric", "Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Facade", "Liquidation", "Rapid Spin", "Spiky Shield", "Swords Dance"],
+                "abilities": ["Poison Heal"],
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -525,7 +531,7 @@
         ]
     },
     "saharaja": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "AV Pivot",
@@ -548,7 +554,7 @@
         ]
     },
     "hemogoblin": {
-        "level": 78,
+        "level": 79,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -617,6 +623,23 @@
                 "movepool": ["Blizzard", "Inferno", "Polar Flare", "Thunder"],
                 "abilities": ["No Guard"],
                 "teraTypes": ["Electric", "Flying", "Water"]
+            }
+        ]
+    },
+    "obliteryx": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Beak Blast", "Darkest Lariat", "Encore", "Roost", "Sucker Punch"],
+                "abilities": ["Opportunist"],
+                "teraTypes": ["Fire", "Steel"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Beak Blast", "Body Press", "Knock Off", "Roost", "Stealth Rock"],
+                "abilities": ["Analytic"],
+                "teraTypes": ["Fire", "Steel"]
             }
         ]
     }

--- a/data/random-battles/gen9ffa/sets.json
+++ b/data/random-battles/gen9ffa/sets.json
@@ -1659,7 +1659,7 @@
         ]
     },
     "blissey": {
-        "level": 96,
+        "level": 90,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2275,7 +2275,7 @@
         ]
     },
     "banette": {
-        "level": 94,
+        "level": 93,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -5900,7 +5900,7 @@
         ]
     },
     "alcremie": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Setup",


### PR DESCRIPTION
**Gen 9 Random Battle:**
-Dudunsparce now only has one Calm Mind set with Tera Ghost/Poison and a lower-than-before chance of running Earth Power. It now has a new set of Boomburst, Earthquake, Toxic, and Roost with Rattled and Tera Ghost/Ground/Poison.
-Perrserker's Steely Spirit Wallbreaker set has been removed.
-Fezandipiti's AV Pivot set has been removed.
-Meloetta (Aria)'s role changed to Bulky Attacker so that it gets Leftovers instead of Life Orb with Calm Mind.
-Mewtwo's role changed to Setup Sweeper to remove all sets that are not Nasty Plot. It now no longer runs Choice Specs.
-Bulky Setup Seviper: +Shed Skin
-Fast Bulky Setup Alolan Persian: -Power Gem, -Tera Dark, +Burning Jealousy; it now always runs Thunderbolt on this set.
-non-Tera Blast Polteageist: -Giga Drain, +Tera Dark
-Setup Sweeper Cacturne: -Drain Punch (now always has Knock Off)
-Clangorous Soul Kommo-o: -Close Combat
-Alcremie: -Psychic
-Medicham: +Trick
-Fast Attacker Shaymin-Sky: +Tera Ground
-Abomasnow: -Tera Ice, +Tera Ghost
-Tatsugiri: +Tera Steel
-Alolan Muk: -Tera Dark, +Tera Fighting (it now always runs Drain Punch)
-Fast Attacker Electivire: -Tera Electric, +Tera Flying, +Tera Ice
-Drifblim: -Tera Ghost, +Tera Dark, +Tera Steel
-Bulky Attacker Copperajah: -Tera Steel, +Tera Flying
-Oricorio-Sensu: -Tera Ghost
-Galarian Slowking: -all STAB Teras on sets that have them, +Tera Fairy and Tera Dark on sets that do not have them

Due to statistical analysis, the following is happening:
-Pikachu's role is no longer AV Pivot and is now something that isn't face-value stupid as hell
-Swords Dance Chien-Pao can now run Ice Shard again.

**Gen 9 Random Doubles:**
-Prankster Tailwind users with the Doubles Support role now have a 75% chance to get Covert Cloak.
-Shiftry's non-Tailwind set is now Doubles Fast Attacker to make it get Focus Sash.
-Dugtrio now has a second set of Doubles Fast Attacker with Protect, Endeavor, Rock Slide, and Stomping Tantrum with a Focus Sash. Its other set no longer runs Helping Hand.
-Cinderace: now has three sets: the preexisting Offensive Protect set, a Doubles Fast Attacker set with Focus Sash, and a Doubles Wallbreaker set with Choice Band and Libero.
-Weavile: now has three sets: a Doubles Fast Attacker set with Focus Sash and Fake Out, an Offensive Protect set with Life Orb and Ice Shard, and a Doubles Wallbreaker set with Choice Band.
-Iron Moth: No longer runs Acid Spray, instead running Meteor Beam. Tera Types and role adjusted to match this change.
-Sunflora's set has been split into two such that it always gets Earth Power.
-Hisuian Lilligant now has a second set of Doubles Fast Attacker with Focus Sash, Victory Dance, Protect, and Hustle.
-Klefki: now always runs dual screens with Dazzling Gleam and Thunder Wave.
-Grimmsnarl: now always runs dual screens with Spirit Break and Thunder Wave or Parting Shot.
-Arceus-Rock: -Fire Blast (now always gets Recover)
-Crabominable: -Gunk Shot, +Knock Off, +Tera Dark
-Ampharos: -Thunder Wave
-Masquerain: -Baton Pass
-Deoxys-Defense: +Stealth Rock (rolled with Spikes)
-Iron Leaves: -Tera Psychic on all sets
-Hawlucha: -Tera Flying, +Tera Steel
-Urshifu-Rapid-Strike: +Tera Fire, +Tera Steel (I swear I removed these teras before, but there's demand now to add them)

**Gen 8 Random Battle:**
figured this can get its own section for now.
-Wish and Spiky Shield will now always generate together (sorry Togedemaru for the inconvenience before)
-Giratina-Origin has had all Hone Claws sets removed.
-Silvally-Ghost has had its Swords Dance U-turn set removed.
-Swoobat has had its Air Slashless set removed.
-Hatterene now has a third set of Life Orb Trick Room.
-Choice Band Dracovish can now generate again. 50% odds. Bovis is back.
-Mr. Rime can no longer generate with screens setters.
-Galarian Mr. Mime: -Screen Cleaner, +Vital Spirit
-Mantine: +Swift Swim
-Corviknight: +Pressure
-Krookodile: +Bulk Up

**Old Gens:**
-In Gens 4-5, Jumpluff can now roll Leaf Guard instead of Chlorophyll because it's already fast as shit
-In Gen 5, Liepard now has an additional Fast Support set with Foul Play and U-turn.
-In Gen 5, Mantine now has a Staller set with STABs + Toxic + Protect
-In Gen 5, Golduck now runs HP Grass instead of Focus Blast
-In Gen 5, Rain Dance Swanna now runs Scald instead of Surf
-In Gen 4, Ditto now rolls between Choice Scarf, Quick Powder, and Sitrus Berry.
-In Gen 4, Primeape can now run Bulk Up.
-In Gen 3, Gardevoir no longer runs Ice Punch, can now run Will-O-Wisp, and can now generate without Fire Punch.
-In Gen 3, Deoxys-Speed no longer runs Calm Mind.
-In Gen 3, Unown now rolls completely randomly between HP Fighting, Flying, Ghost, Ground, Psychic, and Rock.
-In Gen 3, Generalist Dusclops no longer runs Ice Beam and Bulky Attacker can now run Pain Split + Will-O-Wisp sometimes instead of RestTalk.
-In Gen 3, Berry Sweeper Persian no longer runs Iron Tail
-In Gen 3, Arcanine's second set is now Fire Blast HP Grass Espeed Toxic instead of what it was before.
-In Gen 3, Flareon's set that was full of random physical attacks is now instead just Fire Blast HP Grass Double-Edge Toxic.
-In Gen 3, Qwilfish now always runs Spikes can no longer runs setup.
-In Gen 3, Berry Sweeper and Fast Attacker Sceptile can now run Hidden Power Fire. Fast Attacker Sceptile has also lost Thunder Punch.
-In Gen 3, Berry Sweeper Typhlosion can now run HP Grass.
-In Gen 3, Weezing no longer runs Toxic.
-In Gen 1, Starmie no longer runs Hydro Pump.
-In Gen 1, Tauros no longer runs Thunderbolt.

**Other Formats:**
-In Free-For-All, Blissey's level has been reduced by 6 and Alcremie's level has been reduced by 2.
-CAP Rands has added Obliteryx. It has two sets: one with Knock Off, Beak Blast, Roost, and Stealth Rock/Body Press with Analytic, and one with Darkest Lariat, Beak Blast, Roost, and Encore/Sucker Punch with Opportunist. It is level 80. Its Tera Types are Fire/Steel on both sets.
-In CAP Rands, Snaelstrom now has an additional set of Liquidation, Facade, Swords Dance, and Rapid Spin/Spiky Shield with Tera Normal.
-In CAP Rands, Fidgit's role has been changed to Bulky Support; it no longer runs Heavy-Duty Boots and now always runs Rapid Spin.
-In CAP Rands, Hemogoblin and Saharaja have gained one level each.