### PR TITLE
Implement Champions Random Battle

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -275,6 +275,14 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		section: "Champions",
 	},
 	{
+		name: "[Gen 9 Champions] Random Battle",
+		desc: `Randomized teams of Pok&eacute;mon with sets that are generated to be competitively viable.`,
+		mod: 'champions',
+		team: 'random',
+		bestOfDefault: true,
+		ruleset: ['Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Illusion Level Mod', 'Level Clause Mod'],
+	},
+	{
 		name: "[Gen 9 Champions] OU",
 		mod: 'champions',
 		ruleset: ['Standard'],

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -280,7 +280,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'champions',
 		team: 'random',
 		bestOfDefault: true,
-		ruleset: ['Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Illusion Level Mod', 'Level Clause Mod'],
+		ruleset: ['Obtainable', 'Species Clause', 'Cancel Mod', 'Sleep Clause Mod', 'Illusion Level Mod', 'Level Clause Mod'],
 	},
 	{
 		name: "[Gen 9 Champions] OU",

--- a/data/mods/champions/rulesets.ts
+++ b/data/mods/champions/rulesets.ts
@@ -52,4 +52,13 @@ export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable 
 			this.makeRequest('teampreview');
 		},
 	},
+	levelclausemod: {
+		effectType: 'Rule',
+		name: 'Level Clause Mod',
+		desc: "Changes stat calculation to depend on the Pok&eacute;mon's level, which need not be 50.",
+		onBegin() {
+			this.add('rule', "Level Clause Mod: Pok&eacute;mon levels are not fixed at 50, with stats calculated accordingly.");
+		},
+		// Implemented in mods/champions/scripts.ts
+	},
 };

