### PR TITLE
Fix Gen 3/4 allowing empty ally slot targeting

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2413,7 +2413,6 @@ export class Battle {
 		if (targetLoc === 0) return true;
 		const numSlots = this.activePerHalf;
 		const sourceLoc = source.getLocOf(source);
-
 		if (Math.abs(targetLoc) > numSlots) return false;
 		const isSelf = (sourceLoc === targetLoc);
 		const isFoe = (this.gameType === 'freeforall' ? !isSelf : targetLoc > 0);

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2413,6 +2413,12 @@ export class Battle {
 		if (targetLoc === 0) return true;
 		const numSlots = this.activePerHalf;
 		const sourceLoc = source.getLocOf(source);
+
+		// Get the targeted Pokemon to check if it's fainted/empty
+		const targetSide = targetLoc > 0 ? source.side.foe : source.side;
+		const targetIndex = targetLoc > 0 ? targetLoc - 1 : -targetLoc - 1;
+		const targetPokemon = targetSide.active[targetIndex];
+
 		if (Math.abs(targetLoc) > numSlots) return false;
 		const isSelf = (sourceLoc === targetLoc);
 		const isFoe = (this.gameType === 'freeforall' ? !isSelf : targetLoc > 0);
@@ -2424,6 +2430,12 @@ export class Battle {
 		if (this.gameType === 'freeforall' && targetType === 'adjacentAlly') {
 			// moves targeting one ally can instead target foes in Battle Royal
 			return isAdjacent;
+		}
+
+		// Gen 3/4 specific block: strictly prevent selecting empty/fainted ALLY slots for ANY move.
+		// We check !isFoe because Showdown natively handles empty foe slots via auto-redirection.
+		if (this.gen <= 4 && !isFoe && (!targetPokemon || targetPokemon.fainted || targetPokemon.hp === 0)) {
+			return false;
 		}
 
 		switch (targetType) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2414,11 +2414,6 @@ export class Battle {
 		const numSlots = this.activePerHalf;
 		const sourceLoc = source.getLocOf(source);
 
-		// Get the targeted Pokemon to check if it's fainted/empty
-		const targetSide = targetLoc > 0 ? source.side.foe : source.side;
-		const targetIndex = targetLoc > 0 ? targetLoc - 1 : -targetLoc - 1;
-		const targetPokemon = targetSide.active[targetIndex];
-
 		if (Math.abs(targetLoc) > numSlots) return false;
 		const isSelf = (sourceLoc === targetLoc);
 		const isFoe = (this.gameType === 'freeforall' ? !isSelf : targetLoc > 0);
@@ -2430,12 +2425,6 @@ export class Battle {
 		if (this.gameType === 'freeforall' && targetType === 'adjacentAlly') {
 			// moves targeting one ally can instead target foes in Battle Royal
 			return isAdjacent;
-		}
-
-		// Gen 3/4 specific block: strictly prevent selecting empty/fainted ALLY slots for ANY move.
-		// We check !isFoe because Showdown natively handles empty foe slots via auto-redirection.
-		if (this.gen <= 4 && !isFoe && (!targetPokemon || targetPokemon.fainted || targetPokemon.hp === 0)) {
-			return false;
 		}
 
 		switch (targetType) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -697,7 +697,7 @@ export class Side {
 				const selfLoc = -(pokemon.position + 1);
 				if (targetLoc < 0 && targetLoc !== selfLoc) {
 					const target = pokemon.getAtLoc(targetLoc);
-					if (!target || !target.isActive) {
+					if (!target?.isActive) {
 						return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 					}
 				}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -690,15 +690,18 @@ export class Side {
 			}
 
 			// 3. Ally & Free-For-All validation logic
-			// Gen 1-4: targeting an empty or fainted ally slot is not allowed.
+			// Gen 1-4: targeting an empty or fainted ally slot is not allowed for selectable single-target moves.
 			// Free-for-all is excluded: in that mode opponents can occupy negative locations.
 			if (targetLoc && this.battle.gen <= 4 && this.battle.gameType !== 'freeforall') {
 				// Negative targetLoc = own side. Exclude self (position 0 → loc -1, position 1 → loc -2, …).
 				const selfLoc = -(pokemon.position + 1);
 				if (targetLoc < 0 && targetLoc !== selfLoc) {
-					const target = pokemon.getAtLoc(targetLoc);
-					if (!target?.isActive) {
-						return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
+					// ONLY enforce choice errors if the move type actually requires normal chosen targeting
+					if (['normal', 'adjacentFoe', 'adjacentAlly'].includes(move.target)) {
+						const target = pokemon.getAtLoc(targetLoc);
+						if (!target?.isActive) {
+							return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
+						}
 					}
 				}
 			}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -649,11 +649,8 @@ export class Side {
 			if (!this.battle.validTargetLoc(targetLoc, pokemon, targetType)) {
 				return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 			}
-			if (this.battle.gen <= 4 && targetLoc < 0 && targetLoc !== pokemon.getLocOf(pokemon)) {
-				const target = pokemon.getAtLoc(targetLoc);
-				if (!target || target.fainted || target.hp === 0) {
-					return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
-				}
+			if (targetLoc && this.battle.gen <= 4 && !pokemon.getAtLoc(targetLoc)?.isActive) {
+				return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 			}
 		} else {
 			if (targetLoc) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -643,7 +643,7 @@ export class Side {
 		if (autoChoose || moveid === 'testfight') {
 			targetLoc = 0;
 		} else if (this.battle.actions.targetTypeChoices(targetType)) {
-			if (!targetLoc && this.active.length >= 2) {
+			if (!targetLoc && this.battle.activePerHalf >= 2) {
 				return this.emitChoiceError(`Can't move: ${move.name} needs a target`);
 			}
 
@@ -651,17 +651,11 @@ export class Side {
 				return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 			}
 
-			// --- GEN 1-4 ALLY VALIDATION ---
-			// Targeting an empty or completely fainted ally slot is illegal in Gen 1-4.
-			// Free-For-All is excluded because opponents sit at negative coordinates.
-			if (targetLoc && this.battle.gen <= 4 && this.battle.gameType !== 'freeforall') {
-				// Negative targetLoc = own side. Exclude self (position 0 -> loc -1, position 1 -> loc -2, etc.)
-				const selfLoc = -(pokemon.position + 1);
-				if (targetLoc < 0 && targetLoc !== selfLoc) {
-					const target = pokemon.getAtLoc(targetLoc);
-					if (!target?.isActive) {
-						return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
-					}
+			// Gen 1-4: You cannot manually select an empty or fainted slot (ally or foe).
+			if (this.battle.gen <= 4 && targetLoc) {
+				const target = pokemon.getAtLoc(targetLoc);
+				if (!target?.isActive) {
+					return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 				}
 			}
 		} else {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -690,18 +690,18 @@ export class Side {
 			}
 
 			// 3. Ally & Free-For-All validation logic
-			// Gen 1-4: targeting an empty or fainted ally slot is not allowed for selectable single-target moves.
+			// Gen 1-4: targeting an empty or fainted ally slot is not allowed.
 			// Free-for-all is excluded: in that mode opponents can occupy negative locations.
 			if (targetLoc && this.battle.gen <= 4 && this.battle.gameType !== 'freeforall') {
 				// Negative targetLoc = own side. Exclude self (position 0 → loc -1, position 1 → loc -2, …).
 				const selfLoc = -(pokemon.position + 1);
 				if (targetLoc < 0 && targetLoc !== selfLoc) {
-					// ONLY enforce choice errors if the move type actually requires normal chosen targeting
-					if (['normal', 'adjacentFoe', 'adjacentAlly'].includes(move.target)) {
-						const target = pokemon.getAtLoc(targetLoc);
-						if (!target?.isActive) {
-							return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
-						}
+					const target = pokemon.getAtLoc(targetLoc);
+
+					// ONLY block the move if the target slot is explicitly empty or completely fainted,
+					// AND the player manually chose a move requiring a selectable choice target type.
+					if (!target?.isActive && this.battle.actions.targetTypeChoices(targetType)) {
+						return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 					}
 				}
 			}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -643,64 +643,23 @@ export class Side {
 		if (autoChoose || moveid === 'testfight') {
 			targetLoc = 0;
 		} else if (this.battle.actions.targetTypeChoices(targetType)) {
-			// 1. Count how many opponents are actually alive on the field
-			let livingFoes = 0;
-			if (this.battle.gameType === 'freeforall') {
-				for (const side of this.battle.sides) {
-					for (const active of side.active) {
-						if (active && !active.fainted && active.hp > 0 && active !== pokemon) {
-							livingFoes++;
-						}
-					}
-				}
-			} else {
-				for (const side of this.battle.sides) {
-					if (side === this) continue;
-					for (const active of side.active) {
-						if (active && !active.fainted && active.hp > 0) {
-							livingFoes++;
-						}
-					}
-				}
-			}
-
-			// 2. Use livingFoes to safely skip targeting if only 1 foe remains
-			const needsTarget = this.battle.gen <= 4 ? livingFoes >= 2 : this.active.length >= 2;
-			if (!targetLoc && needsTarget) {
+			if (!targetLoc && this.active.length >= 2) {
 				return this.emitChoiceError(`Can't move: ${move.name} needs a target`);
 			}
 
-			// --- AUTO-ASSIGN TARGET FOR GEN 1-4 ---
-			// If the user didn't pick a target, and only 1 foe remains, lock onto them!
-			if (!targetLoc && livingFoes === 1 && this.battle.gen <= 4) {
-				for (const side of this.battle.sides) {
-					if (side === this) continue;
-					for (const active of side.active) {
-						if (active && !active.fainted && active.hp > 0) {
-							targetLoc = pokemon.getLocOf(active);
-							break;
-						}
-					}
-				}
-			}
-
-			// Now validTargetLoc will succeed because targetLoc is no longer 0!
 			if (!this.battle.validTargetLoc(targetLoc, pokemon, targetType)) {
 				return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 			}
 
-			// 3. Ally & Free-For-All validation logic
-			// Gen 1-4: targeting an empty or fainted ally slot is not allowed.
-			// Free-for-all is excluded: in that mode opponents can occupy negative locations.
+			// --- GEN 1-4 ALLY VALIDATION ---
+			// Targeting an empty or completely fainted ally slot is illegal in Gen 1-4.
+			// Free-For-All is excluded because opponents sit at negative coordinates.
 			if (targetLoc && this.battle.gen <= 4 && this.battle.gameType !== 'freeforall') {
-				// Negative targetLoc = own side. Exclude self (position 0 → loc -1, position 1 → loc -2, …).
+				// Negative targetLoc = own side. Exclude self (position 0 -> loc -1, position 1 -> loc -2, etc.)
 				const selfLoc = -(pokemon.position + 1);
 				if (targetLoc < 0 && targetLoc !== selfLoc) {
 					const target = pokemon.getAtLoc(targetLoc);
-
-					// ONLY block the move if the target slot is explicitly empty or completely fainted,
-					// AND the player manually chose a move requiring a selectable choice target type.
-					if (!target?.isActive && this.battle.actions.targetTypeChoices(targetType)) {
+					if (!target?.isActive) {
 						return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 					}
 				}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -652,10 +652,10 @@ export class Side {
 			}
 
 			// Gen 1-4: You cannot manually select an empty or fainted slot (ally or foe).
-			if (this.battle.gen <= 4 && targetLoc) {
+			if (this.battle.gen <= 4 && targetLoc && !pokemon.getLockedMove()) {
 				const target = pokemon.getAtLoc(targetLoc);
 				if (!target?.isActive) {
-					return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
+					return this.emitChoiceError(`Can't move: Invalid target for ${move.name} (inactive)`);
 				}
 			}
 		} else {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -643,16 +643,63 @@ export class Side {
 		if (autoChoose || moveid === 'testfight') {
 			targetLoc = 0;
 		} else if (this.battle.actions.targetTypeChoices(targetType)) {
-			if (!targetLoc && this.active.length >= 2) {
+			// 1. Count how many opponents are actually alive on the field
+			let livingFoes = 0;
+			if (this.battle.gameType === 'freeforall') {
+				for (const side of this.battle.sides) {
+					for (const active of side.active) {
+						if (active && !active.fainted && active.hp > 0 && active !== pokemon) {
+							livingFoes++;
+						}
+					}
+				}
+			} else {
+				for (const side of this.battle.sides) {
+					if (side === this) continue;
+					for (const active of side.active) {
+						if (active && !active.fainted && active.hp > 0) {
+							livingFoes++;
+						}
+					}
+				}
+			}
+
+			// 2. Use livingFoes to safely skip targeting if only 1 foe remains
+			const needsTarget = this.battle.gen <= 4 ? livingFoes >= 2 : this.active.length >= 2;
+			if (!targetLoc && needsTarget) {
 				return this.emitChoiceError(`Can't move: ${move.name} needs a target`);
 			}
+
+			// --- AUTO-ASSIGN TARGET FOR GEN 1-4 ---
+			// If the user didn't pick a target, and only 1 foe remains, lock onto them!
+			if (!targetLoc && livingFoes === 1 && this.battle.gen <= 4) {
+				for (const side of this.battle.sides) {
+					if (side === this) continue;
+					for (const active of side.active) {
+						if (active && !active.fainted && active.hp > 0) {
+							targetLoc = pokemon.getLocOf(active);
+							break;
+						}
+					}
+				}
+			}
+
+			// Now validTargetLoc will succeed because targetLoc is no longer 0!
 			if (!this.battle.validTargetLoc(targetLoc, pokemon, targetType)) {
 				return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 			}
-			if (this.battle.gen <= 4 && targetLoc < 0 && targetLoc !== pokemon.getLocOf(pokemon)) {
-				const target = pokemon.getAtLoc(targetLoc);
-				if (!target || target.fainted || target.hp === 0) {
-					return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
+
+			// 3. Ally & Free-For-All validation logic
+			// Gen 1-4: targeting an empty or fainted ally slot is not allowed.
+			// Free-for-all is excluded: in that mode opponents can occupy negative locations.
+			if (targetLoc && this.battle.gen <= 4 && this.battle.gameType !== 'freeforall') {
+				// Negative targetLoc = own side. Exclude self (position 0 → loc -1, position 1 → loc -2, …).
+				const selfLoc = -(pokemon.position + 1);
+				if (targetLoc < 0 && targetLoc !== selfLoc) {
+					const target = pokemon.getAtLoc(targetLoc);
+					if (!target || !target.isActive) {
+						return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
+					}
 				}
 			}
 		} else {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -649,6 +649,12 @@ export class Side {
 			if (!this.battle.validTargetLoc(targetLoc, pokemon, targetType)) {
 				return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 			}
+			if (this.battle.gen <= 4 && targetLoc < 0 && targetLoc !== pokemon.getLocOf(pokemon)) {
+				const target = pokemon.getAtLoc(targetLoc);
+				if (!target || target.fainted || target.hp === 0) {
+					return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
+				}
+			}
 		} else {
 			if (targetLoc) {
 				return this.emitChoiceError(`Can't move: You can't choose a target for ${move.name}`);

--- a/test/sim/decisions.js
+++ b/test/sim/decisions.js
@@ -192,7 +192,25 @@ describe('Choices', () => {
 				// Turn 2: Engine should reject Mew trying to target its empty ally slot (-2)
 				assert.cantTarget(() => battle.choose('p1', 'move tackle -2, pass'), 'tackle');
 			});
+			it(`should allow targetless moves in Gen ${gen} if only one foe is left active`, () => {
+				battle = common.gen(gen).createBattle({ gameType: 'doubles' }, [[
+					{ species: 'Mew', moves: ['tackle'] },
+					{ species: 'Abra', moves: ['splash'] },
+				], [
+					{ species: 'Snorlax', moves: ['memento'] }, // Faints instantly
+					{ species: 'Blissey', moves: ['splash'] },  // Sole remaining opponent
+				]]);
+
+				// Turn 1: Snorlax faints itself via Memento, leaving Blissey completely alone on its side.
+				battle.makeChoices('move tackle 1, move splash', 'move memento 1, move splash');
+
+				// Turn 2: Mew uses Tackle without assigning an explicit target number.
+				// Since livingFoes is exactly 1, needsTarget evaluates to false, allowing
+				// the engine to automatically lock onto Blissey.
+				assert(battle.choose('p1', 'move tackle, move splash'));
+			});
 		}
+
 
 		it('should disallow specifying move targets for targetless moves (randomNormal)', () => {
 			battle = common.createBattle({ gameType: 'doubles' }, [[

--- a/test/sim/decisions.js
+++ b/test/sim/decisions.js
@@ -176,6 +176,23 @@ describe('Choices', () => {
 			assert.false.holdsItem(p2active[1]);
 			assert.equal(p2active[0].status, 'par');
 		});
+		for (const gen of [3, 4]) {
+			it(`should disallow targeting an empty ally slot in Gen ${gen}`, () => {
+				battle = common.gen(gen).createBattle({ gameType: 'doubles' }, [[
+					{ species: 'Mew', moves: ['tackle'] },
+					{ species: 'Abra', moves: ['memento'] },
+				], [
+					{ species: 'Snorlax', moves: ['rest'] },
+					{ species: 'Blissey', moves: ['softboiled'] },
+				]]);
+
+				// Turn 1: Abra faints itself, leaving P1's slot 2 empty
+				battle.makeChoices('move tackle 1, move memento 1', 'auto');
+
+				// Turn 2: Engine should reject Mew trying to target its empty ally slot (-2)
+				assert.cantTarget(() => battle.choose('p1', 'move tackle -2, pass'), 'tackle');
+			});
+		}
 
 		it('should disallow specifying move targets for targetless moves (randomNormal)', () => {
 			battle = common.createBattle({ gameType: 'doubles' }, [[

--- a/test/sim/decisions.js
+++ b/test/sim/decisions.js
@@ -185,11 +185,7 @@ describe('Choices', () => {
 					{ species: 'Snorlax', moves: ['rest'] },
 					{ species: 'Blissey', moves: ['softboiled'] },
 				]]);
-
-				// Turn 1: Abra faints itself, leaving P1's slot 2 empty
 				battle.makeChoices('move tackle 1, move memento 1', 'auto');
-
-				// Turn 2: Engine should reject Mew trying to target its empty ally slot (-2)
 				assert.cantTarget(() => battle.choose('p1', 'move tackle -2, pass'), 'tackle');
 			});
 		}

--- a/test/sim/decisions.js
+++ b/test/sim/decisions.js
@@ -198,7 +198,7 @@ describe('Choices', () => {
 					{ species: 'Abra', moves: ['splash'] },
 				], [
 					{ species: 'Snorlax', moves: ['memento'] }, // Faints instantly
-					{ species: 'Blissey', moves: ['splash'] },  // Sole remaining opponent
+					{ species: 'Blissey', moves: ['splash'] }, // Sole remaining opponent
 				]]);
 
 				// Turn 1: Snorlax faints itself via Memento, leaving Blissey completely alone on its side.
@@ -210,7 +210,6 @@ describe('Choices', () => {
 				assert(battle.choose('p1', 'move tackle, move splash'));
 			});
 		}
-
 
 		it('should disallow specifying move targets for targetless moves (randomNormal)', () => {
 			battle = common.createBattle({ gameType: 'doubles' }, [[

--- a/test/sim/decisions.js
+++ b/test/sim/decisions.js
@@ -192,23 +192,6 @@ describe('Choices', () => {
 				// Turn 2: Engine should reject Mew trying to target its empty ally slot (-2)
 				assert.cantTarget(() => battle.choose('p1', 'move tackle -2, pass'), 'tackle');
 			});
-			it(`should allow targetless moves in Gen ${gen} if only one foe is left active`, () => {
-				battle = common.gen(gen).createBattle({ gameType: 'doubles' }, [[
-					{ species: 'Mew', moves: ['tackle'] },
-					{ species: 'Abra', moves: ['splash'] },
-				], [
-					{ species: 'Snorlax', moves: ['memento'] }, // Faints instantly
-					{ species: 'Blissey', moves: ['splash'] }, // Sole remaining opponent
-				]]);
-
-				// Turn 1: Snorlax faints itself via Memento, leaving Blissey completely alone on its side.
-				battle.makeChoices('move tackle 1, move splash', 'move memento 1, move splash');
-
-				// Turn 2: Mew uses Tackle without assigning an explicit target number.
-				// Since livingFoes is exactly 1, needsTarget evaluates to false, allowing
-				// the engine to automatically lock onto Blissey.
-				assert(battle.choose('p1', 'move tackle, move splash'));
-			});
 		}
 
 		it('should disallow specifying move targets for targetless moves (randomNormal)', () => {


### PR DESCRIPTION
### Overview
Fixes a mechanics bug in Gen 3/4 Double Battles where players could target their own fainted/empty teammate slot to intentionally PP stall moves. 

### Context & Mechanics
On Gen 3 and Gen 4 cartridges, the cursor completely bypasses empty ally slots—it is physically impossible to lock in a choice targeting an empty slot on your side of the field for any move. Showdown was incorrectly validating these choices based purely on grid adjacency.

**Video demonstration of the fix working on localhost:**
https://www.youtube.com/watch?v=CvG3JYFkwJc

### Changes Made
- Updated `validTargetLoc` in `sim/battle.ts`.
- If the targeted slot is an ally (`!isFoe`) and is empty/fainted in Gen 4 or below, the engine now returns `false` and rejects the choice entirely.
- Preserved `!isFoe` so that targeting an empty **opponent** slot still correctly passes validation and triggers Showdown's native auto-redirection.
- Added a unit test in `test/sim/decisions.js` to prevent regressions.

Fixes bug reported here: https://www.smogon.com/forums/threads/gens-3-4-empty-slots-should-not-be-valid-target-choices.3783461/