### PR TITLE
Attempt to normalize exported species names

### DIFF
--- a/sim/teams.ts
+++ b/sim/teams.ts
@@ -380,9 +380,9 @@ export const Teams = new class Teams {
 			set.name = removeNicknames(set.name) || set.species;
 		}
 		if (set.name && set.name !== set.species && removeNicknames !== true) {
-			out += `${set.name} (${set.species})`;
+			out += `${set.name.normalize("NFC")} (${set.species.normalize("NFC")})`;
 		} else {
-			out += set.species;
+			out += set.species.normalize("NFC");
 		}
 		if (set.gender === 'M') out += ` (M)`;
 		if (set.gender === 'F') out += ` (F)`;


### PR DESCRIPTION
## Summary

This PR is an attempt to address issue #9569 regarding combining diacritical marks in species names.

## Changes

* Investigated the export logic in `teams.ts`
* Applied NFC normalization to exported species names
* Attempted to improve compatibility with downstream applications

Feedback is appreciated.
