### PR TITLE
Random Battles set updates

### DIFF
--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -230,12 +230,12 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Fire Blast", "Focus Blast", "Moonblast", "Moonlight"],
+                "movepool": ["Calm Mind", "Fire Blast", "Moonblast", "Moonlight"],
                 "abilities": ["Magic Guard"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Air Slash", "Focus Blast", "Knock Off", "Moonblast", "Moonlight", "Stealth Rock", "Thunder Wave"],
+                "movepool": ["Fire Blast", "Knock Off", "Moonblast", "Moonlight", "Stealth Rock", "Thunder Wave"],
                 "abilities": ["Magic Guard"]
             }
         ]
@@ -558,7 +558,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Power Whip", "Temper Flare", "Waterfall"],
-                "abilities": ["Intimidate"],
+                "abilities": ["Intimidate", "Moxie"],
                 "preferredTypes": ["Fire"]
             }
         ]

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -1526,8 +1526,8 @@
         "level": 46,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Body Press", "Iron Defense", "Meteor Mash", "Psychic Fangs", "Trailblaze"],
+                "role": "Fast Attacker",
+                "movepool": ["Body Press", "Bullet Punch", "Iron Defense", "Meteor Mash", "Psychic Fangs", "Trailblaze"],
                 "abilities": ["Clear Body"],
                 "preferredTypes": ["Psychic"]
             }

--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -539,7 +539,7 @@
     "kangaskhan": {
         "level": 73,
         "moves": ["bodyslam", "earthquake", "hyperbeam"],
-        "exclusiveMoves": ["blizzard", "counter", "rockslide", "rockslide", "surf"]
+        "exclusiveMoves": ["blizzard", "counter", "rockslide", "rockslide"]
     },
     "horsea": {
         "level": 88,
@@ -653,8 +653,8 @@
     },
     "omastar": {
         "level": 74,
-        "moves": ["bodyslam", "rest", "seismictoss"],
-        "essentialMoves": ["blizzard"],
+        "moves": ["rest", "rest", "seismictoss"],
+        "essentialMoves": ["blizzard", "bodyslam"],
         "exclusiveMoves": ["hydropump", "surf"]
     },
     "kabuto": {

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -1047,7 +1047,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerfire", "icebeam", "rest", "sleeptalk"],
+                "movepool": ["icebeam", "rest", "sleeptalk", "toxic"],
                 "abilities": ["Pressure"]
             }
         ]
@@ -1316,9 +1316,18 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["brickbreak", "doubleedge", "hiddenpowerghost", "hydropump", "rest", "return", "sleeptalk"],
-                "abilities": ["Huge Power"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["brickbreak", "doubleedge", "hiddenpowerghost", "hydropump", "return"],
+                "abilities": ["Huge Power"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["bodyslam", "focuspunch", "hiddenpowerghost", "return", "substitute"],
+                "abilities": ["Huge Power"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["bodyslam", "hydropump", "rest", "return", "sleeptalk"],
+                "abilities": ["Huge Power"]
             }
         ]
     },
@@ -2551,8 +2560,8 @@
         "level": 89,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["earthquake", "explosion", "fireblast", "rest", "rockslide", "sleeptalk", "toxic"],
+                "role": "Bulky Attacker",
+                "movepool": ["earthquake", "explosion", "fireblast", "rest", "sleeptalk", "toxic"],
                 "abilities": ["Magma Armor"]
             }
         ]

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -631,12 +631,14 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		species: Species,
 		pokemon: RandomTeamsTypes.RandomSet[],
 	): boolean {
+		const reversalUsers = ['raticate', 'primeape', 'hitmonlee', 'furret', 'yanma', 'heracross', 'blaziken', 'medicham'];
+		const flailUsers = ['dodrio', 'farfetchd'];
 		const incompatibilityList = [
 			// These Pokemon are incompatible because the presence of one actively harms the other.
 			// Prevent Shedinja + Tyranitar
 			['shedinja', 'tyranitar'],
 			// Prevent Reversal/Flail users + Tyranitar
-			[['dodrio', 'raticate', 'primeape', 'hitmonlee', 'furret', 'yanma', 'heracross', 'blaziken', 'medicham'], 'tyranitar'],
+			[[...flailUsers, ...reversalUsers], 'tyranitar'],
 		];
 
 		for (const pair of incompatibilityList) {

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1207,16 +1207,6 @@
             }
         ]
     },
