### PR TITLE
Gen 1: Fix critical-hit level calculation

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -37,7 +37,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (ppData.pp < 0) {
 				this.battle.hint("In Gen 1, if a Pokémon is forced to use a move with 0 PP, the move will underflow to have 63 PP.");
 			}
-			ppData.pp = ((ppData.pp % 64) + 64) % 64;
+			ppData.pp = this.battle.trunc(ppData.pp, 6);
 
 			if (ppData.virtual && !this.transformed) {
 				// sync PP from Mimic's slot, or Metronome/Mirror Move that called Mimic
@@ -877,7 +877,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				level *= 2;
 				if (!suppressMessages) this.battle.add('-crit', target);
 			}
-			level = (level % 256 + 256) % 256;
+			level = this.battle.trunc(level, 8);
 
 			if (move.ignoreOffensive) {
 				this.battle.debug('Negating (sp)atk boost/penalty.');
@@ -896,9 +896,9 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (attack >= 1024 || defense >= 1024) {
 					this.battle.hint("In Gen 1, a stat will roll over to a small number if it is larger than 1024.");
 				}
-				attack = this.battle.clampIntRange(Math.floor(attack / 4) % 256, 1);
+				attack = this.battle.clampIntRange(this.battle.trunc(Math.floor(attack / 4), 8), 1);
 				// Defense isn't checked on the cartridge, but we don't want those / 0 bugs on the sim.
-				defense = Math.floor(defense / 4) % 256;
+				defense = this.battle.trunc(Math.floor(defense / 4), 8);
 				if (defense === 0) {
 					this.battle.hint('Pokemon Showdown avoids division by zero by rounding defense up to 1. ' +
 						'In game, the battle would have crashed.');

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -874,7 +874,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (isCrit) {
 				move.ignoreOffensive = true;
 				move.ignoreDefensive = true;
-				level *= 2;
+				level = ((level * 2) % 256 + 256) % 256;
 				if (!suppressMessages) this.battle.add('-crit', target);
 			}
 

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -877,7 +877,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				level *= 2;
 				if (!suppressMessages) this.battle.add('-crit', target);
 			}
-			level = (level % 256 + 256) % 256
+			level = (level % 256 + 256) % 256;
 
 			if (move.ignoreOffensive) {
 				this.battle.debug('Negating (sp)atk boost/penalty.');

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -35,7 +35,10 @@ export const Scripts: ModdedBattleScriptsData = {
 			ppData.pp -= amount;
 
 			if (ppData.pp < 0) {
-				this.battle.hint("In Gen 1, if a Pokémon is forced to use a move with 0 PP, the move will underflow to have 63 PP.");
+				this.battle.hint(
+					"In Gen 1, if a Pokémon is forced to use a move with 0 PP, the move will underflow to have 63 PP.",
+					undefined, this.side,
+				);
 			}
 			ppData.pp = this.battle.trunc(ppData.pp, 6);
 

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -874,9 +874,10 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (isCrit) {
 				move.ignoreOffensive = true;
 				move.ignoreDefensive = true;
-				level = ((level * 2) % 256 + 256) % 256;
+				level *= 2;
 				if (!suppressMessages) this.battle.add('-crit', target);
 			}
+			level = (level % 256 + 256) % 256
 
 			if (move.ignoreOffensive) {
 				this.battle.debug('Negating (sp)atk boost/penalty.');

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -694,9 +694,9 @@ export const Scripts: ModdedBattleScriptsData = {
 			// When either attack or defense are higher than 256, they are both divided by 4 and moded by 256.
 			// This is what causes the rollover bugs.
 			if (attack >= 256 || defense >= 256) {
-				attack = this.battle.clampIntRange(Math.floor(attack / 4) % 256, 1);
+				attack = this.battle.clampIntRange(this.battle.trunc(Math.floor(attack / 4), 8), 1);
 				// Defense isn't checked on the cartridge, but we don't want those / 0 bugs on the sim.
-				defense = this.battle.clampIntRange(Math.floor(defense / 4) % 256, 1);
+				defense = this.battle.clampIntRange(this.battle.trunc(Math.floor(defense / 4), 8), 1);
 			}
 
 			// Self destruct moves halve defense at this point.

--- a/data/mods/gen2/scripts.ts
+++ b/data/mods/gen2/scripts.ts
@@ -638,8 +638,8 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (attack >= 1024 || defense >= 1024) {
 					this.battle.hint("In Gen 2, a stat will roll over to a small number if it is larger than 1024.");
 				}
-				attack = this.battle.clampIntRange(Math.floor(attack / 4) % 256, 1);
-				defense = this.battle.clampIntRange(Math.floor(defense / 4) % 256, 1);
+				attack = this.battle.clampIntRange(this.battle.trunc(Math.floor(attack / 4), 8), 1);
+				defense = this.battle.clampIntRange(this.battle.trunc(Math.floor(defense / 4), 8), 1);
 			}
 
 			// Self destruct moves halve defense at this point.

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3319,7 +3319,7 @@ export class Battle {
 	 * https://www.smogon.com/forums/threads/10352797
 	 */
 	getOverflowedTurnCount(): number {
-		return this.gen >= 8 ? (this.turn - 1) % 256 : this.turn - 1;
+		return this.gen >= 8 ? this.trunc(this.turn - 1, 8) : this.turn - 1;
 	}
 
 	initEffectState(obj: Partial<EffectState>, effectOrder?: number): EffectState {

--- a/test/sim/misc/statdownoverflow.js
+++ b/test/sim/misc/statdownoverflow.js
@@ -31,7 +31,8 @@ describe('[Gen 1] Stat Drop Overflow', () => {
 	});
 
 	it(`Not SafeTwo`, () => {
-		battle = common.gen(1).createBattle([[
+		// set format to avoid truncation changes
+		battle = common.gen(1).createBattle({ formatid: 'gen1ou' }, [[
 			{ species: 'Mewtwo', moves: ['amnesia', 'luckychant'], evs: { 'spa': 255, 'spd': 255 } },
 		], [
 			{ species: 'Slowbro', moves: ['amnesia', 'surf'], evs: { 'spa': 255, 'spd': 255 } },

--- a/test/sim/moves/hyperbeam.js
+++ b/test/sim/moves/hyperbeam.js
@@ -86,7 +86,8 @@ describe(`Hyper Beam [Gen 1]`, () => {
 	});
 
 	it(`Hyper Beam Wrap underflow glitch`, () => {
-		battle = common.gen(1).createBattle({ seed: [0, 0, 0, 4] }, [[
+		// set format to avoid truncation changes
+		battle = common.gen(1).createBattle({ formatid: 'gen1ou', seed: [0, 0, 0, 4] }, [[
 			{ species: 'dragonite', moves: ['agility', 'wrap'] },
 		], [
 			{ species: 'alakazam', moves: ['hyperbeam'] },


### PR DESCRIPTION
https://www.smogon.com/forums/threads/gen-1-level-overflows-during-critical-hits.3785092/
In the post, I wrote:

> To be honest, I feel weird fixing this because these issues affect all kind of values. For example, if you load a Pokémon with a level above 255, it will overflow as well. Many types of values can overflow across different Pokémon generations.