### PR TITLE
Fix July 2026 tier shifts (Thwackey)

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -4804,8 +4804,6 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 	},
 	thwackey: {
 		tier: "NFE",
-		doublesTier: "NFE",
-		natDexTier: "NFE",
 	},
 	rillaboom: {
 		tier: "OU",

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -4803,7 +4803,7 @@ export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable =
 		tier: "LC",
 	},
 	thwackey: {
-		tier: "PU",
+		tier: "NFE",
 		doublesTier: "NFE",
 		natDexTier: "NFE",
 	},


### PR DESCRIPTION
Thwackey originally rose from NFE in January and did not have adequate usage to have made PU, so it should return to NFE. 

https://www.smogon.com/forums/threads/usage-based-tier-update-for-january-2026-february-30-march-40.3775727/
 51   | Thwackey           |  3.052% |