### PR TITLE
Update Champions Random Battle for 1.1.0 changes

### DIFF
--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -1328,7 +1328,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Crunch", "Ice Fang", "Protect", "Psychic Fangs", "Waterfall"],
+                "movepool": ["Close Combat", "Crunch", "Ice Fang", "Protect", "Psychic Fangs", "Waterfall"],
                 "abilities": ["Speed Boost"]
             }
         ]

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -25,7 +25,7 @@
         ]
     },
     "charizard": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -152,7 +152,7 @@
         ]
     },
     "pikachu": {
-        "level": 58,
+        "level": 59,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -271,13 +271,12 @@
         ]
     },
     "arcanine": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Morning Sun", "Roar", "Will-O-Wisp"],
-                "abilities": ["Intimidate"],
-                "preferredTypes": ["Fighting"]
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -789,7 +788,7 @@
         ]
     },
     "ampharosmega": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1037,7 +1036,7 @@
         ]
     },
     "houndoommega": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2621,7 +2620,7 @@
         ]
     },
     "floetteeternal": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3057,7 +3056,7 @@
         ]
     },
     "noivern": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3300,7 +3299,7 @@
         ]
     },
     "drampamega": {
-        "level": 50,
+        "level": 51,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3310,7 +3309,7 @@
         ]
     },
     "kommoo": {
-        "level": 48,
+        "level": 49,
         "sets": [
             {
                 "role": "Bulky Setup",

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -3499,7 +3499,7 @@
         ]
     },
     "basculegion": {
-        "level": 50,
+        "level": 49,
         "sets": [
             {
                 "role": "Fast Attacker",

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -708,7 +708,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Solar Beam", "Synthesis", "Weather Ball"],
-                "abilities": ["Overgrow"]
+                "abilities": ["Leaf Guard"]
             }
         ]
     },
@@ -1737,7 +1737,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Swords Dance"],
-                "abilities": ["Justified"]
+                "abilities": ["Inner Focus"]
             },
             {
                 "role": "Bulky Setup",
@@ -2378,7 +2378,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Energy Ball", "Fire Blast", "Flame Charge", "Pain Split", "Shadow Ball", "Will-O-Wisp"],
-                "abilities": ["Flame Body", "Flash Fire"]
+                "abilities": ["Flash Fire"]
             }
         ]
     },
@@ -2841,7 +2841,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Flip Turn", "Focus Blast", "Sludge Bomb", "Toxic Spikes"],
-                "abilities": ["Adaptability"]
+                "abilities": ["Poison Point"]
             }
         ]
     },
@@ -3162,7 +3162,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Ice Hammer", "Mach Punch"],
-                "abilities": ["Iron Fist"]
+                "abilities": ["Hyper Cutter"]
             }
         ]
     },

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -3532,7 +3532,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Crunch", "Gunk Shot", "Liquidation", "Swords Dance"],
+                "movepool": ["Agility", "Crunch", "Gunk Shot", "Liquidation", "Swords Dance"],
                 "abilities": ["Intimidate"]
             },
             {

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -40,7 +40,7 @@
         ]
     },
     "charizardmegax": {
-        "level": 48,
+        "level": 47,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -55,7 +55,7 @@
         ]
     },
     "charizardmegay": {
-        "level": 48,
+        "level": 47,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -116,7 +116,7 @@
         ]
     },
     "pidgeot": {
-        "level": 58,
+        "level": 57,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -211,7 +211,7 @@
         ]
     },
     "clefable": {
-        "level": 51,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -226,7 +226,7 @@
         ]
     },
     "clefablemega": {
-        "level": 48,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -297,7 +297,7 @@
         ]
     },
     "alakazam": {
-        "level": 48,
+        "level": 49,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -308,7 +308,7 @@
         ]
     },
     "alakazammega": {
-        "level": 45,
+        "level": 46,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -335,7 +335,7 @@
         ]
     },
     "victreebel": {
-        "level": 58,
+        "level": 57,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -355,7 +355,7 @@
         ]
     },
     "victreebelmega": {
-        "level": 52,
+        "level": 51,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -365,7 +365,7 @@
         ]
     },
     "slowbro": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -375,7 +375,7 @@
         ]
     },
     "slowbromega": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -405,7 +405,7 @@
         ]
     },
     "gengar": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -415,7 +415,7 @@
         ]
     },
     "gengarmega": {
-        "level": 42,
+        "level": 44,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -425,7 +425,7 @@
         ]
     },
     "kangaskhan": {
-        "level": 56,
+        "level": 55,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -435,7 +435,7 @@
         ]
     },
     "kangaskhanmega": {
-        "level": 50,
+        "level": 49,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -483,7 +483,7 @@
         ]
     },
     "pinsirmega": {
-        "level": 48,
+        "level": 47,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -565,7 +565,7 @@
         ]
     },
     "gyaradosmega": {
-        "level": 47,
+        "level": 46,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -626,7 +626,7 @@
         ]
     },
     "aerodactyl": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Fast Support",