--- a/data/mods/champions/scripts.ts
+++ b/data/mods/champions/scripts.ts
@@ -11,10 +11,20 @@ export const Scripts: ModdedBattleScriptsData = {
 		const tr = this.trunc;
 		let stat = baseStats[statName];
 		const evs = set.evs[statName];
-		if (statName === 'hp') {
-			return stat + evs + 75;
+		if (this.ruleTable.has('levelclausemod')) {
+			// Stat calculation is modified to depend on level
+			// We use the formula from main line formats, with each stat point treated as 8 EVs
+			const level = set.level;
+			if (statName === 'hp') {
+				return tr((2 * stat + 31 + 2 * evs) * level / 100) + level + 10;
+			}
+			stat = tr((2 * stat + 31 + 2 * evs) * level / 100) + 5;
+		} else {
+			if (statName === 'hp') {
+				return stat + evs + 75;
+			}
+			stat = stat + evs + 20;
 		}
-		stat = stat + evs + 20;
 		const nature = this.dex.natures.get(set.nature);
 		// Natures are calculated with 16-bit truncation.
 		// This only affects Eternatus-Eternamax in Pure Hackmons.

--- a/data/mods/champions/scripts.ts
+++ b/data/mods/champions/scripts.ts
@@ -19,7 +19,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (statName === 'hp') {
 				return tr((2 * stat + 31 + Math.max(2 * evs - 1, 0)) * level / 100) + level + 10;
 			}
-			stat = tr((2 * stat + 31 + 2 * Math.max(2 * evs - 1, 0)) * level / 100) + 5;
+			stat = tr((2 * stat + 31 + Math.max(2 * evs - 1, 0)) * level / 100) + 5;
 		} else {
 			if (statName === 'hp') {
 				return stat + evs + 75;

--- a/data/mods/champions/scripts.ts
+++ b/data/mods/champions/scripts.ts
@@ -13,12 +13,13 @@ export const Scripts: ModdedBattleScriptsData = {
 		const evs = set.evs[statName];
 		if (this.ruleTable.has('levelclausemod')) {
 			// Stat calculation is modified to depend on level
-			// We use the formula from main line formats, with each stat point treated as 8 EVs
+			// We use the formula from main line formats
+			// The first stat point gives 4 EVs and the others give 8 EVs.
 			const level = set.level;
 			if (statName === 'hp') {
-				return tr((2 * stat + 31 + 2 * evs) * level / 100) + level + 10;
+				return tr((2 * stat + 31 + Math.max(2 * evs - 1, 0)) * level / 100) + level + 10;
 			}
-			stat = tr((2 * stat + 31 + 2 * evs) * level / 100) + 5;
+			stat = tr((2 * stat + 31 + 2 * Math.max(2 * evs - 1, 0)) * level / 100) + 5;
 		} else {
 			if (statName === 'hp') {
 				return stat + evs + 75;

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -1,0 +1,3370 @@
+{
+    "venusaur": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earth Power", "Energy Ball", "Knock Off", "Sleep Powder", "Sludge Bomb", "Synthesis", "Toxic"],
+                "abilities": ["Chlorophyll", "Overgrow"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Giga Drain", "Leech Seed", "Sleep Powder", "Sludge Bomb", "Substitute"],
+                "abilities": ["Chlorophyll", "Overgrow"]
+            }
+        ]
+    },
+    "venusaurmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Sleep Powder", "Sludge Bomb", "Synthesis", "Toxic"],
+                "abilities": ["Chlorophyll"]
+            }
+        ]
+    },
+    "charizard": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Flamethrower", "Hurricane", "Roost", "Scorching Sands", "Will-O-Wisp"],
+                "abilities": ["Blaze"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Acrobatics", "Earthquake", "Flare Blitz", "Swords Dance"],
+                "abilities": ["Blaze"]
+            }
+        ]
+    },
+    "charizardmegax": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Claw", "Flame Charge", "Flare Blitz", "Swords Dance"],
+                "abilities": ["Blaze"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Claw", "Dragon Dance", "Earthquake", "Flare Blitz", "Roost"],
+                "abilities": ["Blaze"]
+            }
+        ]
+    },
+    "charizardmegay": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dragon Pulse", "Roost", "Solar Beam", "Weather Ball"],
+                "abilities": ["Blaze"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Air Slash", "Roost", "Solar Beam", "Weather Ball"],
+                "abilities": ["Blaze"]
+            }
+        ]
+    },
+    "blastoise": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Hydro Pump", "Ice Beam", "Shell Smash"],
+                "abilities": ["Torrent"]
+            }
+        ]
+    },
+    "blastoisemega": {
+        "level": 45,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Shell Smash", "Water Pulse"],
+                "abilities": ["Rain Dish"]
+            }
+        ]
+    },
+    "beedrill": {
+        "level": 60,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Knock Off", "Poison Jab", "Toxic Spikes", "U-turn"],
+                "abilities": ["Swarm"]
+            }
+        ]
+    },
+    "beedrillmega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Drill Run", "Knock Off", "Poison Jab", "U-turn"],
+                "abilities": ["Swarm"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Drill Run", "Knock Off", "Lunge", "Poison Jab", "Swords Dance"],
+                "abilities": ["Swarm"],
+                "preferredTypes": ["Bug"]
+            }
+        ]
+    },
+    "pidgeot": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Brave Bird", "Heat Wave", "Quick Attack", "Roost", "U-turn"],
+                "abilities": ["Big Pecks"]
+            }
+        ]
+    },
+    "pidgeotmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Heat Wave", "Hurricane", "Roost", "U-turn"],
+                "abilities": ["Big Pecks"]
+            }
+        ]
+    },
+    "arbok": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Glare", "Gunk Shot", "Knock Off", "Toxic Spikes"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Coil", "Earthquake", "Gunk Shot", "Sucker Punch", "Trailblaze"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Ground"]
+            }
+        ]
+    },
+    "pikachu": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Fake Out", "Knock Off", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
+                "abilities": ["Lightning Rod"],
+                "preferredTypes": ["Water"]
+            }
+        ]
+    },
+    "raichu": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Encore", "Knock Off", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Lightning Rod"],
+                "preferredTypes": ["Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Alluring Voice", "Encore", "Focus Blast", "Nasty Plot", "Surf", "Thunderbolt"],
+                "abilities": ["Lightning Rod"],
+                "preferredTypes": ["Water"]
+            }
+        ]
+    },
+    "raichualola": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock", "Surf", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Surge Surfer"]
+            }
+        ]
+    },
+    "clefable": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Fire Blast", "Moonblast", "Moonlight"],
+                "abilities": ["Magic Guard", "Unaware"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Fire Blast", "Knock Off", "Moonblast", "Moonlight", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Magic Guard", "Unaware"]
+            }
+        ]
+    },
+    "clefablemega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Fire Blast", "Focus Blast", "Moonblast", "Moonlight"],
+                "abilities": ["Magic Guard"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Air Slash", "Focus Blast", "Knock Off", "Moonblast", "Moonlight", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Magic Guard"]
+            }
+        ]
+    },
+    "ninetales": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Fire Blast", "Nasty Plot", "Scorching Sands", "Solar Beam"],
+                "abilities": ["Drought"]
+            }
+        ]
+    },
+    "ninetalesalola": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Aurora Veil", "Blizzard", "Encore", "Freeze-Dry", "Moonblast", "Nasty Plot"],
+                "abilities": ["Snow Warning"]
+            }
+        ]
+    },
+    "arcanine": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Morning Sun", "Roar", "Will-O-Wisp"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "arcaninehisui": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Extreme Speed", "Flare Blitz", "Head Smash", "Morning Sun", "Stealth Rock", "Will-O-Wisp"],
+                "abilities": ["Rock Head"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Flare Blitz", "Head Smash", "Wild Charge"],
+                "abilities": ["Rock Head"]
+            }
+        ]
+    },
+    "alakazam": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Encore", "Focus Blast", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball"],
+                "abilities": ["Magic Guard"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "alakazammega": {
+        "level": 45,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Encore", "Focus Blast", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball", "Substitute"],
+                "abilities": ["Magic Guard"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "machamp": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Bullet Punch", "Dynamic Punch", "Knock Off", "Stone Edge"],
+                "abilities": ["No Guard"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dynamic Punch", "Earthquake", "Heavy Slam", "Knock Off", "Stone Edge"],
+                "abilities": ["No Guard"],
+                "preferredTypes": ["Rock"]
+            }
+        ]
+    },
+    "victreebel": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Power Whip", "Sludge Wave", "Sunny Day", "Weather Ball"],
+                "abilities": ["Chlorophyll"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Poison Jab", "Power Whip", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Chlorophyll"]
+            }
+        ]
+    },
+    "victreebelmega": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Giga Drain", "Knock Off", "Sleep Powder", "Sludge Bomb", "Strength Sap", "Sucker Punch", "Toxic", "Toxic Spikes"],
+                "abilities": ["Chlorophyll"]
+            }
+        ]
+    },
+    "slowbro": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "slowbromega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Scald", "Slack Off"],
+                "abilities": ["Regenerator"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Calm Mind", "Psychic Noise", "Psyshock", "Scald", "Slack Off"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "slowbrogalar": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Fire Blast", "Haze", "Psychic", "Shell Side Arm", "Slack Off", "Thunder Wave", "Toxic Spikes"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "gengar": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Focus Blast", "Nasty Plot", "Shadow Ball", "Sludge Wave", "Taunt", "Toxic Spikes", "Trick", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"]
+            }
+        ]
+    },
+    "gengarmega": {
+        "level": 42,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Focus Blast", "Nasty Plot", "Shadow Ball", "Sludge Wave", "Substitute"],
+                "abilities": ["Cursed Body"]
+            }
+        ]
+    },
+    "kangaskhan": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Double-Edge", "Drain Punch", "Earthquake", "Fake Out", "Sucker Punch"],
+                "abilities": ["Scrappy"]
+            }
+        ]
+    },
+    "kangaskhanmega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Crunch", "Earthquake", "Fake Out", "Sucker Punch"],
+                "abilities": ["Scrappy"],
+                "preferredTypes": ["Ground"]
+            }
+        ]
+    },
+    "starmie": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Ice Beam", "Psyshock", "Recover", "Scald", "Thunderbolt"],
+                "abilities": ["Analytic"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Psyshock", "Rapid Spin", "Recover", "Scald", "Thunder Wave"],
+                "abilities": ["Natural Cure"]
+            }
+        ]
+    },
+    "starmiemega": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bulk Up", "Ice Spinner", "Liquidation", "Recover", "Zen Headbutt"],
+                "abilities": ["Natural Cure"],
+                "preferredTypes": ["Psychic"]
+            }
+        ]
+    },
+    "pinsir": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Earthquake", "Lunge", "Stone Edge", "Swords Dance"],
+                "abilities": ["Moxie"],
+                "preferredTypes": ["Rock"]
+            }
+        ]
+    },
+    "pinsirmega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Slam", "Close Combat", "Quick Attack", "Swords Dance"],
+                "abilities": ["Moxie"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Body Slam", "Earthquake", "Quick Attack", "Swords Dance"],
+                "abilities": ["Moxie"]
+            }
+        ]
+    },
+    "tauros": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Close Combat", "Earthquake", "Throat Chop"],
+                "abilities": ["Sheer Force"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Slam", "Close Combat", "Throat Chop", "Zen Headbutt"],
+                "abilities": ["Sheer Force"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Double-Edge", "Earthquake", "Throat Chop"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
+    "taurospaldeacombat": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Iron Head", "Megahorn", "Stone Edge", "Throat Chop"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Dark"]
+            }
+        ]
+    },
+    "taurospaldeablaze": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Close Combat", "Raging Bull", "Substitute"],
+                "abilities": ["Cud Chew"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Flare Blitz", "Stone Edge", "Wild Charge"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
+    "taurospaldeaaqua": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Megahorn", "Stone Edge", "Wave Crash"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aqua Jet", "Bulk Up", "Close Combat", "Liquidation", "Substitute"],
+                "abilities": ["Cud Chew"]
+            }
+        ]
+    },
+    "gyarados": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Earthquake", "Power Whip", "Temper Flare", "Waterfall"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Fire"]
+            }
+        ]
+    },
+    "gyaradosmega": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Crunch", "Dragon Dance", "Earthquake", "Power Whip", "Substitute", "Waterfall"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
+    "ditto": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Transform"],
+                "abilities": ["Imposter"]
+            }
+        ]
+    },
+    "vaporeon": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Flip Turn", "Ice Beam", "Protect", "Scald", "Wish"],
+                "abilities": ["Water Absorb"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Protect", "Roar", "Scald", "Wish"],
+                "abilities": ["Water Absorb"]
+            }
+        ]
+    },
+    "jolteon": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Alluring Voice", "Calm Mind", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Volt Absorb"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Alluring Voice", "Calm Mind", "Shadow Ball", "Substitute", "Thunderbolt"],
+                "abilities": ["Volt Absorb"],
+                "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "flareon": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Flare Blitz", "Protect", "Superpower", "Wish"],
+                "abilities": ["Flash Fire", "Guts"]
+            }
+        ]
+    },
+    "aerodactyl": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Earthquake", "Roost", "Stealth Rock", "Stone Edge", "Taunt"],
+                "abilities": ["Pressure", "Unnerve"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Dual Wingbeat", "Earthquake", "Stone Edge"],
+                "abilities": ["Pressure", "Unnerve"]
+            }
+        ]
+    },
+    "aerodactylmega": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dragon Dance", "Dual Wingbeat", "Earthquake", "Roost", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Unnerve"],
+                "preferredTypes": ["Ground"]
+            }
+        ]
+    },
+    "snorlax": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Curse", "Rest", "Sleep Talk"],
+                "abilities": ["Thick Fat"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Slam", "Crunch", "Curse", "Earthquake", "Rest"],
+                "abilities": ["Thick Fat"]
+            }
+        ]
+    },
+    "dragonite": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Outrage", "Roost"],
+                "abilities": ["Multiscale"],
+                "preferredTypes": ["Ground"]
+            }
+        ]
+    },
+    "dragonitemega": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Hurricane", "Hydro Pump", "Roost"],
+                "abilities": ["Multiscale"]
+            }
+        ]
+    },
+    "meganium": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dragon Tail", "Encore", "Energy Ball", "Knock Off", "Leech Seed", "Synthesis"],
+                "abilities": ["Overgrow"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earthquake", "Knock Off", "Leaf Blade", "Swords Dance"],
+                "abilities": ["Overgrow"]
+            }
+        ]
+    },
+    "meganiummega": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dazzling Gleam", "Solar Beam", "Synthesis", "Weather Ball"],
+                "abilities": ["Overgrow"]
+            }
+        ]
+    },
+    "typhlosion": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earthquake", "Eruption", "Fire Blast", "Play Rough"],
+                "abilities": ["Flash Fire"]
+            }
+        ]
+    },
+    "typhlosionhisui": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Eruption", "Fire Blast", "Focus Blast", "Shadow Ball"],
+                "abilities": ["Blaze"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Calm Mind", "Fire Blast", "Focus Blast", "Shadow Ball", "Substitute", "Will-O-Wisp"],
+                "abilities": ["Blaze"]
+            }
+        ]
+    },
+    "feraligatr": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Crunch", "Dragon Dance", "Ice Punch", "Liquidation", "Trailblaze"],
+                "abilities": ["Sheer Force"],
+                "preferredTypes": ["Ice"]
+            }
+        ]
+    },
+    "feraligatrmega": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Double-Edge", "Dragon Dance", "Facade", "Liquidation"],
+                "abilities": ["Sheer Force"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aqua Jet", "Double-Edge", "Dragon Dance", "Liquidation"],
+                "abilities": ["Sheer Force"]
+            }
+        ]
+    },
+    "ariados": {
+        "level": 60,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["First Impression", "Knock Off", "Megahorn", "Poison Jab", "Sticky Web", "Sucker Punch", "Toxic Spikes"],
+                "abilities": ["Swarm"]
+            }
+        ]
+    },
+    "ampharos": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dazzling Gleam", "Dragon Tail", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Static"]
+            }
+        ]
+    },
+    "ampharosmega": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Discharge", "Dragon Pulse", "Dragon Tail", "Rest", "Sleep Talk", "Volt Switch"],
+                "abilities": ["Static"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Agility", "Dragon Pulse", "Parabolic Charge", "Thunderbolt"],
+                "abilities": ["Static"]
+            }
+        ]
+    },
+    "azumarill": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aqua Jet", "Belly Drum", "Liquidation", "Play Rough"],
+                "abilities": ["Huge Power"]
+            }
+        ]
+    },
+    "politoed": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Encore", "Haze", "Hydro Pump", "Hypnosis", "Ice Beam", "Rest", "Surf"],
+                "abilities": ["Drizzle"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Hydro Pump", "Ice Beam", "Weather Ball"],
+                "abilities": ["Drizzle"]
+            }
+        ]
+    },
+    "espeon": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Alluring Voice", "Calm Mind", "Morning Sun", "Psychic", "Psyshock", "Shadow Ball", "Trick"],
+                "abilities": ["Magic Bounce"],
+                "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "umbreon": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Foul Play", "Protect", "Toxic", "Wish"],
+                "abilities": ["Synchronize"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Foul Play", "Moonlight", "Taunt", "Toxic"],
+                "abilities": ["Synchronize"]
+            }
+        ]
+    },
+    "slowking": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Chilly Reception", "Future Sight", "Scald", "Slack Off"],
+                "abilities": ["Regenerator"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Chilly Reception", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "slowkinggalar": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Chilly Reception", "Fire Blast", "Psychic Noise", "Psyshock", "Slack Off", "Sludge Bomb", "Thunder Wave", "Toxic Spikes"],
+                "abilities": ["Regenerator"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Chilly Reception", "Future Sight", "Slack Off", "Sludge Bomb"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "forretress": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Press", "Iron Head", "Rapid Spin", "Spikes", "Stealth Rock", "Toxic Spikes"],
+                "abilities": ["Sturdy"],
+                "preferredTypes": ["Fighting"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Iron Head", "Rapid Spin", "Spikes", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Sturdy"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Iron Head", "Rapid Spin", "Stealth Rock", "Toxic Spikes", "Volt Switch"],
+                "abilities": ["Sturdy"]
+            }
+        ]
+    },
+    "steelix": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Dragon Tail", "Earthquake", "Heavy Slam", "Stealth Rock"],
+                "abilities": ["Sturdy"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Heavy Slam", "Iron Defense", "Rest", "Rock Polish"],
+                "abilities": ["Sturdy"]
+            }
+        ]
+    },
+    "steelixmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Dragon Tail", "Earthquake", "Heavy Slam", "Stealth Rock"],
+                "abilities": ["Sturdy"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Heavy Slam", "Iron Defense", "Rock Polish"],
+                "abilities": ["Sturdy"]
+            }
+        ]
+    },
+    "scizor": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Bullet Punch", "Close Combat", "Defog", "Knock Off", "Roost", "U-turn"],
+                "abilities": ["Technician"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "Knock Off", "Roost", "Swords Dance"],
+                "abilities": ["Technician"]
+            }
+        ]
+    },
+    "scizormega": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Bullet Punch", "Close Combat", "Defog", "Knock Off", "Roost", "U-turn"],
+                "abilities": ["Light Metal"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "Knock Off", "Roost", "Swords Dance"],
+                "abilities": ["Light Metal"]
+            }
+        ]
+    },
+    "heracross": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Earthquake", "Knock Off", "Megahorn", "Spikes", "Stone Edge", "Swords Dance"],
+                "abilities": ["Moxie"],
+                "preferredTypes": ["Rock"]
+            }
+        ]
+    },
+    "heracrossmega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Pin Missile", "Rock Blast", "Trailblaze"],
+                "abilities": ["Moxie"]
+            }
+        ]
+    },
+    "skarmory": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Brave Bird", "Iron Defense", "Roost", "Spikes", "Stealth Rock"],
+                "abilities": ["Sturdy"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Brave Bird", "Roost", "Spikes", "Stealth Rock", "Whirlwind"],
+                "abilities": ["Sturdy"]
+            }
+        ]
+    },
+    "skarmorymega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Brave Bird", "Drill Run", "Roost", "Swords Dance"],
+                "abilities": ["Weak Armor"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brave Bird", "Drill Run", "Iron Head", "Swords Dance"],
+                "abilities": ["Weak Armor"]
+            }
+        ]
+    },
+    "houndoom": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
+                "abilities": ["Flash Fire"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
+                "abilities": ["Flash Fire"]
+            }
+        ]
+    },
+    "houndoommega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Scorching Sands", "Sludge Bomb", "Taunt"],
+                "abilities": ["Flash Fire"]
+            }
+        ]
+    },
+    "tyranitar": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earthquake", "Knock Off", "Stealth Rock", "Stone Edge", "Superpower", "Thunder Wave"],
+                "abilities": ["Sand Stream"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Knock Off", "Stone Edge"],
+                "abilities": ["Sand Stream"]
+            }
+        ]
+    },
+    "tyranitarmega": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Knock Off", "Stone Edge"],
+                "abilities": ["Sand Stream"]
+            }
+        ]
+    },
+    "pelipper": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Hurricane", "Hydro Pump", "Knock Off", "Roost", "Surf", "U-turn"],
+                "abilities": ["Drizzle"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Hurricane", "Hydro Pump", "U-turn", "Weather Ball"],
+                "abilities": ["Drizzle"]
+            }
+        ]
+    },
+    "gardevoir": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Calm Mind", "Focus Blast", "Healing Wish", "Moonblast", "Mystical Fire", "Psychic", "Psyshock", "Trick"],
+                "abilities": ["Trace"]
+            }
+        ]
+    },
+    "gardevoirmega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Calm Mind", "Encore", "Focus Blast", "Hyper Voice", "Mystical Fire", "Psyshock", "Substitute", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Trace"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Hyper Voice", "Psyshock", "Substitute", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Trace"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "sableye": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Encore", "Knock Off", "Recover", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Prankster"]
+            }
+        ]
+    },
+    "sableyemega": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Dark Pulse", "Recover", "Will-O-Wisp"],
+                "abilities": ["Prankster"]
+            }
+        ]
+    },
+    "aggron": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Head Smash", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Rock Head"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "aggronmega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Heavy Slam", "Roar", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Sturdy"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Heavy Slam", "Iron Defense", "Thunder Wave"],
+                "abilities": ["Sturdy"]
+            }
+        ]
+    },
+    "medicham": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Ice Punch", "Poison Jab", "Trick", "Zen Headbutt"],
+                "abilities": ["Pure Power"]
+            }
+        ]
+    },
+    "medichammega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Bullet Punch", "Close Combat", "Fake Out", "Poison Jab", "Zen Headbutt"],
+                "abilities": ["Pure Power"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bulk Up", "Drain Punch", "Trailblaze", "Zen Headbutt"],
+                "abilities": ["Pure Power"]
+            }
+        ]
+    },
+    "manectric": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flamethrower", "Overheat", "Switcheroo", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Lightning Rod"]
+            }
+        ]
+    },
+    "manectricmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flamethrower", "Overheat", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Lightning Rod"]
+            }
+        ]
+    },
+    "sharpedo": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Close Combat", "Crunch", "Destiny Bond", "Hydro Pump", "Ice Beam", "Protect", "Waterfall"],
+                "abilities": ["Speed Boost"]
+            }
+        ]
+    },
+    "sharpedomega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Crunch", "Ice Fang", "Protect", "Psychic Fangs", "Waterfall"],
+                "abilities": ["Speed Boost"]
+            }
+        ]
+    },
+    "camerupt": {
+        "level": 59,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Overheat", "Roar", "Stealth Rock", "Will-O-Wisp"],
+                "abilities": ["Solid Rock"]
+            }
+        ]
+    },
+    "cameruptmega": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Ancient Power", "Earth Power", "Fire Blast", "Stealth Rock", "Will-O-Wisp"],
+                "abilities": ["Solid Rock"]
+            }
+        ]
+    },
+    "torkoal": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Press", "Lava Plume", "Rapid Spin", "Solar Beam", "Stealth Rock", "Yawn"],
+                "abilities": ["Drought"],
+                "preferredTypes": ["Grass"]
+            }
+        ]
+    },
+    "altaria": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Brave Bird", "Dragon Dance", "Earthquake", "Roost"],
+                "abilities": ["Natural Cure"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Brave Bird", "Defog", "Earthquake", "Haze", "Roost", "Will-O-Wisp"],
+                "abilities": ["Natural Cure"]
+            }
+        ]
+    },
+    "altariamega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Double-Edge", "Dragon Dance", "Earthquake", "Roost"],
+                "abilities": ["Natural Cure"]
+            }
+        ]
+    },
+    "milotic": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dragon Tail", "Haze", "Ice Beam", "Recover", "Scald"],
+                "abilities": ["Competitive"]
+            }
+        ]
+    },
+    "castform": {
+        "level": 60,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Fire Blast", "Ice Beam", "Scald", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Forecast"],
+                "preferredTypes": ["Water"]
+            }
+        ]
+    },
+    "banette": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Thunder Wave", "Will-O-Wisp"],
+                "abilities": ["Cursed Body", "Insomnia"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Cursed Body", "Insomnia"]
+            }
+        ]
+    },
+    "banettemega": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Destiny Bond", "Encore", "Poltergeist", "Will-O-Wisp"],
+                "abilities": ["Frisk"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Frisk"]
+            }
+        ]
+    },
+    "chimecho": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Boomburst", "Calm Mind", "Dazzling Gleam", "Psychic Noise", "Psyshock", "Recover"],
+                "abilities": ["Levitate"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Encore", "Heal Bell", "Knock Off", "Psychic Noise", "Recover", "Thunder Wave"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "chimechomega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Cosmic Power", "Flash Cannon", "Recover", "Stored Power"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "absol": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Knock Off", "Play Rough", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Justified"]
+            }
+        ]
+    },
+    "absolmega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Knock Off", "Play Rough", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Justified"],
+                "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "glalie": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Freeze-Dry", "Spikes", "Taunt"],
+                "abilities": ["Inner Focus"]
+            }
+        ]
+    },
+    "glaliemega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Body Slam", "Earthquake", "Explosion", "Spikes"],
+                "abilities": ["Inner Focus"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Body Slam", "Earthquake", "Explosion", "Freeze-Dry"],
+                "abilities": ["Inner Focus"]
+            }
+        ]
+    },
+    "torterra": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Headlong Rush", "Shell Smash", "Stone Edge", "Wood Hammer"],
+                "abilities": ["Overgrow"]
+            }
+        ]
+    },
+    "infernape": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Swords Dance", "U-turn"],
+                "abilities": ["Blaze"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Close Combat", "Grass Knot", "Gunk Shot", "Knock Off", "Mach Punch", "Overheat", "Stealth Rock", "Stone Edge", "U-turn"],
+                "abilities": ["Blaze"]
+            }
+        ]
+    },
+    "empoleon": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roost", "Stealth Rock", "Surf"],
+                "abilities": ["Competitive"]
+            }
+        ]
+    },
+    "luxray": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Play Rough", "Superpower", "Thunder Wave", "Volt Switch", "Wild Charge"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "roserade": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Giga Drain", "Leaf Storm", "Sleep Powder", "Sludge Bomb", "Spikes", "Synthesis", "Toxic Spikes"],
+                "abilities": ["Natural Cure"]
+            }
+        ]
+    },
+    "rampardos": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earthquake", "Fire Punch", "Head Smash", "Rock Slide"],
+                "abilities": ["Sheer Force"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Fire Punch", "Head Smash", "Rock Slide", "Superpower"],
+                "abilities": ["Sheer Force"]
+            }
+        ]
+    },
+    "bastiodon": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Foul Play", "Iron Defense", "Rest", "Stealth Rock"],
+                "abilities": ["Soundproof"]
+            }
+        ]
+    },
+    "lopunny": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Mega Kick", "Swords Dance", "Triple Axel"],
+                "abilities": ["Limber"]
+            }
+        ]
+    },
+    "lopunnymega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Fake Out", "Mega Kick", "U-turn"],
+                "abilities": ["Limber"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Encore", "Mach Punch", "Mega Kick", "Substitute", "Swords Dance"],
+                "abilities": ["Limber"]
+            }
+        ]
+    },
+    "spiritomb": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Poltergeist", "Protect", "Sucker Punch", "Toxic"],
+                "abilities": ["Pressure"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Foul Play", "Pain Split", "Poltergeist", "Sucker Punch", "Toxic", "Will-O-Wisp"],
+                "abilities": ["Pressure"]
+            }
+        ]
+    },
+    "garchomp": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Dragon Tail", "Earthquake", "Outrage", "Spikes", "Stealth Rock"],
+                "abilities": ["Rough Skin"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Outrage", "Scale Shot", "Swords Dance"],
+                "abilities": ["Rough Skin"]
+            }
+        ]
+    },
+    "garchompmega": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Spikes", "Stealth Rock"],
+                "abilities": ["Rough Skin"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Outrage", "Scale Shot", "Swords Dance"],
+                "abilities": ["Rough Skin"]
+            }
+        ]
+    },
+    "lucario": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Swords Dance"],
+                "abilities": ["Justified"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aura Sphere", "Flash Cannon", "Focus Blast", "Nasty Plot", "Vacuum Wave"],
+                "abilities": ["Inner Focus"]
+            }
+        ]
+    },
+    "lucariomega": {
+        "level": 45,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Swords Dance"],
+                "abilities": ["Justified"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aura Sphere", "Flash Cannon", "Nasty Plot", "Vacuum Wave"],
+                "abilities": ["Inner Focus"]
+            }
+        ]
+    },
+    "hippowdon": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind"],
+                "abilities": ["Sand Stream"]
+            }
+        ]
+    },
+    "toxicroak": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Knock Off"],
+                "abilities": ["Dry Skin"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Knock Off", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Dry Skin"]
+            }
+        ]
+    },
+    "abomasnow": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Aurora Veil", "Blizzard", "Earthquake", "Ice Shard", "Wood Hammer"],
+                "abilities": ["Snow Warning"]
+            }
+        ]
+    },
+    "abomasnowmega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Aurora Veil", "Blizzard", "Earthquake", "Giga Drain", "Ice Shard", "Wood Hammer"],
+                "abilities": ["Snow Warning"]
+            }
+        ]
+    },
+    "weavile": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Ice Shard", "Knock Off", "Low Kick", "Swords Dance", "Triple Axel"],
+                "abilities": ["Pickpocket", "Pressure"]
+            }
+        ]
+    },
+    "rhyperior": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dragon Tail", "Earthquake", "Megahorn", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Solid Rock"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earthquake", "Rock Polish", "Stone Edge", "Swords Dance"],
+                "abilities": ["Solid Rock"]
+            }
+        ]
+    },
+    "leafeon": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Double-Edge", "Knock Off", "Leaf Blade", "Substitute", "Swords Dance", "Synthesis"],
+                "abilities": ["Chlorophyll"],
+                "preferredTypes": ["Dark"]
+            }
+        ]
+    },
+    "glaceon": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Calm Mind", "Freeze-Dry", "Mud Shot", "Protect", "Wish"],
+                "abilities": ["Ice Body"]
+            }
+        ]
+    },
+    "gliscor": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Knock Off", "Spikes", "Stealth Rock", "Toxic Spikes", "U-turn"],
+                "abilities": ["Poison Heal"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dual Wingbeat", "Earthquake", "Knock Off", "Power Whip", "Stone Edge", "Swords Dance"],
+                "abilities": ["Poison Heal"]
+            }
+        ]
+    },
+    "mamoswine": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Knock Off", "Stealth Rock"],
+                "abilities": ["Thick Fat"]
+            }
+        ]
+    },
+    "gallade": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Leaf Blade", "Night Slash", "Psycho Cut", "Sacred Sword", "Trick"],
+                "abilities": ["Sharpness"],
+                "preferredTypes": ["Dark"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Agility", "Night Slash", "Psycho Cut", "Sacred Sword"],
+                "abilities": ["Sharpness"]
+            }
+        ]
+    },
+    "gallademega": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Knock Off", "Swords Dance", "Zen Headbutt"],
+                "abilities": ["Justified"]
+            }
+        ]
+    },
+    "froslass": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Destiny Bond", "Ice Beam", "Poltergeist", "Spikes", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Ice Beam", "Nasty Plot", "Shadow Ball", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"]
+            }
+        ]
+    },
+    "froslassmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Aurora Veil", "Blizzard", "Nasty Plot", "Shadow Ball"],
+                "abilities": ["Cursed Body"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Blizzard", "Nasty Plot", "Shadow Ball", "Will-O-Wisp"],
+                "abilities": ["Cursed Body"]
+            }
+        ]
+    },
+    "rotom": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Nasty Plot", "Shadow Ball", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "rotomheat": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Nasty Plot", "Overheat", "Pain Split", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "rotomwash": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Hydro Pump", "Nasty Plot", "Pain Split", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "rotomfrost": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Blizzard", "Nasty Plot", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "rotomfan": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Air Slash", "Nasty Plot", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "rotommow": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Leaf Storm", "Nasty Plot", "Thunderbolt", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "serperior": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dragon Pulse", "Glare", "Leaf Storm", "Leech Seed", "Substitute", "Synthesis"],
+                "abilities": ["Contrary"]
+            }
+        ]
+    },
+    "emboar": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Flare Blitz", "Head Smash", "Knock Off", "Wild Charge"],
+                "abilities": ["Reckless"]
+            }
+        ]
+    },
+    "emboarmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Flame Charge", "Flare Blitz"],
+                "abilities": ["Reckless"]
+            }
+        ]
+    },
+    "samurott": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flip Turn", "Grass Knot", "Hydro Pump", "Ice Beam", "Knock Off", "Megahorn"],
+                "abilities": ["Torrent"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aqua Jet", "Knock Off", "Liquidation", "Megahorn", "Sacred Sword", "Swords Dance"],
+                "abilities": ["Torrent"]
+            }
+        ]
+    },
+    "samurotthisui": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Ceaseless Edge", "Flip Turn", "Razor Shell", "Sacred Sword"],
+                "abilities": ["Sharpness"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Ceaseless Edge", "Razor Shell", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Sharpness"]
+            }
+        ]
+    },
+    "watchog": {
+        "level": 60,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Crunch", "Double-Edge", "Stomping Tantrum", "Swords Dance"],
+                "abilities": ["Analytic"]
+            }
+        ]
+    },
+    "liepard": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Encore", "Knock Off", "Thunder Wave", "U-turn"],
+                "abilities": ["Prankster"]
+            }
+        ]
+    },
+    "simisage": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Gunk Shot", "Leaf Storm", "Rock Slide", "Superpower"],
+                "abilities": ["Overgrow"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Energy Ball", "Focus Blast", "Nasty Plot", "Substitute"],
+                "abilities": ["Overgrow"]
+            }
+        ]
+    },
+    "simisear": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Scorching Sands"],
+                "abilities": ["Blaze"],
+                "preferredTypes": ["Grass"]
+            }
+        ]
+    },
+    "simipour": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Grass Knot", "Hydro Pump", "Ice Beam", "Nasty Plot", "Substitute"],
+                "abilities": ["Torrent"],
+                "preferredTypes": ["Ice"]
+            }
+        ]
+    },
+    "excadrill": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earthquake", "Iron Head", "Rapid Spin", "Swords Dance"],
+                "abilities": ["Mold Breaker", "Sand Rush"]
+            }
+        ]
+    },
+    "excadrillmega": {
+        "level": 45,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["High Horsepower", "Iron Head", "Rapid Spin", "Swords Dance"],
+                "abilities": ["Mold Breaker", "Sand Rush"]
+            }
+        ]
+    },
+    "audino": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Double-Edge", "Protect", "Thunder Wave", "Wish"],
+                "abilities": ["Regenerator"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Slam", "Encore", "Protect", "Wish"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "audinomega": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Fire Blast", "Protect", "Wish"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "conkeldurr": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Bulk Up", "Defog", "Drain Punch", "Knock Off", "Mach Punch"],
+                "abilities": ["Iron Fist"]
+            }
+        ]
+    },
+    "whimsicott": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Encore", "Leech Seed", "Moonblast", "Substitute"],
+                "abilities": ["Prankster"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Encore", "Giga Drain", "Moonblast", "Stun Spore", "U-turn"],
+                "abilities": ["Prankster"]
+            }
+        ]
+    },
+    "krookodile": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Gunk Shot", "Knock Off", "Stealth Rock"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Poison"]
+            }
+        ]
+    },
+    "cofagrigus": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Haze", "Shadow Ball", "Toxic Spikes", "Will-O-Wisp"],
+                "abilities": ["Mummy"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Rest", "Shadow Ball", "Trick Room"],
+                "abilities": ["Mummy"]
+            }
+        ]
+    },
+    "garbodor": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Gunk Shot", "Haze", "Pain Split", "Spikes", "Stomping Tantrum", "Toxic", "Toxic Spikes"],
+                "abilities": ["Aftermath"]
+            }
+        ]
+    },
+    "zoroark": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flamethrower", "Focus Blast", "Night Daze", "Psychic", "Sludge Bomb", "Trick", "U-turn"],
+                "abilities": ["Illusion"],
+                "preferredTypes": ["Poison"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Encore", "Focus Blast", "Nasty Plot", "Night Daze", "Psychic", "Sludge Bomb"],
+                "abilities": ["Illusion"],
+                "preferredTypes": ["Poison"]
+            }
+        ]
+    },
+    "zoroarkhisui": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bitter Malice", "Flamethrower", "Focus Blast", "Hyper Voice", "Nasty Plot"],
+                "abilities": ["Illusion"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Hyper Voice", "Poltergeist", "Trick", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Illusion"]
+            }
+        ]
+    },
+    "reuniclus": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Focus Blast", "Psychic", "Psyshock", "Recover", "Shadow Ball"],
+                "abilities": ["Magic Guard"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "vanilluxe": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Aurora Veil", "Blizzard", "Flash Cannon", "Freeze-Dry"],
+                "abilities": ["Snow Warning"]
+            }
+        ]
+    },
+    "emolga": {
+        "level": 58,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Acrobatics", "Defog", "Discharge", "Encore", "Roost", "U-turn"],
+                "abilities": ["Motor Drive"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Acrobatics", "Nuzzle", "Roost", "Thunderbolt"],
+                "abilities": ["Motor Drive"]
+            }
+        ]
+    },
+    "chandelure": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Energy Ball", "Fire Blast", "Shadow Ball", "Trick"],
+                "abilities": ["Flash Fire"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Calm Mind", "Energy Ball", "Fire Blast", "Flame Charge", "Pain Split", "Shadow Ball", "Substitute", "Will-O-Wisp"],
+                "abilities": ["Flame Body", "Flash Fire"]
+            }
+        ]
+    },
+    "chandeluremega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Calm Mind", "Energy Ball", "Fire Blast", "Flame Charge", "Pain Split", "Shadow Ball", "Will-O-Wisp"],
+                "abilities": ["Flame Body", "Flash Fire"]
+            }
+        ]
+    },
+    "beartic": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aqua Jet", "Close Combat", "Earthquake", "Icicle Crash", "Snowscape", "Swords Dance"],
+                "abilities": ["Slush Rush", "Swift Swim"]
+            }
+        ]
+    },
+    "stunfisk": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Discharge", "Earth Power", "Rest", "Scald", "Sleep Talk", "Stealth Rock"],
+                "abilities": ["Static"]
+            }
+        ]
+    },
+    "stunfiskgalar": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Pain Split", "Snap Trap", "Stealth Rock", "Stone Edge", "Thunder Wave"],
+                "abilities": ["Mimicry"]
+            }
+        ]
+    },
+    "golurk": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dynamic Punch", "Headlong Rush", "Poltergeist", "Stealth Rock", "Stone Edge"],
+                "abilities": ["No Guard"],
+                "preferredTypes": ["Fighting"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Drain Punch", "Headlong Rush", "Ice Punch", "Poltergeist", "Stealth Rock"],
+                "abilities": ["Iron Fist"]
+            }
+        ]
+    },
+    "golurkmega": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Headlong Rush", "Poltergeist", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Iron Fist"]
+            }
+        ]
+    },
+    "hydreigon": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dark Pulse", "Draco Meteor", "Fire Blast", "Flash Cannon", "U-turn"],
+                "abilities": ["Levitate"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dark Pulse", "Draco Meteor", "Fire Blast", "Flash Cannon", "Nasty Plot"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "volcarona": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bug Buzz", "Fiery Dance", "Fire Blast", "Giga Drain", "Morning Sun", "Quiver Dance"],
+                "abilities": ["Flame Body"]
+            }
+        ]
+    },
+    "chesnaught": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Synthesis", "Trailblaze"],
+                "abilities": ["Bulletproof"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Press", "Knock Off", "Spikes", "Synthesis", "Wood Hammer"],
+                "abilities": ["Bulletproof"]
+            }
+        ]
+    },
+    "chesnaughtmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Synthesis", "Trailblaze"],
+                "abilities": ["Bulletproof"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Press", "Knock Off", "Spikes", "Synthesis", "Wood Hammer"],
+                "abilities": ["Bulletproof"]
+            }
+        ]
+    },
+    "delphox": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock", "Trick"],
+                "abilities": ["Blaze"]
+            }
+        ]
+    },
+    "delphoxmega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Encore", "Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock", "Will-O-Wisp"],
+                "abilities": ["Blaze"]
+            }
+        ]
+    },
+    "greninja": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
+                "abilities": ["Protean"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
+                "abilities": ["Protean"],
+                "preferredTypes": ["Poison"]
+            }
+        ]
+    },
+    "greninjamega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
+                "abilities": ["Protean"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
+                "abilities": ["Protean"],
+                "preferredTypes": ["Poison"]
+            }
+        ]
+    },
+    "diggersby": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Body Slam", "Earthquake", "Foul Play", "Trailblaze", "U-turn"],
+                "abilities": ["Huge Power"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Body Slam", "Earthquake", "Quick Attack", "Swords Dance", "Trailblaze"],
+                "abilities": ["Huge Power"]
+            }
+        ]
+    },
+    "talonflame": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Brave Bird", "Defog", "Overheat", "Roost", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Flame Body"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Brave Bird", "Flare Blitz", "Roost", "Swords Dance"],
+                "abilities": ["Flame Body", "Gale Wings"]
+            }
+        ]
+    },
+    "vivillon": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bug Buzz", "Hurricane", "Quiver Dance", "Sleep Powder"],
+                "abilities": ["Compound Eyes"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Energy Ball", "Hurricane", "Quiver Dance", "Sleep Powder"],
+                "abilities": ["Compound Eyes"]
+            }
+        ]
+    },
+    "floetteeternal": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Light of Ruin", "Moonblast", "Psychic", "Trick"],
+                "abilities": ["Flower Veil"]
+            }
+        ]
+    },
+    "floettemega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Moonblast", "Psychic", "Synthesis"],
+                "abilities": ["Flower Veil"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Calm Mind", "Draining Kiss", "Light of Ruin", "Psychic"],
+                "abilities": ["Flower Veil"]
+            }
+        ]
+    },
+    "florges": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Moonblast", "Psychic", "Psychic Noise", "Synthesis"],
+                "abilities": ["Flower Veil"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Moonblast", "Protect", "Wish"],
+                "abilities": ["Flower Veil"]
+            }
+        ]
+    },
+    "pangoro": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Drain Punch", "Gunk Shot", "Headlong Rush", "Knock Off"],
+                "abilities": ["Iron Fist"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bullet Punch", "Drain Punch", "Knock Off", "Swords Dance"],
+                "abilities": ["Iron Fist"]
+            }
+        ]
+    },
+    "furfrou": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Crunch", "Double-Edge", "Thunder Wave", "U-turn"],
+                "abilities": ["Fur Coat"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Cotton Guard", "Crunch", "Double-Edge", "Rest"],
+                "abilities": ["Fur Coat"]
+            }
+        ]
+    },
+    "meowstic": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Alluring Voice", "Psychic Noise", "Thunder Wave", "Yawn"],
+                "abilities": ["Prankster"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Alluring Voice", "Dark Pulse", "Nasty Plot", "Psychic", "Psyshock", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Prankster"],
+                "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "meowsticmmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Alluring Voice", "Dark Pulse", "Nasty Plot", "Psychic", "Psyshock", "Thunder Wave", "Thunderbolt"],
+                "abilities": ["Prankster"],
+                "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "meowsticf": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Alluring Voice", "Dark Pulse", "Nasty Plot", "Psychic", "Psyshock", "Thunderbolt"],
+                "abilities": ["Competitive"],
+                "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "meowsticfmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Alluring Voice", "Dark Pulse", "Nasty Plot", "Psychic", "Psyshock", "Thunderbolt"],
+                "abilities": ["Competitive"],
+                "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "aegislash": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Close Combat", "Flash Cannon", "King's Shield", "Poltergeist", "Shadow Sneak"],
+                "abilities": ["Stance Change"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Iron Head", "King's Shield", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Stance Change"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "King's Shield", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Stance Change"]
+            }
+        ]
+    },
+    "aromatisse": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Moonblast", "Nasty Plot", "Protect", "Wish"],
+                "abilities": ["Aroma Veil"]
+            }
+        ]
+    },
+    "slurpuff": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Dazzling Gleam", "Flamethrower", "Psychic", "Sticky Web", "Yawn"],
+                "abilities": ["Unburden"],
+                "preferredTypes": ["Fire"]
+            }
+        ]
+    },
+    "clawitzer": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Ice Beam", "U-turn", "Water Pulse"],
+                "abilities": ["Mega Launcher"]
+            }
+        ]
+    },
+    "heliolisk": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Discharge", "Hyper Voice", "Morning Sun", "Shed Tail"],
+                "abilities": ["Dry Skin"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Glare", "Hyper Voice", "Morning Sun", "Surf", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Dry Skin"],
+                "preferredTypes": ["Normal"]
+            }
+        ]
+    },
+    "tyrantrum": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Dragon Dance", "Earthquake", "Head Smash", "Outrage"],
+                "abilities": ["Rock Head"]
+            }
+        ]
+    },
+    "aurorus": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Aurora Veil", "Blizzard", "Earth Power", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Snow Warning"]
+            }
+        ]
+    },
+    "sylveon": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Calm Mind", "Hyper Voice", "Mystical Fire", "Protect", "Wish"],
+                "abilities": ["Pixilate"]
+            }
+        ]
+    },
+    "hawlucha": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brave Bird", "Close Combat", "Encore", "Roost", "Stone Edge", "Swords Dance", "Throat Chop"],
+                "abilities": ["Unburden"]
+            }
+        ]
+    },
+    "hawluchamega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Brave Bird", "Bulk Up", "Drain Punch", "Roost"],
+                "abilities": ["Limber"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brave Bird", "Close Combat", "Encore", "Roost", "Stone Edge", "Swords Dance", "Throat Chop"],
+                "abilities": ["Limber"]
+            }
+        ]
+    },
+    "dedenne": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Dazzling Gleam", "Nuzzle", "Super Fang", "Thunderbolt", "U-turn"],
+                "abilities": ["Cheek Pouch"]
+            }
+        ]
+    },
+    "goodra": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Knock Off", "Power Whip", "Scald", "Sludge Bomb", "Toxic"],
+                "abilities": ["Sap Sipper"]
+            }
+        ]
+    },
+    "goodrahisui": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Heavy Slam", "Hydro Pump", "Knock Off", "Thunderbolt"],
+                "abilities": ["Sap Sipper"]
+            }
+        ]
+    },
+    "klefki": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dazzling Gleam", "Foul Play", "Spikes", "Thunder Wave"],
+                "abilities": ["Prankster"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Magnet Rise", "Play Rough", "Spikes", "Thunder Wave"],
+                "abilities": ["Prankster"]
+            }
+        ]
+    },
+    "trevenant": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Drain Punch", "Earthquake", "Horn Leech", "Poltergeist", "Rest", "Rock Slide", "Wood Hammer"],
+                "abilities": ["Natural Cure"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Horn Leech", "Poltergeist", "Protect", "Toxic"],
+                "abilities": ["Harvest"]
+            }
+        ]
+    },
+    "gourgeist": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Leech Seed", "Pain Split", "Poltergeist", "Power Whip", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Frisk"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Leech Seed", "Poltergeist", "Power Whip", "Substitute"],
+                "abilities": ["Frisk"]
+            }
+        ]
+    },
+    "gourgeistsmall": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Leech Seed", "Poltergeist", "Power Whip", "Substitute"],
+                "abilities": ["Frisk"]
+            }
+        ]
+    },
+    "gourgeistlarge": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Leech Seed", "Pain Split", "Poltergeist", "Power Whip", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Frisk"]
+            }
+        ]
+    },
+    "gourgeistsuper": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Leech Seed", "Pain Split", "Poltergeist", "Power Whip", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Frisk"]
+            }
+        ]
+    },
+    "avalugg": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Avalanche", "Body Press", "Curse", "Rapid Spin", "Recover"],
+                "abilities": ["Sturdy"]
+            }
+        ]
+    },
+    "avalugghisui": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Mountain Gale", "Rapid Spin", "Recover", "Stone Edge"],
+                "abilities": ["Sturdy"]
+            }
+        ]
+    },
+    "noivern": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Hurricane", "Roost", "U-turn"],
+                "abilities": ["Infiltrator"]
+            }
+        ]
+    },
+    "decidueye": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Defog", "Leaf Storm", "Roost", "Spirit Shackle", "U-turn"],
+                "abilities": ["Overgrow"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Leaf Blade", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Overgrow"]
+            }
+        ]
+    },
+    "decidueyehisui": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Defog", "Knock Off", "Leaf Blade", "Roost", "Sucker Punch", "Swords Dance", "Triple Arrows", "U-turn"],
+                "abilities": ["Scrappy"]
+            }
+        ]
+    },
+    "incineroar": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Darkest Lariat", "Earthquake", "Flare Blitz", "Parting Shot", "Will-O-Wisp"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Darkest Lariat", "Flare Blitz", "Swords Dance", "Trailblaze"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
+    "primarina": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Draining Kiss", "Psychic", "Sparkling Aria"],
+                "abilities": ["Torrent"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Draining Kiss", "Moonblast", "Psychic Noise"],
+                "abilities": ["Liquid Voice"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flip Turn", "Hydro Pump", "Moonblast", "Psychic"],
+                "abilities": ["Torrent"]
+            }
+        ]
+    },
+    "toucannon": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Beak Blast", "Boomburst", "Bullet Seed", "Heat Wave", "Knock Off", "Roost", "U-turn"],
+                "abilities": ["Keen Eye", "Sheer Force", "Skill Link"]
+            }
+        ]
+    },
+    "crabominable": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Ice Hammer", "Mach Punch"],
+                "abilities": ["Iron Fist"]
+            }
+        ]
+    },
+    "crabominablemega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Ice Hammer", "Mach Punch"],
+                "abilities": ["Iron Fist"]
+            }
+        ]
+    },
+    "lycanroc": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Accelerock", "Close Combat", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance"],
+                "abilities": ["Sand Rush"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "lycanrocmidnight": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Knock Off", "Play Rough", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
+                "abilities": ["No Guard"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "lycanrocdusk": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Accelerock", "Close Combat", "Stone Edge", "Swords Dance"],
+                "abilities": ["Tough Claws"]
+            }
+        ]
+    },
+    "toxapex": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Haze", "Liquidation", "Recover", "Toxic", "Toxic Spikes"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "mudsdale": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Heavy Slam", "Roar", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Stamina"]
+            }
+        ]
+    },
+    "araquanid": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Leech Life", "Liquidation", "Mirror Coat", "Sticky Web"],
+                "abilities": ["Water Bubble"]
+            }
+        ]
+    },
+    "salazzle": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Flamethrower", "Protect", "Substitute", "Toxic"],
+                "abilities": ["Corrosion"]
+            }
+        ]
+    },
+    "tsareena": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["High Jump Kick", "Knock Off", "Power Whip", "Rapid Spin", "Synthesis", "Trop Kick", "U-turn"],
+                "abilities": ["Queenly Majesty"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["High Jump Kick", "Knock Off", "Power Whip", "Triple Axel", "U-turn"],
+                "abilities": ["Queenly Majesty"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "oranguru": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Focus Blast", "Hyper Voice", "Nasty Plot", "Psyshock", "Thunderbolt"],
+                "abilities": ["Inner Focus"]
+            }
+        ]
+    },
+    "passimian": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Knock Off", "Rock Slide", "U-turn"],
+                "abilities": ["Defiant"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off"],
+                "abilities": ["Defiant"]
+            }
+        ]
+    },
+    "mimikyu": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Play Rough", "Shadow Claw", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Disguise"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Drain Punch", "Play Rough", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Disguise"]
+            }
+        ]
+    },
+    "drampa": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Fire Blast", "Glare", "Hyper Voice", "Roost"],
+                "abilities": ["Berserk"]
+            }
+        ]
+    },
+    "drampamega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Draco Meteor", "Fire Blast", "Glare", "Hyper Voice", "Roost"],
+                "abilities": ["Berserk"]
+            }
+        ]
+    },
+    "kommoo": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Clanging Scales", "Clangorous Soul", "Drain Punch", "Iron Head"],
+                "abilities": ["Bulletproof", "Soundproof"]
+            }
+        ]
+    },
+    "corviknight": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Press", "Brave Bird", "Defog", "Roost", "U-turn"],
+                "abilities": ["Mirror Armor", "Pressure"]
+            }
+        ]
+    },
+    "flapple": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Grav Apple", "Outrage", "Sucker Punch"],
+                "abilities": ["Hustle"]
+            }
+        ]
+    },
+    "appletun": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Apple Acid", "Draco Meteor", "Dragon Pulse", "Dragon Tail", "Leech Seed", "Recover"],
+                "abilities": ["Thick Fat"]
+            }
+        ]
+    },
+    "sandaconda": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Coil", "Earthquake", "Glare", "Rest", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Shed Skin"]
+            }
+        ]
+    },
+    "polteageist": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Giga Drain", "Shadow Ball", "Shell Smash", "Stored Power", "Strength Sap"],
+                "abilities": ["Cursed Body"],
+                "preferredTypes": ["Psychic"]
+            }
+        ]
+    },
+    "hatterene": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic", "Psyshock"],
+                "abilities": ["Magic Bounce"]
+            }
+        ]
+    },
+    "mrrime": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Focus Blast", "Freeze-Dry", "Psychic", "Rapid Spin", "Slack Off"],
+                "abilities": ["Screen Cleaner"]
+            }
+        ]
+    },
+    "runerigus": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Haze", "Poltergeist", "Stealth Rock", "Toxic Spikes", "Will-O-Wisp"],
+                "abilities": ["Wandering Spirit"]
+            }
+        ]
+    },
+    "alcremie": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Alluring Voice", "Calm Mind", "Mystical Fire", "Recover"],
+                "abilities": ["Aroma Veil"]
+            }
+        ]
+    },
+    "morpeko": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Aura Wheel", "Knock Off", "Protect", "Rapid Spin"],
+                "abilities": ["Hunger Switch"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Aura Wheel", "Parting Shot", "Protect", "Rapid Spin"],
+                "abilities": ["Hunger Switch"]
+            }
+        ]
+    },
+    "dragapult": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Dragon Darts", "Hex", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Clear Body", "Cursed Body", "Infiltrator"]
+            }
+        ]
+    },
+    "wyrdeer": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Earthquake", "Megahorn", "Psychic Noise", "Thunder Wave"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Earth Power", "Megahorn", "Psyshield Bash", "Thunder Wave"],
+                "abilities": ["Intimidate"],
+                "preferredTypes": ["Ground"]
+            }
+        ]
+    },
+    "kleavor": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Defog", "Stone Axe", "Swords Dance", "U-turn", "X-Scissor"],
+                "abilities": ["Sharpness"]
+            }
+        ]
+    },
+    "basculegion": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Aqua Jet", "Flip Turn", "Shadow Ball", "Wave Crash"],
+                "abilities": ["Adaptability"]
+            }
+        ]
+    },
+    "basculegionf": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flip Turn", "Hydro Pump", "Shadow Ball", "Wave Crash"],
+                "abilities": ["Adaptability"]
+            }
+        ]
+    },
+    "sneasler": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Acrobatics", "Close Combat", "Dire Claw", "Swords Dance", "Throat Chop"],
+                "abilities": ["Unburden"]
+            }
+        ]
+    },
+    "meowscarada": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Flower Trick", "Knock Off", "Toxic Spikes", "Triple Axel", "U-turn"],
+                "abilities": ["Protean"]
+            }
+        ]
+    },
+    "skeledirge": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Flame Charge", "Shadow Ball", "Slack Off", "Torch Song"],
+                "abilities": ["Unaware"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Hex", "Slack Off", "Torch Song", "Will-O-Wisp"],
+                "abilities": ["Unaware"]
+            }
+        ]
+    },
+    "quaquaval": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Aqua Step", "Close Combat", "Rapid Spin", "Roost", "Swords Dance"],
+                "abilities": ["Moxie"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aqua Step", "Close Combat", "Encore", "Knock Off", "Swords Dance", "Triple Axel"],
+                "abilities": ["Moxie"]
+            }
+        ]
+    },
+    "maushold": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bite", "Encore", "Population Bomb", "Tidy Up"],
+                "abilities": ["Technician"]
+            }
+        ]
+    },
+    "garganacl": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Curse", "Iron Defense", "Recover", "Stealth Rock", "Stone Edge"],
+                "abilities": ["Purifying Salt"]
+            }
+        ]
+    },
+    "armarouge": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Focus Blast", "Psyshock"],
+                "abilities": ["Flash Fire"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Armor Cannon", "Calm Mind", "Energy Ball", "Psyshock"],
+                "abilities": ["Weak Armor"]
+            }
+        ]
+    },
+    "ceruledge": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Bitter Blade", "Close Combat", "Poltergeist", "Swords Dance"],
+                "abilities": ["Weak Armor"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bitter Blade", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "abilities": ["Weak Armor"]
+            }
+        ]
+    },
+    "bellibolt": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Muddy Water", "Slack Off", "Thunderbolt", "Toxic", "Volt Switch"],
+                "abilities": ["Electromorphosis"]
+            }
+        ]
+    },
+    "scovillain": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Flamethrower", "Leech Seed", "Protect", "Substitute"],
+                "abilities": ["Chlorophyll"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Energy Ball", "Flare Blitz", "Leaf Storm", "Overheat"],
+                "abilities": ["Chlorophyll"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Energy Ball", "Flare Blitz", "Stomping Tantrum", "Sunny Day"],
+                "abilities": ["Chlorophyll"]
+            }
+        ]
+    },
+    "scovillainmega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Fire Blast", "Flare Blitz", "Giga Drain", "Trailblaze"],
+                "abilities": ["Chlorophyll"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Flamethrower", "Giga Drain", "Leech Seed", "Protect"],
+                "abilities": ["Chlorophyll"]
+            }
+        ]
+    },
+    "espathra": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Roost", "Stored Power"],
+                "abilities": ["Speed Boost"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Protect", "Stored Power", "Substitute"],
+                "abilities": ["Speed Boost"],
+                "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "tinkaton": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Encore", "Gigaton Hammer", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Mold Breaker"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Gigaton Hammer", "Knock Off", "Play Rough", "Protect", "Swords Dance"],
+                "abilities": ["Mold Breaker"]
+            }
+        ]
+    },
+    "palafin": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Flip Turn", "Jet Punch", "Wave Crash"],
+                "abilities": ["Zero to Hero"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Ice Punch", "Jet Punch", "Wave Crash"],
+                "abilities": ["Zero to Hero"]
+            }
+        ]
+    },
+    "orthworm": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Heavy Slam", "Shed Tail", "Spikes", "Stealth Rock"],
+                "abilities": ["Earth Eater"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Coil", "Iron Tail", "Rest"],
+                "abilities": ["Earth Eater"]
+            }
+        ]
+    },
+    "glimmora": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock"],
+                "abilities": ["Toxic Debris"],
+                "preferredTypes": ["Ground"]
+            }
+        ]
+    },
+    "glimmoramega": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Rock Polish", "Sludge Wave", "Spikes", "Stealth Rock"],
+                "abilities": ["Toxic Debris"],
+                "preferredTypes": ["Ground"]
+            }
+        ]
+    },
+    "farigiraf": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Protect", "Psychic Noise", "Wish"],
+                "abilities": ["Sap Sipper"]
+            }
+        ]
+    },
+    "kingambit": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Supreme Overlord"]
+            }
+        ]
+    },
+    "sinistcha": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Matcha Gotcha", "Shadow Ball", "Strength Sap"],
+                "abilities": ["Heatproof"]
+            }
+        ]
+    },
+    "archaludon": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Aura Sphere", "Draco Meteor", "Dragon Tail", "Flash Cannon", "Stealth Rock", "Thunder Wave"],
+                "abilities": ["Stamina"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Aura Sphere", "Draco Meteor", "Earthquake", "Flash Cannon", "Thunderbolt"],
+                "abilities": ["Stamina", "Sturdy"]
+            }
+        ]
+    },
+    "hydrapple": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earth Power", "Fickle Beam", "Giga Drain", "Leaf Storm", "Recover"],
+                "abilities": ["Regenerator"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earth Power", "Fickle Beam", "Giga Drain", "Nasty Plot"],
+                "abilities": ["Regenerator"]
+            }
+        ]
+    }
+}

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -985,7 +985,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
+                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sucker Punch"],
                 "abilities": ["Flash Fire"]
             }
         ]

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -460,13 +460,8 @@
         "level": 52,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["Body Slam", "Close Combat", "Earthquake", "Throat Chop"],
