### PR TITLE
Remove Unown from Gens 4-7 Random Battle and remove Gen 8 Random Doubles Battle

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3900,15 +3900,6 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		ruleset: ['PotD', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Illusion Level Mod'],
 	},
 	{
-		name: "[Gen 8] Random Doubles Battle",
-		mod: 'gen8',
-		gameType: 'doubles',
-		team: 'random',
-		searchShow: false,
-		bestOfDefault: true,
-		ruleset: ['PotD', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Illusion Level Mod'],
-	},
-	{
 		name: "[Gen 8] Free-For-All Random Battle",
 		mod: 'gen8',
 		team: 'random',

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1207,16 +1207,6 @@
             }
         ]
     },
-    "unown": {
-        "level": 100,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            }
-        ]
-    },
     "wobbuffet": {
         "level": 87,
         "sets": [

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -524,7 +524,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
 		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
-		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (species.id === 'ditto') return this.sample(['Choice Scarf', 'Quick Powder', 'Sitrus Berry']);
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1285,16 +1285,6 @@
             }
         ]
     },
-    "unown": {
-        "level": 100,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            }
-        ]
-    },
     "wobbuffet": {
         "level": 91,
         "sets": [

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -571,7 +571,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
 		if (species.id === 'delibird' && moves.has('counter')) return 'Focus Sash';
-		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
 		if (ability === 'Harvest') return 'Sitrus Berry';
 		if (species.id === 'ditto') return 'Choice Scarf';

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1385,16 +1385,6 @@
             }
         ]
     },
-    "unown": {
-        "level": 100,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            }
-        ]
-    },
     "wobbuffet": {
         "level": 93,
         "sets": [

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -627,7 +627,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';
 		if (species.name === 'Talonflame') return 'Sharp Beak';
 		if (species.name === 'Unfezant' || moves.has('focusenergy')) return 'Scope Lens';
-		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (species.name === 'Shuckle') return 'Mental Herb';
 		if (species.name === 'Honchkrow') return 'Life Orb';

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1597,16 +1597,6 @@
             }
         ]
     },
-    "unown": {
-        "level": 100,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerpsychic"],
-                "abilities": ["Levitate"]
-            }
-        ]
-    },
     "wobbuffet": {
         "level": 95,
         "sets": [

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -689,7 +689,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.name === 'Pikachu') return 'Light Ball';
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';
 		if (species.name === 'Unfezant' || moves.has('focusenergy')) return 'Scope Lens';
-		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (species.name === 'Shuckle') return 'Mental Herb';
 		if (species.name === 'Honchkrow') return 'Life Orb';


### PR DESCRIPTION
This implements a council vote to remove Unown from Gens 4-7 Random Battle. Approved by Zarel.

It also temporarily removes Gen 8 Random Doubles Battle, as it currently doesn't have sets. It will be reintroduced once its own sets are ready.