@@ -641,7 +641,7 @@
         ]
     },
     "aerodactylmega": {
-        "level": 47,
+        "level": 46,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -667,7 +667,7 @@
         ]
     },
     "dragonite": {
-        "level": 46,
+        "level": 47,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -688,7 +688,7 @@
         ]
     },
     "meganium": {
-        "level": 58,
+        "level": 57,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -703,7 +703,7 @@
         ]
     },
     "meganiummega": {
-        "level": 52,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -713,7 +713,7 @@
         ]
     },
     "typhlosion": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -738,7 +738,7 @@
         ]
     },
     "feraligatr": {
-        "level": 49,
+        "level": 48,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -749,7 +749,7 @@
         ]
     },
     "feraligatrmega": {
-        "level": 46,
+        "level": 47,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -850,7 +850,7 @@
         ]
     },
     "slowking": {
-        "level": 55,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -946,7 +946,7 @@
         ]
     },
     "scizor": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -987,7 +987,7 @@
         ]
     },
     "heracrossmega": {
-        "level": 50,
+        "level": 49,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -997,7 +997,7 @@
         ]
     },
     "skarmory": {
-        "level": 50,
+        "level": 49,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1012,7 +1012,7 @@
         ]
     },
     "skarmorymega": {
-        "level": 49,
+        "level": 48,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1289,7 +1289,7 @@
         ]
     },
     "manectric": {
-        "level": 55,
+        "level": 56,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1304,7 +1304,7 @@
         ]
     },
     "manectricmega": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1334,7 +1334,7 @@
         ]
     },
     "camerupt": {
-        "level": 59,
+        "level": 57,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1344,7 +1344,7 @@
         ]
     },
     "cameruptmega": {
-        "level": 55,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1535,7 +1535,7 @@
         ]
     },
     "torterra": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1757,7 +1757,7 @@
         ]
     },
     "toxicroak": {
-        "level": 53,
+        "level": 52,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1838,7 +1838,7 @@
         ]
     },
     "gliscor": {
-        "level": 51,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1904,7 +1904,7 @@
         ]
     },
     "froslassmega": {
-        "level": 49,
+        "level": 48,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2024,7 +2024,7 @@
         ]
     },
     "samurotthisui": {
-        "level": 47,
+        "level": 46,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2074,7 +2074,7 @@
         ]
     },
     "simisear": {
-        "level": 56,
+        "level": 55,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2131,7 +2131,7 @@
         ]
     },
     "audino": {
-        "level": 57,
+        "level": 58,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2272,7 +2272,7 @@
         ]
     },
     "zoroark": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2413,7 +2413,7 @@
         ]
     },
     "golurk": {
-        "level": 56,
+        "level": 54,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -2464,7 +2464,7 @@
         ]
     },
     "chesnaught": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2479,7 +2479,7 @@
         ]
     },
     "chesnaughtmega": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2494,7 +2494,7 @@
         ]
     },
     "delphox": {
-        "level": 52,
+        "level": 51,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2504,7 +2504,7 @@
         ]
     },
     "delphoxmega": {
-        "level": 48,
+        "level": 46,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2646,7 +2646,7 @@
         ]
     },
     "florges": {
-        "level": 55,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2691,7 +2691,7 @@
         ]
     },
     "meowstic": {
-        "level": 55,
+        "level": 56,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2734,7 +2734,7 @@
         ]
     },
     "aegislash": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2764,7 +2764,7 @@
         ]
     },
     "slurpuff": {
-        "level": 54,
+        "level": 53,
         "sets": [
             {
                 "role": "Fast Support",
@@ -2846,7 +2846,7 @@
         ]
     },
     "clawitzer": {
-        "level": 56,
+        "level": 55,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2897,7 +2897,7 @@
         ]
     },
     "sylveon": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2952,7 +2952,7 @@
         ]
     },
     "goodrahisui": {
-        "level": 51,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3209,7 +3209,7 @@
         ]
     },
     "mudsdale": {
-        "level": 52,
+        "level": 51,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3350,7 +3350,7 @@
         ]
     },
     "sandaconda": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3489,7 +3489,7 @@
         ]
     },
     "kleavor": {
-        "level": 48,
+        "level": 47,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3509,7 +3509,7 @@
         ]
     },
     "basculegionf": {
-        "level": 50,
+        "level": 49,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3594,7 +3594,7 @@
         ]
     },
     "garganacl": {
-        "level": 50,
+        "level": 51,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3619,7 +3619,7 @@
         ]
     },
     "ceruledge": {
-        "level": 48,
+        "level": 46,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3735,7 +3735,7 @@
         ]
     },
     "glimmora": {
-        "level": 46,
+        "level": 45,
         "sets": [
             {
                 "role": "Fast Support",

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -2579,7 +2579,7 @@
         "level": 53,
         "sets": [
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Bug Buzz", "Hurricane", "Quiver Dance", "Sleep Powder"],
                 "abilities": ["Compound Eyes"]
             },

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -80,7 +80,7 @@
         ]
     },
     "blastoisemega": {
-        "level": 45,
+        "level": 46,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -319,7 +319,7 @@
         ]
     },
     "machamp": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -652,7 +652,7 @@
         ]
     },
     "snorlax": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1208,7 +1208,7 @@
         ]
     },
     "sableyemega": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1471,7 +1471,7 @@
         ]
     },
     "absolmega": {
-        "level": 48,
+        "level": 49,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1637,7 +1637,7 @@
         ]
     },
     "bastiodon": {
-        "level": 56,
+        "level": 57,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1782,7 +1782,7 @@
         ]
     },
     "abomasnowmega": {
-        "level": 50,
+        "level": 51,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1802,7 +1802,7 @@
         ]
     },
     "rhyperior": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2121,7 +2121,7 @@
         ]
     },
     "excadrillmega": {
-        "level": 45,
+        "level": 46,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2191,7 +2191,7 @@
         ]
     },
     "whimsicott": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3842,7 +3842,7 @@
         ]
     },
     "hydrapple": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -166,7 +166,7 @@
         "level": 56,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Encore", "Knock Off", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Lightning Rod"],
                 "preferredTypes": ["Water"]
@@ -179,11 +179,32 @@
             }
         ]
     },
+    "raichumegax": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Fake Out", "Knock Off", "Play Rough", "Rising Voltage", "Surf", "Volt Switch", "Volt Tackle"],
+                "abilities": ["Lightning Rod"],
+                "preferredTypes": ["Dark"]
+            }
+        ]
+    },
+    "raichumegay": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Nasty Plot", "Surf", "Volt Switch", "Zap Cannon"],
+                "abilities": ["Lightning Rod"]
+            }
+        ]
+    },
     "raichualola": {
         "level": 54,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock", "Surf", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Surge Surfer"]
             }
@@ -230,12 +251,22 @@
         ]
     },
     "ninetalesalola": {
-        "level": 50,
+        "level": 48,
         "sets": [
             {
                 "role": "Bulky Support",
                 "movepool": ["Aurora Veil", "Blizzard", "Encore", "Freeze-Dry", "Moonblast", "Nasty Plot"],
                 "abilities": ["Snow Warning"]
+            }
+        ]
+    },
+    "vileplume": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Giga Drain", "Leech Seed", "Sleep Powder", "Sludge Bomb", "Strength Sap"],
+                "abilities": ["Effect Spore"]
             }
         ]
     },
@@ -315,6 +346,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Poison Jab", "Power Whip", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Chlorophyll"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Knock Off", "Power Whip", "Sleep Powder", "Sludge Wave", "Strength Sap", "Sucker Punch"],
+                "abilities": ["Chlorophyll"]
             }
         ]
     },
@@ -360,6 +396,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Fire Blast", "Haze", "Psychic", "Shell Side Arm", "Slack Off", "Thunder Wave", "Toxic Spikes"],
                 "abilities": ["Regenerator"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Fire Blast", "Psychic", "Shell Side Arm", "Trick Room"],
+                "abilities": ["Regenerator"]
             }
         ]
     },
@@ -367,7 +408,7 @@
         "level": 49,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Wallbreaker",
                 "movepool": ["Focus Blast", "Nasty Plot", "Shadow Ball", "Sludge Wave", "Taunt", "Toxic Spikes", "Trick", "Will-O-Wisp"],
                 "abilities": ["Cursed Body"]
             }
@@ -408,8 +449,8 @@
         "level": 50,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Ice Beam", "Psyshock", "Recover", "Scald", "Thunderbolt"],
+                "role": "Wallbreaker",
+                "movepool": ["Hydro Pump", "Ice Beam", "Psyshock", "Recover", "Thunderbolt"],
                 "abilities": ["Analytic"]
             },
             {
@@ -460,14 +501,14 @@
         "level": 52,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Wallbreaker",
                 "movepool": ["Body Slam", "Close Combat", "Earthquake", "Throat Chop"],
                 "abilities": ["Sheer Force"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Double-Edge", "Earthquake", "Throat Chop"],
-                "abilities": ["Intimidate"]
+                "movepool": ["Body Slam", "Close Combat", "Throat Chop", "Zen Headbutt"],
+                "abilities": ["Sheer Force"]
             }
         ]
     },
