### PR TITLE
Remove unnecessary hardcoded redirection code

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -16685,6 +16685,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			contact: 1, charge: 1, protect: 1, mirror: 1, gravity: 1, distance: 1,
 			metronome: 1, nosleeptalk: 1, noassist: 1, failinstruct: 1,
 		},
+		tracksTarget: true,
 		onModifyMove(move, source) {
 			if (!source.volatiles['skydrop']) {
 				move.accuracy = true;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -827,13 +827,7 @@ export class Pokemon {
 				target = possibleTarget;
 			}
 			if (this.battle.activePerHalf > 1 && !move.tracksTarget) {
-				const isCharging = move.flags['charge'] && !this.volatiles['twoturnmove'] &&
-					!(move.id.startsWith('solarb') && ['sunnyday', 'desolateland'].includes(this.effectiveWeather(move))) &&
-					!(move.id === 'electroshot' && ['raindance', 'primordialsea'].includes(this.effectiveWeather(move))) &&
-					!(this.hasItem('powerherb') && move.id !== 'skydrop');
-				if (!isCharging) {
-					target = this.battle.priorityEvent('RedirectTarget', this, this, move, target);
-				}
+				target = this.battle.priorityEvent('RedirectTarget', this, this, move, target);
 			}
 			if (move.smartTarget) {
 				targets = this.getSmartTargets(target, move);

--- a/test/sim/moves/followme.js
+++ b/test/sim/moves/followme.js
@@ -81,6 +81,47 @@ describe('Follow Me', () => {
 		assert.fullHP(battle.p2.active[0]);
 	});
 
+	it(`should redirect charging moves if used on the resolution turn`, () => {
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: "Wynaut", moves: ['sleeptalk'] },
+			{ species: "Wynaut", moves: ['solarbeam'] },
+		], [
+			{ species: "Blissey", moves: ['sleeptalk', 'followme'] },
+			{ species: "Accelgor", moves: ['sleeptalk'] },
+		]]);
+		battle.makeChoices('move sleeptalk, move solarbeam 2', 'move sleeptalk, move sleeptalk');
+		battle.makeChoices('move sleeptalk, move solarbeam 2', 'move followme, move sleeptalk');
+		assert.false.fullHP(battle.p2.active[0]);
+		assert.fullHP(battle.p2.active[1]);
+	});
+
+	it(`should not redirect charging moves if used on the charnging turn`, () => {
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: "Wynaut", moves: ['sleeptalk'] },
+			{ species: "Wynaut", moves: ['solarbeam'] },
+		], [
+			{ species: "Blissey", moves: ['sleeptalk', 'followme'] },
+			{ species: "Accelgor", moves: ['sleeptalk'] },
+		]]);
+		battle.makeChoices('move sleeptalk, move solarbeam 2', 'move followme, move sleeptalk');
+		battle.makeChoices('move sleeptalk, move solarbeam 2', 'move sleeptalk, move sleeptalk');
+		assert.fullHP(battle.p2.active[0]);
+		assert.false.fullHP(battle.p2.active[1]);
+	});
+
+	it(`should redirect charging moves that skip the charging turn`, () => {
+		battle = common.createBattle({ gameType: 'doubles' }, [[
+			{ species: "Wynaut", moves: ['sleeptalk'] },
+			{ species: "Wynaut", ability: 'drought', moves: ['solarbeam'] },
+		], [
+			{ species: "Blissey", moves: ['sleeptalk', 'followme'] },
+			{ species: "Accelgor", moves: ['sleeptalk'] },
+		]]);
+		battle.makeChoices('move sleeptalk, move solarbeam 2', 'move followme, move sleeptalk');
+		assert.false.fullHP(battle.p2.active[0]);
+		assert.fullHP(battle.p2.active[1]);
+	});
+
 	it(`[Gen 3] should continue to redirect moves after the user is knocked out and replaced`, () => {
 		battle = common.gen(3).createBattle({ gameType: 'doubles' }, [[
 			{ species: "Swellow", moves: ['aerialace'] },


### PR DESCRIPTION
These checks are not needed because the `twoturnmove` condition already saves the original location and submits it on the following turn during move selection. It doesn't matter if the move is redirected during the charging turn.

Edit: Redirection during the charging turn is relevant only when the two-turn move is triggered by another move, such as Metronome. The recorded target slot should be of the Follow Me user, which is correct.