### PR TITLE
Champions Random Battle hotfixes

### DIFF
--- a/data/mods/champions/rulesets.ts
+++ b/data/mods/champions/rulesets.ts
@@ -57,7 +57,7 @@ export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable 
 		name: 'Level Clause Mod',
 		desc: "Changes stat calculation to depend on the Pok&eacute;mon's level, which need not be 50.",
 		onBegin() {
-			this.add('rule', "Level Clause Mod: Pok&eacute;mon levels are not fixed at 50, with stats calculated accordingly.");
+			this.add('rule', "Level Clause Mod: Pokémon levels are not fixed at 50, with stats calculated accordingly.");
 		},
 		// Implemented in mods/champions/scripts.ts
 	},

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -714,7 +714,7 @@ export class RandomChampionsTeams extends RandomTeams {
 		// Treat Charizard-Mega-X like Charizard-Mega-Y for bluffing purposes
 		if (species.id === 'charizardmegax') srWeakness = 2;
 		while (evs.hp > 0) {
-			const hp = Math.floor((2 * species.baseStats.hp + ivs.hp + evs.hp * 2 + 100) * level / 100 + 10);
+			const hp = Math.floor((2 * species.baseStats.hp + ivs.hp + Math.max(2 * evs.hp - 1, 0) + 100) * level / 100) + 10;
 			if (moves.has('substitute') && item !== 'Leftovers') {
 				if (item === 'Sitrus Berry' || item === 'Salac Berry') {
 					// Two Substitutes should activate Sitrus Berry or Power Construct

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1464,7 +1464,7 @@ export class RandomTeams {
 		if (species.baseSpecies === 'Basculin') return 'Basculin' + this.sample(['', '-Blue-Striped']);
 		if (species.baseSpecies === 'Magearna') return 'Magearna' + this.sample(['', '-Original']);
 		if (species.baseSpecies === 'Keldeo' && this.gen <= 7) return 'Keldeo' + this.sample(['', '-Resolute']);
-		if (species.baseSpecies === 'Pikachu' && this.gen >= 8) {
+		if (species.baseSpecies === 'Pikachu' && this.gen >= 8 && this.format.mod !== 'champions') {
 			return 'Pikachu' + this.sample(
 				['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']
 			);


### PR DESCRIPTION
Just a couple of hotfixes:
- Stop Pikachu hat formes from generating because they don't exist in Champions
- Use the correct HP stat formula when calculating HP EVs
- Fix the Level Clause Mod message in battles to display Pokémon properly