@@ -739,6 +780,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Dragon Tail", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Static"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Agility", "Dazzling Gleam", "Focus Blast", "Thunderbolt"],
+                "abilities": ["Static"]
             }
         ]
     },
@@ -787,7 +833,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Alluring Voice", "Calm Mind", "Morning Sun", "Psychic", "Psyshock", "Shadow Ball", "Trick"],
+                "movepool": ["Alluring Voice", "Calm Mind", "Morning Sun", "Psychic", "Psyshock", "Shadow Ball"],
                 "abilities": ["Magic Bounce"],
                 "preferredTypes": ["Fairy"]
             }
@@ -889,6 +935,21 @@
             }
         ]
     },
+    "qwilfish": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Destiny Bond", "Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Flip Turn", "Gunk Shot", "Pain Split", "Thunder Wave", "Toxic", "Toxic Spikes"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
     "scizor": {
         "level": 49,
         "sets": [
@@ -974,13 +1035,8 @@
         "level": 54,
         "sets": [
             {
-                "role": "Fast Support",
-                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
-                "abilities": ["Flash Fire"]
-            },
-            {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sucker Punch"],
+                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
                 "abilities": ["Flash Fire"]
             }
         ]
@@ -999,8 +1055,8 @@
         "level": 48,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Knock Off", "Stealth Rock", "Stone Edge", "Superpower", "Thunder Wave"],
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Knock Off", "Stealth Rock", "Stone Edge", "Thunder Wave"],
                 "abilities": ["Sand Stream"]
             },
             {
@@ -1017,6 +1073,91 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Knock Off", "Stone Edge"],
                 "abilities": ["Sand Stream"]
+            }
+        ]
+    },
+    "sceptile": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Earth Power", "Focus Blast", "Giga Drain", "Leaf Storm", "Rock Slide", "Shed Tail"],
+                "abilities": ["Overgrow"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Focus Blast", "Giga Drain", "Leech Seed", "Substitute"],
+                "abilities": ["Overgrow"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Leaf Blade", "Rock Slide", "Swords Dance"],
+                "abilities": ["Overgrow"]
+            }
+        ]
+    },
+    "sceptilemega": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Dragon Pulse", "Earth Power", "Focus Blast", "Giga Drain", "Leaf Storm", "Shed Tail"],
+                "abilities": ["Overgrow"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Leaf Blade", "Outrage", "Swords Dance"],
+                "abilities": ["Overgrow"]
+            }
+        ]
+    },
+    "blaziken": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Protect", "Stone Edge", "Swords Dance"],
+                "abilities": ["Speed Boost"]
+            }
+        ]
+    },
+    "blazikenmega": {
+        "level": 44,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Protect", "Stone Edge", "Swords Dance"],
+                "abilities": ["Speed Boost"]
+            }
+        ]
+    },
+    "swampert": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Flip Turn", "Knock Off", "Roar", "Stealth Rock", "Wave Crash", "Yawn"],
+                "abilities": ["Torrent"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earthquake", "Flip Turn", "Knock Off", "Wave Crash"],
+                "abilities": ["Torrent"]
+            }
+        ]
+    },
+    "swampertmega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Ice Punch", "Knock Off", "Poison Jab", "Rain Dance", "Wave Crash"],
+                "abilities": ["Damp"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Earthquake", "Rain Dance", "Wave Crash"],
+                "abilities": ["Damp"]
             }
         ]
     },
@@ -1081,6 +1222,26 @@
             }
         ]
     },
+    "mawile": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Iron Head", "Knock Off", "Play Rough", "Stealth Rock", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Intimidate", "Sheer Force"]
+            }
+        ]
+    },
+    "mawilemega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Iron Head", "Knock Off", "Play Rough", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
     "aggron": {
         "level": 55,
         "sets": [
@@ -1139,6 +1300,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Flamethrower", "Overheat", "Switcheroo", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Lightning Rod"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Flamethrower", "Overheat", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Lightning Rod"]
             }
         ]
     },
@@ -1156,7 +1322,7 @@
         "level": 52,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Crunch", "Destiny Bond", "Hydro Pump", "Ice Beam", "Protect", "Waterfall"],
                 "abilities": ["Speed Boost"]
             }
@@ -1253,13 +1419,8 @@
         "level": 58,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Thunder Wave", "Will-O-Wisp"],
-                "abilities": ["Cursed Body", "Insomnia"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "role": "Wallbreaker",
+                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Swords Dance", "Thunder Wave", "Will-O-Wisp"],
                 "abilities": ["Cursed Body", "Insomnia"]
             }
         ]
@@ -1339,14 +1500,42 @@
         "level": 50,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["Body Slam", "Earthquake", "Explosion", "Spikes"],
                 "abilities": ["Inner Focus"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Body Slam", "Earthquake", "Explosion", "Freeze-Dry"],
                 "abilities": ["Inner Focus"]
+            }
+        ]
+    },
+    "metagross": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Bullet Punch", "Earthquake", "Meteor Mash", "Psychic Fangs", "Stealth Rock"],
+                "abilities": ["Clear Body"],
+                "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Agility", "Earthquake", "Meteor Mash", "Psychic Fangs", "Trick"],
+                "abilities": ["Clear Body"],
+                "preferredTypes": ["Ground"]
+            }
+        ]
+    },
+    "metagrossmega": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Body Press", "Iron Defense", "Meteor Mash", "Psychic Fangs", "Trailblaze"],
+                "abilities": ["Clear Body"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -1385,6 +1574,31 @@
             }
         ]
     },
+    "staraptor": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Roost"],
+                "abilities": ["Reckless"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "U-turn"],
+                "abilities": ["Reckless"]
+            }
+        ]
+    },
+    "staraptormega": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Brave Bird", "Close Combat", "Roost", "Substitute", "U-turn", "Whirlwind"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
     "luxray": {
         "level": 57,
         "sets": [
@@ -1418,6 +1632,12 @@
                 "role": "Fast Attacker",
                 "movepool": ["Fire Punch", "Head Smash", "Rock Slide", "Superpower"],
                 "abilities": ["Sheer Force"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Earthquake", "Fire Punch", "Rock Slide", "Superpower", "Zen Headbutt"],
+                "abilities": ["Sheer Force"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -1432,7 +1652,7 @@
         ]
     },
     "lopunny": {
-        "level": 56,
+        "level": 54,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1505,7 +1725,7 @@
         "level": 52,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Swords Dance"],
                 "abilities": ["Justified"]
             },
@@ -1525,7 +1745,7 @@
                 "abilities": ["Justified"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Aura Sphere", "Flash Cannon", "Nasty Plot", "Vacuum Wave"],
                 "abilities": ["Inner Focus"]
             }
@@ -1557,7 +1777,7 @@
         ]
     },
     "abomasnow": {
-        "level": 53,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1602,7 +1822,7 @@
         ]
     },
     "leafeon": {
-        "level": 55,
+        "level": 54,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1631,8 +1851,8 @@
                 "abilities": ["Poison Heal"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["Acrobatics", "Earthquake", "Knock Off", "Power Whip", "Stone Edge", "Swords Dance"],
+                "role": "Setup Sweeper",
+                "movepool": ["Dual Wingbeat", "Earthquake", "Knock Off", "Power Whip", "Stone Edge", "Swords Dance"],
                 "abilities": ["Poison Heal"]
             }
         ]
