### PR TITLE
Gen 3: Ban Raikou in UUBL

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -5406,7 +5406,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'OU', 'Smeargle + Ingrain', 'Baton Pass + Block', 'Baton Pass + Mean Look', 'Baton Pass + Spider Web', 'Flail', 'Reversal',
 			'Baton Pass + Speed Boost', 'Baton Pass + Agility', 'Baton Pass + Dragon Dance', 'Baton Pass + Salac Berry',
 		],
-		unbanlist: ['Soundproof', 'Sand Veil', 'Regice', 'Raikou', 'Porygon2', 'Quick Claw'],
+		unbanlist: ['Soundproof', 'Sand Veil', 'Regice', 'Porygon2', 'Quick Claw'],
 	},
 	{
 		name: "[Gen 3] ZU",


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/bug-report-teambuilder.3785476/

Raikou is now OU proper, not OU by technicality, and thus banned from Gen 3 UUBL.