-                "abilities": ["Sheer Force"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Body Slam", "Close Combat", "Throat Chop", "Zen Headbutt"],
                 "abilities": ["Sheer Force"]
             },
             {

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -1637,7 +1637,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Dual Wingbeat", "Earthquake", "Knock Off", "Power Whip", "Stone Edge", "Swords Dance"],
+                "movepool": ["Acrobatics", "Earthquake", "Knock Off", "Power Whip", "Stone Edge", "Swords Dance"],
                 "abilities": ["Poison Heal"]
             }
         ]

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -1,0 +1,980 @@
+import { type MoveCounter, RandomTeams } from '../gen9/teams';
+import { toID } from '../../../sim/dex';
+import { type PRNG, type PRNGSeed } from '../../../sim/prng';
+
+// Moves that restore HP:
+const RECOVERY_MOVES = [
+	'healorder', 'milkdrink', 'moonlight', 'morningsun', 'recover', 'roost', 'shoreup', 'slackoff', 'softboiled', 'strengthsap', 'synthesis',
+];
+// Moves that boost Attack:
+const PHYSICAL_SETUP = [
+	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'meditate', 'poweruppunch', 'swordsdance', 'tidyup', 'victorydance',
+];
+// Some moves that only boost Speed:
+const SPEED_SETUP = [
+	'agility', 'autotomize', 'flamecharge', 'rockpolish', 'snowscape', 'trailblaze',
+];
+// Conglomerate for ease of access
+const SETUP = [
+	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'clangoroussoul', 'coil', 'cosmicpower', 'curse', 'dragondance',
+	'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance',
+	'rockpolish', 'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'takeheart', 'tidyup', 'trailblaze', 'workup', 'victorydance',
+];
+// Moves that shouldn't be the only STAB moves:
+const NO_STAB = [
+	'acidspray', 'accelerock', 'aquajet', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
+	'dragontail', 'doomdesire', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'futuresight',
+	'grassyglide', 'iceshard', 'icywind', 'incinerate', 'infestation', 'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit',
+	'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skydrop', 'snarl', 'snaptrap', 'strugglebug', 'suckerpunch', 'trailblaze',
+	'uturn', 'vacuumwave', 'voltswitch', 'watershuriken', 'waterspout',
+];
+// Hazard-setting moves
+const HAZARDS = [
+	'spikes', 'stealthrock', 'stickyweb', 'toxicspikes',
+];
+// Moves that switch the user out
+const PIVOT_MOVES = [
+	'chillyreception', 'flipturn', 'partingshot', 'shedtail', 'teleport', 'uturn', 'voltswitch',
+];
+
+// Moves that should be paired together when possible
+const MOVE_PAIRS = [
+	['sleeptalk', 'rest'],
+	['protect', 'wish'],
+	['leechseed', 'substitute'],
+];
+
+/** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
+const PRIORITY_POKEMON = [
+	'palafin', 'scizor', 'scizormega',
+];
+
+// 1.2x type boosting items
+const TYPE_BOOSTING_ITEMS: { [k: string]: string } = {
+	'Bug': 'Silver Powder',
+	'Dark': 'Black Glasses',
+	'Dragon': 'Dragon Fang',
+	'Electric': 'Magnet',
+	'Fairy': 'Fairy Feather',
+	'Fighting': 'Black Belt',
+	'Fire': 'Charcoal',
+	'Flying': 'Sharp Beak',
+	'Ghost': 'Spell Tag',
+	'Grass': 'Miracle Seed',
+	'Ground': 'Soft Sand',
+	'Ice': 'Never-Melt Ice',
+	'Normal': 'Silk Scarf',
+	'Poison': 'Poison Barb',
+	'Psychic': 'Twisted Spoon',
+	'Rock': 'Hard Stone',
+	'Steel': 'Metal Coat',
+	'Water': 'Mystic Water',
+};
+
+export class RandomChampionsTeams extends RandomTeams {
+	override randomSets: { [species: string]: RandomTeamsTypes.RandomSpeciesData } = require('./sets.json');
+
+	constructor(format: Format | string, prng: PRNG | PRNGSeed | null) {
+		super(format, prng);
+
+		this.noStab = NO_STAB;
+		this.priorityPokemon = PRIORITY_POKEMON;
+
+		this.moveEnforcementCheckers = {
+			Bug: (movePool, moves, abilities, types, counter) => (
+				!counter.get('Bug') && ['megahorn', 'pinmissile', 'xscissor'].some(m => movePool.includes(m))
+			),
+			Dark: (movePool, moves, abilities, types, counter) => !counter.get('Dark'),
+			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
+			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
+			Fairy: (movePool, moves, abilities, types, counter) => !counter.get('Fairy'),
+			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting'),
+			Fire: (movePool, moves, abilities, types, counter) => !counter.get('Fire'),
+			Flying: (movePool, moves, abilities, types, counter, species) => !counter.get('Flying'),
+			Ghost: (movePool, moves, abilities, types, counter) => !counter.get('Ghost'),
+			Grass: (movePool, moves, abilities, types, counter, species) => (
+				!counter.get('Grass') && (
+					species.baseStats.atk >= 100 || movePool.includes('leafstorm') || types.has('Ghost')
+				)
+			),
+			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
+			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
+			Normal: (movePool, moves, abilities, types, counter) => (
+				movePool.includes('boomburst') || ['Electric', 'Ghost', 'Ground'].some(t => types.has(t))
+			),
+			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
+			Psychic: (movePool, moves, abilities, types, counter) => {
+				if (['Ice', 'Water'].some(m => types.has(m))) return false;
+				return !counter.get('Psychic');
+			},
+			Rock: (movePool, moves, abilities, types, counter, species) => (!counter.get('Rock') && species.baseStats.atk >= 80),
+			Steel: (movePool, moves, abilities, types, counter, species) => (!counter.get('Steel') && species.baseStats.atk >= 75),
+			Water: (movePool, moves, abilities, types, counter) => !counter.get('Water'),
+		};
+		this.cachedStatusMoves = this.dex.moves.all().filter(move => move.category === 'Status').map(move => move.id);
+	}
+
+	override cullMovePool(
+		types: Set<string>,
+		moves: Set<string>,
+		abilities: string[],
+		counter: MoveCounter,
+		movePool: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isLead: boolean,
+		preferredType: string,
+		role: RandomTeamsTypes.Role,
+	): void {
+		if (moves.size + movePool.length <= this.maxMoveCount) return;
+		// If we have two unfilled moves and only one unpaired move, cull the unpaired move.
+		if (moves.size === this.maxMoveCount - 2) {
+			const unpairedMoves = [...movePool];
+			for (const pair of MOVE_PAIRS) {
+				if (movePool.includes(pair[0]) && movePool.includes(pair[1])) {
+					this.fastPop(unpairedMoves, unpairedMoves.indexOf(pair[0]));
+					this.fastPop(unpairedMoves, unpairedMoves.indexOf(pair[1]));
+				}
+			}
+			if (unpairedMoves.length === 1) {
+				this.fastPop(movePool, movePool.indexOf(unpairedMoves[0]));
+			}
+		}
+
+		// These moves are paired, and shouldn't appear if there is not room for them both.
+		if (moves.size === this.maxMoveCount - 1) {
+			for (const pair of MOVE_PAIRS) {
+				if (movePool.includes(pair[0]) && movePool.includes(pair[1])) {
+					this.fastPop(movePool, movePool.indexOf(pair[0]));
+					this.fastPop(movePool, movePool.indexOf(pair[1]));
+				}
+			}
+		}
+
+		if (teamDetails.stickyWeb) {
+			if (movePool.includes('stickyweb')) this.fastPop(movePool, movePool.indexOf('stickyweb'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
+		if (teamDetails.stealthRock) {
+			if (movePool.includes('stealthrock')) this.fastPop(movePool, movePool.indexOf('stealthrock'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
+		if (teamDetails.defog || teamDetails.rapidSpin) {
+			if (movePool.includes('defog')) this.fastPop(movePool, movePool.indexOf('defog'));
+			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
+		if (teamDetails.toxicSpikes) {
+			if (movePool.includes('toxicspikes')) this.fastPop(movePool, movePool.indexOf('toxicspikes'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
+		if (teamDetails.spikes && teamDetails.spikes >= 2) {
+			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
+		if (teamDetails.statusCure) {
+			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
+
+		const statusMoves = this.cachedStatusMoves;
+		const statusInflictingMoves = ["nuzzle", 'thunderwave', 'toxic', 'willowisp', 'yawn'];
+
+		// General incompatibilities
+		const incompatiblePairs = [
+			// These moves don't mesh well with other aspects of the set
+			[statusMoves, ['healingwish', 'switcheroo', 'trick']],
+			[SETUP, PIVOT_MOVES],
+			[SETUP, HAZARDS],
+			[SETUP, ['defog', 'haze', 'toxic']],
+			[PHYSICAL_SETUP, PHYSICAL_SETUP],
+			[SPEED_SETUP, 'quickattack'],
+			['curse', 'rapidspin'],
+			['defog', HAZARDS],
+			['uturn', 'trick'],
+			['substitute', PIVOT_MOVES],
+
+			// These attacks are redundant with each other
+			[['psychic', 'psychicnoise'], ['psyshock', 'psychicnoise']],
+			[['surf', 'waterfall'], 'hydropump'],
+			[['gigadrain', 'hornleech', 'tropkick'], ['leafstorm', 'powerwhip', 'woodhammer']],
+			[['fireblast', 'flamethrower'], ['fierydance', 'overheat']],
+			['aurasphere', 'focusblast'],
+			['closecombat', 'drainpunch'],
+			['dragonpulse', 'dracometeor'],
+			['heavyslam', 'flashcannon'],
+
+			// Status move incompatibilities
+			['taunt', 'encore'],
+			[statusInflictingMoves, 'toxicspikes'],
+			[statusInflictingMoves, statusInflictingMoves],
+		];
+
+		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
+
+		if (!types.has('Dark') && preferredType !== 'Dark') {
+			this.incompatibleMoves(moves, movePool, 'knockoff', 'suckerpunch');
+		}
+
+		// This space reserved for assorted hardcodes that make little sense out of context and can't fit in the const:
+		// To force Stealth Rock on Camerupt
+		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
+		if (species.id === 'cameruptmega') this.incompatibleMoves(moves, movePool, 'ancientpower', 'willowisp');
+		// To force Ice Shard on Mamoswine
+		if (species.id === 'mamoswine') this.incompatibleMoves(moves, movePool, 'knockoff', 'stealthrock');
+	}
+
+	// Generate random moveset for a given species, role, preferred type.
+	override randomMoveset(
+		types: Set<string>,
+		abilities: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isLead: boolean,
+		movePool: string[],
+		preferredType: string,
+		role: RandomTeamsTypes.Role,
+	): Set<string> {
+		const moves = new Set<string>();
+		let counter = this.queryMoves(moves, species, preferredType, abilities);
+		this.cullMovePool(types, moves, abilities, counter, movePool, teamDetails, species, isLead,
+			preferredType, role);
+
+		// If there are only four moves, add all moves and return early
+		if (movePool.length <= this.maxMoveCount) {
+			while (movePool.length) {
+				const moveid = this.sample(movePool);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+			return moves;
+		}
+
+		const runEnforcementChecker = (checkerName: string) => {
+			if (!this.moveEnforcementCheckers[checkerName]) return false;
+			return this.moveEnforcementCheckers[checkerName](
+				movePool, moves, abilities, types, counter, species, teamDetails, isLead, false, preferredType, role
+			);
+		};
+
+		// Add required move (e.g. Relic Song for Meloetta-P)
+		if (species.requiredMove) {
+			const move = this.dex.moves.get(species.requiredMove).id;
+			counter = this.addMove(move, moves, types, abilities, teamDetails, species, isLead,
+				movePool, preferredType, role);
+		}
+
+		// Add other moves you really want to have, e.g. STAB, recovery, setup.
+
+		// Enforce Aurora Veil, Blizzard, and Sticky Web
+		for (const moveid of ['auroraveil', 'blizzard', 'stickyweb']) {
+			if (movePool.includes(moveid)) {
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce hazard removal on Bulky Support if the team doesn't already have it
+		if (role === 'Bulky Support' && !teamDetails.defog && !teamDetails.rapidSpin) {
+			if (movePool.includes('rapidspin')) {
+				counter = this.addMove('rapidspin', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+			if (movePool.includes('defog')) {
+				counter = this.addMove('defog', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce Knock Off on pure Normal- and Fighting-types
+		if (types.size === 1 && (types.has('Normal') || types.has('Fighting'))) {
+			if (movePool.includes('knockoff')) {
+				counter = this.addMove('knockoff', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce Body Press on sets with Iron Defense
+		if (movePool.includes('irondefense')) {
+			if (movePool.includes('bodypress')) {
+				counter = this.addMove('bodypress', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce Protect on Sharpedo and Sharpedo-Mega
+		if (species.baseSpecies === 'Sharpedo') {
+			if (movePool.includes('protect')) {
+				counter = this.addMove('protect', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce King's Shield on Bulky Attacker Aegislash
+		if (species.id === 'aegislash' && role === 'Bulky Attacker') {
+			if (movePool.includes('kingsshield')) {
+				counter = this.addMove('kingsshield', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce STAB priority
+		if (this.priorityPokemon.includes(species.id)) {
+			const priorityMoves = [];
+			for (const moveid of movePool) {
+				const move = this.dex.moves.get(moveid);
+				const moveType = this.getMoveType(move, species, abilities, preferredType);
+				if (types.has(moveType) && move.priority > 0 && (move.basePower || move.basePowerCallback)) {
+					priorityMoves.push(moveid);
+				}
+			}
+			if (priorityMoves.length) {
+				const moveid = this.sample(priorityMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce STAB
+		for (const type of types) {
+			// Check if a STAB move of that type should be required
+			const stabMoves = [];
+			for (const moveid of movePool) {
+				const move = this.dex.moves.get(moveid);
+				const moveType = this.getMoveType(move, species, abilities, preferredType);
+				if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback) && type === moveType) {
+					stabMoves.push(moveid);
+				}
+			}
+			while (runEnforcementChecker(type)) {
+				if (!stabMoves.length) break;
+				const moveid = this.sampleNoReplace(stabMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce Preferred Type
+		if (!counter.get(preferredType)) {
+			const stabMoves = [];
+			for (const moveid of movePool) {
+				const move = this.dex.moves.get(moveid);
+				const moveType = this.getMoveType(move, species, abilities, preferredType);
+				if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback) && preferredType === moveType) {
+					stabMoves.push(moveid);
+				}
+			}
+			if (stabMoves.length) {
+				const moveid = this.sample(stabMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// If no STAB move was added, add a STAB move
+		if (!counter.get('stab')) {
+			const stabMoves = [];
+			for (const moveid of movePool) {
+				const move = this.dex.moves.get(moveid);
+				const moveType = this.getMoveType(move, species, abilities, preferredType);
+				if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback) && types.has(moveType)) {
+					stabMoves.push(moveid);
+				}
+			}
+			if (stabMoves.length) {
+				const moveid = this.sample(stabMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce recovery
+		if (role.includes('Bulky')) {
+			const recoveryMoves = movePool.filter(moveid => RECOVERY_MOVES.includes(moveid));
+			if (recoveryMoves.length) {
+				const moveid = this.sample(recoveryMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce setup
+		if (role.includes('Setup')) {
+			// First, try to add a non-Speed setup move
+			const nonSpeedSetupMoves = movePool.filter(moveid => SETUP.includes(moveid) && !SPEED_SETUP.includes(moveid));
+			if (nonSpeedSetupMoves.length) {
+				const moveid = this.sample(nonSpeedSetupMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			} else {
+				// No non-Speed setup moves, so add any (Speed) setup move
+				const setupMoves = movePool.filter(moveid => SETUP.includes(moveid));
+				if (setupMoves.length) {
+					const moveid = this.sample(setupMoves);
+					counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+						movePool, preferredType, role);
+				}
+			}
+		}
+
+		// Enforce a move not on the noSTAB list
+		if (!counter.damagingMoves.size) {
+			// Choose an attacking move
+			const attackingMoves = [];
+			for (const moveid of movePool) {
+				const move = this.dex.moves.get(moveid);
+				if (!this.noStab.includes(moveid) && (move.category !== 'Status')) attackingMoves.push(moveid);
+			}
+			if (attackingMoves.length) {
+				const moveid = this.sample(attackingMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
+		}
+
+		// Enforce coverage move
+		if (['Fast Attacker', 'Setup Sweeper', 'Bulky Attacker'].includes(role)) {
+			if (counter.damagingMoves.size === 1) {
+				// Find the type of the current attacking move
+				const currentAttackType = counter.damagingMoves.values().next().value!.type;
+				// Choose an attacking move that is of different type to the current single attack
+				const coverageMoves = [];
+				for (const moveid of movePool) {
+					const move = this.dex.moves.get(moveid);
+					const moveType = this.getMoveType(move, species, abilities, preferredType);
+					if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback)) {
+						if (currentAttackType !== moveType) coverageMoves.push(moveid);
+					}
+				}
+				if (coverageMoves.length) {
+					const moveid = this.sample(coverageMoves);
+					counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+						movePool, preferredType, role);
+				}
+			}
+		}
+
+		// Choose remaining moves randomly from movepool and add them to moves list:
+		while (moves.size < this.maxMoveCount && movePool.length) {
+			const moveid = this.sample(movePool);
+			counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+				movePool, preferredType, role);
+			for (const pair of MOVE_PAIRS) {
+				if (moveid === pair[0] && movePool.includes(pair[1])) {
+					counter = this.addMove(pair[1], moves, types, abilities, teamDetails, species, isLead,
+						movePool, preferredType, role);
+				}
+				if (moveid === pair[1] && movePool.includes(pair[0])) {
+					counter = this.addMove(pair[0], moves, types, abilities, teamDetails, species, isLead,
+						movePool, preferredType, role);
+				}
+			}
+		}
+		return moves;
+	}
+
+	override shouldCullAbility(
+		ability: string,
+		types: Set<string>,
+		moves: Set<string>,
+		abilities: string[],
+		counter: MoveCounter,
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+	): boolean {
+		switch (ability) {
+		case 'Chlorophyll': case 'Solar Power':
+			return !teamDetails.sun;
+		case 'Hydration': case 'Swift Swim':
+			return !teamDetails.rain;
+		case 'Overgrow':
+			return !counter.get('Grass');
+		case 'Sand Force': case 'Sand Rush':
+			return !teamDetails.sand;
+		case 'Slush Rush':
+			return !teamDetails.snow;
+		case 'Sheer Force': case 'Skill Link':
+			return !counter.get(toID(ability));
+		}
+
+		return false;
+	}
+
+	override getAbility(
+		types: Set<string>,
+		moves: Set<string>,
+		abilities: string[],
+		counter: MoveCounter,
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+	): string {
+		if (abilities.length <= 1) return abilities[0];
+
+		// Hard-code abilities here
+		if (species.id === 'toucannon') {
+			if (counter.get('skilllink')) return 'Skill Link';
+			if (counter.get('sheerforce')) return 'Sheer Force';
+		}
+		if (abilities.includes('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
+
+		const abilityAllowed: string[] = [];
+		// Obtain a list of abilities that are allowed (not culled)
+		for (const ability of abilities) {
+			if (!this.shouldCullAbility(ability, types, moves, abilities, counter, teamDetails, species)) {
+				abilityAllowed.push(ability);
+			}
+		}
+
+		// Pick a random allowed ability
+		if (abilityAllowed.length >= 1) return this.sample(abilityAllowed);
+
+		// If all abilities are rejected, prioritize weather abilities over non-weather abilities
+		if (!abilityAllowed.length) {
+			const weatherAbilities = abilities.filter(
+				a => ['Chlorophyll', 'Sand Rush', 'Slush Rush', 'Solar Power', 'Swift Swim'].includes(a)
+			);
+			if (weatherAbilities.length) return this.sample(weatherAbilities);
+		}
+
+		// Pick a random allowed ability
+		if (abilityAllowed.length >= 1) return this.sample(abilityAllowed);
+
+		// Pick a random ability
+		return this.sample(abilities);
+	}
+
+	override getPriorityItem(
+		ability: string,
+		types: Set<string>,
+		moves: Set<string>,
+		counter: MoveCounter,
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isLead: boolean,
+		preferredType: string,
+		role: RandomTeamsTypes.Role,
+	): string | undefined {
+		if (species.requiredItems) return this.sample(species.requiredItems);
+		if (species.id === 'pikachu') return 'Light Ball';
+		if (
+			['Cheek Pouch', 'Cud Chew', 'Harvest'].some(m => ability === m) || moves.has('bellydrum')
+		) return 'Sitrus Berry';
+		if (species.id === 'alakazam') return 'Focus Sash';
+		if (species.id === 'ditto') return 'Choice Scarf';
+		if (['healingwish', 'switcheroo', 'trick'].some(m => moves.has(m))) return 'Choice Scarf';
+		if (ability === 'Unburden') return moves.has('closecombat') ? 'White Herb' : 'Sitrus Berry';
+		if (moves.has('shellsmash')) return 'White Herb';
+		if (moves.has('acrobatics')) return '';
+		if (
+			moves.has('rest') && !moves.has('sleeptalk') &&
+			ability !== 'Natural Cure' && ability !== 'Shed Skin'
+		) return 'Chesto Berry';
+		if (types.has('Normal') && moves.has('doubleedge') && moves.has('fakeout')) return 'Silk Scarf';
+	}
+
+	override getItem(
+		ability: string,
+		types: Set<string>,
+		moves: Set<string>,
+		counter: MoveCounter,
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isLead: boolean,
+		preferredType: string,
+		role: RandomTeamsTypes.Role,
+	): string {
+		// const defensiveStatTotal = species.baseStats.hp + species.baseStats.def + species.baseStats.spd;
+		if (
+			role === 'Fast Attacker' && !counter.get('priority') &&
+			['fakeout', 'trailblaze'].every(m => !moves.has(m)) &&
+			(!counter.get('Status') || counter.get('Status') === 1 && moves.has('partingshot'))
+		) return 'Choice Scarf';
+		if (moves.has('substitute') || moves.has('kingsshield')) return 'Leftovers';
+		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
+
+		// Default to Leftovers for Bulky roles
+		if (role.includes('Bulky')) return 'Leftovers';
+		// Default to Focus Sash for Fast Support. Bulk threshold is unnecessary for the time being
+		if (role === 'Fast Support' && !counter.get('recovery')) return 'Focus Sash';
+
+		// Pokes with high crit rate STABs
+		if (
+			['aerodactyl', 'gallade', 'leafeon', 'lycanroc', 'lycanrocmidnight'].includes(species.id) && !moves.has('accelerock')
+		) return 'Scope Lens';
+
+		// Give type-boosting items if it only has one STAB attack
+		const stabTypes: string[] = [];
+		for (const type of types) {
+			if (counter.get(type)) stabTypes.push(type);
+		}
+		if (stabTypes.length === 1) {
+			return TYPE_BOOSTING_ITEMS[stabTypes[0]];
+		}
+
+		// Give type-boosting items if it has a STAB regular and priority attack of the same type
+		for (const type of types) {
+			if (!counter.get(type)) continue;
+			for (const moveid of moves) {
+				const move = this.dex.moves.get(moveid);
+				const moveType = this.getMoveType(move, species, [ability], preferredType);
+				if (type === moveType && move.priority > 0 && (move.basePower || move.basePowerCallback)) {
+					return TYPE_BOOSTING_ITEMS[type];
+				}
+			}
+		}
+
+		// Hard-code type-boosting items here
+		if (species.id === 'hydreigon') return 'Dragon Fang';
+		if (['heliolisk', 'raichualola'].includes(species.id)) return 'Magnet';
+		if (species.id === 'gardevoir') return 'Fairy Feather';
+		if (
+			['typhlosionhisui', 'chandelure', 'volcarona', 'delphox', 'armarouge', 'scovillain', 'houndoom'].includes(species.id)
+		) return 'Charcoal';
+		if (species.id === 'vivillon') return 'Sharp Beak';
+		if (species.id === 'victreebel') return 'Miracle Seed';
+		if (['weavile', 'mamoswine'].includes(species.id)) return 'Never-Melt Ice';
+		if (species.id === 'quaquaval') return 'Mystic Water';
+
+		// Randomly choose between their STABs
+		if (
+			['toxicroak', 'heracross', 'zoroarkhisui', 'kleavor', 'infernape'].includes(species.id)
+		) return TYPE_BOOSTING_ITEMS[this.sample([...types])];
+
+		// Default to Leftovers
+		return 'Leftovers';
+	}
+
+	override randomSet(
+		species: string | Species,
+		teamDetails: RandomTeamsTypes.TeamDetails = {},
+		isLead = false
+	): RandomTeamsTypes.RandomSet {
+		const ruleTable = this.dex.formats.getRuleTable(this.format);
+
+		species = this.dex.species.get(species);
+		const forme = this.getForme(species);
+		const sets = this.randomSets[species.id]["sets"];
+		const possibleSets = [];
+
+		for (const set of sets) possibleSets.push(set);
+
+		const set = this.sampleIfArray(possibleSets);
+		const role = set.role;
+		const movePool: string[] = [];
+		for (const movename of set.movepool) {
+			movePool.push(this.dex.moves.get(movename).id);
+		}
+		const preferredTypes = set.preferredTypes;
+		const preferredType = this.sampleIfArray(preferredTypes) || '';
+
+		let ability = '';
+		let item = undefined;
+
+		const evs = { hp: 11, atk: 11, def: 11, spa: 11, spd: 11, spe: 11 };
+		const ivs = { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 };
+
+		const types = new Set(species.types);
+		const baseAbilities = set.abilities!;
+		// Use the mega's ability for moveset generation
+		const abilities = (species.battleOnly && !species.requiredAbility) ? Object.values(species.abilities) : baseAbilities;
+
+		// Get moves
+		const moves = this.randomMoveset(types, abilities, teamDetails, species, isLead, movePool,
+			preferredType, role);
+		const counter = this.queryMoves(moves, species, preferredType, abilities);
+
+		// Get ability
+		ability = this.getAbility(types, moves, baseAbilities, counter, teamDetails, species);
+
+		// Get items
+		item = this.getPriorityItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
+		if (item === undefined) {
+			item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
+		}
+
+		const level = this.getLevel(species);
+
+		// Minimize confusion damage
+		const noAttackStatMoves = [...moves].every(m => {
+			const move = this.dex.moves.get(m);
+			if (move.damageCallback || move.damage) return true;
+			if (move.id === 'shellsidearm') return false;
+			return move.category !== 'Physical' || move.id === 'bodypress' || move.id === 'foulplay';
+		});
+		if (
+			noAttackStatMoves && !moves.has('transform') && !ruleTable.has('forceofthefallenmod')
+		) {
+			evs.atk = 0;
+		}
+
+		// Prepare optimal HP
+		const srImmunity = ability === 'Magic Guard';
+		let srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		// Crash damage move users want an odd HP to survive two misses
+		if (['axekick', 'highjumpkick', 'jumpkick', 'supercellslam'].some(m => moves.has(m))) srWeakness = 2;
+		// Treat Charizard-Mega-X like Charizard-Mega-Y for bluffing purposes
+		if (species.id === 'charizardmegax') srWeakness = 2;
+		while (evs.hp > 0) {
+			const hp = Math.floor((2 * species.baseStats.hp + ivs.hp + evs.hp * 2 + 100) * level / 100 + 10);
+			if (moves.has('substitute') && item !== 'Leftovers') {
+				if (item === 'Sitrus Berry' || item === 'Salac Berry') {
+					// Two Substitutes should activate Sitrus Berry or Power Construct
+					if (hp % 4 === 0) break;
+				} else {
+					// Should be able to use Substitute four times from full HP without fainting
+					if (hp % 4 > 0) break;
+				}
+			} else if ((moves.has('bellydrum') || moves.has('shedtail')) && item === 'Sitrus Berry') {
+				// Belly Drum should activate Sitrus Berry
+				if (hp % 2 === 0) break;
+			} else {
+				// Maximize number of Stealth Rock switch-ins
+				if (srWeakness <= 0 || ability === 'Regenerator') break;
+				if (srWeakness === 1 && item === 'Leftovers') break;
+				if (item !== 'Sitrus Berry' && hp % (4 / srWeakness) > 0) break;
+				// Minimise number of Stealth Rock switch-ins to activate Sitrus Berry
+				if (item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;
+			}
+			evs.hp--;
+		}
+
+		if (['gyroball', 'metalburst', 'trickroom'].some(m => moves.has(m))) evs.spe = 0;
+
+		// shuffle moves to add more randomness to camomons
+		const shuffledMoves = Array.from(moves);
+		this.prng.shuffle(shuffledMoves);
+
+		return {
+			name: species.baseSpecies,
+			species: forme,
+			speciesId: species.id,
+			gender: species.gender || (this.random(2) ? 'F' : 'M'),
+			shiny: this.randomChance(1, 1024),
+			level,
+			moves: shuffledMoves,
+			ability,
+			evs,
+			ivs,
+			item,
+			role,
+		};
+	}
+
+	/**
+	 * Checks if the new species is compatible with the other mons currently on the team.
+	 */
+	override getPokemonCompatibility(
+		species: Species,
+		pokemon: RandomTeamsTypes.RandomSet[],
+	): boolean {
+		const webSetters = ['ariados', 'slurpuff', 'araquanid'];
+		const screenSetters = ['ninetalesalola', 'abomasnow', 'abomasnowmega', 'froslassmega', 'vanilluxe', 'aurorus'];
+
+		const sunSetters = ['charizardmegay', 'ninetales', 'torkoal'];
+
+		const incompatibilityList = [
+			// These combinations are prevented to avoid double webs or screens.
+			[webSetters, webSetters],
+			[screenSetters, screenSetters],
+
+			// These Pokemon are incompatible because the presence of one actively harms the other.
+			// Screen Cleaner is a bad ability
+			['mrrime', screenSetters],
+			// Prevent Dry Skin + sun setting ability
+			[['toxicroak', 'heliolisk'], sunSetters],
+		];
+
+		for (const pair of incompatibilityList) {
+			const monsArrayA = (Array.isArray(pair[0])) ? pair[0] : [pair[0]];
+			const monsArrayB = (Array.isArray(pair[1])) ? pair[1] : [pair[1]];
+			if (monsArrayB.includes(species.id)) {
+				if (pokemon.some(m => monsArrayA.includes(m.speciesId!))) return false;
+			}
+			if (monsArrayA.includes(species.id)) {
+				if (pokemon.some(m => monsArrayB.includes(m.speciesId!))) return false;
+			}
+		}
+
+		return true;
+	}
+
+	override randomTeam() {
+		this.enforceNoDirectCustomBanlistChanges();
+
+		const seed = this.prng.getSeed();
+		const ruleTable = this.dex.formats.getRuleTable(this.format);
+		const pokemon: RandomTeamsTypes.RandomSet[] = [];
+
+		// For Monotype
+		const isMonotype = !!this.forceMonotype || ruleTable.has('sametypeclause');
+		const typePool = this.dex.types.names().filter(name => name !== "Stellar");
+		const type = this.forceMonotype || this.sample(typePool);
+
+		const baseFormes: { [k: string]: number } = {};
+		let hasMega = false;
+
+		const typeCount: { [k: string]: number } = {};
+		const typeComboCount: { [k: string]: number } = {};
+		const typeWeaknesses: { [k: string]: number } = {};
+		const typeDoubleWeaknesses: { [k: string]: number } = {};
+		const teamDetails: RandomTeamsTypes.TeamDetails = {};
+
+		const pokemonList = Object.keys(this.randomSets);
+		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
+			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
+			const currentSpeciesPool: Species[] = [];
+			// Check if the base species has a mega forme available
+			let canMega = false;
+			for (const poke of pokemonPool[baseSpecies]) {
+				const species = this.dex.species.get(poke);
+				if (!hasMega && species.isMega) canMega = true;
+			}
+			for (const poke of pokemonPool[baseSpecies]) {
+				const species = this.dex.species.get(poke);
+				// Prevent multiple megas
+				if (hasMega && species.isMega) continue;
+				// Prevent base forme, if a mega is available
+				if (canMega && !species.isMega) continue;
+				currentSpeciesPool.push(species);
+			}
+			const species = this.sample(currentSpeciesPool);
+
+			if (!species.exists) continue;
+
+			// Limit to one of each species (Species Clause)
+			if (baseFormes[species.baseSpecies]) continue;
+
+			// Illusion shouldn't be on the last slot
+			if (species.name === 'Zoroark' && pokemon.length < 1) continue;
+
+			const types = species.types;
+			const typeCombo = types.slice().sort().join();
+			const weakToFreezeDry = (
+				this.dex.getEffectiveness('Ice', species) > 0 ||
+				(this.dex.getEffectiveness('Ice', species) > -2 && types.includes('Water'))
+			);
+			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
+			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
+
+			if (!isMonotype && !this.forceMonotype) {
+				let skip = false;
+
+				// Limit two of any type
+				for (const typeName of types) {
+					if (typeCount[typeName] >= 2 * limitFactor) {
+						skip = true;
+						break;
+					}
+				}
+				if (skip) continue;
+
+				// Limit three weak to any type, and one double weak to any type
+				for (const typeName of this.dex.types.names()) {
+					// it's weak to the type
+					if (this.dex.getEffectiveness(typeName, species) > 0) {
+						if (!typeWeaknesses[typeName]) typeWeaknesses[typeName] = 0;
+						if (typeWeaknesses[typeName] >= 3 * limitFactor) {
+							skip = true;
+							break;
+						}
+					}
+					if (this.dex.getEffectiveness(typeName, species) > 1) {
+						if (!typeDoubleWeaknesses[typeName]) typeDoubleWeaknesses[typeName] = 0;
+						if (typeDoubleWeaknesses[typeName] >= limitFactor) {
+							skip = true;
+							break;
+						}
+					}
+				}
+				if (skip) continue;
+
+				// Count Dry Skin/Fluffy as Fire weaknesses
+				if (
+					this.dex.getEffectiveness('Fire', species) === 0 &&
+					Object.values(species.abilities).filter(a => ['Dry Skin', 'Fluffy'].includes(a)).length
+				) {
+					if (!typeWeaknesses['Fire']) typeWeaknesses['Fire'] = 0;
+					if (typeWeaknesses['Fire'] >= 3 * limitFactor) continue;
+				}
+
+				// Limit four weak to Freeze-Dry
+				if (weakToFreezeDry) {
+					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
+					if (typeWeaknesses['Freeze-Dry'] >= 4 * limitFactor) continue;
+				}
+
+				// Check compatibility with team
+				if (!this.getPokemonCompatibility(species, pokemon)) continue;
+			}
+
+			// Limit three of any type combination in Monotype
+			if (!this.forceMonotype && isMonotype && (typeComboCount[typeCombo] >= 3 * limitFactor)) continue;
+
+			const set = this.randomSet(species, teamDetails, pokemon.length === 0);
+			pokemon.unshift(set);
+
+			// Don't bother tracking details for the last Pokemon
+			if (pokemon.length === this.maxTeamSize) break;
+
+			// Now that our Pokemon has passed all checks, we can increment our counters
+			baseFormes[species.baseSpecies] = 1;
+
+			// Increment type counters
+			for (const typeName of types) {
+				if (typeName in typeCount) {
+					typeCount[typeName]++;
+				} else {
+					typeCount[typeName] = 1;
+				}
+			}
+			if (typeCombo in typeComboCount) {
+				typeComboCount[typeCombo]++;
+			} else {
+				typeComboCount[typeCombo] = 1;
+			}
+
+			// Increment weakness counter
+			for (const typeName of this.dex.types.names()) {
+				// it's weak to the type
+				if (this.dex.getEffectiveness(typeName, species) > 0) {
+					typeWeaknesses[typeName]++;
+				}
+				if (this.dex.getEffectiveness(typeName, species) > 1) {
+					typeDoubleWeaknesses[typeName]++;
+				}
+			}
+			// Count Dry Skin/Fluffy as Fire weaknesses
+			if (['Dry Skin', 'Fluffy'].includes(set.ability) && this.dex.getEffectiveness('Fire', species) === 0) {
+				typeWeaknesses['Fire']++;
+			}
+			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
+
+			// Track what the team has
+			if (this.dex.items.get(set.item).megaStone) hasMega = true;
+			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;
+			if (set.ability === 'Drought' || set.moves.includes('sunnyday')) teamDetails.sun = 1;
+			if (set.ability === 'Sand Stream') teamDetails.sand = 1;
+			if (set.ability === 'Snow Warning' || set.moves.includes('snowscape') || set.moves.includes('chillyreception')) {
+				teamDetails.snow = 1;
+			}
+			if (set.moves.includes('healbell')) teamDetails.statusCure = 1;
+			if (set.moves.includes('spikes') || set.moves.includes('ceaselessedge')) {
+				teamDetails.spikes = (teamDetails.spikes || 0) + 1;
+			}
+			if (set.moves.includes('toxicspikes') || set.ability === 'Toxic Debris') teamDetails.toxicSpikes = 1;
+			if (set.moves.includes('stealthrock') || set.moves.includes('stoneaxe')) teamDetails.stealthRock = 1;
+			if (set.moves.includes('stickyweb')) teamDetails.stickyWeb = 1;
+			if (set.moves.includes('defog')) teamDetails.defog = 1;
+			if (set.moves.includes('rapidspin') || set.moves.includes('mortalspin')) teamDetails.rapidSpin = 1;
+			if (set.moves.includes('auroraveil')) teamDetails.screens = 1;
+		}
+		if (pokemon.length < this.maxTeamSize && pokemon.length < 12 && !isMonotype) { // large teams sometimes cannot be built
+			throw new Error(`Could not build a random team for ${this.format} (seed=${seed})`);
+		}
+
+		return pokemon;
+	}
+}
+
+export default RandomChampionsTeams;

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -602,6 +602,23 @@ export class RandomChampionsTeams extends RandomTeams {
 			['aerodactyl', 'gallade', 'leafeon', 'lycanroc', 'lycanrocmidnight'].includes(species.id) && !moves.has('accelerock')
 		) return 'Scope Lens';
 
