### PR TITLE
Use utility types to define ModdedBattle types

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1129,6 +1129,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 				}
 				this.constructor.prototype.endTurn.call(this);
 			},
+			// @ts-expect-error Hack
 			getAllActive(includeFainted, includeCommanding) {
 				const pokemonList: Pokemon[] = [];
 				for (const side of this.sides) {

--- a/data/mods/champions/scripts.ts
+++ b/data/mods/champions/scripts.ts
@@ -322,7 +322,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			const move = this.dex.getActiveMove(moveOrMoveName);
 			let hitResult: boolean | number | null = true;
-			let moveData = hitEffect!;
+			let moveData = hitEffect as ActiveMove;
 			if (!moveData) moveData = move;
 			if (!moveData.flags) moveData.flags = {};
 			if (move.target === 'all' && !isSelf) {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -62,77 +62,40 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.modifiedStats![statName] = modifiedStats;
 		},
 		// In generation 1, boosting function increases the stored modified stat and checks for opponent's status.
-		boostBy(boost) {
-			let changed: boolean | number = false;
-			let i: BoostID;
-			for (i in boost) {
-				const delta = boost[i];
-				if (delta === undefined) continue;
-				if (delta > 0 && this.boosts[i] >= 6) continue;
-				if (delta < 0 && this.boosts[i] <= -6) continue;
-				if (i === 'evasion' || i === 'accuracy') {
-					this.boosts[i] += delta;
-					if (this.boosts[i] > 6) {
-						this.boosts[i] = 6;
-					}
-					if (this.boosts[i] < -6) {
-						this.boosts[i] = -6;
-					}
-					changed = true;
-					continue;
-				}
-				// Stat being modified is not evasion or accuracy, so change modifiedStats.
+		boostBy(boosts) {
+			boosts = this.getCappedBoost(boosts);
+			let delta = 0;
+			let boostName: BoostID;
+			for (boostName in boosts) {
+				delta = boosts[boostName]!;
+				this.boosts[boostName] += delta;
+				if (boostName === 'evasion' || boostName === 'accuracy') continue;
 				if (delta > 0) {
-					if (this.modifiedStats![i] === 999) {
-						// Intended max stat value
-						this.boosts[i] += delta;
-						if (this.boosts[i] > 6) {
-							this.boosts[i] = 6;
-						}
-						this.boosts[i]--;
-						// changed = 0 corresponds to increasing stats at 999 (or decreasing at 1).
-						changed = 0;
-					} else {
-						this.boosts[i] += delta;
-						if (this.boosts[i] > 6) {
-							this.boosts[i] = 6;
-						}
-						changed = true;
+					if (this.modifiedStats![boostName] === 999) {
+						this.boosts[boostName]--;
+						delta = 0;
+					}
+				} else if (delta < 0) {
+					if (this.modifiedStats![boostName] === 1) {
+						this.boosts[boostName]++;
+						delta = 0;
 					}
 				}
-				if (delta < 0) {
-					if (this.modifiedStats![i] === 1) {
-						// Minimum stat value
-						this.boosts[i] += delta;
-						if (this.boosts[i] < -6) {
-							this.boosts[i] = -6;
-						}
-						this.boosts[i]++;
-						// changed = 0 corresponds to increasing stats at 999 (or decreasing at 1).
-						changed = 0;
-					} else {
-						this.boosts[i] += delta;
-						if (this.boosts[i] < -6) {
-							this.boosts[i] = -6;
-						}
-						changed = true;
-					}
-				}
-				if (changed) {
+				if (delta) {
 					// Recalculate the modified stat
-					this.modifiedStats![i] = this.storedStats[i];
-					if (this.boosts[i] >= 0) {
-						this.modifyStat!(i, [1, 1.5, 2, 2.5, 3, 3.5, 4][this.boosts[i]]);
+					this.modifiedStats![boostName] = this.storedStats[boostName];
+					if (this.boosts[boostName] >= 0) {
+						this.modifyStat!(boostName, [1, 1.5, 2, 2.5, 3, 3.5, 4][this.boosts[boostName]]);
 					} else {
-						this.modifyStat!(i, [100, 66, 50, 40, 33, 28, 25][-this.boosts[i]] / 100);
+						this.modifyStat!(boostName, [100, 66, 50, 40, 33, 28, 25][-this.boosts[boostName]] / 100);
 					}
-					if (delta > 0 && this.modifiedStats![i] > 999) {
+					if (delta > 0 && this.modifiedStats![boostName] > 999) {
 						// Cap the stat at 999
-						this.modifiedStats![i] = 999;
+						this.modifiedStats![boostName] = 999;
 					}
 				}
 			}
-			return changed;
+			return delta;
 		},
 		clearBoosts() {
 			let i: BoostID;
@@ -371,7 +334,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 		// This function attempts a move hit and returns the attempt result before the actual hit happens.
 		// It deals with partial trapping weirdness and accuracy bugs as well.
-		tryMoveHit(target, pokemon, move) {
+		tryMoveHit(target: Pokemon, pokemon, move) {
 			let damage: number | false | undefined = 0;
 
 			// Add Thrashing effect before the move does damage, or add confusion if Thrash effect is ending
@@ -529,12 +492,15 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 		// It deals with the actual move hit, as the name indicates, dealing damage and/or effects.
 		// This function also deals with the Gen 1 Substitute behaviour on the hitting process.
-		moveHit(target, pokemon, move, moveData, isSecondary, isSelf) {
+		moveHit(target: Pokemon | null, pokemon, move, hitEffect, isSecondary, isSelf) {
 			let damage: number | false | null | undefined = 0;
 
 			if (!isSecondary && !isSelf) this.battle.setActiveMove(move, pokemon, target);
 			let hitResult: number | boolean = true;
+
+			let moveData = hitEffect as ActiveMove;
 			if (!moveData) moveData = move;
+			if (!moveData.flags) moveData.flags = {};
 
 			if (move.ignoreImmunity === undefined) {
 				move.ignoreImmunity = (move.category === 'Status');

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -42,25 +42,16 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 		},
 		// Stadium's fixed boosting function.
-		boostBy(boost) {
-			let changed = false;
-			let i: BoostID;
-			for (i in boost) {
-				let delta = boost[i];
-				if (delta === undefined) continue;
-				this.boosts[i] += delta;
-				if (this.boosts[i] > 6) {
-					delta -= this.boosts[i] - 6;
-					this.boosts[i] = 6;
-				}
-				if (this.boosts[i] < -6) {
-					delta -= this.boosts[i] - (-6);
-					this.boosts[i] = -6;
-				}
-				if (delta) changed = true;
+		boostBy(boosts) {
+			boosts = this.getCappedBoost(boosts);
+			let delta = 0;
+			let boostName: BoostID;
+			for (boostName in boosts) {
+				delta = boosts[boostName]!;
+				this.boosts[boostName] += delta;
 			}
 			this.recalculateStats!();
-			return changed;
+			return delta;
 		},
 		// Remove stat recalculation logic from gen 1
 		clearBoosts() {
@@ -234,7 +225,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.battle.runEvent('AfterMoveSecondarySelf', pokemon, target, move);
 			return true;
 		},
-		tryMoveHit(target, pokemon, move) {
+		tryMoveHit(target: Pokemon, pokemon, move) {
 			let damage: number | false | undefined = 0;
 
 			// First, check if the target is semi-invulnerable
@@ -370,13 +361,16 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			return damage;
 		},
-		moveHit(target, pokemon, moveOrMoveName, moveData, isSecondary, isSelf) {
+		moveHit(target: Pokemon | null, pokemon, moveOrMoveName, hitEffect, isSecondary, isSelf) {
 			let damage: number | false | null | undefined = 0;
 			const move = this.dex.getActiveMove(moveOrMoveName);
 
 			if (!isSecondary && !isSelf) this.battle.setActiveMove(move, pokemon, target);
 			let hitResult: number | boolean = true;
+
+			let moveData = hitEffect as ActiveMove;
 			if (!moveData) moveData = move;
+			if (!moveData.flags) moveData.flags = {};
 
 			if (move.ignoreImmunity === undefined) {
 				move.ignoreImmunity = (move.category === 'Status');

--- a/data/mods/gen2/scripts.ts
+++ b/data/mods/gen2/scripts.ts
@@ -7,7 +7,7 @@ export const Scripts: ModdedBattleScriptsData = {
 	gen: 2,
 	pokemon: {
 		inherit: true,
-		getStat(statName, unboosted, unmodified, fastReturn) {
+		getStat(statName, unboosted, unmodified) {
 			// @ts-expect-error type checking prevents 'hp' from being passed, but we're paranoid
 			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
 
@@ -41,7 +41,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// Gen 2 caps stats at 999 and min is 1.
 			stat = this.battle.clampIntRange(stat, 1, 999);
-			if (fastReturn) return stat;
+			// if (fastReturn) return stat;
 
 			// Screens
 			if (!unboosted) {
@@ -138,7 +138,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
 			if (!move.selfSwitch && pokemon.side.foe.active[0].hp) this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
 		},
-		tryMoveHit(target, pokemon, move) {
+		tryMoveHit(target: Pokemon, pokemon, move) {
 			const positiveBoostTable = [1, 1.33, 1.66, 2, 2.33, 2.66, 3];
 			const negativeBoostTable = [1, 0.75, 0.6, 0.5, 0.43, 0.36, 0.33];
 			const doSelfDestruct = true;
@@ -300,12 +300,15 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			return damage;
 		},
-		moveHit(target, pokemon, move, moveData, isSecondary, isSelf) {
+		moveHit(target: Pokemon | null, pokemon, move, hitEffect, isSecondary, isSelf) {
 			let damage: number | false | null | undefined = undefined;
 			move = this.dex.getActiveMove(move);
 
-			if (!moveData) moveData = move;
 			let hitResult: boolean | number | null = true;
+
+			let moveData = hitEffect as ActiveMove;
+			if (!moveData) moveData = move;
+			if (!moveData.flags) moveData.flags = {};
 
 			if (move.target === 'all' && !isSelf) {
 				hitResult = this.battle.singleEvent('TryHitField', moveData, {}, target, pokemon, move);

--- a/data/mods/gen2stadium2/scripts.ts
+++ b/data/mods/gen2stadium2/scripts.ts
@@ -6,7 +6,7 @@ export const Scripts: ModdedBattleScriptsData = {
 	gen: 2,
 	pokemon: {
 		inherit: true,
-		getStat(statName, unboosted, unmodified, fastReturn) {
+		getStat(statName, unboosted, unmodified) {
 			// @ts-expect-error type checking prevents 'hp' from being passed, but we're paranoid
 			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
 
@@ -37,7 +37,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// Gen 2 caps stats at 999 and min is 1.
 			stat = this.battle.clampIntRange(stat, 1, 999);
-			if (fastReturn) return stat;
+			// if (fastReturn) return stat;
 
 			// Screens
 			if (!unboosted) {
@@ -65,7 +65,7 @@ export const Scripts: ModdedBattleScriptsData = {
 	// Stadium 2 shares gen 2 code but it fixes some problems with it.
 	actions: {
 		inherit: true,
-		tryMoveHit(target, pokemon, move) {
+		tryMoveHit(target: Pokemon, pokemon, move) {
 			const positiveBoostTable = [1, 1.33, 1.66, 2, 2.33, 2.66, 3];
 			const negativeBoostTable = [1, 0.75, 0.6, 0.5, 0.43, 0.36, 0.33];
 			const doSelfDestruct = true;

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -261,7 +261,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			return true;
 		},
-		tryMoveHit(target, pokemon, move) {
+		tryMoveHit(target: Pokemon, pokemon, move) {
 			this.battle.setActiveMove(move, pokemon, target);
 			let naturalImmunity = false;
 			let accPass = true;

--- a/data/mods/gen9ssb/scripts.ts
+++ b/data/mods/gen9ssb/scripts.ts
@@ -1400,7 +1400,8 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			const move = this.dex.getActiveMove(moveOrMoveName);
 			let hitResult: boolean | number | null = true;
-			const moveData = hitEffect || move;
+			let moveData = hitEffect as ActiveMove;
+			if (!moveData) moveData = move;
 			if (!moveData.flags) moveData.flags = {};
 			if (move.target === 'all' && !isSelf) {
 				hitResult = this.battle.singleEvent('TryHitField', moveData, {}, target || null, pokemon, move);

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1887,7 +1887,7 @@ export class BattleActions {
 		return megaEvolution && megaEvolution !== species.name ? megaEvolution : null;
 	}
 
-	canUltraBurst(pokemon: Pokemon) {
+	canUltraBurst(pokemon: Pokemon): string | null {
 		if (['Necrozma-Dawn-Wings', 'Necrozma-Dusk-Mane'].includes(pokemon.baseSpecies.name) &&
 			pokemon.getItem().id === 'ultranecroziumz') {
 			return "Necrozma-Ultra";

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -6,7 +6,7 @@ type Mutable<T> = {
 
 type MethodsOf<T> = {
 	[K in keyof T as NonNullable<T[K]> extends (...args: any[]) => any ? K : never]: T[K];
-}
+};
 
 type Battle = import('./battle').Battle;
 type BattleQueue = import('./battle-queue').BattleQueue;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -4,6 +4,12 @@ type Mutable<T> = {
 	-readonly [P in keyof T]: T[P];
 };
 
+type MethodKeys<T> = {
+	[K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
+}[keyof T];
+
+type MethodsOf<T> = Pick<T, MethodKeys<T>>;
+
 type Battle = import('./battle').Battle;
 type BattleQueue = import('./battle-queue').BattleQueue;
 type BattleActions = import('./battle-actions').BattleActions;
@@ -158,257 +164,54 @@ interface BattleScriptsData {
 	gen: number;
 }
 
-interface ModdedBattleActions {
-	inherit?: true;
-	afterMoveSecondaryEvent?: (this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => undefined;
-	applyRecoilDamage?: (this: BattleActions, damageDealt: number, move: Move, pokemon: Pokemon) => number | null;
-	canMegaEvo?: (this: BattleActions, pokemon: Pokemon) => string | undefined | null;
-	canMegaEvoX?: (this: BattleActions, pokemon: Pokemon) => string | undefined | null;
-	canMegaEvoY?: (this: BattleActions, pokemon: Pokemon) => string | undefined | null;
-	canTerastallize?: (this: BattleActions, pokemon: Pokemon) => string | null;
-	canUltraBurst?: (this: BattleActions, pokemon: Pokemon) => string | null;
-	canZMove?: (this: BattleActions, pokemon: Pokemon) => ZMoveOptions | void;
-	forceSwitch?: (
-		this: BattleActions, damage: SpreadMoveDamage, targets: SpreadMoveTargets, source: Pokemon,
-		move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean, isSelf?: boolean
-	) => SpreadMoveDamage;
-	getActiveMaxMove?: (this: BattleActions, move: Move, pokemon: Pokemon) => ActiveMove;
-	getActiveZMove?: (this: BattleActions, move: Move, pokemon: Pokemon) => ActiveMove;
-	getMaxMove?: (this: BattleActions, move: Move, pokemon: Pokemon) => Move | undefined;
-	getSpreadDamage?: (
-		this: BattleActions, damage: SpreadMoveDamage, targets: SpreadMoveTargets, source: Pokemon,
-		move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean, isSelf?: boolean
-	) => SpreadMoveDamage;
-	getZMove?: (this: BattleActions, move: Move, pokemon: Pokemon, skipChecks?: boolean) => string | true | undefined;
-	hitStepAccuracy?: (this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[];
-	hitStepBreakProtect?: (this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => undefined;
-	hitStepMoveHitLoop?: (this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => SpreadMoveDamage;
-	hitStepTryImmunity?: (this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[];
-	hitStepStealBoosts?: (this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => undefined;
-	hitStepTryHitEvent?: (this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => (boolean | '')[];
-	hitStepInvulnerabilityEvent?: (
-		this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove
-	) => boolean[];
-	hitStepTypeImmunity?: (this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[];
-	moveHit?: (
-		this: BattleActions, target: Pokemon | null, pokemon: Pokemon, move: ActiveMove,
-		moveData?: ActiveMove, isSecondary?: boolean, isSelf?: boolean
-	) => number | undefined | false;
-	runAction?: (this: BattleActions, action: Action) => void;
-	runMegaEvo?: (this: BattleActions, pokemon: Pokemon) => boolean;
-	runMegaEvoX?: (this: BattleActions, pokemon: Pokemon) => boolean;
-	runMegaEvoY?: (this: BattleActions, pokemon: Pokemon) => boolean;
-	runMove?: (
-		this: BattleActions, moveOrMoveName: Move | string, pokemon: Pokemon, targetLoc: number, options?: {
-			sourceEffect?: Effect | null, zMove?: string, externalMove?: boolean,
-			maxMove?: string, originalTarget?: Pokemon,
-		}
-	) => void;
-	runMoveEffects?: (
-		this: BattleActions, damage: SpreadMoveDamage, targets: SpreadMoveTargets, source: Pokemon,
-		move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean, isSelf?: boolean
-	) => SpreadMoveDamage;
-	runSwitch?: (this: BattleActions, pokemon: Pokemon) => boolean;
-	runZPower?: (this: BattleActions, move: ActiveMove, pokemon: Pokemon) => void;
-	secondaries?: (
-		this: BattleActions, targets: SpreadMoveTargets, source: Pokemon, move: ActiveMove,
-		moveData: ActiveMove, isSelf?: boolean
-	) => void;
-	selfDrops?: (
-		this: BattleActions, targets: SpreadMoveTargets, source: Pokemon,
-		move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean
-	) => void;
-	spreadMoveHit?: (
-		this: BattleActions, targets: SpreadMoveTargets, pokemon: Pokemon, move: ActiveMove,
-		moveData?: ActiveMove, isSecondary?: boolean, isSelf?: boolean
-	) => [SpreadMoveDamage, SpreadMoveTargets];
-	switchIn?: (
-		this: BattleActions, pokemon: Pokemon, pos: number, sourceEffect: Effect | null, isDrag?: boolean
-	) => boolean | "pursuitfaint";
-	targetTypeChoices?: (this: BattleActions, targetType: string) => boolean;
-	terastallize?: (this: BattleActions, pokemon: Pokemon) => void;
-	tryMoveHit?: (
-		this: BattleActions, target: Pokemon, pokemon: Pokemon, move: ActiveMove
-	) => number | undefined | false | '';
-	tryPrimaryHitEvent?: (
-		this: BattleActions, damage: SpreadMoveDamage, targets: SpreadMoveTargets, pokemon: Pokemon,
-		move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean
-	) => SpreadMoveDamage;
-	trySpreadMoveHit?: (
-		this: BattleActions, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove, notActive?: boolean
-	) => boolean;
-	useMove?: (
-		this: BattleActions, move: Move, pokemon: Pokemon, options?: {
-			target?: Pokemon | null, sourceEffect?: Effect | null,
-			zMove?: string, maxMove?: string,
-		}
-	) => boolean;
-	useMoveInner?: (
-		this: BattleActions, move: Move, pokemon: Pokemon, options?: {
-			target?: Pokemon | null, sourceEffect?: Effect | null,
-			zMove?: string, maxMove?: string,
-		}
-	) => boolean;
-	getDamage?: (
-		this: BattleActions, pokemon: Pokemon, target: Pokemon, move: string | number | ActiveMove, suppressMessages: boolean
-	) => number | undefined | null | false;
-	modifyDamage?: (
-		this: BattleActions, baseDamage: number, pokemon: Pokemon, target: Pokemon, move: ActiveMove, suppressMessages?: boolean
-	) => void;
-
-	// oms
-	mutateOriginalSpecies?: (this: BattleActions, species: Species, deltas: AnyObject) => Species;
-	getFormeChangeDeltas?: (this: BattleActions, formeChangeSpecies: Species, pokemon?: Pokemon) => AnyObject;
-	getMixedSpecies?: (this: BattleActions, originalName: string, megaName: string, pokemon?: Pokemon) => Species;
-}
-
-interface ModdedBattleSide {
-	inherit?: true;
-	addSideCondition?: (
-		this: Side, status: string | Condition, source: Pokemon | 'debug' | null, sourceEffect: Effect | null
-	) => boolean;
-	allies?: (this: Side, all?: boolean) => Pokemon[];
-	canDynamaxNow?: (this: Side) => boolean;
-	chooseSwitch?: (this: Side, slotText?: string) => any;
-	getChoice?: (this: Side) => string;
-	getRequestData?: (this: Side, forAlly?: boolean) => { name: string, id: ID, pokemon: AnyObject[] };
-}
-
-interface ModdedBattlePokemon {
-	inherit?: true;
-	lostItemForDelibird?: Item | null;
-	boostBy?: (this: Pokemon, boost: SparseBoostsTable) => boolean | number;
-	clearBoosts?: (this: Pokemon) => void;
-	clearVolatile?: (this: Pokemon, includeSwitchFlags?: boolean) => void;
-	calculateStat?: (this: Pokemon, statName: StatIDExceptHP, boost: number, modifier?: number) => number;
-	cureStatus?: (this: Pokemon, silent?: boolean) => boolean;
-	deductPP?: (
-		this: Pokemon, move: string | Move, amount?: number | null, target?: Pokemon | null | false
-	) => number;
-	eatItem?: (this: Pokemon, force?: boolean, source?: Pokemon, sourceEffect?: Effect) => boolean;
-	effectiveWeather?: (this: Pokemon, sourceEffect?: Effect, message?: string | boolean) => ID;
-	formeChange?: (
-		this: Pokemon, speciesId: string | Species, source: Effect, isPermanent?: boolean, abilitySlot?: string,
-		message?: string,
-	) => boolean;
-	hasType?: (this: Pokemon, type: string | string[]) => boolean;
-	getAbility?: (this: Pokemon) => Ability;
-	getActionSpeed?: (this: Pokemon) => number;
-	getItem?: (this: Pokemon) => Item;
-	getMoveRequestData?: (this: Pokemon) => {
-		moves: { move: string, id: ID, target?: string, disabled?: boolean }[],
-		maybeDisabled?: boolean, trapped?: boolean, maybeTrapped?: boolean,
-		canMegaEvo?: boolean, canUltraBurst?: boolean, canZMove?: ZMoveOptions,
-	};
-	getMoves?: (this: Pokemon, lockedMove?: string | null, restrictData?: boolean) => {
-		move: string, id: string, disabled?: string | boolean, disabledSource?: string,
-		target?: string, pp?: number, maxpp?: number,
-	}[];
-	getMoveTargets?: (this: Pokemon, move: ActiveMove, target: Pokemon) => {
-		targets: Pokemon[], pressureTargets: Pokemon[],
-	};
-	getStat?: (
-		this: Pokemon, statName: StatIDExceptHP, unboosted?: boolean, unmodified?: boolean, fastReturn?: boolean
-	) => number;
-	getTypes?: (this: Pokemon, excludeAdded?: boolean, preterastallized?: boolean) => string[];
-	getWeight?: (this: Pokemon) => number;
-	hasAbility?: (this: Pokemon, ability: string | string[]) => boolean;
-	hasItem?: (this: Pokemon, item: string | string[]) => boolean;
-	isGrounded?: (this: Pokemon, negateImmunity: boolean | undefined) => boolean | null;
-	modifyStat?: (this: Pokemon, statName: StatIDExceptHP, modifier: number) => void;
-	moveUsed?: (this: Pokemon, move: ActiveMove, targetLoc?: number) => void;
-	recalculateStats?: (this: Pokemon) => void;
-	runEffectiveness?: (this: Pokemon, move: ActiveMove) => number;
-	runImmunity?: (this: Pokemon, source: ActiveMove | string, message?: string | boolean) => boolean;
-	setAbility?: (
-		this: Pokemon, ability: string | Ability, source?: Pokemon | null, sourceEffect?: Effect | null,
-		isFromFormeChange?: boolean, isTransform?: boolean
-	) => ID | false | null;
-	setItem?: (this: Pokemon, item: string | Item, source?: Pokemon, effect?: Effect) => boolean;
-	setStatus?: (
-		this: Pokemon, status: string | Condition, source: Pokemon | null,
-		sourceEffect: Effect | null, ignoreImmunities: boolean
-	) => boolean;
-	takeItem?: (this: Pokemon, source: Pokemon | undefined) => boolean | Item;
-	transformInto?: (this: Pokemon, pokemon: Pokemon, effect: Effect | null) => boolean;
-	useItem?: (this: Pokemon, source?: Pokemon, sourceEffect?: Effect) => boolean;
-	ignoringAbility?: (this: Pokemon) => boolean;
-	ignoringItem?: (this: Pokemon) => boolean;
+type ModdedBattleActions = Partial<BattleActions> & {
+	inherit?: true,
 
 	// OM
-	getLinkedMoves?: (this: Pokemon, ignoreDisabled?: boolean) => [ActiveMove, ActiveMove] | [];
-	hasLinkedMove?: (this: Pokemon, move: ActiveMove) => boolean;
-	getIsMoveLocked?: (this: Pokemon) => boolean;
-	getWillLockMove?: (this: Pokemon) => boolean;
-	getCanLinkMove?: (this: Pokemon, move: ActiveMove) => boolean;
+	mutateOriginalSpecies?: (species: Species, deltas: AnyObject) => Species,
+	getFormeChangeDeltas?: (formeChangeSpecies: Species, pokemon?: Pokemon) => AnyObject,
+	getMixedSpecies?: (originalName: string, megaName: string, pokemon?: Pokemon) => Species,
+} & ThisType<BattleActions>;
+
+type ModdedBattleSide = Partial<Side> & {
+	inherit?: true,
+} & ThisType<Side>;
+
+type ModdedBattlePokemon = Partial<Pokemon> & {
+	inherit?: true,
+
+	// OM
+	lostItemForDelibird?: Item | null,
+	getLinkedMoves?: (this: Pokemon, ignoreDisabled?: boolean) => [ActiveMove, ActiveMove] | [],
+	hasLinkedMove?: (this: Pokemon, move: ActiveMove) => boolean,
+	getIsMoveLocked?: (this: Pokemon) => boolean,
+	getWillLockMove?: (this: Pokemon) => boolean,
+	getCanLinkMove?: (this: Pokemon, move: ActiveMove) => boolean,
 	queryLinkMove?: (
 		this: Pokemon, move: ActiveMove, ignoreDisabled?: boolean
-	) => { linkIndex: number, linkedMoves: [ActiveMove, ActiveMove] };
-}
+	) => { linkIndex: number, linkedMoves: [ActiveMove, ActiveMove] },
+} & ThisType<Pokemon>;
 
-interface ModdedBattleQueue extends Partial<BattleQueue> {
-	inherit?: true;
-	resolveAction?: (this: BattleQueue, action: ActionChoice, midTurn?: boolean) => Action[];
-}
+type ModdedBattleQueue = Partial<BattleQueue> & {
+	inherit?: true,
+} & ThisType<BattleQueue>;
 
-interface ModdedField extends Partial<Field> {
-	inherit?: true;
-	suppressingWeather?: (this: Field) => boolean;
-	addPseudoWeather?: (
-		this: Field, status: string | Condition, source: Pokemon | 'debug' | null, sourceEffect: Effect | null
-	) => boolean;
-	setWeather?: (
-		this: Field, status: string | Condition, source: Pokemon | 'debug' | null, sourceEffect: Effect | null
-	) => boolean | null;
-	setTerrain?: (
-		this: Field, status: string | Effect, source: Pokemon | 'debug' | null, sourceEffect: Effect | null
-	) => boolean;
-}
+type ModdedField = Partial<Field> & {
+	inherit?: true,
+} & ThisType<Field>;
 
-interface ModdedBattleScriptsData extends Partial<BattleScriptsData> {
-	inherit?: string;
-	actions?: ModdedBattleActions;
-	pokemon?: ModdedBattlePokemon;
-	queue?: ModdedBattleQueue;
-	field?: ModdedField;
-	side?: ModdedBattleSide;
-	boost?: (
-		this: Battle, boost: SparseBoostsTable, target: Pokemon, source?: Pokemon | null,
-		effect?: Effect | null, isSecondary?: boolean, isSelf?: boolean
-	) => boolean | null | 0;
-	debug?: (this: Battle, activity: string) => void;
-	getActionSpeed?: (this: Battle, action: AnyObject) => void;
-	init?: (this: ModdedDex) => void;
-	maybeTriggerEndlessBattleClause?: (
-		this: Battle, trappedBySide: boolean[], stalenessBySide: ('internal' | 'external' | undefined)[]
-	) => boolean | undefined;
-	endTurn?: (this: Battle) => void;
-	runAction?: (this: Battle, action: Action) => void;
-	statModify?: (this: Battle, baseStats: StatsTable, set: PokemonSet, statName: StatID) => number;
-	start?: (this: Battle) => void;
-	runPickTeam?: () => void;
-	suppressingWeather?: (this: Battle) => boolean;
-	trunc?: (n: number) => number;
-	win?: (this: Battle, side?: SideID | '' | Side | null) => boolean;
-	faintMessages?: (this: Battle, lastFirst?: boolean, forceCheck?: boolean, checkWin?: boolean) => boolean | undefined;
-	tiebreak?: (this: Battle) => boolean;
-	calculatePP?: (this: Battle, move: Move, ppUps?: number) => number;
-	checkMoveMakesContact?: (
-		this: Battle, move: ActiveMove, attacker: Pokemon, defender: Pokemon, announcePads?: boolean
-	) => boolean;
-	checkMoveBypassesProtect?: (
-		this: Battle, move: ActiveMove, attacker: Pokemon, defender: Pokemon, blockStatus?: boolean
-	) => boolean;
-	checkWin?: (this: Battle, faintQueue?: Battle['faintQueue'][0]) => true | undefined;
-	fieldEvent?: (this: Battle, eventid: string, targets?: Pokemon[]) => void;
-	getAllActive?: (this: Battle, includeFainted?: boolean, includeCommanding?: boolean) => Pokemon[];
-	getTarget?: (
-		this: Battle, pokemon: Pokemon, move: string | Move, targetLoc: number, originalTarget?: Pokemon
-	) => Pokemon | null;
+type ModdedBattleScriptsData = Partial<BattleScriptsData> & Partial<MethodsOf<Battle>> & {
+	inherit?: string,
+	init?: (this: ModdedDex) => void,
+	actions?: ModdedBattleActions,
+	pokemon?: ModdedBattlePokemon,
+	queue?: ModdedBattleQueue,
+	field?: ModdedField,
+	side?: ModdedBattleSide,
 
 	// OM
-	resolveTargetLoc?: (this: Battle, targetLoc: number, action: Action, move: ActiveMove) => number;
-}
+	resolveTargetLoc?: (targetLoc: number, action: Action, move: ActiveMove) => number,
+} & ThisType<Battle>;
 
 type TypeInfo = import('./dex-data').TypeInfo;
 

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -4,11 +4,9 @@ type Mutable<T> = {
 	-readonly [P in keyof T]: T[P];
 };
 
-type MethodKeys<T> = {
-	[K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
-}[keyof T];
-
-type MethodsOf<T> = Pick<T, MethodKeys<T>>;
+type MethodsOf<T> = {
+	[K in keyof T as NonNullable<T[K]> extends (...args: any[]) => any ? K : never]: T[K];
+}
 
 type Battle = import('./battle').Battle;
 type BattleQueue = import('./battle-queue').BattleQueue;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -164,7 +164,7 @@ interface BattleScriptsData {
 	gen: number;
 }
 
-type ModdedBattleActions = Partial<BattleActions> & {
+type ModdedBattleActions = Partial<MethodsOf<BattleActions>> & {
 	inherit?: true,
 
 	// OM
@@ -173,11 +173,11 @@ type ModdedBattleActions = Partial<BattleActions> & {
 	getMixedSpecies?: (originalName: string, megaName: string, pokemon?: Pokemon) => Species,
 } & ThisType<BattleActions>;
 
-type ModdedBattleSide = Partial<Side> & {
+type ModdedBattleSide = Partial<MethodsOf<Side>> & {
 	inherit?: true,
 } & ThisType<Side>;
 
-type ModdedBattlePokemon = Partial<Pokemon> & {
+type ModdedBattlePokemon = Partial<MethodsOf<Pokemon>> & {
 	inherit?: true,
 
 	// OM
@@ -192,11 +192,11 @@ type ModdedBattlePokemon = Partial<Pokemon> & {
 	) => { linkIndex: number, linkedMoves: [ActiveMove, ActiveMove] },
 } & ThisType<Pokemon>;
 
-type ModdedBattleQueue = Partial<BattleQueue> & {
+type ModdedBattleQueue = Partial<MethodsOf<BattleQueue>> & {
 	inherit?: true,
 } & ThisType<BattleQueue>;
 
-type ModdedField = Partial<Field> & {
+type ModdedField = Partial<MethodsOf<Field>> & {
 	inherit?: true,
 } & ThisType<Field>;
 


### PR DESCRIPTION
Instead of needing to manually define each function that can be overriden, the types will now extend the types of their base classes in conjunction with `ThisType` to modify the context of all the functions at once. Should also fix any issues when it comes to mismatched types on modded functions in relation to their base functions.