### PR TITLE
Fix memory leak when hotpatching

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -120,7 +120,7 @@ export default configure([
 				...[
 					"Config", "Chat", "Dex", "Teams", "IPTools", "Ladders", "LoginServer", "Monitor",
 					"nodeOomHeapdump", "Punishments", "Rooms", "Sockets", "TeamValidatorAsync",
-					"Tournaments", "Users", "Verifier", "toID", "__version",
+					"TeamValidator", "Tournaments", "Users", "Verifier", "toID", "__version",
 				].map(name => ({
 					name,
 					message: `sim/ and data/ must not use globals; import what you need instead of using the ${name} global.`,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -64,6 +64,19 @@ export function stripHTML(htmlContent: string) {
 }
 
 /**
+ * Normalize a message for the purposes of searching.
+ */
+export function normalize(message: string) {
+	message = message.replace(/'/g, '').replace(/[^A-Za-z0-9]+/g, ' ').trim();
+	if (!/[A-Za-z][A-Za-z]/.test(message)) {
+		message = message.replace(/ */g, '');
+	} else if (!message.includes(' ')) {
+		message = message.replace(/([A-Z])/g, ' $1').trim();
+	}
+	return ' ' + message.toLowerCase() + ' ';
+}
+
+/**
  * Maps numbers to their ordinal string.
  */
 export function formatOrder(place: number) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -313,8 +313,7 @@ export function clampIntRange(num: any, min?: number, max?: number): number {
 }
 
 export function clearRequireCache(options: { exclude?: string[] } = {}) {
-	const excludes = options?.exclude || [];
-	excludes.push('/node_modules/');
+	const excludes = [...(options?.exclude || []), '/node_modules/'];
 
 	for (const path in require.cache) {
 		if (excludes.some(p => path.includes(p))) continue;
@@ -326,13 +325,14 @@ export function clearRequireCache(options: { exclude?: string[] } = {}) {
 }
 
 export function uncacheModuleTree(mod: NodeJS.Module, excludes: string[]) {
-	if (!mod.children?.length || excludes.some(p => mod.filename.includes(p))) return;
-	for (const [i, child] of mod.children.entries()) {
+	const children = mod.children;
+	if (!children?.length || excludes.some(p => mod.filename.includes(p))) return;
+	// delete before recursing in case of circular requires
+	delete (mod as any).children;
+	for (const child of children) {
 		if (excludes.some(p => child.filename.includes(p))) continue;
-		mod.children?.splice(i, 1);
 		uncacheModuleTree(child, excludes);
 	}
-	delete (mod as any).children;
 }
 
 export function deepClone(obj: any): any {

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -677,11 +677,18 @@ export const commands: Chat.ChatCommands = {
 				}
 				this.sendReply('Hotpatching processmanager prototypes...');
 
-				// keep references
-				const cache = { ...require.cache };
-				Utils.clearRequireCache();
+				// grab new prototypes and graft them onto old PM instances.
+				// restore the old require.cache afterwards because it has all
+				// the references to the modules actually being used
+				const pmPath = require.resolve('../../lib/process-manager');
+				const oldPMModule = require.cache[pmPath];
+				delete require.cache[pmPath];
 				const newPM = reRequire('../../lib/process-manager');
-				require.cache = cache;
+				if (oldPMModule) {
+					require.cache[pmPath] = oldPMModule;
+				} else {
+					delete require.cache[pmPath];
+				}
 
 				const protos = [
 					[ProcessManager.QueryProcessManager, newPM.QueryProcessManager],

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -12,6 +12,7 @@
 
 import * as path from 'path';
 import * as child_process from 'child_process';
+import { createRequire } from 'module';
 import { FS, Utils, ProcessManager, SQL } from '../../lib';
 
 interface ProcessData {
@@ -615,6 +616,14 @@ export const commands: Chat.ChatCommands = {
 		target = toID(target);
 		try {
 			Utils.clearRequireCache({ exclude: ['/lib/process-manager'] });
+			// Node retains `module.parent`, which means each hotpatch refers to the `admin.ts`
+			// from the hotpatch before it in an unbroken chain through every hotpatch,
+			// preventing any of them from being GC'd. There's no way to break this reference,
+			// either.
+			//
+			// But createRequire makes a new module to be a parent, breaking this chain and
+			// allowing hotpatched modules to be GC'd.
+			const reRequire = createRequire(__filename);
 			if (target === 'all') {
 				if (lock['all']) {
 					throw new Chat.ErrorMessage(`Hot-patching all has been disabled by ${lock['all'].by} (${lock['all'].reason})`);
@@ -648,9 +657,9 @@ export const commands: Chat.ChatCommands = {
 				const oldPlugins = Chat.plugins;
 				Chat.destroy();
 
-				global.Chat = require('../chat').Chat;
+				global.Chat = reRequire('../chat').Chat;
 				Chat.start(Config.subprocessescache);
-				global.Tournaments = require('../tournaments').Tournaments;
+				global.Tournaments = reRequire('../tournaments').Tournaments;
 
 				this.sendReply("Reloading chat plugins...");
 				Chat.loadPlugins(oldPlugins);
@@ -667,7 +676,7 @@ export const commands: Chat.ChatCommands = {
 				// keep references
 				const cache = { ...require.cache };
 				Utils.clearRequireCache();
-				const newPM = require('../../lib/process-manager');
+				const newPM = reRequire('../../lib/process-manager');
 				require.cache = cache;
 
 				const protos = [
@@ -700,12 +709,12 @@ export const commands: Chat.ChatCommands = {
 				let newProto: any, oldProto: any, message: string;
 				switch (target) {
 				case 'usersp':
-					newProto = require('../users').User.prototype;
+					newProto = reRequire('../users').User.prototype;
 					oldProto = Users.User.prototype;
 					message = 'user prototypes';
 					break;
 				case 'roomsp':
-					newProto = require('../rooms').BasicRoom.prototype;
+					newProto = reRequire('../rooms').BasicRoom.prototype;
 					oldProto = Rooms.BasicRoom.prototype;
 					message = 'rooms prototypes';
 					break;
@@ -751,7 +760,7 @@ export const commands: Chat.ChatCommands = {
 				}
 				this.sendReply("Hotpatching tournaments...");
 
-				global.Tournaments = require('../tournaments').Tournaments;
+				global.Tournaments = reRequire('../tournaments').Tournaments;
 				Chat.loadPlugin(Tournaments, 'tournaments');
 				this.sendReply("DONE");
 			} else if (target === 'formats' || target === 'battles') {
@@ -767,7 +776,7 @@ export const commands: Chat.ChatCommands = {
 				this.sendReply("Hotpatching formats...");
 
 				// reload .sim-dist/dex.js
-				global.Dex = require('../../sim/dex').Dex;
+				global.Dex = reRequire('../../sim/dex').Dex;
 				// rebuild the formats list
 				Rooms.global.formatList = '';
 				// respawn validator processes
@@ -777,14 +786,14 @@ export const commands: Chat.ChatCommands = {
 				// respawn datasearch processes (crashes otherwise, since the Dex data in the PM can be out of date)
 				void Chat.plugins.datasearch?.PM?.respawn();
 				// update teams global
-				global.Teams = require('../../sim/teams').Teams;
+				global.Teams = reRequire('../../sim/teams').Teams;
 				// broadcast the new formats list to clients
 				Rooms.global.sendAll(Rooms.global.formatListText);
 				this.sendReply("DONE");
 			} else if (target === 'loginserver') {
 				this.sendReply("Hotpatching loginserver...");
 				FS('config/custom.css').unwatch();
-				global.LoginServer = require('../loginserver').LoginServer;
+				global.LoginServer = reRequire('../loginserver').LoginServer;
 				this.sendReply("DONE. New login server requests will use the new code.");
 			} else if (target === 'learnsets' || target === 'validator') {
 				if (lock['validator']) {
@@ -797,7 +806,7 @@ export const commands: Chat.ChatCommands = {
 				this.sendReply("Hotpatching validator...");
 				void TeamValidatorAsync.PM.respawn();
 				// update teams global too while we're at it
-				global.Teams = require('../../sim/teams').Teams;
+				global.Teams = reRequire('../../sim/teams').Teams;
 				this.sendReply("DONE. Any battles started after now will have teams be validated according to the new code.");
 			} else if (target === 'punishments') {
 				if (lock['punishments']) {
@@ -805,12 +814,12 @@ export const commands: Chat.ChatCommands = {
 				}
 
 				this.sendReply("Hotpatching punishments...");
-				global.Punishments = require('../punishments').Punishments;
+				global.Punishments = reRequire('../punishments').Punishments;
 				this.sendReply("DONE");
 			} else if (target === 'dnsbl' || target === 'datacenters' || target === 'iptools') {
 				this.sendReply("Hotpatching ip-tools...");
 
-				global.IPTools = require('../ip-tools').IPTools;
+				global.IPTools = reRequire('../ip-tools').IPTools;
 				void IPTools.loadHostsAndRanges();
 				this.sendReply("DONE");
 			} else if (target === 'modlog') {

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -609,13 +609,17 @@ export const commands: Chat.ChatCommands = {
 		await this.parse(`/rebuild`);
 		const lock = Monitor.hotpatchLock;
 		const hotpatches = [
-			'chat', 'formats', 'loginserver', 'punishments', 'dnsbl', 'modlog',
+			'formats', 'chat', 'loginserver', 'punishments', 'dnsbl', 'modlog',
 			'processmanager', 'roomsp', 'usersp',
 		];
 
 		target = toID(target);
 		try {
-			Utils.clearRequireCache({ exclude: ['/lib/process-manager'] });
+			const exclude = ['/lib/process-manager'];
+			if (!['all', 'formats', 'battles', 'validator', 'learnsets'].includes(target)) {
+				exclude.push('/sim/');
+			}
+			Utils.clearRequireCache({ exclude });
 			// Node retains `module.parent`, which means each hotpatch refers to the `admin.ts`
 			// from the hotpatch before it in an unbroken chain through every hotpatch,
 			// preventing any of them from being GC'd. There's no way to break this reference,
@@ -686,7 +690,7 @@ export const commands: Chat.ChatCommands = {
 					[ProcessManager.RawProcessManager, newPM.RawProcessManager],
 					[ProcessManager.QueryProcessWrapper, newPM.QueryProcessWrapper],
 					[ProcessManager.StreamProcessWrapper, newPM.StreamProcessWrapper],
-					[ProcessManager.RawProcessManager, newPM.RawProcessWrapper],
+					[ProcessManager.RawProcessWrapper, newPM.RawProcessWrapper],
 				].map(part => part.map(constructor => constructor.prototype));
 
 				for (const [oldProto, newProto] of protos) {
@@ -777,6 +781,7 @@ export const commands: Chat.ChatCommands = {
 
 				// reload .sim-dist/dex.js
 				global.Dex = reRequire('../../sim/dex').Dex;
+				global.TeamValidator = reRequire('../../sim/team-validator').TeamValidator;
 				// rebuild the formats list
 				Rooms.global.formatList = '';
 				// respawn validator processes
@@ -805,6 +810,7 @@ export const commands: Chat.ChatCommands = {
 
 				this.sendReply("Hotpatching validator...");
 				void TeamValidatorAsync.PM.respawn();
+				// don't update the same-process TeamValidator; that one gets hotpatched with Dex
 				// update teams global too while we're at it
 				global.Teams = reRequire('../../sim/teams').Teams;
 				this.sendReply("DONE. Any battles started after now will have teams be validated according to the new code.");

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -11,7 +11,6 @@
 import * as ConfigLoader from '../config-loader';
 import { ProcessManager, Utils } from '../../lib';
 import type { FormatData } from '../../sim/dex-formats';
-import { TeamValidator } from '../../sim/team-validator';
 
 interface DexOrGroup {
 	abilities: { [k: string]: boolean };
@@ -3111,6 +3110,7 @@ if (!PM.isParentProcess) {
 	}
 
 	global.Dex = require('../../sim/dex').Dex;
+	global.TeamValidator = require('../../sim/team-validator').TeamValidator;
 	global.toID = Dex.toID;
 	Dex.includeData();
 

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -12,7 +12,6 @@ import * as ConfigLoader from '../config-loader';
 import { ProcessManager, Utils } from '../../lib';
 import type { FormatData } from '../../sim/dex-formats';
 import { TeamValidator } from '../../sim/team-validator';
-import { Chat } from '../chat';
 
 interface DexOrGroup {
 	abilities: { [k: string]: boolean };
@@ -2763,7 +2762,7 @@ function runAbilitysearch(target: string, cmd: string, message: string) {
 		// add more general quantifier words to descriptions
 		if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
 		descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
-		const descWordsArray = Chat.normalize(descWords).split(' ');
+		const descWordsArray = Utils.normalize(descWords).split(' ');
 
 		for (const word of searchedWords) {
 			switch (word) {

--- a/server/chat-plugins/responder.ts
+++ b/server/chat-plugins/responder.ts
@@ -73,7 +73,7 @@ export class AutoResponder {
 		const room = this.room;
 		const helpFaqs = roomFaqs[room.roomid];
 		if (!helpFaqs) return null;
-		const normalized = Chat.normalize(question);
+		const normalized = Utils.normalize(question);
 		if (this.data.ignore) {
 			if (this.data.ignore.some(t => new RegExp(t, "i").test(normalized))) {
 				return null;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -30,7 +30,6 @@ import * as ConfigLoader from './config-loader';
 import * as Friends from './friends';
 import { SQL, FS, Utils } from '../lib';
 import * as Artemis from './artemis';
-import { Dex } from '../sim';
 import { PrivateMessages } from './private-messages';
 import * as pathModule from 'path';
 import * as JSX from './chat-jsx';
@@ -1740,8 +1739,7 @@ export const Chat = new class {
 			if (/[^a-z0-9]/.test(dirname)) continue;
 			const dir = FS(`${TRANSLATION_DIRECTORY}/${dirname}`);
 
-			// For some reason, toID() isn't available as a global when this executes.
-			const languageID = Dex.toID(dirname);
+			const languageID = toID(dirname);
 			const files = await dir.readdir();
 			for (const filename of files) {
 				if (!filename.endsWith('.js')) continue;
@@ -2548,21 +2546,6 @@ export const Chat = new class {
 	}
 
 	/**
-	 * Normalize a message for the purposes of applying chat filters.
-	 *
-	 * Not used by PS itself, but feel free to use it in your own chat filters.
-	 */
-	normalize(message: string) {
-		message = message.replace(/'/g, '').replace(/[^A-Za-z0-9]+/g, ' ').trim();
-		if (!/[A-Za-z][A-Za-z]/.test(message)) {
-			message = message.replace(/ */g, '');
-		} else if (!message.includes(' ')) {
-			message = message.replace(/([A-Z])/g, ' $1').trim();
-		}
-		return ' ' + message.toLowerCase() + ' ';
-	}
-
-	/**
 	 * Generates dimensions to fit an image at url into a maximum size of maxWidth x maxHeight,
 	 * preserving aspect ratio.
 	 *
@@ -2668,6 +2651,7 @@ export const Chat = new class {
 // backwards compatibility; don't actually use these
 // they're just there so forks have time to slowly transition
 (Chat as any).escapeHTML = Utils.escapeHTML;
+(Chat as any).normalize = Utils.normalize;
 (Chat as any).splitFirst = Utils.splitFirst;
 (Chat as any).sendPM = Chat.PrivateMessages.send.bind(Chat.PrivateMessages);
 (CommandContext.prototype as any).can = CommandContext.prototype.checkCan;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -173,7 +173,7 @@ const EMOJI_REGEX = /[\p{Emoji_Modifier_Base}\p{Emoji_Presentation}\uFE0F]/u;
 
 const TRANSLATION_DIRECTORY = pathModule.resolve(__dirname, '..', 'translations');
 
-const PM = SQL('chat-db', module, {
+const database = SQL('chat-db', module, {
 	file: global.Config?.nofswriting ? ':memory:' : PLUGIN_DATABASE_PATH,
 });
 
@@ -1561,7 +1561,12 @@ export const Chat = new class {
 	commands!: AnnotatedChatCommands;
 	basePages!: PageTable;
 	pages!: PageTable;
-	readonly destroyHandlers: (() => void)[] = [Artemis.destroy, Friends.destroy];
+	readonly destroyHandlers: (() => void)[] = [
+		Artemis.destroy,
+		Friends.destroy,
+		() => void database.destroy(),
+		() => Chat.PrivateMessages.destroy(),
+	];
 	readonly crqHandlers: { [k: string]: CRQHandler } = {};
 	readonly handlers: { [k: string]: ((...args: any) => any)[] } = Object.create(null);
 	/** The key is the name of the plugin. */
@@ -1821,7 +1826,7 @@ export const Chat = new class {
 	 * All chat plugins share one database.
 	 * Chat.databaseReadyPromise will be truthy if the database is not yet ready.
 	 */
-	database = PM;
+	database = database;
 	databaseReadyPromise: Promise<void> | null = null;
 
 	async prepareDatabase() {
@@ -1857,11 +1862,6 @@ export const Chat = new class {
 		for (const { file } of migrationsToRun) {
 			await this.database.runFile(pathModule.resolve(migrationsFolder, file));
 		}
-
-		Chat.destroyHandlers.push(
-			() => void Chat.database?.destroy(),
-			() => Chat.PrivateMessages.destroy(),
-		);
 	}
 
 	readonly MessageContext = MessageContext;
@@ -2721,7 +2721,7 @@ export interface Monitor {
 	monitor?: MonitorHandler;
 }
 
-if (!PM.isParentProcess) {
+if (!database.isParentProcess) {
 	ConfigLoader.ensureLoaded();
 	global.Monitor = {
 		crashlog(error: Error, source = 'A chat child process', details: AnyObject | null = null) {
@@ -2736,12 +2736,12 @@ if (!PM.isParentProcess) {
 		Monitor.crashlog(err as Error, 'A chat database process');
 	});
 	// eslint-disable-next-line no-eval
-	PM.startRepl(cmd => eval(cmd));
+	database.startRepl(cmd => eval(cmd));
 }
 
 function start(processCount: ConfigLoader.SubProcessesConfig) {
 	if (Config.usesqlite) {
-		PM.spawn(processCount['chatdb'] ?? 1);
+		database.spawn(processCount['chatdb'] ?? 1);
 		Chat.databaseReadyPromise = Chat.prepareDatabase();
 	}
 	Chat.PrivateMessages.start(processCount);

--- a/server/global-variables.d.ts
+++ b/server/global-variables.d.ts
@@ -33,6 +33,7 @@ declare global {
 			Rooms: any;
 			Sockets: any
 			TeamValidatorAsync: any;
+			TeamValidator: any;
 			Tournaments: any;
 			Users: any;
 			Verifier: any;
@@ -52,6 +53,7 @@ declare global {
 	var Rooms: typeof RoomsType.Rooms;
 	var Sockets: typeof SocketsType.Sockets;
 	var TeamValidatorAsync: typeof TeamValidatorAsyncType;
+	var TeamValidator: typeof TeamValidatorAsyncType.TeamValidator;
 	var Tournaments: typeof TournamentsType;
 	var Users: typeof UsersType.Users;
 	var Verifier: typeof VerifierType;

--- a/server/index.ts
+++ b/server/index.ts
@@ -125,6 +125,7 @@ function setupGlobals() {
 
 	const TeamValidatorAsync = require('./team-validator-async');
 	global.TeamValidatorAsync = TeamValidatorAsync;
+	global.TeamValidator = TeamValidatorAsync.TeamValidator;
 
 	global.Sockets = Sockets;
 	if (!Config.lazysockets) {

--- a/server/modlog/index.ts
+++ b/server/modlog/index.ts
@@ -35,7 +35,7 @@ const PUNISHMENTS = [
 	'TOUR BAN', 'TOUR UNBAN', 'UNNAMELOCK', 'PERMABLACKLIST',
 ];
 
-const PM = SQL('modlog', module, {
+const database = SQL('modlog', module, {
 	file: MODLOG_DB_PATH,
 	extension: 'server/modlog/transactions.js',
 	sqliteOptions: Config.modlogsqliteoptions,
@@ -109,7 +109,7 @@ export class Modlog {
 	constructor() {
 		this.queuedEntries = [];
 		this.databaseReady = false;
-		this.database = PM;
+		this.database = database;
 		this.readyPromise = null;
 	}
 
@@ -468,7 +468,7 @@ export class Modlog {
 
 export const mainModlog = new Modlog();
 
-if (!PM.isParentProcess) {
+if (!database.isParentProcess) {
 	ConfigLoader.ensureLoaded();
 	global.Monitor = {
 		crashlog(error: Error, source = 'A modlog child process', details: AnyObject | null = null) {
@@ -488,17 +488,17 @@ export function start(processCount: ConfigLoader.SubProcessesConfig) {
 	if (!Config.usesqlite || !Config.usesqlitemodlog) {
 		return;
 	}
-	PM.spawn(processCount['modlog'] ?? 1);
+	database.spawn(processCount['modlog'] ?? 1);
 	mainModlog.setup();
 }
 
 export function restart() {
-	void PM.respawn();
+	void database.respawn();
 	mainModlog.setup();
 }
 
 export function destroy() {
 	// No need to destroy the PM under normal circumstances, since
 	// hotpatching uses PM.respawn()
-	void PM.destroy();
+	void database.destroy();
 }

--- a/server/private-messages/index.ts
+++ b/server/private-messages/index.ts
@@ -17,7 +17,7 @@ export const MAX_PENDING = 20;
 // this would be in database.ts, but for some weird reason, if the extension and the pm are the same
 // it doesn't work. all the keys in the require() result are there, but they're also set to undefined.
 // no idea why.
-export const PM = SQL('private-messages', module, {
+export const database = SQL('private-messages', module, {
 	file: 'databases/offline-pms.db',
 	extension: 'server/private-messages/database.js',
 });
@@ -31,12 +31,12 @@ export interface ReceivedPM {
 }
 
 export const PrivateMessages = new class {
-	database = PM;
+	database = database;
 	clearInterval = this.nextClear();
 	offlineIsEnabled = Config.usesqlitepms && Config.usesqlite;
 	async sendOffline(to: string, from: User | string, message: string, context?: Chat.CommandContext) {
 		await this.checkCanSend(to, from);
-		const result = await PM.transaction('send', [toID(from), toID(to), message]);
+		const result = await database.transaction('send', [toID(from), toID(to), message]);
 		if (result.error) throw new Chat.ErrorMessage(result.error);
 		if (typeof from === 'object') {
 			from.send(`|pm|${this.getIdentity(from)}|${this.getIdentity(to)}|${message} __[sent offline]__`);
@@ -48,10 +48,10 @@ export const PrivateMessages = new class {
 		return changed;
 	}
 	getSettings(userid: string) {
-		return PM.get(statements.getSettings, [toID(userid)]);
+		return database.get(statements.getSettings, [toID(userid)]);
 	}
 	deleteSettings(userid: string) {
-		return PM.run(statements.deleteSettings, [toID(userid)]);
+		return database.run(statements.deleteSettings, [toID(userid)]);
 	}
 	async checkCanSend(to: string, from: User | string) {
 		from = toID(from);
@@ -91,9 +91,9 @@ export const PrivateMessages = new class {
 	setViewOnly(user: User | string, val: string | null) {
 		const id = toID(user);
 		if (!val) { // if null, no need to save
-			return PM.run(statements.deleteSettings, [id]);
+			return database.run(statements.deleteSettings, [id]);
 		}
-		return PM.run(statements.setBlock, [id, val]);
+		return database.run(statements.setBlock, [id, val]);
 	}
 	checkCanUse(user: User, options = { forceBool: false, isLogin: false }) {
 		if (!this.offlineIsEnabled) {
@@ -137,7 +137,7 @@ export const PrivateMessages = new class {
 		return `${Users.globalAuth.get(toID(user))}${user}`;
 	}
 	nextClear(): NodeJS.Timeout {
-		if (!PM.isParentProcess) return null!;
+		if (!database.isParentProcess) return null!;
 		const time = Date.now();
 		// even though we expire once a week atm, we check once a day
 		const nextMidnight = new Date();
@@ -151,7 +151,7 @@ export const PrivateMessages = new class {
 		return this.clearInterval;
 	}
 	clearSeen() {
-		return PM.run(statements.clearSeen, [Date.now(), SEEN_EXPIRY_TIME]);
+		return database.run(statements.clearSeen, [Date.now(), SEEN_EXPIRY_TIME]);
 	}
 	send(message: string, user: User, pmTarget: User, onlyRecipient: User | null = null) {
 		const buf = `|pm|${user.getIdentity()}|${pmTarget.getIdentity()}|${message}`;
@@ -163,10 +163,10 @@ export const PrivateMessages = new class {
 	}
 	async fetchUnseen(user: User | string): Promise<ReceivedPM[]> {
 		const userid = toID(user);
-		return (await PM.transaction('listNew', [userid])) || [];
+		return (await database.transaction('listNew', [userid])) || [];
 	}
 	async fetchAll(user: User | string): Promise<ReceivedPM[]> {
-		return (await PM.all(statements.fetch, [toID(user)])) || [];
+		return (await database.all(statements.fetch, [toID(user)])) || [];
 	}
 	async renderReceived(user: User) {
 		const all = await this.fetchAll(user);
@@ -203,17 +203,19 @@ export const PrivateMessages = new class {
 		return buf;
 	}
 	clearOffline() {
-		return PM.run(statements.clearDated, [Date.now(), EXPIRY_TIME]);
+		return database.run(statements.clearDated, [Date.now(), EXPIRY_TIME]);
 	}
 	destroy() {
-		void PM.destroy();
+		if (this.clearInterval) clearTimeout(this.clearInterval);
+		this.clearInterval = null!;
+		void database.destroy();
 	}
 	start(processCount: ConfigLoader.SubProcessesConfig) {
 		start(processCount);
 	}
 };
 
-if (!PM.isParentProcess) {
+if (!database.isParentProcess) {
 	ConfigLoader.ensureLoaded();
 	global.Monitor = {
 		crashlog(error: Error, source = 'A private message child process', details: AnyObject | null = null) {
@@ -233,7 +235,7 @@ function start(processCount: ConfigLoader.SubProcessesConfig) {
 	if (!Config.usesqlite) {
 		return;
 	}
-	PM.spawn(processCount['pm'] ?? 1);
+	database.spawn(processCount['pm'] ?? 1);
 	// clear super old pms on startup
-	void PM.run(statements.clearDated, [Date.now(), EXPIRY_TIME]);
+	void database.run(statements.clearDated, [Date.now(), EXPIRY_TIME]);
 }

--- a/server/team-validator-async.ts
+++ b/server/team-validator-async.ts
@@ -103,6 +103,8 @@ if (!PM.isParentProcess) {
 	PM.startRepl((cmd: string) => eval(cmd));
 }
 
+export { TeamValidator };
+
 export function start(processCount: ConfigLoader.SubProcessesConfig) {
 	PM.spawn(processCount['validator'] ?? 1);
 }


### PR DESCRIPTION
After a lot of research, I've finally figured this one out. The important part is using `createRequire` instead of regular `require`, that's the part that fixes the continuous memory leak. As I commented:

```ts
// Node retains `module.parent`, which means each hotpatch refers to the `admin.ts`
// from the hotpatch before it in an unbroken chain through every hotpatch,
// preventing any of them from being GC'd. There's no way to break this reference,
// either.
//
// But createRequire makes a new module to be a parent, breaking this chain and
// allowing hotpatched modules to be GC'd.
const reRequire = createRequire(__filename);
```

The rest of the changes are just other, smaller hotpatch bugs and memory use issues.