### PR TITLE
Fix avatars help text

### DIFF
--- a/server/chat-commands/avatars.tsx
+++ b/server/chat-commands/avatars.tsx
@@ -19,7 +19,7 @@ const AVATARS_FILE = 'config/avatars.json';
 type AvatarID = string;
 const AVATAR_FORMATS_MESSAGE = Config.serverid === 'showdown' ?
 	"Custom avatars start with '#', like '#splxraiders'." :
-	"Custom avatars look like 'example.png'. Custom avatars should be put in `config/avatars/`. Your server must be registered for custom avatars to work.";
+	"Custom avatars look like 'example.png'. Custom avatars should be put in `config/avatars/`.";
 
 interface AvatarEntry {
 	timeReceived?: number;
@@ -820,7 +820,7 @@ export const commands: Chat.ChatCommands = {
 	},
 	avatarshelp: [
 		`/avatars - Explains how to change avatars.`,
-		`/avatars [username] - Shows custom avatars available to a user.`,
+		`/avatars [username] - Shows custom avatars available to a user. Requires: % @ ~`,
 		`!avatars - Show everyone that information. Requires: + % @ # ~`,
 	],
 


### PR DESCRIPTION
Doesn't need registration anymore, and avatars <user> is only global staff (read: can't be /cmd by a reg or !cmd by a voice)