### PR TITLE
Declaration that a Pokemon is trying to switch should happen before pursuit goes off.

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -73,6 +73,7 @@ export class BattleActions {
 		const unfaintedActive = oldActive?.hp ? oldActive : null;
 		if (unfaintedActive) {
 			oldActive.beingCalledBack = true;
+			this.battle.add('preswitch', oldActive, oldActive.getFullDetails);
 			let switchCopyFlag: 'copyvolatile' | 'shedtail' | boolean = false;
 			if (sourceEffect && typeof (sourceEffect as Move).selfSwitch === 'string') {
 				switchCopyFlag = (sourceEffect as Move).selfSwitch!;


### PR DESCRIPTION
**Bug Report**
https://www.smogon.com/forums/threads/bug-report-client.3785313/
When a Pokemon is attempting to switch the message that the pokemon is withdrawing should happen before pursuit goes off.
Proof of interaction in Ultra Sun
https://youtu.be/XUlAr1TjSMo?t=855

**Fix**
Add 'preswitch' to battle prior to BeforeSwitchOut event
[Gen9NationalDexDoubles-2026-07-19-bumathelesser-pursuittest (3).html](https://github.com/user-attachments/files/30169160/Gen9NationalDexDoubles-2026-07-19-bumathelesser-pursuittest.3.html)

**Related Client PR**
https://github.com/smogon/pokemon-showdown-client/pull/2721