-    "unown": {
-        "level": 100,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            }
-        ]
-    },
     "wobbuffet": {
         "level": 87,
         "sets": [

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -843,9 +843,9 @@
         "level": 77,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit", "return", "selfdestruct"],
-                "abilities": ["Thick Fat"],
+                "role": "Bulky Setup",
+                "movepool": ["bodyslam", "crunch", "curse", "earthquake", "selfdestruct"],
+                "abilities": ["Immunity", "Thick Fat"],
                 "preferredTypes": ["Ground"]
             },
             {
@@ -854,7 +854,7 @@
                 "abilities": ["Thick Fat"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Bulky Attacker",
                 "movepool": ["bodyslam", "curse", "earthquake", "rest"],
                 "abilities": ["Thick Fat"]
             }
@@ -3373,7 +3373,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "toxic", "trick", "willowisp"],
+                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "toxic", "willowisp"],
                 "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             },

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1207,6 +1207,16 @@
             }
         ]
     },
+    "unown": {
+        "level": 100,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
     "wobbuffet": {
         "level": 87,
         "sets": [

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -524,7 +524,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
 		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
-		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (species.id === 'ditto') return this.sample(['Choice Scarf', 'Quick Powder', 'Sitrus Berry']);
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -524,6 +524,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
 		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
+		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (species.id === 'ditto') return this.sample(['Choice Scarf', 'Quick Powder', 'Sitrus Berry']);
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1285,16 +1285,6 @@
             }
         ]
     },
-    "unown": {
-        "level": 100,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            }
-        ]
-    },
     "wobbuffet": {
         "level": 91,
         "sets": [

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -906,12 +906,12 @@
         "level": 80,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["bodyslam", "crunch", "earthquake", "rest", "sleeptalk"],
-                "abilities": ["Thick Fat"]
+                "role": "Bulky Setup",
+                "movepool": ["bodyslam", "crunch", "curse", "earthquake"],
+                "abilities": ["Immunity", "Thick Fat"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Bulky Support",
                 "movepool": ["bodyslam", "curse", "rest", "sleeptalk"],
                 "abilities": ["Thick Fat"]
             },
@@ -1526,7 +1526,7 @@
                 "abilities": ["Sturdy"]
             },
             {
-                "role": "Staller",
+                "role": "Bulky Attacker",
                 "movepool": ["bravebird", "roost", "spikes", "toxic"],
                 "abilities": ["Sturdy"]
             }
@@ -3489,14 +3489,19 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "toxic", "trick", "willowisp"],
+                "role": "Bulky Support",
+                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "toxic", "willowisp"],
                 "abilities": ["Pressure"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
                 "movepool": ["earthquake", "protect", "shadowsneak", "toxic"],
+                "abilities": ["Pressure"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["focuspunch", "painsplit", "shadowsneak", "substitute"],
                 "abilities": ["Pressure"]
             }
         ]

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -4809,13 +4809,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["bravebird", "foulplay", "roost", "taunt", "toxic", "whirlwind"],
-                "abilities": ["Overcoat"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["foulplay", "roost", "taunt", "toxic", "whirlwind"],
                 "abilities": ["Overcoat"]
             }
         ]
@@ -4957,7 +4952,7 @@
         "level": 74,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Staller",
                 "movepool": ["boltstrike", "dracometeor", "outrage", "roost", "voltswitch"],
                 "abilities": ["Teravolt"]
             },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1285,6 +1285,16 @@
             }
         ]
     },
