### PR TITLE
gen5bw1: Fix Basculin-Blue-Striped

### DIFF
--- a/data/mods/gen5bw1/pokedex.ts
+++ b/data/mods/gen5bw1/pokedex.ts
@@ -394,6 +394,7 @@ export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable 
 	basculinbluestriped: {
 		inherit: true,
 		unreleasedHidden: true,
+		abilities: { 0: "Reckless", 1: "Adaptability", H: "Mold Breaker", S: "Rock Head" },
 	},
 	sandile: {
 		inherit: true,

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -2455,7 +2455,7 @@ export const Chat = new class {
 				buf += `<span class="col abilitycol">${species.abilities['0']}</span>`;
 			}
 			if (species.abilities['H'] && species.abilities['S']) {
-				buf += `<span class="col twoabilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}<br />(${species.abilities['S']})</em></span>`;
+				buf += `<span class="col twoabilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}<br /><span style="display: inline-block;">(${species.abilities['S']})</span></em></span>`;
 			} else if (species.abilities['H']) {
 				buf += `<span class="col abilitycol${species.unreleasedHidden ? ' unreleasedhacol' : ''}"><em>${species.abilities['H']}</em></span>`;
 			} else if (species.abilities['S']) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -736,6 +736,7 @@ export class TeamValidator {
 			}
 		}
 
+		let rockHeadBasculin = false;
 		if (!set.ability) set.ability = 'No Ability';
 		if (ruleTable.has('obtainableabilities')) {
 			if (dex.gen <= 2 || dex.currentMod === 'gen7letsgo') {
@@ -775,6 +776,16 @@ export class TeamValidator {
 					}
 				} else {
 					setSources.isHidden = false;
+				}
+				if (dex.currentMod === 'gen5bw1' && species.id === 'basculinbluestriped' && set.ability === 'Rock Head') {
+					const eventData: EventInfo = {
+						generation: 5, level: 25, gender: "M", ivs: { hp: 20, atk: 31, def: 20, spa: 20, spd: 20, spe: 20 }, nature: "Adamant",
+					};
+					const eventProblems = this.validateEvent(
+						set, setSources, eventData, species, ` to have Rock Head`, `from an in-game trade`
+					);
+					if (eventProblems) problems.push(...eventProblems);
+					rockHeadBasculin = true;
 				}
 			}
 		}
@@ -1056,7 +1067,7 @@ export class TeamValidator {
 				problems.push(`${name} has a Hidden Ability - it can't use moves from before Gen 5.`);
 			}
 			if (
-				species.maleOnlyHidden && setSources.isHidden && setSources.sourcesBefore < 5 &&
+				((species.maleOnlyHidden && setSources.isHidden) || rockHeadBasculin) && setSources.sourcesBefore < 5 &&
 				setSources.sources.every(source => source.charAt(1) === 'E')
 			) {
 				problems.push(`${name} has an unbreedable Hidden Ability - it can't use egg moves.`);

--- a/test/sim/team-validator/events.js
+++ b/test/sim/team-validator/events.js
@@ -195,4 +195,24 @@ describe('Team Validator', () => {
 		assert.false.legalTeam(team, 'gen4anythinggoes');
 		assert.legalTeam(team, 'gen4anythinggoes@@@fullarceusclause');
 	});
+
+	it(`should properly validate Rock Head Basculin-Blue-Striped in gen5bw1`, () => {
+		// only available from an in-game trade - it must be male, at least level 25, have Adamant nature, and IVs 20/31/20/20/20/20
+		let team = [
+			{ species: 'basculinbluestriped', ability: 'rockhead', moves: ['aquajet'], evs: { hp: 1 } },
+		];
+		assert.false.legalTeam(team, 'gen5bw1ou');
+
+		// legal
+		team = [
+			{ species: 'basculinbluestriped', ability: 'rockhead', moves: ['aquajet'], evs: { hp: 1 }, nature: 'Adamant', ivs: { hp: 20, atk: 31, def: 20, spa: 20, spd: 20, spe: 20 } },
+		];
+		assert.legalTeam(team, 'gen5bw1ou');
+
+		// can't have egg moves
+		team = [
+			{ species: 'basculinbluestriped', ability: 'rockhead', moves: ['agility'], evs: { hp: 1 }, nature: 'Adamant', ivs: { hp: 20, atk: 31, def: 20, spa: 20, spd: 20, spe: 20 } },
+		];
+		assert.false.legalTeam(team, 'gen5bw1ou');
+	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-report-validator.3784844/

This additionally fixes an issue where `/dt basculinb,gen5bw1` incorrectly crosses out the special ability when it is actually usable