### PR TITLE
Fix statcalc real for HP and negative EVs

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -1531,7 +1531,7 @@ export const commands: Chat.ChatCommands = {
 		if (realSet) {
 			if (!baseSet) {
 				if (calcHP) {
-					baseStat = Math.ceil((100 * realStat - 10 - level * (Math.floor(ev / 4) + iv + 100)) / (2 * level));
+					baseStat = Math.ceil((100 * (realStat - 10) - level * (Math.floor(ev / 4) + iv + 100)) / (2 * level));
 				} else {
 					if (!positiveMod) {
 						realStat *= (2 + modifier) / 2;

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -1560,7 +1560,10 @@ export const commands: Chat.ChatCommands = {
 					ev = Math.ceil(-1 * (2 * (nature * (baseStat * level + 250) - 50 * Math.ceil(realStat))) / (level * nature));
 				}
 				ev -= 31;
-				if (ev < 0) iv += ev;
+				if (ev < 0) {
+					iv += ev;
+					ev = 0;
+				}
 				ev *= 4;
 				if (iv < 0 || ev > 255) {
 					return this.sendReplyBox(`No valid EV/IV combination possible with given parameters. Maybe try a different nature?${ev}`);


### PR DESCRIPTION
Current calculation formula for real HP is wrong (off by 900 in numerator and 450/level overall)
Can be checked by /statcalc hp lv[any level] [any number] and then /statcalc hp lv[same level] [result]real 