### PR TITLE
Revert "Automodchat: Prevent idle or busy staff from being treated as online"

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1079,7 +1079,7 @@ export abstract class BasicRoom {
 	runAutoModchat() {
 		if (!this.settings.autoModchat || this.settings.autoModchat.active) return;
 		// they are staff and online
-		const staff = Object.values(this.users).filter(u => this.auth.atLeast(u, '%') && u.statusType === 'online');
+		const staff = Object.values(this.users).filter(u => this.auth.atLeast(u, '%'));
 		if (!staff.length) {
 			const { time } = this.settings.autoModchat;
 			if (!time || time < 5) {


### PR DESCRIPTION
this change actually broke the feature resulting in unexpected behavior, i had plans to fix this but i got busy and i never got time to work on it, i couldnt even investigate the issue :<, hence it will be better if we revert this change and make automodchat working again as some rooms (including lobby, hindi etc) been having problems with it.

sorry for the delay and troubles!