+		// Hard-code type-boosting items here
+		if (species.id === 'hydreigon') return 'Dragon Fang';
+		if (['heliolisk', 'raichualola'].includes(species.id)) return 'Magnet';
+		if (species.id === 'gardevoir') return 'Fairy Feather';
+		if (
+			['armarouge', 'chandelure', 'delphox', 'scovillain', 'typhlosionhisui', 'volcarona'].includes(species.id)
+		) return 'Charcoal';
+		if (species.id === 'vivillon') return 'Sharp Beak';
+		if (species.id === 'victreebel') return 'Miracle Seed';
+		if (species.id === 'weavile') return 'Never-Melt Ice';
+		if (species.id === 'quaquaval') return 'Mystic Water';
+
+		// Randomly choose between their STABs
+		if (
+			['heracross', 'houndoom', 'infernape', 'kleavor', 'toxicroak', 'zoroarkhisui'].includes(species.id)
+		) return TYPE_BOOSTING_ITEMS[this.sample([...types])];
+
 		// Give type-boosting items if it only has one STAB attack
 		const stabTypes: string[] = [];
 		for (const type of types) {
@@ -622,23 +639,6 @@ export class RandomChampionsTeams extends RandomTeams {
 				}
 			}
 		}
-
-		// Hard-code type-boosting items here
-		if (species.id === 'hydreigon') return 'Dragon Fang';
-		if (['heliolisk', 'raichualola'].includes(species.id)) return 'Magnet';
-		if (species.id === 'gardevoir') return 'Fairy Feather';
-		if (
-			['typhlosionhisui', 'chandelure', 'volcarona', 'delphox', 'armarouge', 'scovillain', 'houndoom'].includes(species.id)
-		) return 'Charcoal';
-		if (species.id === 'vivillon') return 'Sharp Beak';
-		if (species.id === 'victreebel') return 'Miracle Seed';
-		if (['weavile', 'mamoswine'].includes(species.id)) return 'Never-Melt Ice';
-		if (species.id === 'quaquaval') return 'Mystic Water';
-
-		// Randomly choose between their STABs
-		if (
-			['toxicroak', 'heracross', 'zoroarkhisui', 'kleavor', 'infernape'].includes(species.id)
-		) return TYPE_BOOSTING_ITEMS[this.sample([...types])];
 
 		// Default to Leftovers
 		return 'Leftovers';

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -202,7 +202,6 @@ export class RandomChampionsTeams extends RandomTeams {
 			['aurasphere', 'focusblast'],
 			['closecombat', 'drainpunch'],
 			['dragonpulse', 'dracometeor'],
-			['heavyslam', 'flashcannon'],
 
 			// Status move incompatibilities
 			['taunt', 'encore'],

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1425,7 +1425,7 @@ export class RandomTeams {
 	): number {
 		if (this.adjustLevel) return this.adjustLevel;
 		// Temporarily modified for Mega Invasion randomized spotlight
-		if (this.gen === 9 && (species.id in this.randomMegaSets)) return this.randomMegaSets[species.id]["level"]!;
+		if (this.format.mod === 'gen9' && (species.id in this.randomMegaSets)) return this.randomMegaSets[species.id]["level"]!;
 		// doubles levelling
 		if (isDoubles && this.randomDoublesSets[species.id]["level"]) return this.randomDoublesSets[species.id]["level"]!;
 		if (!isDoubles && this.randomSets[species.id]["level"]) return this.randomSets[species.id]["level"]!;

--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -535,8 +535,9 @@ export const commands: Chat.ChatCommands = {
 		if (!args[0]) return this.parse(`/help randombattles`);
 
 		const { dex } = this.splitFormat(target, true);
-		const isLetsGo = (dex.currentMod === 'gen7letsgo');
-		const isBDSP = (dex.currentMod === 'gen8bdsp');
+		const mod = (dex.currentMod === 'base') ? 'gen9' : dex.currentMod;
+		const isLetsGo = (mod === 'gen7letsgo');
+		const isBDSP = (mod === 'gen8bdsp');
 
 		const searchResults = dex.dataSearch(args[0], ['Pokedex']);
 
@@ -550,12 +551,12 @@ export const commands: Chat.ChatCommands = {
 		}
 		const species = dex.species.get(searchResults[0].name);
 		if (species.isMega || species.forme === 'Primal') isMegaInvasion = true;
-		const extraFormatModifier = isLetsGo ? 'letsgo' : (isBDSP ? 'bdsp' : '');
 		const babyModifier = isBaby ? 'baby' : '';
-		const doublesModifier = isDoubles ? 'doubles' : '';
-		const freeForAllModifier = isFFA ? (dex.gen !== 9 ? 'doubles' : 'freeforall') : '';
+		// Gen 8 Random Doubles is temporarily using singles sets
+		const doublesModifier = (isDoubles && mod === 'gen9') ? 'doubles' : '';
+		const freeForAllModifier = (isFFA && mod === 'gen9') ? 'freeforall' : '';
 		const noDMaxModifier = isNoDMax ? 'nodmax' : '';
-		const formatName = `gen${dex.gen}${extraFormatModifier}${freeForAllModifier}${babyModifier}random${doublesModifier}battle${noDMaxModifier}`;
+		const formatName = `${mod}${freeForAllModifier}${babyModifier}random${doublesModifier}battle${noDMaxModifier}`;
 		const format = dex.formats.get(formatName);
 
 		const movesets = [];
@@ -596,11 +597,11 @@ export const commands: Chat.ChatCommands = {
 			}
 		} else {
 			const setsToCheck = [species];
-			if (dex.gen >= 8 && !isNoDMax) setsToCheck.push(dex.species.get(`${args[0]}gmax`));
+			if (mod === 'gen8' && !isNoDMax) setsToCheck.push(dex.species.get(`${args[0]}gmax`));
 			if (species.otherFormes) setsToCheck.push(...species.otherFormes.map(pkmn => dex.species.get(pkmn)));
 			for (const pokemon of setsToCheck) {
 				// For Gen 9, only show megas/primals if they were the argument or the command was used in a mega invasion battle room
-				if (dex.gen === 9 && (pokemon.isMega || pokemon.forme === 'Primal') && !isMegaInvasion) continue;
+				if (mod === 'gen9' && (pokemon.isMega || pokemon.forme === 'Primal') && !isMegaInvasion) continue;
 				const data = getSets(pokemon, format.id);
 				if (!data) continue;
 				const sets = data.sets;
@@ -609,7 +610,7 @@ export const commands: Chat.ChatCommands = {
 				buf += `<b>Level</b>: ${level}`;
 				for (const set of sets) {
 					buf += `<details class="details"><summary>${set.role}</summary>`;
-					if (dex.gen === 9) {
+					if (mod === 'gen9') {
 						buf += `<b>Tera Type${Chat.plural(set.teraTypes)}</b>: ${set.teraTypes.join(', ')}<br/>`;
 					} else if (set.preferredTypes) {
 						buf += `<b>Preferred Type${Chat.plural(set.preferredTypes)}</b>: ${set.preferredTypes.join(', ')}<br/>`;
@@ -753,6 +754,7 @@ export const commands: Chat.ChatCommands = {
 			formatOrSpecies = args.shift();
 		}
 		const dex = Dex.forFormat(format);
+		const mod = (dex.currentMod === 'base') ? 'gen9' : dex.currentMod;
 
 		// Species
 		const species = dex.species.get(formatOrSpecies);
@@ -761,14 +763,12 @@ export const commands: Chat.ChatCommands = {
 		}
 
 		let setExists: boolean;
-		if ([2, 3, 4, 5, 6, 7, 9].includes(dex.gen)) {
+		if (!['gen1', 'gen7letsgo', 'gen8bdsp'].includes(mod)) {
 			setExists = !!getSets(species, format);
 		} else {
 			const data = getData(species, format);
 			if (!data) {
 				setExists = false;
-			} else if (format.gameType === 'doubles' || format.gameType === 'freeforall') {
-				setExists = !!data.doublesMoves;
 			} else {
 				setExists = !!data.moves;
 			}
@@ -864,7 +864,7 @@ export const commands: Chat.ChatCommands = {
 				}
 				break;
 			case 'tera': case 'teratype':
-				if (dex.gen < 9) throw new Chat.ErrorMessage("Tera Types do not exist in the specified format.");
+				if (mod !== 'gen9') throw new Chat.ErrorMessage("Tera Types do not exist in the specified format.");
 				const type = dex.types.get(value);
 				if (!type.exists) {
 					throw new Chat.ErrorMessage(`"${value}" is not a type in the specified format.`);

--- a/server/chat-plugins/randombattles/winrates.tsx
+++ b/server/chat-plugins/randombattles/winrates.tsx
@@ -50,6 +50,7 @@ function getDefaultStats(): Stats {
 			gen9chatbats: { mons: {} },
 			gen9ccapm2025randombattle: { mons: {} },
 			gen9superstaffbrosultimate: { mons: {} },
+			gen9championsrandombattle: { mons: {} },
 			gen8randombattle: { mons: {} },
 			gen7randombattle: { mons: {} },
 			gen6randombattle: { mons: {} },
@@ -175,8 +176,10 @@ async function collectStats(battle: RoomBattle, winner: ID, players: ID[]) {
 	const formatData = stats.formats[battle.format];
 	let eloFloor = stats.elo;
 	const format = Dex.formats.get(battle.format);
-	if (format.mod === 'gen2') {
+	if (format.mod === 'champions') {
 		// ladder is inactive, so use a lower threshold
+		eloFloor = 1200;
+	} else if (format.mod === 'gen2') {
 		eloFloor = 1150;
 	} else if (format.team === 'randomBaby') {
 		// ladder is even more inactive, so an even lower threshold

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -118,6 +118,10 @@ describe('value rule support (slow)', () => {
 describe("New set format (slow)", () => {
 	// formatInfo lists filenames and roles for each format
 	const formatInfo = {
+		"gen9championsrandombattle": {
+			filename: "champions/sets",
+			roles: ["Fast Attacker", "Setup Sweeper", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support"],
+		},
 		"gen2randombattle": {
 			filename: "gen2/sets",
 			roles: ["Fast Attacker", "Setup Sweeper", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Generalist", "Thief user"],
@@ -171,6 +175,7 @@ describe("New set format (slow)", () => {
 		const filename = formatInfo[format].filename;
 		const setsJSON = require(`../../dist/data/random-battles/${filename}.json`);
 		const dex = common.mod(common.getFormat({ formatid: format }).mod).dex; // verifies format exists
+		const mod = (dex.currentMod === 'base') ? 'gen9' : dex.currentMod;
 		const genNum = dex.gen;
 		const rounds = 100;
 		it(`${filename}.json should have valid set data`, () => {
@@ -193,7 +198,7 @@ describe("New set format (slow)", () => {
 								problems.push(`${species.name} has misformatted move: ${move}`);
 							}
 						}
-						if (!validateLearnset(dexMove, { species }, 'ubers', `gen${genNum}`)) {
+						if (!validateLearnset(dexMove, { species }, 'ou', mod)) {
 							problems.push(`${species.name} can't learn ${move}`);
 						}
 					}
@@ -218,7 +223,7 @@ describe("New set format (slow)", () => {
 							}
 						}
 					}
-					if (genNum === 9) {
+					if (mod === 'gen9') {
 						if (!set.teraTypes) problems.push(`${species.name} has no Tera Types`);
 						for (const type of set.teraTypes) {
 							const dexType = dex.types.get(type);
@@ -265,7 +270,7 @@ describe("New set format (slow)", () => {
 					const role = set.role;
 					const moves = new Set(set.movepool.map(m => (m.startsWith('hiddenpower') ? m : dex.moves.get(m).id)));
 					const abilities = set.abilities || [];
-					const specialTypes = genNum === 9 ? set.teraTypes : set.preferredTypes;
+					const specialTypes = mod === 'gen9' ? set.teraTypes : set.preferredTypes;
 					// Go through all possible teamDetails combinations, if necessary
 					for (let j = 0; j < rounds; j++) {
 						// In Gens 2-3, if a set has multiple preferred types, we enforce moves of all the types.
@@ -282,7 +287,7 @@ describe("New set format (slow)", () => {
 							// randomMoveset() deletes moves from the movepool, so recreate it every time
 							const movePool = set.movepool.map(m => (m.startsWith('hiddenpower') ? m : dex.moves.get(m).id));
 							let moveSet;
-							if (genNum === 9) {
+							if (mod === 'gen9') {
 								moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, specialType, role, format.includes('doubles'));
 							} else {
 								moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, specialType, role);

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -118,10 +118,6 @@ describe('value rule support (slow)', () => {
 describe("New set format (slow)", () => {
 	// formatInfo lists filenames and roles for each format
 	const formatInfo = {
-		"championsrandombattle": {
-			filename: "champions/sets",
-			roles: ["Fast Attacker", "Setup Sweeper", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support"],
-		},
 		"gen2randombattle": {
 			filename: "gen2/sets",
 			roles: ["Fast Attacker", "Setup Sweeper", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Generalist", "Thief user"],
@@ -169,6 +165,10 @@ describe("New set format (slow)", () => {
 		"gen9freeforallrandombattle": {
 			filename: "gen9ffa/sets",
 			roles: ["Fast Attacker", "Setup Sweeper", "Wallbreaker", "Tera Blast user", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support", "AV Pivot", "Choice Item user", "Imprisoner"],
+		},
+		"gen9championsrandombattle": {
+			filename: "champions/sets",
+			roles: ["Fast Attacker", "Setup Sweeper", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support"],
 		},
 	};
 	for (const format of Object.keys(formatInfo)) {

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -118,7 +118,7 @@ describe('value rule support (slow)', () => {
 describe("New set format (slow)", () => {
 	// formatInfo lists filenames and roles for each format
 	const formatInfo = {
-		"gen9championsrandombattle": {
+		"championsrandombattle": {
 			filename: "champions/sets",
 			roles: ["Fast Attacker", "Setup Sweeper", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support"],
 		},


### PR DESCRIPTION
This pull request implements Champions Random Battle. It is ready to merge.

It is mostly similar to other randomised formats, with a few differences due to the different environment from Champions.

It includes Level Clause Mod: instead of all levels being fixed at 50, they can be modified for balancing. We have obtained permission to not include Item Clause.

Pokémon, by default, have 11 Stat Points in each stat.

Due to the reduced item pool, item generation is different from other randomised formats. Pokémon with the Fast Support role can obtain Focus Sash outside the lead slot, and with the absence of Life Orb, some Pokémon with offensive roles can obtain Scope Lens or type-boosting items. Depending on the item pool, we will see if they last.