### PR TITLE
Winrates: Fix CCAPM2025 elo floor

### DIFF
--- a/server/chat-plugins/randombattles/winrates.tsx
+++ b/server/chat-plugins/randombattles/winrates.tsx
@@ -190,7 +190,8 @@ async function collectStats(battle: RoomBattle, winner: ID, players: ID[]) {
 		// may need to be raised again if ladder takes off further
 		eloFloor = 1400;
 	}
-	if (!formatData || ((format.mod !== 'gen9ssb' && format.mod !== 'chatbats') && battle.rated < eloFloor) || !winner)
+	if (!formatData || ((format.mod !== 'gen9ssb' && format.mod !== 'chatbats' &&
+		format.mod !== 'ccapm2025') && battle.rated < eloFloor) || !winner)
 		return;
 	checkRollover();
 	for (const p of battle.players) {


### PR DESCRIPTION
I never set an override like chatbats/ssb, so the winrates weren't logging since nobody is at 1400 elo. oops