### PR TITLE
Replace `-zbroken` with `-brokeprotect`

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2797,7 +2797,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 					if (bypassProtect !== true && bypassProtect.effectType === 'Ability') {
 						this.battle.add('-ability', pokemon, bypassProtect.name);
 					}
-					this.battle.add('-zbroken', target);
+					this.battle.add('-brokeprotect', target);
 				}
 
 				// Generation 6-7 moves the check for minimum 1 damage after the final modifier...

--- a/data/mods/afd/scripts.ts
+++ b/data/mods/afd/scripts.ts
@@ -474,7 +474,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (bypassProtect !== true && bypassProtect.effectType === 'Ability') {
 					this.battle.add('-ability', pokemon, bypassProtect.name);
 				}
-				this.battle.add('-zbroken', target);
+				this.battle.add('-brokeprotect', target);
 			}
 
 			// Generation 6-7 moves the check for minimum 1 damage after the final modifier...

--- a/data/mods/ccapm2025/scripts.ts
+++ b/data/mods/ccapm2025/scripts.ts
@@ -208,7 +208,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (bypassProtect !== true && bypassProtect.effectType === 'Ability') {
 					this.battle.add('-ability', pokemon, bypassProtect.name);
 				}
-				this.battle.add('-zbroken', target);
+				this.battle.add('-brokeprotect', target);
 			}
 
 			// Generation 6-7 moves the check for minimum 1 damage after the final modifier...

--- a/data/mods/champions/scripts.ts
+++ b/data/mods/champions/scripts.ts
@@ -236,7 +236,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (bypassProtect !== true && bypassProtect.effectType === 'Ability') {
 					this.battle.add('-ability', pokemon, bypassProtect.name);
 				}
-				this.battle.add('-zbroken', target);
+				this.battle.add('-brokeprotect', target);
 			}
 
 			// Generation 6-7 moves the check for minimum 1 damage after the final modifier...

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -778,7 +778,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (bypassProtect !== true && bypassProtect.effectType === 'Ability') {
 					this.battle.add('-ability', pokemon, bypassProtect.name);
 				}
-				this.battle.add('-zbroken', target);
+				this.battle.add('-brokeprotect', target);
 			}
 
 			// Generation 6-7 moves the check for minimum 1 damage after the final modifier...

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -7932,7 +7932,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 				target.volatiles['protect'] || target.volatiles['banefulbunker'] || target.volatiles['kingsshield'] ||
 				target.volatiles['spikyshield'] || target.side.getSideCondition('matblock')
 			) {
-				this.add('-zbroken', target);
+				this.add('-brokeprotect', target);
 				return this.clampIntRange(Math.ceil(hp75 / 4 - 0.5), 1);
 			}
 			return this.clampIntRange(hp75, 1);

--- a/data/text/default.ts
+++ b/data/text/default.ts
@@ -35,7 +35,7 @@ export const DefaultText: { [id: IDEntry]: DefaultText } = {
 		transformMega: "[POKEMON] has Mega Evolved into Mega [SPECIES]!",
 		primal: "[POKEMON]'s Primal Reversion! It reverted to its primal state!",
 		zPower: "  [POKEMON] surrounded itself with its Z-Power!",
-		zBroken: "  [POKEMON] couldn't fully protect itself and got hurt!",
+		brokeProtect: "  [POKEMON] couldn't fully protect itself and got hurt!",
 		terastallize: "  [POKEMON] has Terastallized into the [TYPE]-type!", // filler
 
 		// in case the different default messages didn't make it obvious, the difference

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -547,9 +547,9 @@ stat boosts are minor actions.
 
 > The Pokémon `POKEMON` has used the z-move version of its move.
 
-`|-zbroken|POKEMON`
+`|-brokeprotect|POKEMON`
 
-> A z-move has broken through protect and hit the `POKEMON`.
+> A move has broken through a protecting move and hit the `POKEMON`.
 
 `|-activate|EFFECT`
 

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1835,7 +1835,7 @@ export class BattleActions {
 			if (bypassProtect !== true && bypassProtect.effectType === 'Ability') {
 				this.battle.add('-ability', pokemon, bypassProtect.name);
 			}
-			this.battle.add('-zbroken', target);
+			this.battle.add('-brokeprotect', target);
 		}
 
 		// Generation 6-7 moves the check for minimum 1 damage after the final modifier...


### PR DESCRIPTION
Now that there are multiple effects that aren't Z moves that can break Protect, using `-zbroken` as a Protect bypass identifier doesn't make as much sense.

Also adjusts the `SIM-PROTOCOL.md` description.

Requires https://github.com/smogon/pokemon-showdown-client/pull/2701 to function.