@@ -1641,7 +1861,7 @@
         "level": 51,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Knock Off", "Stealth Rock"],
                 "abilities": ["Thick Fat"]
             }
@@ -1674,15 +1894,15 @@
         ]
     },
     "froslass": {
-        "level": 54,
+        "level": 53,
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Destiny Bond", "Ice Beam", "Poltergeist", "Spikes", "Taunt", "Will-O-Wisp"],
+                "movepool": ["Destiny Bond", "Poltergeist", "Spikes", "Taunt", "Triple Axel", "Will-O-Wisp"],
                 "abilities": ["Cursed Body"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Ice Beam", "Nasty Plot", "Shadow Ball", "Will-O-Wisp"],
                 "abilities": ["Cursed Body"]
             }
@@ -1824,7 +2044,7 @@
         ]
     },
     "watchog": {
-        "level": 60,
+        "level": 58,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1847,7 +2067,7 @@
         "level": 56,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Wallbreaker",
                 "movepool": ["Gunk Shot", "Leaf Storm", "Rock Slide", "Superpower"],
                 "abilities": ["Overgrow"]
             },
@@ -1877,6 +2097,21 @@
                 "movepool": ["Grass Knot", "Hydro Pump", "Ice Beam", "Nasty Plot", "Substitute"],
                 "abilities": ["Torrent"],
                 "preferredTypes": ["Ice"]
+            }
+        ]
+    },
+    "musharna": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Moonblast", "Moonlight", "Psychic", "Thunder Wave"],
+                "abilities": ["Synchronize"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Moonblast", "Moonlight", "Psyshock"],
+                "abilities": ["Synchronize"]
             }
         ]
     },
@@ -1935,6 +2170,31 @@
             }
         ]
     },
+    "scolipede": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earthquake", "Gunk Shot", "Megahorn", "Spikes", "Swords Dance", "Toxic Spikes"],
+                "abilities": ["Speed Boost"]
+            }
+        ]
+    },
+    "scolipedemega": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earthquake", "Gunk Shot", "Protect", "Spikes", "Toxic Spikes"],
+                "abilities": ["Speed Boost"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Gunk Shot", "Leech Life", "Swords Dance"],
+                "abilities": ["Speed Boost"]
+            }
+        ]
+    },
     "whimsicott": {
         "level": 52,
         "sets": [
@@ -1955,9 +2215,39 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Gunk Shot", "Knock Off", "Stealth Rock"],
+                "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Knock Off", "Stealth Rock"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Poison"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Earthquake", "Gunk Shot", "Knock Off"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
+    "scrafty": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dragon Dance", "Drain Punch", "Iron Head", "Knock Off"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Knock Off", "Rest"],
+                "abilities": ["Shed Skin"]
+            }
+        ]
+    },
+    "scraftymega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Drain Punch", "Iron Head", "Knock Off"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1990,14 +2280,8 @@
         "level": 51,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Flamethrower", "Focus Blast", "Night Daze", "Psychic", "Sludge Bomb", "Trick", "U-turn"],
-                "abilities": ["Illusion"],
-                "preferredTypes": ["Poison"]
-            },
-            {
                 "role": "Setup Sweeper",
-                "movepool": ["Encore", "Focus Blast", "Nasty Plot", "Night Daze", "Psychic", "Sludge Bomb"],
+                "movepool": ["Encore", "Flamethrower", "Focus Blast", "Nasty Plot", "Night Daze", "Psychic", "Sludge Bomb"],
                 "abilities": ["Illusion"],
                 "preferredTypes": ["Poison"]
             }
@@ -2013,7 +2297,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Focus Blast", "Hyper Voice", "Poltergeist", "Trick", "U-turn", "Will-O-Wisp"],
+                "movepool": ["Focus Blast", "Hyper Voice", "Poltergeist", "Will-O-Wisp"],
                 "abilities": ["Illusion"]
             }
         ]
@@ -2022,10 +2306,9 @@
         "level": 54,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Calm Mind", "Focus Blast", "Psychic", "Psyshock", "Recover", "Shadow Ball"],
-                "abilities": ["Magic Guard"],
-                "preferredTypes": ["Fighting"]
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Focus Blast", "Psychic", "Psyshock", "Recover"],
+                "abilities": ["Magic Guard"]
             }
         ]
     },
@@ -2051,6 +2334,31 @@
                 "role": "Bulky Support",
                 "movepool": ["Acrobatics", "Nuzzle", "Roost", "Thunderbolt"],
                 "abilities": ["Motor Drive"]
+            }
+        ]
+    },
+    "eelektross": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Coil", "Drain Punch", "Knock Off", "Supercell Slam"],
+                "abilities": ["Levitate"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Close Combat", "Flamethrower", "Giga Drain", "Knock Off", "Supercell Slam", "Thunder Wave", "U-turn"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
+    "eelektrossmega": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Coil", "Drain Punch", "Knock Off", "Supercell Slam"],
+                "abilities": ["Levitate"]
             }
         ]
     },
@@ -2113,7 +2421,7 @@
         "level": 56,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Dynamic Punch", "Headlong Rush", "Poltergeist", "Stealth Rock", "Stone Edge"],
                 "abilities": ["No Guard"],
                 "preferredTypes": ["Fighting"]
@@ -2195,7 +2503,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock", "Trick"],
+                "movepool": ["Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock"],
                 "abilities": ["Blaze"]
             }
         ]
@@ -2214,12 +2522,12 @@
         "level": 50,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Wallbreaker",
                 "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
                 "abilities": ["Protean"]
             },
             {
-                "role": "Fast Support",
+                "role": "Wallbreaker",
                 "movepool": ["Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
                 "abilities": ["Protean"],
                 "preferredTypes": ["Poison"]
@@ -2230,12 +2538,12 @@
         "level": 48,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
                 "abilities": ["Protean"]
             },
             {
-                "role": "Fast Support",
+                "role": "Wallbreaker",
                 "movepool": ["Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
                 "abilities": ["Protean"],
                 "preferredTypes": ["Poison"]
@@ -2247,12 +2555,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Body Slam", "Earthquake", "Foul Play", "Trailblaze", "U-turn"],
+                "movepool": ["Agility", "Body Slam", "Earthquake", "Foul Play", "U-turn"],
                 "abilities": ["Huge Power"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Body Slam", "Earthquake", "Quick Attack", "Swords Dance", "Trailblaze"],
+                "movepool": ["Agility", "Body Slam", "Earthquake", "Quick Attack", "Swords Dance"],
                 "abilities": ["Huge Power"]
             }
         ]
@@ -2284,6 +2592,36 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Energy Ball", "Hurricane", "Quiver Dance", "Sleep Powder"],
                 "abilities": ["Compound Eyes"]
+            }
+        ]
+    },
+    "pyroar": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Fire Blast", "Hyper Voice", "Scorching Sands", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Unnerve"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Fire Blast", "Hyper Voice", "Solar Beam", "Sunny Day"],
+                "abilities": ["Unnerve"]
+            }
+        ]
+    },
+    "pyroarmega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Fire Blast", "Hyper Voice", "Solar Beam", "Sunny Day"],
+                "abilities": ["Unnerve"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Fire Blast", "Hyper Voice", "Taunt", "Will-O-Wisp"],
+                "abilities": ["Unnerve"]
             }
         ]
     },
