### PR TITLE
Fix crash in NatDex Draft

### DIFF
--- a/data/mods/champions/scripts.ts
+++ b/data/mods/champions/scripts.ts
@@ -1,3 +1,5 @@
+import { toID } from '../../../sim/dex';
+
 export const Scripts: ModdedBattleScriptsData = {
 	gen: 9,
 	init() {


### PR DESCRIPTION
# Problem

A failure to import `toID` from `sim\dex.ts` caused a **ReferenceError** when running `onMegaEvo` under the case that handles Rayquaza-Mega's Mega Evolution constraint. This results in a battle crash every time Rayquaza is brought in **[Gen 9 Champions ] NatDex Draft**.

As was documented in https://www.smogon.com/forums/threads/3784338/, it only affects Rayquaza's Mega Evolution and not Primal Reversion mechanics.

# Solution

Explicity import the `toID` function from `sim\dex.ts` to ensure the reference is defined.

# Test plan

`npm run lint` — clean
`npm run tsc` — clean
`node build` — clean
`npx mocha` — full suite, 2334 passing
Did not run `node pokemon-showdown` because clearly that doesn't affect anything and is not a viable test option.


([...if you need some context]( https://discord.com/channels/630837856075513856/630973468409856020/1514601430810492948))