### PR TITLE
Allow banning types and Tera types in challenge codes

### DIFF
--- a/config/CUSTOM-RULES.md
+++ b/config/CUSTOM-RULES.md
@@ -33,6 +33,12 @@ Bans are just a `-` followed by the thing you want to ban.
 
 `- item: Metronome` - ban an item with an ambiguous name
 
+### Type bans
+
+`- type: Fire` - ban all Pokémon of a specific type
+
+`- teratype: Fire` - ban all Pokémon from using a specific Tera type
+
 ### Species group bans
 
 `- OU` or `- DUU` - ban a tier

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3976,7 +3976,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 			'Perish Song', 'Petaya Berry', 'Pheromosa', 'Photon Geyser', 'Pidgeot-Mega', 'Pinsir-Mega', 'Pixie Plate', 'Plasma Fists',
 			'Play Rough', 'Poison Heal', 'Poison Point', 'Poison Touch', 'Pollen Puff', 'Poltergeist', 'Population Bomb', 'Porygon-Z',
 			'Power Gem', 'Power Trip', 'Power Whip', 'Prankster', 'Precipice Blades', 'Primarina', 'Primordial Sea', 'Prism Armor',
-			'Probopass', 'Protean', 'Protect', 'Psyblade', 'Psychic Fangs', 'Psychic Surge', 'Psychic', 'Psycho Boost', 'Psyshield Bash',
+			'Probopass', 'Protean', 'Protect', 'Psyblade', 'Psychic Fangs', 'Psychic Surge', 'move:Psychic', 'Psycho Boost', 'Psyshield Bash',
 			'Psystrike', 'Pulverizing Pancake', 'Pure Power', 'Purifying Salt', 'Pursuit', 'Pyro Ball', 'Quaquaval', 'Quick Claw',
 			'Quiver Dance', 'Rage Fist', 'Raging Bolt', 'Raging Bull', 'Raging Fury', 'Raikou', 'Rapid Spin', 'Rayquaza', 'Rayquaza-Mega',
 			'Razor Claw', 'Recover', 'Red Card', 'Reflect', 'Regenerator', 'Regice', 'Regidrago', 'Regieleki', 'Regigigas', 'Regirock',