@@ -2336,7 +2674,7 @@
                 "abilities": ["Iron Fist"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Bullet Punch", "Drain Punch", "Knock Off", "Swords Dance"],
                 "abilities": ["Iron Fist"]
             }
@@ -2361,15 +2699,9 @@
         "level": 55,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Alluring Voice", "Psychic Noise", "Thunder Wave", "Yawn"],
+                "role": "Bulky Support",
+                "movepool": ["Alluring Voice", "Light Screen", "Psychic Noise", "Reflect", "Thunder Wave"],
                 "abilities": ["Prankster"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Alluring Voice", "Dark Pulse", "Nasty Plot", "Psychic", "Psyshock", "Thunder Wave", "Thunderbolt"],
-                "abilities": ["Prankster"],
-                "preferredTypes": ["Fairy"]
             }
         ]
     },
@@ -2447,11 +2779,81 @@
             }
         ]
     },
+    "malamar": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Knock Off", "Rest", "Sleep Talk", "Superpower"],
+                "abilities": ["Contrary"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Knock Off", "Rest", "Superpower", "Zen Headbutt"],
+                "abilities": ["Contrary"]
+            }
+        ]
+    },
+    "malamarmega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Knock Off", "Rest", "Sleep Talk", "Superpower"],
+                "abilities": ["Contrary"]
+            }
+        ]
+    },
+    "barbaracle": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Liquidation", "Shell Smash", "Stone Edge"],
+                "abilities": ["Tough Claws"]
+            }
+        ]
+    },
+    "barbaraclemega": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Earthquake", "Liquidation", "Night Slash", "Poison Jab", "Shell Smash", "Stone Edge"],
+                "abilities": ["Tough Claws"]
+            }
+        ]
+    },
+    "dragalge": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Dragon Tail", "Flip Turn", "Focus Blast", "Sludge Bomb", "Toxic Spikes"],
+                "abilities": ["Adaptability"]
+            }
+        ]
+    },
+    "dragalgemega": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Dragon Tail", "Flip Turn", "Focus Blast", "Sludge Bomb", "Toxic Spikes"],
+                "abilities": ["Adaptability"]
+            }
+        ]
+    },
     "clawitzer": {
         "level": 56,
         "sets": [
             {
                 "role": "Fast Attacker",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Ice Beam", "U-turn", "Water Pulse"],
+                "abilities": ["Mega Launcher"]
+            },
+            {
+                "role": "Wallbreaker",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Ice Beam", "U-turn", "Water Pulse"],
                 "abilities": ["Mega Launcher"]
             }
@@ -2461,7 +2863,7 @@
         "level": 53,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Wallbreaker",
                 "movepool": ["Discharge", "Hyper Voice", "Morning Sun", "Shed Tail"],
                 "abilities": ["Dry Skin"]
             },
@@ -2578,7 +2980,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Drain Punch", "Earthquake", "Horn Leech", "Poltergeist", "Rest", "Rock Slide", "Wood Hammer"],
+                "movepool": ["Drain Punch", "Earthquake", "Horn Leech", "Poltergeist", "Rest", "Rock Slide", "Will-O-Wisp", "Wood Hammer"],
                 "abilities": ["Natural Cure"]
             },
             {
@@ -2693,7 +3095,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Darkest Lariat", "Earthquake", "Flare Blitz", "Parting Shot", "Will-O-Wisp"],
+                "movepool": ["Close Combat", "Darkest Lariat", "Earthquake", "Flare Blitz", "Parting Shot"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Close Combat", "Darkest Lariat", "Flare Blitz", "Parting Shot", "Will-O-Wisp"],
                 "abilities": ["Intimidate"]
             },
             {
@@ -2736,6 +3143,11 @@
     "crabominable": {
         "level": 56,
         "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bulk Up", "Drain Punch", "Ice Hammer", "Mach Punch"],
+                "abilities": ["Iron Fist"]
+            },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Drain Punch", "Ice Hammer", "Mach Punch"],
@@ -2871,12 +3283,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Play Rough", "Shadow Claw", "Shadow Sneak", "Swords Dance"],
-                "abilities": ["Disguise"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Drain Punch", "Play Rough", "Shadow Sneak", "Swords Dance"],
+                "movepool": ["Drain Punch", "Play Rough", "Shadow Claw", "Shadow Sneak", "Swords Dance"],
                 "abilities": ["Disguise"]
             }
         ]
@@ -2972,6 +3379,16 @@
             }
         ]
     },
+    "grimmsnarl": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Light Screen", "Parting Shot", "Reflect", "Spirit Break", "Taunt"],
+                "abilities": ["Prankster"]
+            }
+        ]
+    },
     "mrrime": {
         "level": 57,
         "sets": [
@@ -3002,6 +3419,26 @@
             }
         ]
     },
+    "falinks": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat", "Rock Slide"],
+                "abilities": ["Defiant"]
+            }
+        ]
+    },
+    "falinksmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat", "Rock Slide"],
+                "abilities": ["Defiant"]
+            }
+        ]
+    },
     "morpeko": {
         "level": 56,
         "sets": [
@@ -3024,6 +3461,12 @@
                 "role": "Bulky Support",
                 "movepool": ["Dragon Darts", "Hex", "U-turn", "Will-O-Wisp"],
                 "abilities": ["Clear Body", "Cursed Body", "Infiltrator"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Dragon Darts", "Fire Blast", "Shadow Ball", "U-turn", "Will-O-Wisp"],
+                "abilities": ["Clear Body", "Infiltrator"],
+                "preferredTypes": ["Fire"]
             }
         ]
     },
@@ -3084,6 +3527,21 @@
             }
         ]
     },
+    "overqwil": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Crunch", "Gunk Shot", "Liquidation", "Swords Dance"],
+                "abilities": ["Intimidate"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Crunch", "Gunk Shot", "Spikes", "Taunt", "Toxic Spikes"],
+                "abilities": ["Intimidate"]
+            }
+        ]
+    },
     "meowscarada": {
         "level": 48,
         "sets": [
@@ -3125,7 +3583,7 @@
         ]
     },
     "maushold": {
-        "level": 50,
+        "level": 48,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3163,13 +3621,8 @@
         "level": 48,
         "sets": [
             {
-                "role": "Fast Support",
-                "movepool": ["Bitter Blade", "Close Combat", "Poltergeist", "Swords Dance"],
-                "abilities": ["Weak Armor"]
-            },
-            {
                 "role": "Setup Sweeper",
-                "movepool": ["Bitter Blade", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "movepool": ["Bitter Blade", "Close Combat", "Poltergeist", "Shadow Sneak", "Swords Dance"],
                 "abilities": ["Weak Armor"]
             }
         ]
@@ -3302,6 +3755,31 @@
             }
         ]
     },