+    "unown": {
+        "level": 100,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
     "wobbuffet": {
         "level": 91,
         "sets": [

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -571,7 +571,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
 		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
-		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (ability === 'Harvest') return 'Sitrus Berry';
 		if (species.id === 'ditto') return 'Choice Scarf';

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -571,6 +571,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
 		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
+		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (ability === 'Harvest') return 'Sitrus Berry';
 		if (species.id === 'ditto') return 'Choice Scarf';

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -648,8 +648,14 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
 		if (
-			(ability === 'Rough Skin') || (species.id !== 'hooh' && role !== 'Wallbreaker' &&
-				ability === 'Regenerator' && species.baseStats.hp + species.baseStats.def >= 180 && this.randomChance(1, 2))
+			(ability === 'Rough Skin') || (
+				species.id !== 'hooh' &&
+				ability === 'Regenerator' && species.baseStats.hp + species.baseStats.def >= 180 && this.randomChance(1, 2)
+			) || (
+				ability !== 'Regenerator' && !counter.get('setup') && counter.get('recovery') &&
+				this.dex.getEffectiveness('Fighting', species) < 1 &&
+				(species.baseStats.hp + species.baseStats.def) > 200 && this.randomChance(1, 2)
+			)
 		) return 'Rocky Helmet';
 		if (['protect', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (
@@ -732,11 +738,13 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			if (move.startsWith('hiddenpower')) hasHiddenPower = true;
 		}
 
-		if (hasHiddenPower) {
+		if (hasHiddenPower || species.id === 'ditto') {
 			let hpType;
 			for (const move of moves) {
 				if (move.startsWith('hiddenpower')) hpType = move.substr(11);
 			}
+			// Ditto gets IVs to copy Hidden Power Ice
+			if (species.id === 'ditto') hpType = 'ice';
 			if (!hpType) throw new Error(`hasHiddenPower is true, but no Hidden Power move was found.`);
 			const HPivs = this.dex.types.get(hpType).HPivs;
 			let iv: StatID;

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -68,7 +68,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting'),
 			Fire: (movePool, moves, abilities, types, counter) => !counter.get('Fire'),
 			Flying: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Flying') && !['aerodactyl', 'mantine', 'murkrow'].includes(species.id) &&
+				!counter.get('Flying') && !['aerodactyl', 'mandibuzz', 'mantine', 'murkrow'].includes(species.id) &&
 				!movePool.includes('hiddenpowerflying')
 			),
 			Ghost: (movePool, moves, abilities, types, counter) => !counter.get('Ghost'),

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1385,16 +1385,6 @@
             }
         ]
     },
-    "unown": {
-        "level": 100,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            }
-        ]
-    },
     "wobbuffet": {
         "level": 93,
         "sets": [

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -2305,7 +2305,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "highjumpkick", "icepunch", "thunderpunch", "zenheadbutt"],
+                "movepool": ["fakeout", "highjumpkick", "thunderpunch", "zenheadbutt"],
+                "abilities": ["Pure Power"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["fakeout", "highjumpkick", "icepunch", "zenheadbutt"],
                 "abilities": ["Pure Power"]
             }
         ]
@@ -2402,7 +2407,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Staller",
                 "movepool": ["crunch", "destinybond", "earthquake", "icebeam", "protect", "waterfall"],
                 "abilities": ["Speed Boost"]
             }

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1385,6 +1385,16 @@
             }
         ]
     },
+    "unown": {
+        "level": 100,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
     "wobbuffet": {
         "level": 93,
         "sets": [

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -819,11 +819,13 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			if (move.startsWith('hiddenpower')) hasHiddenPower = true;
 		}
 
-		if (hasHiddenPower) {
+		if (hasHiddenPower || species.id === 'ditto') {
 			let hpType;
 			for (const move of moves) {
 				if (move.startsWith('hiddenpower')) hpType = move.substr(11);
 			}
+			// Ditto gets IVs to copy Hidden Power Ice
+			if (species.id === 'ditto') hpType = 'ice';
 			if (!hpType) throw new Error(`hasHiddenPower is true, but no Hidden Power move was found.`);
 			const HPivs = ivs.atk === 0 ? ZeroAttackHPIVs[hpType] : this.dex.types.get(hpType).HPivs;
 			let iv: StatID;

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -627,7 +627,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';
 		if (species.name === 'Talonflame') return 'Sharp Beak';
 		if (species.name === 'Unfezant' || moves.has('focusenergy')) return 'Scope Lens';
-		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (species.name === 'Shuckle') return 'Mental Herb';
 		if (species.name === 'Honchkrow') return 'Life Orb';

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -627,6 +627,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';
 		if (species.name === 'Talonflame') return 'Sharp Beak';
 		if (species.name === 'Unfezant' || moves.has('focusenergy')) return 'Scope Lens';
+		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (species.name === 'Shuckle') return 'Mental Herb';
 		if (species.name === 'Honchkrow') return 'Life Orb';

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1597,16 +1597,6 @@
             }
         ]
     },
-    "unown": {
-        "level": 100,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            }
-        ]
-    },
     "wobbuffet": {
         "level": 95,
         "sets": [

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -2642,7 +2642,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Staller",
                 "movepool": ["crunch", "destinybond", "earthquake", "icebeam", "protect", "waterfall"],
                 "abilities": ["Speed Boost"]
             }
@@ -2652,7 +2652,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Staller",
                 "movepool": ["crunch", "icefang", "protect", "psychicfangs", "waterfall"],
                 "abilities": ["Speed Boost"]
             }

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1597,6 +1597,16 @@
             }
         ]
     },