@@ -4045,22 +4045,16 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		bestOfDefault: true,
 		ruleset: ['Max Team Size = 2', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: [
-			'Chandelure-Mega', 'Pokestar Spirit', 'Pecharunt', 'Terapagos', 'Shedinja + Sturdy', 'Cheek Pouch', 'Commander', 'Cursed Body', 'Dry Skin', 'Earth Eater', 'Fur Coat',
-			'Gorilla Tactics', 'Grassy Surge', 'Huge Power', 'Ice Body', 'Iron Barbs', 'Moody', 'Neutralizing Gas', 'Opportunist', 'Parental Bond', 'Perish Body',
-			'Poison Heal', 'Power Construct', 'Pressure', 'Pure Power', 'Rain Dish', 'Rough Skin', 'Sand Spit', 'Sand Stream', 'Seed Sower', 'Spicy Spray', 'Stamina',
-			'Toxic Chain', 'Volt Absorb', 'Water Absorb', 'Wonder Guard', 'Harvest + Jaboca Berry', 'Harvest + Rowap Berry', 'Aguav Berry', 'Assault Vest', 'Berry',
-			'Berry Juice', 'Berserk Gene', 'Black Sludge', 'Chandelurite', 'Chimechite', 'Enigma Berry', 'Figy Berry', 'Gold Berry', 'Iapapa Berry', 'Kangaskhanite',
-			'Leftovers', 'Mago Berry', 'Mawilite',	'Medichamite', 'Scovillainite', 'Starminite', 'Steel Memory', 'Oran Berry', 'Rocky Helmet', 'Shell Bell',
-			'Sitrus Berry', 'Tatsugirinite', 'Wiki Berry',
+			'type:Steel', 'teratype:Steel', 'Chandelure-Mega', 'Pokestar Spirit', 'Pecharunt', 'Terapagos', 'Shedinja + Sturdy', 'Cheek Pouch', 'Commander',
+			'Cursed Body', 'Dry Skin', 'Earth Eater', 'Fur Coat', 'Gorilla Tactics', 'Grassy Surge', 'Huge Power', 'Ice Body', 'Iron Barbs', 'Moody', 'Neutralizing Gas',
+			'Opportunist', 'Parental Bond', 'Perish Body', 'Poison Heal', 'Power Construct', 'Pressure', 'Pure Power', 'Rain Dish', 'Rough Skin', 'Sand Spit',
+			'Sand Stream', 'Seed Sower', 'Spicy Spray', 'Stamina', 'Toxic Chain', 'Volt Absorb', 'Water Absorb', 'Wonder Guard', 'Harvest + Jaboca Berry',
+			'Harvest + Rowap Berry', 'Aguav Berry', 'Assault Vest', 'Berry', 'Berry Juice', 'Berserk Gene', 'Black Sludge', 'Chandelurite', 'Chimechite',
+			'Enigma Berry', 'Figy Berry', 'Gold Berry', 'Iapapa Berry', 'Kangaskhanite', 'Leftovers', 'Mago Berry', 'Mawilite',	'Medichamite', 'Scovillainite',
+			'Starminite', 'Steel Memory', 'Oran Berry', 'Rocky Helmet', 'Shell Bell', 'Sitrus Berry', 'Tatsugirinite', 'Wiki Berry',
 		],
 		onValidateSet(set) {
 			const species = this.dex.species.get(set.species);
-			if (species.types.includes('Steel')) {
-				return [`${species.name} is a Steel-type, which is banned from Metronome Battle.`];
-			}
-			if (set.teraType === 'Steel') {
-				return [`${species.name} has Steel as its Tera type, which is banned from Metronome Battle.`];
-			}
 			if (species.bst > 625) {
 				return [`${species.name} is banned.`, `(Pok\u00e9mon with a BST higher than 625 are banned)`];
 			}

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -1139,7 +1139,7 @@ export class DexFormats {
 		if (id === 'unreleased') return 'unreleased';
 		if (id === 'nonexistent') return 'nonexistent';
 		const matches = [];
-		let matchTypes = ['pokemon', 'move', 'ability', 'item', 'nature', 'tag'];
+		let matchTypes = ['pokemon', 'move', 'ability', 'item', 'type', 'teratype', 'nature', 'tag'];
 		for (const matchType of matchTypes) {
 			if (rule.startsWith(`${matchType}:`)) {
 				matchTypes = [matchType];
@@ -1157,6 +1157,8 @@ export class DexFormats {
 			case 'move': table = this.dex.data.Moves; break;
 			case 'item': table = this.dex.data.Items; break;
 			case 'ability': table = this.dex.data.Abilities; break;
+			case 'type': table = this.dex.data.TypeChart; break;
+			case 'teratype': table = this.dex.data.TypeChart; break;
 			case 'nature': table = this.dex.data.Natures; break;
 			case 'tag':
 				// valid tags

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -718,6 +718,8 @@ export class TeamValidator {
 			} else if (species.requiredTeraType && species.requiredTeraType !== type.name && ruleTable.has('obtainablemisc')) {
 				problems.push(`${species.name}'s Terastal type needs to be ${species.requiredTeraType}.`);
 			}
+			const problem = this.checkTeraType(set, type, setHas);
+			if (problem) problems.push(problem);
 			set.teraType = type.name;
 		} else {
 			delete set.teraType;
@@ -728,6 +730,11 @@ export class TeamValidator {
 
 		problem = this.checkItem(set, item, setHas);
 		if (problem) problems.push(problem);
+
+		for (const typeName of species.types) {
+			problem = this.checkType(set, dex.types.get(typeName), setHas);
+			if (problem) problems.push(problem);
+		}
 		if (ruleTable.has('obtainablemisc')) {
 			if (dex.gen === 4 && item.id === 'griseousorb' && species.num !== 487) {
 				problems.push(`${set.name} cannot hold the Griseous Orb.`, `(In Gen 4, only Giratina could hold the Griseous Orb).`);
@@ -1985,6 +1992,34 @@ export class TeamValidator {
 
 		const tagProblem = this.checkTagRules(set, move, setHas);
 		if (tagProblem !== undefined) return tagProblem;
+
+		return null;
+	}
+
+	checkType(set: PokemonSet, type: TypeInfo, setHas: { [k: string]: true }) {
+		const ruleTable = this.ruleTable;
+
+		setHas['type:' + type.id] = true;
+
+		const banReason = ruleTable.check('type:' + type.id);
+		if (banReason) {
+			return `${set.name}'s type ${type.name} is ${banReason}.`;
+		}
+		if (banReason === '') return null;
+
+		return null;
+	}
+
+	checkTeraType(set: PokemonSet, teraType: TypeInfo, setHas: { [k: string]: true }) {
+		const ruleTable = this.ruleTable;
+
+		setHas['teratype:' + teraType.id] = true;
+
+		const banReason = ruleTable.check('teratype:' + teraType.id);
+		if (banReason) {
+			return `${set.name}'s Tera type ${teraType.name} is ${banReason}.`;
+		}
+		if (banReason === '') return null;
 
 		return null;
 	}


### PR DESCRIPTION
https://www.smogon.com/forums/threads/allow-banning-of-certain-tera-types-as-rules.3786017/

CHANGES:
Added `type` and `teraType` to matchTypes in dex-formats.ts
Added `checkType` and `checkTeraType` functions to team-validator.ts
Added type ban and Tera type bans to CUSTOM-RULES.md
Changed Broken Cup's ban of `Psychic` to `move:Psychic` in formats.ts
Changed Metronome Battle to ban `type:Steel` and `teratype:Steel` directly in the banlist in formats.ts

There might be an issue with the list of matchTypes, since the user has to explicitly mention either
`-type:[type]`
`-teratype:[type]`
in order to ban a specific type or Tera type, instead of just writing out `-[type]`.