+    "houndstone": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Poltergeist", "Roar", "Shadow Sneak", "Will-O-Wisp"],
+                "abilities": ["Fluffy"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Press", "Poltergeist", "Rest", "Sleep Talk"],
+                "abilities": ["Fluffy"]
+            }
+        ]
+    },
+    "annihilape": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Rage Fist", "Rest", "Taunt"],
+                "abilities": ["Defiant"]
+            }
+        ]
+    },
     "farigiraf": {
         "level": 57,
         "sets": [
@@ -3319,6 +3797,21 @@
                 "role": "Bulky Setup",
                 "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Supreme Overlord"]
+            }
+        ]
+    },
+    "gholdengo": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Focus Blast", "Make It Rain", "Nasty Plot", "Shadow Ball", "Trick"],
+                "abilities": ["Good as Gold"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Make It Rain", "Nasty Plot", "Recover", "Shadow Ball"],
+                "abilities": ["Good as Gold"]
             }
         ]
     },

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -2161,7 +2161,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Bulk Up", "Defog", "Drain Punch", "Knock Off", "Mach Punch"],
-                "abilities": ["Iron Fist"]
+                "abilities": ["Guts", "Iron Fist"]
             }
         ]
     },

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -3475,7 +3475,7 @@
         "level": 55,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Body Slam", "Earthquake", "Megahorn", "Psychic Noise", "Thunder Wave"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -2789,8 +2789,9 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Knock Off", "Rest", "Superpower", "Zen Headbutt"],
-                "abilities": ["Contrary"]
+                "movepool": ["Knock Off", "Poison Jab", "Rest", "Superpower", "Zen Headbutt"],
+                "abilities": ["Contrary"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -2800,6 +2801,11 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Knock Off", "Rest", "Sleep Talk", "Superpower"],
+                "abilities": ["Contrary"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Knock Off", "Poison Jab", "Superpower", "Zen Headbutt"],
                 "abilities": ["Contrary"]
             }
         ]

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -846,11 +846,6 @@
                 "role": "Bulky Support",
                 "movepool": ["Foul Play", "Protect", "Toxic", "Wish"],
                 "abilities": ["Synchronize"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Foul Play", "Moonlight", "Taunt", "Toxic"],
-                "abilities": ["Synchronize"]
             }
         ]
     },

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -2579,7 +2579,7 @@
         "level": 53,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Bug Buzz", "Hurricane", "Quiver Dance", "Sleep Powder"],
                 "abilities": ["Compound Eyes"]
             },

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -803,7 +803,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			if (baseFormes[species.baseSpecies]) continue;
 
 			// Illusion shouldn't be on the last slot
-			if (species.name === 'Zoroark' && pokemon.length < 1) continue;
+			if (species.baseSpecies === 'Zoroark' && pokemon.length < 1) continue;
 
 			const types = species.types;
 			const typeCombo = types.slice().sort().join();

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -12,13 +12,13 @@ const PHYSICAL_SETUP = [
 ];
 // Some moves that only boost Speed:
 const SPEED_SETUP = [
-	'agility', 'autotomize', 'flamecharge', 'rockpolish', 'snowscape', 'trailblaze',
+	'agility', 'autotomize', 'flamecharge', 'raindance', 'rockpolish', 'snowscape', 'sunnyday', 'trailblaze',
 ];
 // Conglomerate for ease of access
 const SETUP = [
 	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'clangoroussoul', 'coil', 'cosmicpower', 'curse', 'dragondance',
-	'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance',
-	'rockpolish', 'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'takeheart', 'tidyup', 'trailblaze', 'workup', 'victorydance',
+	'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance', 'raindance',
+	'rockpolish', 'shellsmash', 'shiftgear', 'sunnyday', 'swordsdance', 'tailglow', 'takeheart', 'tidyup', 'trailblaze', 'workup', 'victorydance',
 ];
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
@@ -42,34 +42,13 @@ const MOVE_PAIRS = [
 	['sleeptalk', 'rest'],
 	['protect', 'wish'],
 	['leechseed', 'substitute'],
+	['reflect', 'lightscreen'],
 ];
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'palafin', 'scizor', 'scizormega',
+	'mimikyu', 'palafin', 'scizor', 'scizormega',
 ];
