### PR TITLE
Fix Stadium rulesets

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -5467,7 +5467,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		name: "[Gen 1] Stadium OU",
 		mod: 'gen1stadium',
 		searchShow: false,
-		ruleset: ['Standard', 'Team Preview'],
+		ruleset: ['Standard'],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
@@ -5478,7 +5478,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		desc: `Only Pok&eacute;mon sets that can be rented through the American Stadium Pok&eacute; Cup are legal.`,
 		mod: 'gen1stadium',
 		searchShow: false,
-		ruleset: ['Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Nickname Clause', 'Team Preview', 'Stadium Poke Cup Rentals'],
+		ruleset: ['Standard AG', 'Stadium Poke Cup Rentals', 'Species Clause'],
 		banlist: ['Uber'],
 	},
 	{

--- a/data/mods/gen1stadium/rulesets.ts
+++ b/data/mods/gen1stadium/rulesets.ts
@@ -2,7 +2,7 @@ export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable 
 	standardag: {
 		inherit: true,
 		ruleset: [
-			'Obtainable', 'Exact HP Mod', 'Cancel Mod',
+			'Obtainable', 'Exact HP Mod', 'Cancel Mod', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Team Preview'
 		],
 	},
 	standard: {
@@ -10,7 +10,7 @@ export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable 
 		name: 'Standard',
 		ruleset: [
 			'Standard AG',
-			'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause',
+			'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause',
 		],
 	},
 	stadiumpokecuprentals: {

--- a/data/mods/gen1stadium/rulesets.ts
+++ b/data/mods/gen1stadium/rulesets.ts
@@ -2,7 +2,7 @@ export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable 
 	standardag: {
 		inherit: true,
 		ruleset: [
-			'Obtainable', 'Exact HP Mod', 'Cancel Mod', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Team Preview'
+			'Obtainable', 'Exact HP Mod', 'Cancel Mod', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Team Preview',
 		],
 	},
 	standard: {


### PR DESCRIPTION
Adds Standard AG to gen1stadium rentals, as its missing it (meaning it doesnt have obtainable, Exact HP Mod, nor Cancel Mod), and adds Team Preview to standard AG while also moving Stadium Sleep clause and Freeze Clause Mod up to Standard AG (as they are enforced by stadium itself.)