### PR TITLE
Fix BeforeMovePriority in Gens 1-4

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -36,7 +36,7 @@ export const Conditions: import('../sim/dex-conditions').ConditionDataTable = {
 			}
 			return spe;
 		},
-		onBeforeMovePriority: 1,
+		onBeforeMovePriority: 2,
 		onBeforeMove(pokemon) {
 			if (this.randomChance(1, 4)) {
 				this.add('cant', pokemon, 'par');

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -33,7 +33,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onStart(target) {
 			this.add('-status', target, 'par');
 		},
-		onBeforeMovePriority: 2,
+		onBeforeMovePriority: 1,
 		onBeforeMove(pokemon) {
 			if (this.randomChance(63, 256)) {
 				this.add('cant', pokemon, 'par');
@@ -67,18 +67,16 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 				this.add('-end', target, 'Nightmare', '[silent]');
 			}
 		},
-		onBeforeMovePriority: 10,
+		onBeforeMovePriority: 13,
 		onBeforeMove(pokemon, target, move) {
 			pokemon.statusState.time--;
 			if (pokemon.statusState.time > 0) {
 				this.add('cant', pokemon, 'slp');
+			} else {
+				pokemon.cureStatus();
 			}
 			pokemon.lastMove = null;
 			return false;
-		},
-		onAfterMoveSelfPriority: 3,
-		onAfterMoveSelf(pokemon) {
-			if (pokemon.statusState.time <= 0) pokemon.cureStatus();
 		},
 		onDisableMove(target) {
 			target.maybeLocked = false; // the player knows it is locked
@@ -141,8 +139,16 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onEnd(target) {
 			this.add('-end', target, 'confusion');
 		},
-		onBeforeMovePriority: 3,
+		onBeforeMovePriority: 4,
 		onBeforeMove(pokemon, target) {
+			/**
+			 * Even though the Confusion check happens before the Disable check
+			 * the Disable duration tick happens before both
+			 */
+			if (pokemon.volatiles['disable'] && pokemon.volatiles['disable'].time === 1) {
+				pokemon.removeVolatile('disable');
+			}
+
 			pokemon.volatiles['confusion'].time--;
 			if (!pokemon.volatiles['confusion'].time) {
 				pokemon.removeVolatile('confusion');
@@ -169,7 +175,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onStart(target) {
 			target.removeVolatile('mustrecharge');
 		},
-		onBeforeMovePriority: 8,
+		onBeforeMovePriority: 9,
 		onBeforeMove(pokemon) {
 			if (!this.runEvent('Flinch', pokemon)) {
 				return;
@@ -197,7 +203,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		duration: 2,
 		// defender still takes PSN damage, etc
 		// TODO: research exact mechanics
-		onBeforeMovePriority: 9,
+		onBeforeMovePriority: 10,
 		onBeforeMove(pokemon) {
 			this.add('cant', pokemon, 'partiallytrapped');
 			return false;
@@ -276,7 +282,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 	mustrecharge: {
 		inherit: true,
 		duration: 0,
-		onBeforeMovePriority: 7,
+		onBeforeMovePriority: 8,
 		onStart: undefined, // no inherit
 		onAfterMove(pokemon, target, move) {
 			if (target && target.hp <= 0) {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -145,7 +145,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			 * Even though the Confusion check happens before the Disable check
 			 * the Disable duration tick happens before both
 			 */
-			if (pokemon.volatiles['disable'] && pokemon.volatiles['disable'].time === 1) {
+			if (pokemon.volatiles['disable']?.time === 1) {
 				pokemon.removeVolatile('disable');
 			}
 

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -210,7 +210,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		},
 		condition: {
 			inherit: true,
-			durationCallback: undefined, // no inherit
 			onStart(pokemon) {
 				// disable can only select moves that have pp > 0, hence the onTryHit modification
 				const [slotIndex, moveSlot] = this.sample(Array.from(pokemon.moveSlots.entries()).filter(([i, ms]) => ms.pp > 0));
@@ -221,7 +220,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				// 1-8 turns (which will in effect translate to 0-7 missed turns for the target)
 				this.effectState.time = this.random(1, 9);
 			},
-			onBeforeMovePriority: 6,
+			onBeforeMovePriority: 2,
 			onBeforeMove(pokemon, target, move) {
 				pokemon.volatiles['disable'].time--;
 				if (!pokemon.volatiles['disable'].time) {

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -53,11 +53,9 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		onBeforeMove(pokemon, target, move) {
 			pokemon.statusState.time--;
 			this.add('cant', pokemon, 'slp');
+			if (pokemon.statusState.time <= 0) pokemon.cureStatus();
 			pokemon.lastMove = null;
 			return false;
-		},
-		onAfterMoveSelf(pokemon) {
-			if (pokemon.statusState.time <= 0) pokemon.cureStatus();
 		},
 	},
 	frz: {

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -121,6 +121,13 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			return 2 * this.lastDamage;
 		},
 	},
+	disable: {
+		inherit: true,
+		condition: {
+			inherit: true,
+			onBeforeMovePriority: 3,
+		},
+	},
 	firespin: {
 		inherit: true,
 		// FIXME: onBeforeMove() {},

--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -16,7 +16,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 	par: {
 		name: 'par',
 		inherit: true,
-		onBeforeMovePriority: 2,
+		onBeforeMovePriority: 1,
 		onBeforeMove(pokemon) {
 			if (this.randomChance(63, 256)) {
 				this.add('cant', pokemon, 'par');
@@ -40,7 +40,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 				this.add('-end', target, 'Nightmare', '[silent]');
 			}
 		},
-		onBeforeMovePriority: 10,
+		onBeforeMovePriority: 13,
 		onBeforeMove(pokemon, target, move) {
 			pokemon.statusState.time--;
 			if (pokemon.statusState.time <= 0) {
@@ -127,7 +127,16 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 				this.effectState.time = this.random(2, 6);
 			}
 		},
+		onBeforeMovePriority: 4,
 		onBeforeMove(pokemon, target, move) {
+			/**
+			 * Even though the Confusion check happens before the Disable check
+			 * the Disable duration tick happens before both
+			 */
+			if (pokemon.volatiles['disable'] && pokemon.volatiles['disable'].time === 1) {
+				pokemon.removeVolatile('disable');
+			}
+
 			pokemon.volatiles['confusion'].time--;
 			if (!pokemon.volatiles['confusion'].time) {
 				pokemon.removeVolatile('confusion');
@@ -200,6 +209,10 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 				this.queue.changeAction(pokemon, { choice: 'move', moveid: move.id });
 			}
 		},
+	},
+	mustrecharge: {
+		inherit: true,
+		onBeforeMovePriority: 14,
 	},
 	futuremove: {
 		inherit: true,

--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -133,7 +133,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			 * Even though the Confusion check happens before the Disable check
 			 * the Disable duration tick happens before both
 			 */
-			if (pokemon.volatiles['disable'] && pokemon.volatiles['disable'].time === 1) {
+			if (pokemon.volatiles['disable']?.time === 1) {
 				pokemon.removeVolatile('disable');
 			}
 

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -7,6 +7,28 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		critRatio: 3,
 	},
+	attract: {
+		inherit: true,
+		condition: {
+			inherit: true,
+			onBeforeMovePriority: 3,
+			onBeforeMove(pokemon, target, move) {
+				/**
+				 * Even though the Infatuation check happens before the Disable check
+				 * the Disable duration tick happens before both
+				 */
+				if (pokemon.volatiles['disable'] && pokemon.volatiles['disable'].time === 1) {
+					pokemon.removeVolatile('disable');
+				}
+
+				this.add('-activate', pokemon, 'move: Attract', '[of] ' + this.effectState.source);
+				if (this.randomChance(1, 2)) {
+					this.add('cant', pokemon, 'Attract');
+					return false;
+				}
+			},
+		},
+	},
 	beatup: {
 		inherit: true,
 		onModifyMove(move, pokemon) {
@@ -147,6 +169,46 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			onSourceBasePower(basePower, target, source, move) {
 				if (move.id === 'earthquake' || move.id === 'magnitude') {
 					return this.chainModify(2);
+				}
+			},
+		},
+	},
+	disable: {
+		inherit: true,
+		condition: {
+			inherit: true,
+			durationCallback: undefined, // no inherit
+			onStart(pokemon) {
+				this.effectState.time = this.random(2, 6);
+				if (!this.queue.willMove(pokemon)) {
+					this.effectState.time!++;
+				}
+				if (!pokemon.lastMove) {
+					return false;
+				}
+				for (const moveSlot of pokemon.moveSlots) {
+					if (moveSlot.id === pokemon.lastMove.id) {
+						if (!moveSlot.pp) {
+							return false;
+						} else {
+							this.add('-start', pokemon, 'Disable', moveSlot.move);
+							this.effectState.move = pokemon.lastMove.id;
+							return;
+						}
+					}
+				}
+				return false;
+			},
+			onBeforeMovePriority: 2,
+			onBeforeMove(pokemon, defender, move) {
+				pokemon.volatiles['disable'].time--;
+				if (!pokemon.volatiles['disable'].time) {
+					pokemon.removeVolatile('disable');
+					return;
+				}
+				if (!(move.isZ && move.isZOrMaxPowered) && move.id === this.effectState.move) {
+					this.add('cant', pokemon, 'Disable', move);
+					return false;
 				}
 			},
 		},

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -17,7 +17,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				 * Even though the Infatuation check happens before the Disable check
 				 * the Disable duration tick happens before both
 				 */
-				if (pokemon.volatiles['disable'] && pokemon.volatiles['disable'].time === 1) {
+				if (pokemon.volatiles['disable']?.time === 1) {
 					pokemon.removeVolatile('disable');
 				}
 

--- a/data/mods/gen2stadium2/conditions.ts
+++ b/data/mods/gen2stadium2/conditions.ts
@@ -30,7 +30,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			this.add('-status', target, 'par');
 			target.addVolatile('parspeeddrop');
 		},
-		onBeforeMovePriority: 2,
+		onBeforeMovePriority: 1,
 		onBeforeMove(pokemon) {
 			if (this.randomChance(1, 4)) {
 				this.add('cant', pokemon, 'par');
@@ -57,7 +57,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 				this.add('-end', target, 'Nightmare', '[silent]');
 			}
 		},
-		onBeforeMovePriority: 10,
+		onBeforeMovePriority: 13,
 		onBeforeMove(pokemon, target, move) {
 			pokemon.statusState.time--;
 			if (pokemon.statusState.time <= 0) {

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -523,6 +523,10 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 		},
 		flags: { notrace: 1 },
 	},
+	truant: {
+		inherit: true,
+		onBeforeMovePriority: 11,
+	},
 	vitalspirit: {
 		inherit: true,
 		rating: 2.5,

--- a/data/mods/gen4/conditions.ts
+++ b/data/mods/gen4/conditions.ts
@@ -20,8 +20,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		},
 	},
 	slp: {
-		name: 'slp',
-		effectType: 'Status',
+		inherit: true,
 		onStart(target, source, sourceEffect) {
 			if (sourceEffect && sourceEffect.effectType === 'Move') {
 				this.add('-status', target, 'slp', `[from] move: ${sourceEffect.name}`);
@@ -35,22 +34,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 				this.add('-end', target, 'Nightmare', '[silent]');
 			}
 		},
-		onBeforeMovePriority: 10,
-		onBeforeMove(pokemon, target, move) {
-			if (pokemon.hasAbility('earlybird')) {
-				pokemon.statusState.time--;
-			}
-			pokemon.statusState.time--;
-			if (pokemon.statusState.time <= 0) {
-				pokemon.cureStatus();
-				return;
-			}
-			this.add('cant', pokemon, 'slp');
-			if (move.sleepUsable) {
-				return;
-			}
-			return false;
-		},
+		onBeforeMovePriority: 13,
 	},
 	psn: {
 		inherit: true,
@@ -61,6 +45,19 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 		inherit: true,
 		onResidualOrder: 10,
 		onResidualSubOrder: 6,
+	},
+	frz: {
+		inherit: true,
+		onBeforeMovePriority: 12,
+		onBeforeMove(pokemon, target, move) {
+			if (this.randomChance(1, 5)) {
+				pokemon.cureStatus();
+				return;
+			}
+			if (move.flags['defrost']) return;
+			this.add('cant', pokemon, 'frz');
+			return false;
+		},
 	},
 	confusion: {
 		inherit: true,
@@ -84,17 +81,9 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			return false;
 		},
 	},
-	frz: {
+	flinch: {
 		inherit: true,
-		onBeforeMove(pokemon, target, move) {
-			if (this.randomChance(1, 5)) {
-				pokemon.cureStatus();
-				return;
-			}
-			if (move.flags['defrost']) return;
-			this.add('cant', pokemon, 'frz');
-			return false;
-		},
+		onBeforeMovePriority: 9,
 	},
 	substitutebroken: {
 		noCopy: true,
@@ -126,6 +115,10 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			if (!pokemon.lastMove) return false;
 			this.effectState.move = pokemon.lastMove.id;
 		},
+	},
+	mustrecharge: {
+		inherit: true,
+		onBeforeMovePriority: 10,
 	},
 	futuremove: {
 		inherit: true,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -324,6 +324,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				}
 				return false;
 			},
+			onBeforeMovePriority: 8,
 			onResidualOrder: 10,
 			onResidualSubOrder: 13,
 		},
@@ -574,6 +575,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		condition: {
 			inherit: true,
+			onBeforeMovePriority: 5,
 			onFieldResidualOrder: 9,
 			onFieldResidualSubOrder: undefined, // no inherit
 		},
@@ -614,6 +616,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		flags: { protect: 1, mirror: 1, metronome: 1 },
 		condition: {
 			inherit: true,
+			onBeforeMovePriority: 4,
 			onResidualOrder: 10,
 			onResidualSubOrder: 17,
 			onTryHeal(damage, pokemon, source, effect) {
@@ -670,6 +673,10 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				}
 			}
 			return false;
+		},
+		condition: {
+			inherit: true,
+			onFoeBeforeMovePriority: 6,
 		},
 	},
 	ingrain: {
@@ -1397,7 +1404,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 					}
 				}
 			},
-			onBeforeMovePriority: 5,
+			onBeforeMovePriority: 7,
 			onBeforeMove(attacker, defender, move) {
 				if (move.category === 'Status') {
 					this.add('cant', attacker, 'move: Taunt', move);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -739,7 +739,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 					pokemon.removeVolatile('attract');
 				}
 			},
-			onBeforeMovePriority: 2,
+			onBeforeMovePriority: 1,
 			onBeforeMove(pokemon, target, move) {
 				this.add('-activate', pokemon, 'move: Attract', '[of] ' + this.effectState.source);
 				if (this.randomChance(1, 2)) {
@@ -3508,7 +3508,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 					source.faint();
 				}
 			},
-			onBeforeMovePriority: -1,
+			onBeforeMovePriority: 100,
 			onBeforeMove(pokemon, target, move) {
 				if (move.id === 'destinybond') return;
 				this.debug('removing Destiny Bond before attack');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -3508,7 +3508,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 					source.faint();
 				}
 			},
-			onBeforeMovePriority: 100,
+			onBeforeMovePriority: -1,
 			onBeforeMove(pokemon, target, move) {
 				if (move.id === 'destinybond') return;
 				this.debug('removing Destiny Bond before attack');


### PR DESCRIPTION
Gen 8 reference: https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/page-54#post-8548957

In Gen 2, Disable was ticking at the end of the turn when it should tick at the beginning of move execution.

BeforeMovePriority | Gen 8 | Gen 4 | Gen 3 | Gen 2 | Gen 1
-- | -- | -- | -- | -- | --
14 | — | — | — | Recharge | —
13 | — | Sleep | Sleep | Sleep | Sleep
12 | Sky Drop | Freeze | Freeze | Freeze | Freeze
11 | Recharge | Truant | Truant | — | —
10 | Sleep/Freeze | Recharge | Recharge | — | Wrap
9 | Truant | Flinch | Flinch | Flinch | Flinch
8 | Flinch | Disable | Disable | — | Recharge
7 | Disable | Taunt | Taunt | — | —
6 | Gravity/Heal Block | Imprison | Imprison | — | —
5 | Taunt | Gravity | — | Disable (timer) | Disable (timer)
4 | Imprison | Heal Block | — | Confusion | Confusion
3 | Confusion | Confusion | Confusion | Attract | —
2 | Paralysis | Paralysis | Paralysis | Disable | Disable
1 | Attract | Attract | Attract | Paralysis | Paralysis