+    "unown": {
+        "level": 100,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
+                "abilities": ["Levitate"]
+            }
+        ]
+    },
     "wobbuffet": {
         "level": 95,
         "sets": [

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -689,7 +689,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.name === 'Pikachu') return 'Light Ball';
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';
 		if (species.name === 'Unfezant' || moves.has('focusenergy')) return 'Scope Lens';
-		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (species.name === 'Shuckle') return 'Mental Herb';
 		if (species.name === 'Honchkrow') return 'Life Orb';

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -907,11 +907,13 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		}
 
 		// Fix IVs for non-Bottle Cap-able sets
-		if (hasHiddenPower && level < 100) {
+		if ((hasHiddenPower || species.id === 'ditto') && level < 100) {
 			let hpType;
 			for (const move of moves) {
 				if (move.startsWith('hiddenpower')) hpType = move.substr(11);
 			}
+			// Ditto gets IVs to copy Hidden Power Ice
+			if (species.id === 'ditto') hpType = 'ice';
 			if (!hpType) throw new Error(`hasHiddenPower is true, but no Hidden Power move was found.`);
 			const HPivs = ivs.atk === 0 ? ZeroAttackHPIVs[hpType] : this.dex.types.get(hpType).HPivs;
 			let iv: StatID;

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -689,6 +689,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.name === 'Pikachu') return 'Light Ball';
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';
 		if (species.name === 'Unfezant' || moves.has('focusenergy')) return 'Scope Lens';
+		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (species.name === 'Shuckle') return 'Mental Herb';
 		if (species.name === 'Honchkrow') return 'Life Orb';

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -2485,7 +2485,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Earth Power", "Helping Hand", "Icy Wind", "Muddy Water", "Recover", "Yawn"],
+                "movepool": ["Earth Power", "Helping Hand", "Icy Wind", "Muddy Water", "Recover"],
                 "abilities": ["Storm Drain"],
                 "teraTypes": ["Fire"]
             },
@@ -2771,7 +2771,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Air Slash", "Bug Buzz", "Giga Drain", "U-turn"],
+                "movepool": ["Air Slash", "Bug Buzz", "Struggle Bug", "U-turn"],
                 "abilities": ["Tinted Lens"],
                 "teraTypes": ["Bug"]
             },
@@ -3848,7 +3848,7 @@
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Electroweb", "Flamethrower", "Giga Drain", "Knock Off", "Thunderbolt", "U-turn"],
                 "abilities": ["Levitate"],
-                "teraTypes": ["Electric", "Poison"]
+                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },
@@ -6472,6 +6472,12 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Aqua Cutter", "Aqua Jet", "Night Slash", "Psycho Cut"],
+                "abilities": ["Sharpness"],
+                "teraTypes": ["Dark", "Psychic", "Water"]
+            },
+            {
+                "role": "Choice Item user",
+                "movepool": ["Aqua Cutter", "Final Gambit", "Night Slash", "Psycho Cut"],
                 "abilities": ["Sharpness"],
                 "teraTypes": ["Dark", "Psychic", "Water"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -6886,6 +6886,12 @@
                 "movepool": ["Collision Course", "Dragon Claw", "Flare Blitz", "U-turn"],
                 "abilities": ["Orichalcum Pulse"],
                 "teraTypes": ["Fire"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Close Combat", "Dragon Claw", "Flare Blitz", "Protect"],
+                "abilities": ["Orichalcum Pulse"],
+                "teraTypes": ["Fire"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -914,6 +914,12 @@
                 "teraTypes": ["Electric", "Fairy"]
             },
             {
+                "role": "Fast Support",
+                "movepool": ["Alluring Voice", "Calm Mind", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Volt Absorb"],
+                "teraTypes": ["Electric", "Fairy", "Flying"]
+            },
+            {
                 "role": "Tera Blast user",
                 "movepool": ["Calm Mind", "Substitute", "Tera Blast", "Thunderbolt"],
                 "abilities": ["Volt Absorb"],
@@ -1692,6 +1698,23 @@
             }
         ]
     },
+    "stantler": {
+        "level": 92,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Earthquake", "Throat Chop", "Thunder Wave"],
+                "abilities": ["Intimidate"],
+                "teraTypes": ["Fairy", "Ghost", "Ground", "Poison"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Calm Mind", "Earth Power", "Shadow Ball", "Tera Blast"],
+                "abilities": ["Intimidate"],
+                "teraTypes": ["Fairy"]
+            }
+        ]
+    },
     "smeargle": {
         "level": 95,
         "sets": [
@@ -1762,6 +1785,12 @@
                 "movepool": ["Calm Mind", "Scald", "Shadow Ball", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Electric", "Water"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Scald", "Thunderbolt", "Volt Switch"],
+                "abilities": ["Pressure"],
+                "teraTypes": ["Electric", "Flying", "Water"]
             }
         ]
     },
