### PR TITLE
Actually fix `/exportinputlog`'s help text

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -874,7 +874,7 @@ export const commands: Chat.ChatCommands = {
 			this.sendReply(this.tr`Battle input log re-requested.`);
 		}
 	},
-	exportinputloghelp: [`/exportinputlog - Asks players in a battle for permission to export an inputlog. Requires: +`],
+	exportinputloghelp: [`/exportinputlog - Asks players in a battle for permission to export an inputlog. Requires: + % @ ~`],
 
 	importinputlog(target, room, user, connection) {
 		this.checkCan('importinputlog');


### PR DESCRIPTION
Corrects https://github.com/smogon/pokemon-showdown/commit/286dfb5c3f912e33ea6805dc232e4e6e0bcd21bf

"Requires" usually lists _all_ the auth ranks that can use it (exempt * and # unless specially allowed), not just the lowest.