-
-// 1.2x type boosting items
-const TYPE_BOOSTING_ITEMS: { [k: string]: string } = {
-	'Bug': 'Silver Powder',
-	'Dark': 'Black Glasses',
-	'Dragon': 'Dragon Fang',
-	'Electric': 'Magnet',
-	'Fairy': 'Fairy Feather',
-	'Fighting': 'Black Belt',
-	'Fire': 'Charcoal',
-	'Flying': 'Sharp Beak',
-	'Ghost': 'Spell Tag',
-	'Grass': 'Miracle Seed',
-	'Ground': 'Soft Sand',
-	'Ice': 'Never-Melt Ice',
-	'Normal': 'Silk Scarf',
-	'Poison': 'Poison Barb',
-	'Psychic': 'Twisted Spoon',
-	'Rock': 'Hard Stone',
-	'Steel': 'Metal Coat',
-	'Water': 'Mystic Water',
-};
 
 export class RandomChampionsTeams extends RandomTeams {
 	override randomSets: { [species: string]: RandomTeamsTypes.RandomSpeciesData } = require('./sets.json');
@@ -104,7 +83,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			),
 			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
 			Psychic: (movePool, moves, abilities, types, counter) => {
-				if (['Ice', 'Water'].some(m => types.has(m))) return false;
+				if (['Ice', 'Steel', 'Water'].some(m => types.has(m))) return false;
 				return !counter.get('Psychic');
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => (!counter.get('Rock') && species.baseStats.atk >= 80),
@@ -202,9 +181,11 @@ export class RandomChampionsTeams extends RandomTeams {
 			['aurasphere', 'focusblast'],
 			['closecombat', 'drainpunch'],
 			['dragonpulse', 'dracometeor'],
+			['risingvoltage', 'volttackle'],
 
 			// Status move incompatibilities
 			['taunt', 'encore'],
+			['roar', 'yawn'],
 			[statusInflictingMoves, 'toxicspikes'],
 			[statusInflictingMoves, statusInflictingMoves],
 		];
@@ -219,8 +200,6 @@ export class RandomChampionsTeams extends RandomTeams {
 		// To force Stealth Rock on Camerupt
 		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
 		if (species.id === 'cameruptmega') this.incompatibleMoves(moves, movePool, 'ancientpower', 'willowisp');
-		// To force Ice Shard on Mamoswine
-		if (species.id === 'mamoswine') this.incompatibleMoves(moves, movePool, 'knockoff', 'stealthrock');
 	}
 
 	// Generate random moveset for a given species, role, preferred type.
@@ -318,7 +297,7 @@ export class RandomChampionsTeams extends RandomTeams {
 		}
 
 		// Enforce STAB priority
-		if (this.priorityPokemon.includes(species.id)) {
+		if (role === 'Wallbreaker' || this.priorityPokemon.includes(species.id)) {
 			const priorityMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
@@ -432,7 +411,7 @@ export class RandomChampionsTeams extends RandomTeams {
 		}
 
 		// Enforce coverage move
-		if (['Fast Attacker', 'Setup Sweeper', 'Bulky Attacker'].includes(role)) {
+		if (['Fast Attacker', 'Wallbreaker', 'Setup Sweeper', 'Bulky Attacker'].includes(role)) {
 			if (counter.damagingMoves.size === 1) {
 				// Find the type of the current attacking move
 				const currentAttackType = counter.damagingMoves.values().next().value!.type;
@@ -558,17 +537,24 @@ export class RandomChampionsTeams extends RandomTeams {
 		if (
 			['Cheek Pouch', 'Cud Chew', 'Harvest'].some(m => ability === m) || moves.has('bellydrum')
 		) return 'Sitrus Berry';
-		if (species.id === 'alakazam') return 'Focus Sash';
+		if (species.id === 'alakazam' && this.randomChance(1, 2)) return 'Focus Sash';
+		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (species.id === 'ditto') return 'Choice Scarf';
 		if (['healingwish', 'switcheroo', 'trick'].some(m => moves.has(m))) return 'Choice Scarf';
 		if (ability === 'Unburden') return moves.has('closecombat') ? 'White Herb' : 'Sitrus Berry';
 		if (moves.has('shellsmash')) return 'White Herb';
+		if ((ability === 'Magic Guard' || ability === 'Sheer Force') && species.id !== 'toucannon') return 'Life Orb';
 		if (moves.has('acrobatics')) return '';
+		if (moves.has('auroraveil') || moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
 		if (
 			moves.has('rest') && !moves.has('sleeptalk') &&
 			ability !== 'Natural Cure' && ability !== 'Shed Skin'
 		) return 'Chesto Berry';
 		if (types.has('Normal') && moves.has('doubleedge') && moves.has('fakeout')) return 'Silk Scarf';
+		if (
+			(species.id === 'froslass' && moves.has('tripleaxel')) || moves.has('populationbomb') ||
+			(ability === 'Hustle' && counter.get('setup') && this.randomChance(1, 2))
+		) return 'Wide Lens';
 	}
 
 	override getItem(
@@ -588,55 +574,24 @@ export class RandomChampionsTeams extends RandomTeams {
 			['fakeout', 'trailblaze'].every(m => !moves.has(m)) &&
 			(!counter.get('Status') || counter.get('Status') === 1 && moves.has('partingshot'))
 		) return 'Choice Scarf';
-		if (moves.has('substitute') || moves.has('kingsshield')) return 'Leftovers';
+		if (['kingsshield', 'nuzzle', 'rapidspin', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
 
 		// Default to Leftovers for Bulky roles
 		if (role.includes('Bulky')) return 'Leftovers';
-		// Default to Focus Sash for Fast Support. Bulk threshold is unnecessary for the time being
-		if (role === 'Fast Support' && !counter.get('recovery')) return 'Focus Sash';
 
-		// Pokes with high crit rate STABs
-		if (
-			['aerodactyl', 'gallade', 'leafeon', 'lycanroc', 'lycanrocmidnight'].includes(species.id) && !moves.has('accelerock')
-		) return 'Scope Lens';
-
-		// Hard-code type-boosting items here
-		if (species.id === 'hydreigon') return 'Dragon Fang';
-		if (['heliolisk', 'raichualola'].includes(species.id)) return 'Magnet';
-		if (species.id === 'gardevoir') return 'Fairy Feather';
-		if (
-			['armarouge', 'chandelure', 'delphox', 'scovillain', 'typhlosionhisui', 'volcarona'].includes(species.id)
-		) return 'Charcoal';
-		if (species.id === 'vivillon') return 'Sharp Beak';
-		if (species.id === 'victreebel') return 'Miracle Seed';
-		if (species.id === 'weavile') return 'Never-Melt Ice';
-		if (species.id === 'quaquaval') return 'Mystic Water';
-
-		// Randomly choose between their STABs
-		if (
-			['heracross', 'houndoom', 'infernape', 'kleavor', 'toxicroak', 'zoroarkhisui'].includes(species.id)
-		) return TYPE_BOOSTING_ITEMS[this.sample([...types])];
-
-		// Give type-boosting items if it only has one STAB attack
-		const stabTypes: string[] = [];
-		for (const type of types) {
-			if (counter.get(type)) stabTypes.push(type);
-		}
-		if (stabTypes.length === 1) {
-			return TYPE_BOOSTING_ITEMS[stabTypes[0]];
+		// Default to Life Orb for offensive roles
+		if (['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].includes(role)) {
+			if (['basculegion', 'palafin'].includes(species.id)) return 'Mystic Water';
+			if (this.dex.getEffectiveness('Rock', species) < 2) return 'Life Orb';
 		}
 
-		// Give type-boosting items if it has a STAB regular and priority attack of the same type
-		for (const type of types) {
-			if (!counter.get(type)) continue;
-			for (const moveid of moves) {
-				const move = this.dex.moves.get(moveid);
-				const moveType = this.getMoveType(move, species, [ability], preferredType);
-				if (type === moveType && move.priority > 0 && (move.basePower || move.basePowerCallback)) {
-					return TYPE_BOOSTING_ITEMS[type];
-				}
-			}
+		// Fast Support defaults to Life Orb if >= 3 attacks and Leftovers otherwise. It can generate Focus Sash in the lead slot with hazar
+		if (role === 'Fast Support') {
+			if (isLead && !counter.get('recovery') && !counter.get('recoil') && counter.get('hazards')) return 'Focus Sash';
+			return (
+				counter.get('Physical') + counter.get('Special') >= 3 && this.dex.getEffectiveness('Rock', species) < 2
+			) ? 'Life Orb' : 'Leftovers';
 		}
 
 		// Default to Leftovers
@@ -767,7 +722,9 @@ export class RandomChampionsTeams extends RandomTeams {
 		pokemon: RandomTeamsTypes.RandomSet[],
 	): boolean {
 		const webSetters = ['ariados', 'slurpuff', 'araquanid'];
-		const screenSetters = ['ninetalesalola', 'abomasnow', 'abomasnowmega', 'froslassmega', 'vanilluxe', 'aurorus'];
+		const screenSetters = [
+			'ninetalesalola', 'abomasnow', 'abomasnowmega', 'froslassmega', 'vanilluxe', 'aurorus', 'grimmsnarl', 'meowstic',
+		];
 
 		const sunSetters = ['charizardmegay', 'ninetales', 'torkoal'];
 

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -538,6 +538,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			['Cheek Pouch', 'Cud Chew', 'Harvest'].some(m => ability === m) || moves.has('bellydrum')
 		) return 'Sitrus Berry';
 		if (species.id === 'alakazam' && this.randomChance(1, 2)) return 'Focus Sash';
+		if (species.id === 'glimmora') return 'Focus Sash';
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (species.id === 'ditto') return 'Choice Scarf';
 		if (['healingwish', 'switcheroo', 'trick'].some(m => moves.has(m))) return 'Choice Scarf';

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -868,7 +868,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			// Limit three of any type combination in Monotype
 			if (!this.forceMonotype && isMonotype && (typeComboCount[typeCombo] >= 3 * limitFactor)) continue;
 
-			const set = this.randomSet(species, teamDetails, pokemon.length === 0);
+			const set = this.randomSet(species, teamDetails, pokemon.length === this.maxTeamSize - 1);
 			pokemon.unshift(set);
 
 			// Don't bother tracking details for the last Pokemon

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -586,7 +586,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			if (this.dex.getEffectiveness('Rock', species) < 2) return 'Life Orb';
 		}
 
-		// Fast Support defaults to Life Orb if >= 3 attacks and Leftovers otherwise. It can generate Focus Sash in the lead slot with hazar
+		// Fast Support defaults to Life Orb if >= 3 attacks and Leftovers otherwise. It can generate Focus Sash in the lead slot with hazards
 		if (role === 'Fast Support') {
 			if (isLead && !counter.get('recovery') && !counter.get('recoil') && counter.get('hazards')) return 'Focus Sash';
 			return (

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -575,7 +575,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			['fakeout', 'trailblaze'].every(m => !moves.has(m)) &&
 			(!counter.get('Status') || counter.get('Status') === 1 && moves.has('partingshot'))
 		) return 'Choice Scarf';
-		if (['kingsshield', 'nuzzle', 'rapidspin', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
+		if (['flamecharge', 'kingsshield', 'nuzzle', 'rapidspin', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
 
 		// Default to Leftovers for Bulky roles

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -87,7 +87,7 @@ export class RandomChampionsTeams extends RandomTeams {
 				return !counter.get('Psychic');
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => (!counter.get('Rock') && species.baseStats.atk >= 80),
-			Steel: (movePool, moves, abilities, types, counter, species) => (!counter.get('Steel') && species.baseStats.atk >= 75),
+			Steel: (movePool, moves, abilities, types, counter, species) => (!counter.get('Steel') && species.baseStats.atk >= 60),
 			Water: (movePool, moves, abilities, types, counter) => !counter.get('Water'),
 		};
 		this.cachedStatusMoves = this.dex.moves.all().filter(move => move.category === 'Status').map(move => move.id);

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -79,7 +79,9 @@ export class RandomChampionsTeams extends RandomTeams {
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
 			Normal: (movePool, moves, abilities, types, counter) => (
-				movePool.includes('boomburst') || ['Electric', 'Fire', 'Ghost', 'Ground'].some(t => types.has(t))
+				!counter.get('Normal') && (
+					movePool.includes('boomburst') || ['Electric', 'Fire', 'Ghost', 'Ground'].some(t => types.has(t))
+				)
 			),
 			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
 			Psychic: (movePool, moves, abilities, types, counter) => {

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -79,7 +79,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
 			Normal: (movePool, moves, abilities, types, counter) => (
-				movePool.includes('boomburst') || ['Electric', 'Ghost', 'Ground'].some(t => types.has(t))
+				movePool.includes('boomburst') || ['Electric', 'Fire', 'Ghost', 'Ground'].some(t => types.has(t))
 			),
 			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
 			Psychic: (movePool, moves, abilities, types, counter) => {

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -83,7 +83,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			),
 			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
 			Psychic: (movePool, moves, abilities, types, counter) => {
-				if (['Ice', 'Steel', 'Water'].some(m => types.has(m))) return false;
+				if (['Dark', 'Ice', 'Steel', 'Water'].some(m => types.has(m))) return false;
 				return !counter.get('Psychic');
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => (!counter.get('Rock') && species.baseStats.atk >= 80),

--- a/server/chat-plugins/randombattles/winrates.tsx
+++ b/server/chat-plugins/randombattles/winrates.tsx
@@ -136,6 +136,7 @@ export function getSpeciesName(set: PokemonSet, format: Format) {
 	} else if (species === "Groudon" && item.name === "Red Orb") {
 		return "Groudon-Primal";
 	} else if (item.megaStone) {
+		if (species === 'Meowstic-F') return "Meowstic-F-Mega";
 		return Object.values(item.megaStone)[0];
 	} else if (species === "Rayquaza" && moves.includes('Dragon Ascent') && !item.zMove && megaRayquazaPossible) {
 		return "Rayquaza-Mega";

--- a/server/chat-plugins/randombattles/winrates.tsx
+++ b/server/chat-plugins/randombattles/winrates.tsx
@@ -135,9 +135,8 @@ export function getSpeciesName(set: PokemonSet, format: Format) {
 		return "Kyogre-Primal";
 	} else if (species === "Groudon" && item.name === "Red Orb") {
 		return "Groudon-Primal";
-	} else if (item.megaStone) {
-		if (species === 'Meowstic-F') return "Meowstic-F-Mega";
-		return Object.values(item.megaStone)[0];
+	} else if (item.megaStone?.[species]) {
+		return item.megaStone[species];
 	} else if (species === "Rayquaza" && moves.includes('Dragon Ascent') && !item.zMove && megaRayquazaPossible) {
 		return "Rayquaza-Mega";
 	} else if (species === "Poltchageist-Artisan") { // Babymons from here on out

--- a/test/random-battles/all-gens.js
+++ b/test/random-battles/all-gens.js
@@ -168,7 +168,7 @@ describe("New set format (slow)", () => {
 		},
 		"gen9championsrandombattle": {
 			filename: "champions/sets",
-			roles: ["Fast Attacker", "Setup Sweeper", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support"],
+			roles: ["Fast Attacker", "Setup Sweeper", "Wallbreaker", "Bulky Attacker", "Bulky Setup", "Bulky Support", "Fast Support"],
 		},
 	};
 	for (const format of Object.keys(formatInfo)) {


### PR DESCRIPTION
This pull request updates Champions Random Battles sets for 1.1.0. Ready to merge.

Summary:
- Added sets for new mons.
- Adjusted sets and levels of existing mons due to Life Orb, Light Clay, and Wide Lens returning
- Light Clay and Wide Lens generate in the same places as Gen 9 rands - basically, exactly where you'd expect them to.
- Reintroduces the Wallbreaker role, which enforces STAB priority and defaults to Life Orb. Since Choice Band/Specs don't exist, it gets Choice Scarf with Trick.
- Setup Sweeper and Fast Attacker also default to Life Orb, replacing nearly all type-boosting items.
- Fast Support now generates Focus Sash only in the lead slot, aside from Glimmora, which always obtains it. In the back, Fast Support defaults to Life Orb if it has 3 or more attacks and Leftovers otherwise.
- Normal set updates and manual level changes - too many changes to list here.

Also fixes a couple of errors:
- win rates for Meowstic-F-Mega get tracked separately from Meowstic-M-Mega.
- Zoroark-Hisui won't generate in the last slot (previously, only Zoroark was prevented).