@@ -3103,7 +3132,7 @@
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Ice Punch", "Knock Off", "Supercell Slam", "Volt Switch"],
                 "abilities": ["Motor Drive"],
-                "teraTypes": ["Dark", "Flying", "Ground", "Ice"]
+                "teraTypes": ["Dark", "Flying", "Ground"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1787,7 +1787,7 @@
                 "teraTypes": ["Electric", "Water"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Fast Support",
                 "movepool": ["Calm Mind", "Scald", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Pressure"],
                 "teraTypes": ["Electric", "Flying", "Water"]


### PR DESCRIPTION
Please give a warm welcome to Stantler, the newest NFE addition to Gen 9 Random Battles! It was added following a unanimous council vote.

**Gen 9 Random Battle:**
- Adds Stantler at Level 92 with two sets: a Bulky Attacker set with Body Slam, Thunder Wave, and coverage, and a setup set with Calm Mind, Tera Blast and coverage. Tera Blast is a STAB move regardless of whether it Terastallizes (to Fairy). Both sets hold Eviolite and have Intimidate.
- Electivire: -Tera Ice.
- Raikou: adds a Boots set with Calm Mind, Thunderbolt, Scald, and Volt Switch, running Tera Electric/Water/Flying.
- Jolteon: adds a Boots set with Calm Mind, Thunderbolt, Alluring Voice, and Volt Switch, running Tera Electric/Fairy/Flying.

**Gen 9 Random Doubles Battle:**
- Eelektross: -Tera Electric, +Tera Steel.
- Doubles Support Gastrodon: -Yawn (its other set retains Yawn).
- Specs Yanmega: -Giga Drain, +Struggle Bug.
- Veluza: adds a Choice Scarf set with Final Gambit. It has more HP than Annihilape!
- Koraidon: adds a Life Orb set with Close Combat.

**Champions Random Battle:**
- Regular Gyarados can now roll Moxie with Intimidate.
- Mega Clefable no longer runs Air Slash or Focus Blast.
- Mega Metagross: +Bullet Punch.

**Old Gens Random Battle:**
- In Gens 5–7, Ditto's IVs are modified so its Hidden Power type is Ice instead of Dark. This isn't necessary in Gens 2-4, since Ditto copies its opponent's Hidden Power type there.
- In Gens 6-7, Sharpedo and Mega Sharpedo now always run Protect.
- In Gen 6, Mega Medicham now always runs Fake Out.
- In Gen 5, physically bulky Pokémon with recovery that meet certain conditions can now roll Rocky Helmet some of the time, as in later gens. Some sets' roles have been adjusted to accommodate this.
- In Gens 4–5, Snorlax no longer runs non-Curse sets and can now run a Curse + 3 Attacks set, which rolls between Thick Fat and Immunity.
- In Gens 4-5, Dusknoir no longer runs Choice Band. In Gen 5, it can now run a SubPunch set identical to its Gen 4 set.
- In Gen 3, Rest + Sleep Talk Articuno now runs Toxic instead of Hidden Power Fire.
- In Gen 3, Camerupt no longer runs Rock Slide or Choice Band.
- In Gen 3, Flail Farfetch'd no longer generates alongside Tyranitar.
- In Gen 3, Azumarill now has a SubPunch set, and its Normal-type attacks have been tweaked so that its Choice Band set runs Return/Double-Edge while its other sets run Body Slam/Return.
- In Gen 1, Kangaskhan no longer runs Surf.
- In Gen 1, Omastar now always runs Body Slam, with its final moveslot being 66% Rest and 33% Seismic Toss.