### PR TITLE
Fix Gen 3 Poliwhirl/Poliwrath minimum level restriction

### DIFF
--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -9071,6 +9071,9 @@ export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 			weatherball: ["9M"],
 			whirlpool: ["9M", "8M", "7V", "4M"],
 		},
+		eventData: [
+			{generation: 3, level: 20},
+		],
 		encounters: [
 			{generation: 1, level: 15},
 			{generation: 2, level: 10},


### PR DESCRIPTION
### Overview
This PR corrects the minimum legal level for Poliwhirl and Poliwrath in Generation 3 formats from level 25 down to level 20. 

### Context & Legality
Currently, the validator implicitly enforces Poliwag's evolution level (level 25) as a hard floor for Poliwhirl. However, Poliwhirl can be caught directly in the wild at **Level 20** using the Super Rod in *Pokémon FireRed & LeafGreen* (specifically via fishing encounters on Routes 6, 22, 23, and 25). 

Because Poliwrath evolves from Poliwhirl using a Water Stone (which has no level requirement), a level 20 Poliwrath is also completely legal in Gen 3.

### Changes Made
- Added a baseline `eventData` entry (`{generation: 3, level: 20}`) to Poliwhirl's entry in `data/learnsets.ts`. This correctly signals the validator that wild baseline encounters exist at level 20 for this generation.

### Verification & Testing
- Ran `npm test` locally; all 2334 linter, database, and structure tests pass successfully with clean TypeScript compilation (`tsc`).
- Verified directly on a local test server client—setting a level 20 Poliwhirl now successfully validates as legal in Gen 3 formats instead of throwing an error.
<img width="1610" height="711" alt="Screenshot 2026-06-09 225319" src="https://github.com/user-attachments/assets/b3700817-9574-42d8-a05a-d8f594f20e69" />
