### PR TITLE
Fix ticomon visible trainer avatar

### DIFF
--- a/.github/workflows/pvptest2-node22.yml
+++ b/.github/workflows/pvptest2-node22.yml
@@ -1,0 +1,25 @@
+name: Pvptest2 ticket auth (Node 22)
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - server/chat-commands/core.ts
+      - server/users.ts
+      - test/server/ticomon-pvptest2.js
+      - .github/workflows/pvptest2-node22.yml
+  workflow_dispatch:
+
+jobs:
+  pvptest2-ticket-auth:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+      - run: npm ci --include=dev
+      - run: npm run tsc
+      - run: npm run lint -- --no-cache server/chat-commands/core.ts server/users.ts test/server/ticomon-pvptest2.js
+      - run: npx mocha --no-config --timeout 8000 --forbid-only -g ".*" test/main.js test/server/ticomon-pvptest2.js

--- a/.github/workflows/pvptest2-node22.yml
+++ b/.github/workflows/pvptest2-node22.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   pvptest2-ticket-auth:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -22,4 +23,4 @@ jobs:
       - run: npm ci --include=dev
       - run: npm run tsc
       - run: npm run lint -- --no-cache server/chat-commands/core.ts server/users.ts test/server/ticomon-pvptest2.js
-      - run: npx mocha --no-config --timeout 8000 --forbid-only -g ".*" test/main.js test/server/ticomon-pvptest2.js
+      - run: npx mocha --no-config --exit --timeout 8000 --forbid-only -g ".*" test/main.js test/server/ticomon-pvptest2.js

--- a/.github/workflows/ticomon-battle-timer.yml
+++ b/.github/workflows/ticomon-battle-timer.yml
@@ -45,11 +45,11 @@ jobs:
         run: npm run build
 
       - name: Run TicoMon timer tests
-        run: npx mocha --no-config --file ./test/main.js --timeout 8000 --forbid-only test/server/room-battle-timer.js
+        run: npx mocha --no-config --exit --file ./test/main.js --timeout 8000 --forbid-only test/server/room-battle-timer.js
 
       - name: Run timer and room battle tests
         run: |
-          npx mocha --no-config --file ./test/main.js --timeout 8000 --forbid-only \
+          npx mocha --no-config --exit --file ./test/main.js --timeout 8000 --forbid-only \
             test/server/room-battle-timer.js \
             test/server/room-battle.js
 

--- a/.github/workflows/ticomon-battle-timer.yml
+++ b/.github/workflows/ticomon-battle-timer.yml
@@ -45,11 +45,11 @@ jobs:
         run: npm run build
 
       - name: Run TicoMon timer tests
-        run: npx mocha --timeout 8000 --forbid-only test/server/room-battle-timer.js
+        run: npx mocha --no-config --require ./test/main.js --timeout 8000 --forbid-only test/server/room-battle-timer.js
 
       - name: Run timer and room battle tests
         run: |
-          npx mocha --timeout 8000 --forbid-only \
+          npx mocha --no-config --require ./test/main.js --timeout 8000 --forbid-only \
             test/server/room-battle-timer.js \
             test/server/room-battle.js
 

--- a/.github/workflows/ticomon-battle-timer.yml
+++ b/.github/workflows/ticomon-battle-timer.yml
@@ -1,0 +1,60 @@
+name: TicoMon battle timer (Node 22)
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - server/room-battle.ts
+      - test/server/room-battle-timer.js
+      - package.json
+      - package-lock.json
+      - tsconfig.json
+      - .github/workflows/ticomon-battle-timer.yml
+  pull_request:
+    branches: [master]
+    paths:
+      - server/room-battle.ts
+      - test/server/room-battle-timer.js
+      - package.json
+      - package-lock.json
+      - tsconfig.json
+      - .github/workflows/ticomon-battle-timer.yml
+  workflow_dispatch:
+
+jobs:
+  battle-timer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Show runtime versions
+        run: |
+          node --version
+          npm --version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build focused test artifacts
+        run: npm run build
+
+      - name: Run TicoMon timer tests
+        run: npx mocha --timeout 8000 --forbid-only test/server/room-battle-timer.js
+
+      - name: Run timer and room battle tests
+        run: |
+          npx mocha --timeout 8000 --forbid-only \
+            test/server/room-battle-timer.js \
+            test/server/room-battle.js
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+      - name: Check diff
+        run: git diff --check

--- a/.github/workflows/ticomon-battle-timer.yml
+++ b/.github/workflows/ticomon-battle-timer.yml
@@ -45,11 +45,11 @@ jobs:
         run: npm run build
 
       - name: Run TicoMon timer tests
-        run: npx mocha --no-config --require ./test/main.js --timeout 8000 --forbid-only test/server/room-battle-timer.js
+        run: npx mocha --no-config --file ./test/main.js --timeout 8000 --forbid-only test/server/room-battle-timer.js
 
       - name: Run timer and room battle tests
         run: |
-          npx mocha --no-config --require ./test/main.js --timeout 8000 --forbid-only \
+          npx mocha --no-config --file ./test/main.js --timeout 8000 --forbid-only \
             test/server/room-battle-timer.js \
             test/server/room-battle.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 8000
+
+CMD ["node", "pokemon-showdown", "start", "--no-security"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 
-RUN npm ci
+RUN npm ci --include=dev
 
 COPY . .
 
+RUN node --version
 RUN npm run build
 
 EXPOSE 8000

--- a/package.json
+++ b/package.json
@@ -4,6 +4,30 @@
   "version": "0.11.10",
   "main": "dist/sim/index.js",
   "types": "dist/sim/index.d.ts",
+  "dependencies": {
+    "esbuild": "^0.25.0",
+    "mysql2": "^3.14.2",
+    "preact": "^10.5.15",
+    "preact-render-to-string": "^6.5.13",
+    "sockjs": "^0.3.21",
+    "ts-chacha20": "^1.2.0"
+  },
+  "optionalDependencies": {
+    "better-sqlite3": "^11.10.0",
+    "cloud-env": "^0.2.3",
+    "githubhook": "^1.9.3",
+    "nodemailer": "^7.0.5",
+    "permessage-deflate": "^0.1.7",
+    "pg": "^8.16.3",
+    "probe-image-size": "^7.2.3",
+    "source-map-support": "^0.5.21",
+    "sql-template-strings": "^2.2.2",
+    "sqlite": "^5.1.1",
+    "sqlite3": "^5.1.7"
+  },
+  "secretDependencies": {
+    "node-oom-heapdump": "^1.2.0"
+  },
   "engines": {
     "node": ">=22.0.0"
   },
@@ -21,8 +45,7 @@
     "posttest": "npm run tsc",
     "full-test": "eslint --max-warnings 0 && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\" && npm run test-npm",
     "full-test-ci": "eslint --max-warnings 0 && tsc && (([ \"$SKIPSIMTESTS\" = true ] && mocha --timeout 8000 --forbid-only -g \".*\" --exclude \"test/{sim,random-battles}/**\") || mocha --timeout 8000 --forbid-only -g \".*\") && npm run test-npm"
-  }
-}
+  },
   "bin": "./pokemon-showdown",
   "homepage": "http://pokemonshowdown.com",
   "repository": {
@@ -32,7 +55,7 @@
   "author": {
     "name": "Guangcong Luo",
     "email": "guangcongluo@gmail.com",
-    "url": "http://guangcongluo.com"
+    "url": "http://www.smogon.com"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -4,34 +4,9 @@
   "version": "0.11.10",
   "main": "dist/sim/index.js",
   "types": "dist/sim/index.d.ts",
-  "dependencies": {
-    "esbuild": "^0.25.0",
-    "mysql2": "^3.14.2",
-    "preact": "^10.5.15",
-    "preact-render-to-string": "^6.5.13",
-    "sockjs": "^0.3.21",
-    "ts-chacha20": "^1.2.0"
-  },
-  "optionalDependencies": {
-    "better-sqlite3": "^11.10.0",
-    "cloud-env": "^0.2.3",
-    "githubhook": "^1.9.3",
-    "nodemailer": "^7.0.5",
-    "permessage-deflate": "^0.1.7",
-    "pg": "^8.16.3",
-    "probe-image-size": "^7.2.3",
-    "source-map-support": "^0.5.21",
-    "sql-template-strings": "^2.2.2",
-    "sqlite": "^5.1.1",
-    "sqlite3": "^5.1.7"
-  },
-  "secretDependencies": {
-    "node-oom-heapdump": "^1.2.0"
-  },
   "engines": {
     "node": ">=22.0.0"
   },
-"scripts": {
   "scripts": {
     "start": "node pokemon-showdown start",
     "build": "node build",
@@ -46,7 +21,8 @@
     "posttest": "npm run tsc",
     "full-test": "eslint --max-warnings 0 && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\" && npm run test-npm",
     "full-test-ci": "eslint --max-warnings 0 && tsc && (([ \"$SKIPSIMTESTS\" = true ] && mocha --timeout 8000 --forbid-only -g \".*\" --exclude \"test/{sim,random-battles}/**\") || mocha --timeout 8000 --forbid-only -g \".*\") && npm run test-npm"
-  },
+  }
+}
   "bin": "./pokemon-showdown",
   "homepage": "http://pokemonshowdown.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "engines": {
     "node": ">=22.0.0"
-  }
+  },
+"scripts": {
   "scripts": {
     "start": "node pokemon-showdown start",
     "build": "node build",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "node-oom-heapdump": "^1.2.0"
   },
   "engines": {
-    "node": ">=16.0.0"
-  },
+    "node": ">=22.0.0"
+  }
   "scripts": {
     "start": "node pokemon-showdown start",
     "build": "node build",

--- a/patches/pvptest2-ticket-auth.patch
+++ b/patches/pvptest2-ticket-auth.patch
@@ -1,0 +1,122 @@
+diff --git a/server/chat-commands/core.ts b/server/chat-commands/core.ts
+index 83aba4618..9fd229dc5 100644
+--- a/server/chat-commands/core.ts
++++ b/server/chat-commands/core.ts
+@@ -14,7 +14,7 @@
+  */
+ 
+ /* eslint no-else-return: "error" */
+-import { Utils, ProcessManager } from '../../lib';
++import { Net, Utils, ProcessManager } from '../../lib';
+ import type { UserSettings } from '../users';
+ import type { GlobalPermission, RoomPermission } from '../user-groups';
+ 
+@@ -1695,6 +1695,52 @@ export const commands: Chat.ChatCommands = {
+ 
+ 		return user.rename(name, token || '', registered, connection);
+ 	},
++	async ticomonauth(target, room, user, connection) {
++		const ticket = target.trim();
++		const endpoint = process.env.TICOMON_PVPTEST2_TICKET_CONSUME_URL;
++		const serviceToken = process.env.TICOMON_PVPTEST2_INTERNAL_SERVICE_TOKEN;
++		if (!ticket || !endpoint || !serviceToken || !/^[A-Za-z0-9_-]{43,}$/.test(ticket)) {
++			connection.send(`|popup|Unable to connect this battle client.`);
++			return false;
++		}
++
++		let ticketData: { valid?: boolean, userid?: string, roomId?: string };
++		try {
++			const response = await Net(endpoint).post({
++				headers: {
++					'Content-Type': 'application/json',
++					'X-TicoMon-Service-Token': serviceToken,
++				},
++			}, JSON.stringify({ ticket }));
++			ticketData = JSON.parse(response);
++		} catch {
++			connection.send(`|popup|Unable to connect this battle client.`);
++			return false;
++		}
++		if (
++			ticketData.valid !== true ||
++			typeof ticketData.userid !== 'string' ||
++			typeof ticketData.roomId !== 'string' ||
++			toID(ticketData.userid) !== ticketData.userid ||
++			!ticketData.roomId.startsWith('battle-')
++		) {
++			connection.send(`|popup|Unable to connect this battle client.`);
++			return false;
++		}
++		const targetUser = Users.get(ticketData.userid);
++		const battleRoom = Rooms.get(ticketData.roomId as RoomID);
++		if (!targetUser || !battleRoom?.battle?.playerTable[targetUser.id]) {
++			connection.send(`|popup|Unable to connect this battle client.`);
++			return false;
++		}
++		if (!targetUser.attachTicoMonPvptest2Connection(connection, battleRoom.roomid)) {
++			connection.send(`|popup|Unable to connect this battle client.`);
++		}
++		return false;
++	},
++	ticomonauthhelp: [
++		`/ticomon-auth [ticket] - Authenticates an assigned TicoMon Activity connection.`,
++	],
+ 	trnhelp: [
+ 		`/trn [username], [registered], [token] - Finishes a rename to the [username] with a given [token].`,
+ 	],
+diff --git a/server/users.ts b/server/users.ts
+index 45bbb1ef3..75b1e5ad5 100644
+--- a/server/users.ts
++++ b/server/users.ts
+@@ -235,6 +235,7 @@ export class Connection {
+ 	user: User;
+ 	challenge: string;
+ 	autojoins: string;
++	ticomonPvptest2Room: RoomID | null;
+ 	/** The last bot html page this connection requested, formatted as `${bot.id}-${pageid}` */
+ 	lastRequestedPage: string | null;
+ 	lastActiveTime: number;
+@@ -270,6 +271,7 @@ export class Connection {
+ 
+ 		this.challenge = '';
+ 		this.autojoins = '';
++		this.ticomonPvptest2Room = null;
+ 		this.lastRequestedPage = null;
+ 		this.lastActiveTime = now;
+ 		this.openPages = null;
+@@ -1091,6 +1093,21 @@ export class User extends Chat.MessageContext {
+ 		}
+ 		this.updateReady(connection);
+ 	}
++	attachTicoMonPvptest2Connection(connection: Connection, roomid: RoomID) {
++		const previousUser = connection.user;
++		if (!previousUser || previousUser === this || !Rooms.get(roomid)) return false;
++		const previousIndex = previousUser.connections.indexOf(connection);
++		if (previousIndex >= 0) previousUser.connections.splice(previousIndex, 1);
++		if (!previousUser.connections.length) previousUser.markDisconnected();
++
++		for (const existing of [...this.connections]) {
++			if (existing.ticomonPvptest2Room === roomid) existing.destroy();
++		}
++		connection.ticomonPvptest2Room = roomid;
++		this.mergeConnection(connection);
++		this.joinRoom(roomid, connection);
++		return true;
++	}
+ 	debugData() {
+ 		let str = `${this.tempGroup}${this.name} (${this.id})`;
+ 		for (const [i, connection] of this.connections.entries()) {
+@@ -1305,6 +1322,13 @@ export class User extends Chat.MessageContext {
+ 			connection.sendTo(roomid, `|noinit|nonexistent|The room "${roomid}" does not exist.`);
+ 			return false;
+ 		}
++		if (
++			connection.ticomonPvptest2Room && room.battle &&
++			room.roomid !== connection.ticomonPvptest2Room
++		) {
++			connection.sendTo(roomid, `|noinit|joinfailed|This battle client is assigned to another room.`);
++			return false;
++		}
+ 		if (!room.checkModjoin(this)) {
+ 			if (!this.named) return Rooms.RETRY_AFTER_LOGIN;
+ 			connection.sendTo(roomid, `|noinit|joinfailed|The room "${roomid}" is invite-only, and you haven't been invited.`);

--- a/patches/pvptest2-ticket-auth.patch
+++ b/patches/pvptest2-ticket-auth.patch
@@ -1,5 +1,5 @@
 diff --git a/server/chat-commands/core.ts b/server/chat-commands/core.ts
-index 83aba4618..9fd229dc5 100644
+index 83aba4618..1fc12ff05 100644
 --- a/server/chat-commands/core.ts
 +++ b/server/chat-commands/core.ts
 @@ -14,7 +14,7 @@
@@ -11,7 +11,7 @@ index 83aba4618..9fd229dc5 100644
  import type { UserSettings } from '../users';
  import type { GlobalPermission, RoomPermission } from '../user-groups';
  
-@@ -1695,6 +1695,52 @@ export const commands: Chat.ChatCommands = {
+@@ -1695,6 +1695,53 @@ export const commands: Chat.ChatCommands = {
  
  		return user.rename(name, token || '', registered, connection);
  	},
@@ -58,6 +58,7 @@ index 83aba4618..9fd229dc5 100644
 +		}
 +		return false;
 +	},
++	'ticomon-auth': 'ticomonauth',
 +	ticomonauthhelp: [
 +		`/ticomon-auth [ticket] - Authenticates an assigned TicoMon Activity connection.`,
 +	],

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -19,7 +19,7 @@ import type { UserSettings } from '../users';
 import type { GlobalPermission, RoomPermission } from '../user-groups';
 import { isTicoMonTrainerAvatar } from './ticomon-avatar';
 
-const ticomonPvptest2Avatars = new WeakMap<User, Map<string, string>>();
+const ticomonPvptest2Avatars = new WeakMap<User, Map<string, User['avatar']>>();
 
 export const crqHandlers: { [k: string]: Chat.CRQHandler } = {
 	userdetails(target, user, trustable) {
@@ -1784,7 +1784,7 @@ export const commands: Chat.ChatCommands = {
 				targetUser.avatar = initialAvatar;
 			} else {
 				const requestedAvatar = ticketData.trainerAvatar;
-				const avatar = requestedAvatar === undefined ? `${targetUser.avatar}` : requestedAvatar;
+				const avatar = requestedAvatar === undefined ? targetUser.avatar : requestedAvatar;
 				roomAvatars.set(battleRoom.roomid, avatar);
 				targetUser.avatar = avatar;
 			}

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1792,6 +1792,7 @@ export const commands: Chat.ChatCommands = {
 				report('attach_failed');
 				return false;
 			}
+			battleRoom.battle.updatePlayerAvatar(targetUser);
 		} else if (role === 'spectator') {
 			if (
 				ticketData.side != null ||

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1696,11 +1696,15 @@ export const commands: Chat.ChatCommands = {
 		return user.rename(name, token || '', registered, connection);
 	},
 	async ticomonauth(target, room, user, connection) {
+		const report = (category: string) => {
+			console.log(`ticomon_auth_result category=${category}`);
+			connection.send(category === 'ok' ? '|ticomonauth|ok' : `|ticomonauth|error|${category}`);
+		};
 		const ticket = target.trim();
 		const endpoint = process.env.TICOMON_PVPTEST2_TICKET_CONSUME_URL;
 		const serviceToken = process.env.TICOMON_PVPTEST2_INTERNAL_SERVICE_TOKEN;
 		if (!ticket || !endpoint || !serviceToken || !/^[A-Za-z0-9_-]{43,}$/.test(ticket)) {
-			connection.send(`|popup|Unable to connect this battle client.`);
+			report('config');
 			return false;
 		}
 
@@ -1712,9 +1716,15 @@ export const commands: Chat.ChatCommands = {
 					'X-TicoMon-Service-Token': serviceToken,
 				},
 			}, JSON.stringify({ ticket }));
-			ticketData = JSON.parse(response);
-		} catch {
-			connection.send(`|popup|Unable to connect this battle client.`);
+			try {
+				ticketData = JSON.parse(response);
+			} catch {
+				report('consume_invalid_json');
+				return false;
+			}
+		} catch (error) {
+			const statusCode = (error as { statusCode?: number }).statusCode;
+			report(statusCode === 403 ? 'consume_403' : statusCode === 404 ? 'consume_404' : 'consume_network');
 			return false;
 		}
 		if (
@@ -1724,18 +1734,28 @@ export const commands: Chat.ChatCommands = {
 			toID(ticketData.userid) !== ticketData.userid ||
 			!ticketData.roomId.startsWith('battle-')
 		) {
-			connection.send(`|popup|Unable to connect this battle client.`);
+			report('consume_invalid_payload');
 			return false;
 		}
 		const targetUser = Users.get(ticketData.userid);
+		if (!targetUser) {
+			report('user_missing');
+			return false;
+		}
 		const battleRoom = Rooms.get(ticketData.roomId as RoomID);
-		if (!targetUser || !battleRoom?.battle?.playerTable[targetUser.id]) {
-			connection.send(`|popup|Unable to connect this battle client.`);
+		if (!battleRoom?.battle) {
+			report('room_missing');
+			return false;
+		}
+		if (!battleRoom.battle.playerTable[targetUser.id]) {
+			report('not_participant');
 			return false;
 		}
 		if (!targetUser.attachTicoMonPvptest2Connection(connection, battleRoom.roomid)) {
-			connection.send(`|popup|Unable to connect this battle client.`);
+			report('attach_failed');
+			return false;
 		}
+		report('ok');
 		return false;
 	},
 	'ticomon-auth': 'ticomonauth',

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1738,6 +1738,7 @@ export const commands: Chat.ChatCommands = {
 		}
 		return false;
 	},
+	'ticomon-auth': 'ticomonauth',
 	ticomonauthhelp: [
 		`/ticomon-auth [ticket] - Authenticates an assigned TicoMon Activity connection.`,
 	],

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -14,7 +14,7 @@
  */
 
 /* eslint no-else-return: "error" */
-import { Utils, ProcessManager } from '../../lib';
+import { Net, Utils, ProcessManager } from '../../lib';
 import type { UserSettings } from '../users';
 import type { GlobalPermission, RoomPermission } from '../user-groups';
 
@@ -1695,6 +1695,52 @@ export const commands: Chat.ChatCommands = {
 
 		return user.rename(name, token || '', registered, connection);
 	},
+	async ticomonauth(target, room, user, connection) {
+		const ticket = target.trim();
+		const endpoint = process.env.TICOMON_PVPTEST2_TICKET_CONSUME_URL;
+		const serviceToken = process.env.TICOMON_PVPTEST2_INTERNAL_SERVICE_TOKEN;
+		if (!ticket || !endpoint || !serviceToken || !/^[A-Za-z0-9_-]{43,}$/.test(ticket)) {
+			connection.send(`|popup|Unable to connect this battle client.`);
+			return false;
+		}
+
+		let ticketData: { valid?: boolean, userid?: string, roomId?: string };
+		try {
+			const response = await Net(endpoint).post({
+				headers: {
+					'Content-Type': 'application/json',
+					'X-TicoMon-Service-Token': serviceToken,
+				},
+			}, JSON.stringify({ ticket }));
+			ticketData = JSON.parse(response);
+		} catch {
+			connection.send(`|popup|Unable to connect this battle client.`);
+			return false;
+		}
+		if (
+			ticketData.valid !== true ||
+			typeof ticketData.userid !== 'string' ||
+			typeof ticketData.roomId !== 'string' ||
+			toID(ticketData.userid) !== ticketData.userid ||
+			!ticketData.roomId.startsWith('battle-')
+		) {
+			connection.send(`|popup|Unable to connect this battle client.`);
+			return false;
+		}
+		const targetUser = Users.get(ticketData.userid);
+		const battleRoom = Rooms.get(ticketData.roomId as RoomID);
+		if (!targetUser || !battleRoom?.battle?.playerTable[targetUser.id]) {
+			connection.send(`|popup|Unable to connect this battle client.`);
+			return false;
+		}
+		if (!targetUser.attachTicoMonPvptest2Connection(connection, battleRoom.roomid)) {
+			connection.send(`|popup|Unable to connect this battle client.`);
+		}
+		return false;
+	},
+	ticomonauthhelp: [
+		`/ticomon-auth [ticket] - Authenticates an assigned TicoMon Activity connection.`,
+	],
 	trnhelp: [
 		`/trn [username], [registered], [token] - Finishes a rename to the [username] with a given [token].`,
 	],

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -17,6 +17,9 @@
 import { Net, Utils, ProcessManager } from '../../lib';
 import type { UserSettings } from '../users';
 import type { GlobalPermission, RoomPermission } from '../user-groups';
+import { isTicoMonTrainerAvatar } from './ticomon-avatar';
+
+const ticomonPvptest2Avatars = new WeakMap<User, Map<string, string>>();
 
 export const crqHandlers: { [k: string]: Chat.CRQHandler } = {
 	userdetails(target, user, trustable) {
@@ -1755,6 +1758,13 @@ export const commands: Chat.ChatCommands = {
 				report('consume_invalid_payload');
 				return false;
 			}
+			if (
+				Object.prototype.hasOwnProperty.call(ticketData, 'trainerAvatar') &&
+				!isTicoMonTrainerAvatar(ticketData.trainerAvatar)
+			) {
+				report('consume_invalid_payload');
+				return false;
+			}
 			const targetUser = Users.get(ticketData.showdownUserid);
 			if (!targetUser) {
 				report('user_missing');
@@ -1764,12 +1774,30 @@ export const commands: Chat.ChatCommands = {
 				report('not_participant');
 				return false;
 			}
+			let roomAvatars = ticomonPvptest2Avatars.get(targetUser);
+			if (!roomAvatars) {
+				roomAvatars = new Map();
+				ticomonPvptest2Avatars.set(targetUser, roomAvatars);
+			}
+			const initialAvatar = roomAvatars.get(battleRoom.roomid);
+			if (initialAvatar) {
+				targetUser.avatar = initialAvatar;
+			} else {
+				const requestedAvatar = ticketData.trainerAvatar;
+				const avatar = requestedAvatar === undefined ? `${targetUser.avatar}` : requestedAvatar;
+				roomAvatars.set(battleRoom.roomid, avatar);
+				targetUser.avatar = avatar;
+			}
 			if (!targetUser.attachTicoMonPvptest2Connection(connection, battleRoom.roomid)) {
 				report('attach_failed');
 				return false;
 			}
 		} else if (role === 'spectator') {
-			if (ticketData.side != null || ticketData.showdownUserid != null) {
+			if (
+				ticketData.side != null ||
+				ticketData.showdownUserid != null ||
+				Object.prototype.hasOwnProperty.call(ticketData, 'trainerAvatar')
+			) {
 				report('consume_invalid_payload');
 				return false;
 			}

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1708,7 +1708,7 @@ export const commands: Chat.ChatCommands = {
 			return false;
 		}
 
-		let ticketData: { valid?: boolean, userid?: string, roomId?: string };
+		let ticketData: any;
 		try {
 			const response = await Net(endpoint).post({
 				headers: {
@@ -1727,32 +1727,56 @@ export const commands: Chat.ChatCommands = {
 			report(statusCode === 403 ? 'consume_403' : statusCode === 404 ? 'consume_404' : 'consume_network');
 			return false;
 		}
+
 		if (
 			ticketData.valid !== true ||
-			typeof ticketData.userid !== 'string' ||
 			typeof ticketData.roomId !== 'string' ||
-			toID(ticketData.userid) !== ticketData.userid ||
 			!ticketData.roomId.startsWith('battle-')
 		) {
 			report('consume_invalid_payload');
 			return false;
 		}
-		const targetUser = Users.get(ticketData.userid);
-		if (!targetUser) {
-			report('user_missing');
-			return false;
-		}
+
 		const battleRoom = Rooms.get(ticketData.roomId as RoomID);
 		if (!battleRoom?.battle) {
 			report('room_missing');
 			return false;
 		}
-		if (!battleRoom.battle.playerTable[targetUser.id]) {
-			report('not_participant');
-			return false;
-		}
-		if (!targetUser.attachTicoMonPvptest2Connection(connection, battleRoom.roomid)) {
-			report('attach_failed');
+
+		const role = ticketData.role;
+
+		if (role === 'player') {
+			if (
+				typeof ticketData.showdownUserid !== 'string' ||
+				!ticketData.showdownUserid ||
+				toID(ticketData.showdownUserid) !== ticketData.showdownUserid ||
+				(ticketData.side !== 1 && ticketData.side !== 2)
+			) {
+				report('consume_invalid_payload');
+				return false;
+			}
+			const targetUser = Users.get(ticketData.showdownUserid);
+			if (!targetUser) {
+				report('user_missing');
+				return false;
+			}
+			if (!battleRoom.battle.playerTable[targetUser.id]) {
+				report('not_participant');
+				return false;
+			}
+			if (!targetUser.attachTicoMonPvptest2Connection(connection, battleRoom.roomid)) {
+				report('attach_failed');
+				return false;
+			}
+		} else if (role === 'spectator') {
+			if (ticketData.side != null || ticketData.showdownUserid != null) {
+				report('consume_invalid_payload');
+				return false;
+			}
+			connection.ticomonPvptest2Room = battleRoom.roomid;
+			user.joinRoom(battleRoom.roomid, connection);
+		} else {
+			report('consume_invalid_payload');
 			return false;
 		}
 		report('ok');

--- a/server/chat-commands/ticomon-avatar.ts
+++ b/server/chat-commands/ticomon-avatar.ts
@@ -1,0 +1,24 @@
+export const TICOMON_TRAINER_AVATARS = new Set([
+	'red',
+	'leaf-gen3',
+	'blue',
+	'silver',
+	'ethan',
+	'lyra',
+	'brendan',
+	'dawn',
+	'lucas',
+	'barry',
+	'dawn-gen4pt',
+	'lucas-gen4pt',
+	'lance',
+	'cheryl',
+	'buck',
+	'marley',
+	'mira',
+	'riley',
+]);
+
+export function isTicoMonTrainerAvatar(value: unknown): value is string {
+	return typeof value === 'string' && TICOMON_TRAINER_AVATARS.has(value);
+}

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -51,6 +51,9 @@ const MAX_TURN_TIME_CHALLENGE = 300;
 const DISCONNECTION_TIME = 60;
 const DISCONNECTION_BANK_TIME = 300;
 
+const TICOMON_DECISION_TIMEOUT_SECONDS = 60;
+const TICOMON_FORCED_SWITCH_TIMEOUT_SECONDS = 30;
+
 // time after a player disabling the timer before they can re-enable it
 const TIMER_COOLDOWN = 20 * SECONDS;
 const LOCKDOWN_PERIOD = 30 * 60 * 1000; // 30 minutes
@@ -164,6 +167,7 @@ export class RoomBattleTimer {
 	readonly battle: RoomBattle;
 	readonly timerRequesters = new Set<ID>();
 	timer: NodeJS.Timeout | null = null;
+	isTicoMon = false;
 	isFirstRequest = true;
 	turn: number | null = null;
 	/**
@@ -211,9 +215,51 @@ export class RoomBattleTimer {
 			player.dcSecondsLeft = this.settings.dcTimerBank ? DISCONNECTION_BANK_TIME : DISCONNECTION_TIME;
 		}
 	}
+	markTicoMon() {
+		if (this.isTicoMon) return;
+		this.isTicoMon = true;
+		this.settings = {
+			...this.settings,
+			dcTimer: true,
+			dcTimerBank: false,
+			starting: TICOMON_DECISION_TIMEOUT_SECONDS,
+			grace: 0,
+			addPerTurn: 0,
+			maxPerTurn: TICOMON_DECISION_TIMEOUT_SECONDS,
+			maxFirstTurn: TICOMON_DECISION_TIMEOUT_SECONDS,
+			timeoutAutoChoose: false,
+			accelerate: false,
+		};
+		for (const player of this.battle.players) {
+			if (player.request.isWait) continue;
+			const timeout = this.getDecisionTimeout(player);
+			player.secondsLeft = Math.min(player.secondsLeft, timeout);
+			player.turnSecondsLeft = Math.min(player.turnSecondsLeft, timeout);
+			player.dcSecondsLeft = Math.min(player.dcSecondsLeft, timeout);
+		}
+		if (this.timerRequesters.size) {
+			for (const player of this.battle.players) this.nextRequest(player);
+		} else {
+			this.start();
+		}
+	}
+	getDecisionTimeout(player: RoomBattlePlayer) {
+		if (!this.isTicoMon) return this.settings.maxPerTurn;
+		if (!player.request.request) return TICOMON_DECISION_TIMEOUT_SECONDS;
+		try {
+			const request = JSON.parse(player.request.request);
+			const forceSwitch = request.forceSwitch;
+			// A request is forced when at least one active slot must be replaced.
+			if (forceSwitch === true || (Array.isArray(forceSwitch) && forceSwitch.some(Boolean))) {
+				return TICOMON_FORCED_SWITCH_TIMEOUT_SECONDS;
+			}
+		} catch {}
+		return TICOMON_DECISION_TIMEOUT_SECONDS;
+	}
 	start(requester?: User) {
 		const userid = requester ? requester.id : 'staff' as ID;
 		if (this.timerRequesters.has(userid)) return false;
+		if (this.isTicoMon && requester) return false;
 		if (this.battle.ended) {
 			requester?.sendTo(this.battle.roomid, `|inactiveoff|The timer can't be enabled after a battle has ended.`);
 			return false;
@@ -241,6 +287,7 @@ export class RoomBattleTimer {
 		return true;
 	}
 	stop(requester?: User) {
+		if (this.isTicoMon) return false;
 		if (requester) {
 			if (!this.timerRequesters.has(requester.id)) return false;
 			this.timerRequesters.delete(requester.id);
@@ -307,10 +354,18 @@ export class RoomBattleTimer {
 		}
 	}
 	nextRequest(player: RoomBattlePlayer) {
-		if (player.secondsLeft <= 0) return;
-		if (player.request.isWait) {
-			player.turnSecondsLeft = this.settings.maxPerTurn;
-			return;
+		if (this.isTicoMon) {
+			if (player.request.isWait || this.battle.ended || !this.timerRequesters.size) return;
+			const timeout = this.getDecisionTimeout(player);
+			player.secondsLeft = timeout;
+			player.turnSecondsLeft = timeout;
+			player.dcSecondsLeft = timeout;
+		} else {
+			if (player.secondsLeft <= 0) return;
+			if (player.request.isWait) {
+				player.turnSecondsLeft = this.settings.maxPerTurn;
+				return;
+			}
 		}
 
 		if (this.timer) {
@@ -399,7 +454,9 @@ export class RoomBattleTimer {
 				player.knownActive = false;
 				if (!this.settings.dcTimerBank) {
 					// don't wait longer than 6 ticks (1 minute)
-					if (this.settings.dcTimer) {
+					if (this.isTicoMon) {
+						player.dcSecondsLeft = player.turnSecondsLeft;
+					} else if (this.settings.dcTimer) {
 						player.dcSecondsLeft = DISCONNECTION_TIME;
 					} else {
 						// arbitrary large number
@@ -410,7 +467,9 @@ export class RoomBattleTimer {
 				if (this.timerRequesters.size) {
 					let msg = `!`;
 
-					if (this.settings.dcTimer) {
+					if (this.isTicoMon) {
+						msg = ` and has ${player.dcSecondsLeft} seconds to reconnect!`;
+					} else if (this.settings.dcTimer) {
 						msg = ` and has a minute to reconnect!`;
 					}
 					if (this.settings.dcTimerBank) {
@@ -940,6 +999,13 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 		// the battle
 		const player = this.playerTable[user.id];
 		if (!player) return;
+		// This marker is set only by the authenticated TicoMon ticket path.
+		if (
+			connection?.ticomonPvptest2Room === this.roomid ||
+			user.connections.some(connection => connection.ticomonPvptest2Room === this.roomid)
+		) {
+			this.timer.markTicoMon();
+		}
 		player.updateChannel(connection || user);
 		const request = player.request;
 		if (request.request) {
@@ -997,6 +1063,9 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 		const player = this.playerTable[user.id];
 		if (player && !player.active) {
 			player.active = true;
+			if (user.connections.some(connection => connection.ticomonPvptest2Room === this.roomid)) {
+				this.timer.markTicoMon();
+			}
 			this.timer.checkActivity();
 			this.room.add(`|player|${player.slot}|${user.name}|${user.avatar}|`);
 			Chat.runHandlers('onBattleJoin', player.slot, user, this);

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1067,10 +1067,33 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 				this.timer.markTicoMon();
 			}
 			this.timer.checkActivity();
-			this.room.add(`|player|${player.slot}|${user.name}|${user.avatar}|`);
+			this.room.add(this.getPlayerProtocolLine(player, user));
 			Chat.runHandlers('onBattleJoin', player.slot, user, this);
 		}
 	}
+	private getPlayerProtocolLine(player: RoomBattlePlayer, user: User, name = user.name) {
+		return `|player|${player.slot}|${name}|${user.avatar}|`;
+	}
+
+	updatePlayerAvatar(user: User) {
+		const player = this.playerTable[user.id];
+		if (!player || (player.slot !== 'p1' && player.slot !== 'p2')) return false;
+
+		const playerUser = player.getUser();
+		if (!playerUser || playerUser.id !== user.id) return false;
+		const protocolLine = this.getPlayerProtocolLine(player, playerUser);
+		const playerPrefix = `|player|${player.slot}|`;
+		for (let i = this.room.log.log.length - 1; i >= 0; i--) {
+			const line = this.room.log.log[i];
+			if (!line.startsWith(playerPrefix)) continue;
+			if (line === protocolLine) return false;
+			break;
+		}
+
+		this.room.add(protocolLine).update();
+		return true;
+	}
+
 	override onLeave(user: User, oldUserid?: ID) {
 		const player = this.playerTable[oldUserid || user.id];
 		if (player?.active) {
@@ -1231,7 +1254,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 			void this.stream.write(`>player ${slot} ` + JSON.stringify(options));
 			if (playerOpts) player.hasTeam = true;
 
-			this.room.add(`|player|${slot}|${player.name}|${user.avatar}|`);
+			this.room.add(this.getPlayerProtocolLine(player, user, player.name));
 			Chat.runHandlers('onBattleJoin', slot as string, user, this);
 		} else {
 			player.active = false;

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1002,7 +1002,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 		// This marker is set only by the authenticated TicoMon ticket path.
 		if (
 			connection?.ticomonPvptest2Room === this.roomid ||
-			user.connections.some(connection => connection.ticomonPvptest2Room === this.roomid)
+			user.connections.some(playerConnection => playerConnection.ticomonPvptest2Room === this.roomid)
 		) {
 			this.timer.markTicoMon();
 		}

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -601,6 +601,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 	options: RoomBattleOptions;
 	frozen?: boolean;
 	dataResolvers?: [((args: string[]) => void), ((error: Error) => void)][];
+	private readonly ticomonPlayerAvatars = new Map<'p1' | 'p2', User['avatar']>();
 	constructor(room: GameRoom, options: RoomBattleOptions) {
 		super(room);
 		const format = Dex.formats.get(options.format, true);
@@ -828,10 +829,11 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 			break;
 
 		case 'update':
-			for (const line of lines.slice(1)) {
+			for (let line of lines.slice(1)) {
 				if (line.startsWith('|turn|')) {
 					this.turn = parseInt(line.slice(6));
 				}
+				line = this.applyTicoMonPlayerAvatar(line);
 				this.room.add(line);
 				if (line.startsWith(`|bigerror|You will auto-tie if `) && Config.allowrequestingties && !this.room.tour) {
 					this.room.add(`|-hint|If you want to tie earlier, consider using \`/offertie\`.`);
@@ -1074,6 +1076,16 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 	private getPlayerProtocolLine(player: RoomBattlePlayer, user: User, name = user.name) {
 		return `|player|${player.slot}|${name}|${user.avatar}|`;
 	}
+	private applyTicoMonPlayerAvatar(line: string) {
+		if (!line.startsWith('|player|')) return line;
+		const parts = line.split('|');
+		const slot = parts[2];
+		if ((slot !== 'p1' && slot !== 'p2') || parts.length < 5 || !this.ticomonPlayerAvatars.has(slot)) {
+			return line;
+		}
+		parts[4] = String(this.ticomonPlayerAvatars.get(slot));
+		return parts.join('|');
+	}
 
 	updatePlayerAvatar(user: User) {
 		const player = this.playerTable[user.id];
@@ -1081,6 +1093,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 
 		const playerUser = player.getUser();
 		if (!playerUser || playerUser.id !== user.id) return false;
+		this.ticomonPlayerAvatars.set(player.slot, playerUser.avatar);
 		const protocolLine = this.getPlayerProtocolLine(player, playerUser);
 		const playerPrefix = `|player|${player.slot}|`;
 		for (let i = this.room.log.log.length - 1; i >= 0; i--) {

--- a/server/users.ts
+++ b/server/users.ts
@@ -235,6 +235,7 @@ export class Connection {
 	user: User;
 	challenge: string;
 	autojoins: string;
+	ticomonPvptest2Room: RoomID | null;
 	/** The last bot html page this connection requested, formatted as `${bot.id}-${pageid}` */
 	lastRequestedPage: string | null;
 	lastActiveTime: number;
@@ -270,6 +271,7 @@ export class Connection {
 
 		this.challenge = '';
 		this.autojoins = '';
+		this.ticomonPvptest2Room = null;
 		this.lastRequestedPage = null;
 		this.lastActiveTime = now;
 		this.openPages = null;
@@ -1091,6 +1093,21 @@ export class User extends Chat.MessageContext {
 		}
 		this.updateReady(connection);
 	}
+	attachTicoMonPvptest2Connection(connection: Connection, roomid: RoomID) {
+		const previousUser = connection.user;
+		if (!previousUser || previousUser === this || !Rooms.get(roomid)) return false;
+		const previousIndex = previousUser.connections.indexOf(connection);
+		if (previousIndex >= 0) previousUser.connections.splice(previousIndex, 1);
+		if (!previousUser.connections.length) previousUser.markDisconnected();
+
+		for (const existing of [...this.connections]) {
+			if (existing.ticomonPvptest2Room === roomid) existing.destroy();
+		}
+		connection.ticomonPvptest2Room = roomid;
+		this.mergeConnection(connection);
+		this.joinRoom(roomid, connection);
+		return true;
+	}
 	debugData() {
 		let str = `${this.tempGroup}${this.name} (${this.id})`;
 		for (const [i, connection] of this.connections.entries()) {
@@ -1303,6 +1320,13 @@ export class User extends Chat.MessageContext {
 				return Chat.resolvePage(roomid, this, connection);
 			}
 			connection.sendTo(roomid, `|noinit|nonexistent|The room "${roomid}" does not exist.`);
+			return false;
+		}
+		if (
+			connection.ticomonPvptest2Room && room.battle &&
+			room.roomid !== connection.ticomonPvptest2Room
+		) {
+			connection.sendTo(roomid, `|noinit|joinfailed|This battle client is assigned to another room.`);
 			return false;
 		}
 		if (!room.checkModjoin(this)) {

--- a/test/server/room-battle-timer.js
+++ b/test/server/room-battle-timer.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const assert = require('assert').strict;
+
+const { RoomBattle, RoomBattleTimer } = require('../../dist/server/room-battle');
+
+function makePlayer(slot, request = {}) {
+	return {
+		slot,
+		name: slot,
+		request: {
+			rqid: 1,
+			request: JSON.stringify(request),
+			isWait: false,
+			choice: '',
+		},
+		secondsLeft: 1,
+		turnSecondsLeft: 1,
+		dcSecondsLeft: 1,
+		active: true,
+		knownActive: true,
+		eliminated: false,
+		sendRoom() {},
+		updateChannel() {},
+	};
+}
+
+function makeBattle(p1Request = {}, p2Request = {}) {
+	const messages = [];
+	const calls = [];
+	const p1 = makePlayer('p1', p1Request);
+	const p2 = makePlayer('p2', p2Request);
+	const battle = {
+		format: 'gen9customgame',
+		challengeType: 'challenge',
+		gameType: 'singles',
+		players: [p1, p2],
+		ended: false,
+		turn: 1,
+		requestCount: 0,
+		roomid: 'battle-timer-test',
+		room: {
+			add(message) {
+				messages.push(message);
+				return this;
+			},
+			update() {},
+		},
+		forfeitPlayer(player) {
+			calls.push(['forfeit', player.slot]);
+		},
+		tie() {
+			calls.push(['tie']);
+		},
+	};
+	battle.timer = new RoomBattleTimer(battle);
+	return { battle, p1, p2, calls, messages };
+}
+
+function stopTimer(timer) {
+	timer.end();
+}
+
+describe('TicoMon battle timer policy', () => {
+	it('does not change the timer for non-TicoMon battles', () => {
+		const { battle } = makeBattle();
+		const timer = battle.timer;
+		timer.start();
+
+		assert.equal(timer.isTicoMon, false);
+		assert.equal(timer.settings.starting, 300);
+		assert.equal(timer.settings.maxPerTurn, 300);
+		stopTimer(timer);
+	});
+
+	it('does not start a countdown until a playable request exists', () => {
+		const { battle, p1, p2 } = makeBattle();
+		const timer = battle.timer;
+		p1.request.isWait = 'cantUndo';
+		p2.request.isWait = 'cantUndo';
+
+		timer.markTicoMon();
+
+		assert.equal(timer.timer, null);
+		assert.equal(timer.timerRequesters.has('staff'), true);
+	});
+
+	it('identifies an authenticated TicoMon player connection and starts automatically', () => {
+		const { battle, p1 } = makeBattle();
+		const timer = battle.timer;
+		const connection = {
+			ticomonPvptest2Room: battle.roomid,
+			sendTo() {},
+		};
+		const user = { id: 'p1', connections: [connection] };
+		const roomBattle = Object.create(RoomBattle.prototype);
+		Object.assign(roomBattle, battle, { playerTable: { p1 }, started: true });
+
+		roomBattle.onConnect(user, connection);
+
+		assert.equal(timer.isTicoMon, true);
+		assert.equal(timer.timerRequesters.has('staff'), true);
+		assert.equal(p1.turnSecondsLeft, 60);
+		stopTimer(timer);
+	});
+
+	it('uses 60 seconds for normal decisions and 30 seconds for forced switches', () => {
+		const { battle, p1 } = makeBattle({}, { forceSwitch: [true] });
+		const timer = battle.timer;
+		timer.markTicoMon();
+
+		assert.equal(timer.settings.starting, 60);
+		assert.equal(timer.settings.grace, 0);
+		assert.equal(timer.settings.addPerTurn, 0);
+		assert.equal(timer.settings.timeoutAutoChoose, false);
+		assert.equal(p1.turnSecondsLeft, 60);
+		assert.equal(battle.players[1].turnSecondsLeft, 30);
+
+		p1.request = {
+			rqid: 2,
+			request: JSON.stringify({ forceSwitch: [true] }),
+			isWait: false,
+			choice: '',
+		};
+		timer.nextRequest(p1);
+		assert.equal(p1.turnSecondsLeft, 30);
+
+		p1.request = {
+			rqid: 3,
+			request: JSON.stringify({ active: [{ moves: [] }] }),
+			isWait: false,
+			choice: '',
+		};
+		timer.nextRequest(p1);
+		assert.equal(p1.turnSecondsLeft, 60);
+		stopTimer(timer);
+	});
+
+	it('does not accumulate unused time or restart on timer commands', () => {
+		const { battle, p1 } = makeBattle();
+		const timer = battle.timer;
+		timer.markTicoMon();
+		p1.turnSecondsLeft = 45;
+		p1.secondsLeft = 45;
+
+		assert.equal(timer.start({ id: 'p1' }), false);
+		assert.equal(timer.stop({ id: 'p1' }), false);
+		assert.equal(timer.stop(), false);
+		assert.equal(p1.turnSecondsLeft, 45);
+		assert.equal(timer.timerRequesters.has('staff'), true);
+		stopTimer(timer);
+	});
+
+	it('stops counting a player after a valid decision and keeps invalid decisions on the same window', () => {
+		const { battle, p1, p2 } = makeBattle();
+		const timer = battle.timer;
+		timer.markTicoMon();
+		p1.request.isWait = true;
+		const chosenTime = p1.turnSecondsLeft;
+		timer.nextTick();
+		assert.equal(p1.turnSecondsLeft, chosenTime);
+
+		p2.turnSecondsLeft = 60;
+		p2.secondsLeft = 60;
+		timer.nextTick();
+		assert.equal(p2.turnSecondsLeft, 55);
+		stopTimer(timer);
+	});
+
+	it('forfeits one inactive player and ties when both expire in the same tick', () => {
+		const oneExpired = makeBattle();
+		const oneTimer = oneExpired.battle.timer;
+		oneTimer.markTicoMon();
+		oneExpired.p1.turnSecondsLeft = 0;
+		oneExpired.p2.turnSecondsLeft = 20;
+		assert.equal(oneTimer.checkTimeout(), true);
+		assert.deepEqual(oneExpired.calls, [['forfeit', 'p1']]);
+		stopTimer(oneTimer);
+
+		const bothExpired = makeBattle();
+		const bothTimer = bothExpired.battle.timer;
+		bothTimer.markTicoMon();
+		bothExpired.p1.turnSecondsLeft = 0;
+		bothExpired.p2.turnSecondsLeft = 0;
+		assert.equal(bothTimer.checkTimeout(), true);
+		assert.deepEqual(bothExpired.calls, [['tie']]);
+		assert.equal(bothExpired.messages.includes('|-message|All players are inactive.'), true);
+		stopTimer(bothTimer);
+	});
+
+	it('continues counting during disconnect and does not reset on reconnect', () => {
+		const { battle, p1 } = makeBattle({ forceSwitch: [true] });
+		const timer = battle.timer;
+		timer.markTicoMon();
+		p1.active = false;
+		timer.checkActivity();
+		assert.equal(p1.dcSecondsLeft, 30);
+		timer.nextTick();
+		assert.equal(p1.turnSecondsLeft, 25);
+		p1.active = true;
+		timer.checkActivity();
+		assert.equal(p1.turnSecondsLeft, 25);
+		stopTimer(timer);
+	});
+
+	it('does not duplicate timers for repeated authenticated connections', () => {
+		const { battle, p1 } = makeBattle();
+		const timer = battle.timer;
+		const connection = { ticomonPvptest2Room: battle.roomid, sendTo() {} };
+		const user = { id: 'p1', connections: [connection] };
+		const roomBattle = Object.create(RoomBattle.prototype);
+		Object.assign(roomBattle, battle, { playerTable: { p1 }, started: true });
+
+		roomBattle.onConnect(user, connection);
+		const activeTimer = timer.timer;
+		roomBattle.onConnect(user, connection);
+
+		assert.equal(timer.timerRequesters.size, 1);
+		assert.equal(timer.timer, activeTimer);
+		stopTimer(timer);
+	});
+});

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -5,8 +5,15 @@ const assert = require('assert').strict;
 const { makeConnection, makeUser, destroyUser } = require('../users-utils');
 
 const PACKED_TEAM = 'Pikachu||||thunderbolt||||||';
+const TEST_TICKET_CONSUME_URL = 'https://ticomon-test.invalid/tickets/consume';
+const TEST_INTERNAL_SERVICE_TOKEN = 'test-service-token';
+const TICKET_AUTH_ENV_KEYS = [
+	'TICOMON_PVPTEST2_TICKET_CONSUME_URL',
+	'TICOMON_PVPTEST2_INTERNAL_SERVICE_TOKEN',
+];
 let commands;
 let originalNetPost;
+let originalTicketAuthEnv;
 
 function createBattle(first, second) {
 	return Rooms.createBattle({
@@ -23,8 +30,31 @@ function loadCommands() {
 	({ commands } = require('../../dist/server/chat-commands/core'));
 }
 
+function setupTicketAuthEnvironment() {
+	if (!originalTicketAuthEnv) {
+		originalTicketAuthEnv = Object.fromEntries(
+			TICKET_AUTH_ENV_KEYS.map(key => [key, process.env[key]])
+		);
+	}
+	process.env.TICOMON_PVPTEST2_TICKET_CONSUME_URL = TEST_TICKET_CONSUME_URL;
+	process.env.TICOMON_PVPTEST2_INTERNAL_SERVICE_TOKEN = TEST_INTERNAL_SERVICE_TOKEN;
+}
+
+function restoreTicketAuthEnvironment() {
+	if (!originalTicketAuthEnv) return;
+	for (const key of TICKET_AUTH_ENV_KEYS) {
+		if (originalTicketAuthEnv[key] === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = originalTicketAuthEnv[key];
+		}
+	}
+	originalTicketAuthEnv = null;
+}
+
 function setupMockNet(responseData, error) {
 	const { NetRequest } = require('../../dist/lib/net');
+	setupTicketAuthEnvironment();
 	if (!originalNetPost) originalNetPost = NetRequest.prototype.post;
 	NetRequest.prototype.post = async function () {
 		if (error) throw error;
@@ -34,11 +64,13 @@ function setupMockNet(responseData, error) {
 }
 
 function restoreNet() {
-	if (!originalNetPost) return;
-	const { NetRequest } = require('../../dist/lib/net');
-	NetRequest.prototype.post = originalNetPost;
-	originalNetPost = null;
-	loadCommands();
+	if (originalNetPost) {
+		const { NetRequest } = require('../../dist/lib/net');
+		NetRequest.prototype.post = originalNetPost;
+		originalNetPost = null;
+		loadCommands();
+	}
+	restoreTicketAuthEnvironment();
 }
 
 describe('TicoMon pvptest2 visual connections', () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -219,6 +219,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	});
 
 	it('authenticates p1 with valid player ticket', async () => {
+		const initialPlayerLine = battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1);
 		setupMockNet({
 			valid: true,
 			role: 'player',
@@ -235,6 +236,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		assert.equal(player1.connections.filter(connection => connection === conn).length, 1);
 		assert(!player2.connections.includes(conn));
 		assert(conn.inRooms.has(battle.roomid));
+		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), initialPlayerLine);
 	});
 
 	it('authenticates p2 with valid player ticket', async () => {
@@ -272,6 +274,42 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		assert.equal(battle.battle.p1.getUser().avatar, 'blue');
 	});
 
+	it('publishes the validated avatar to the existing battle protocol', async () => {
+		const initialPlayerLine = battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1);
+		const initialState = {
+			turn: battle.battle.turn,
+			timerTurn: battle.battle.timer.turn,
+			started: battle.battle.started,
+			ended: battle.battle.ended,
+			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
+		};
+		assert(initialPlayerLine);
+		assert(!initialPlayerLine.endsWith('|blue|'));
+
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: battle.roomid,
+			side: 1,
+			trainerAvatar: 'blue',
+		});
+
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
+		assert.equal(player1.avatar, 'blue');
+		assert.equal(battle.battle.p1.getUser().avatar, 'blue');
+		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), '|player|p1|pvpalpha|blue|');
+		assert.notEqual(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), initialPlayerLine);
+		assert.deepEqual({
+			turn: battle.battle.turn,
+			timerTurn: battle.battle.timer.turn,
+			started: battle.battle.started,
+			ended: battle.battle.ended,
+			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
+		}, initialState);
+	});
+
 	it('keeps distinct validated avatars for p1 and p2', async () => {
 		const response = {
 			valid: true,
@@ -289,11 +327,13 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		guest2 = makeUser('', conn2);
 		response.showdownUserid = 'pvpgamma';
 		response.side = 2;
-		response.trainerAvatar = 'dawn-gen4pt';
+		response.trainerAvatar = 'silver';
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
 
 		assert.equal(player1.avatar, 'blue');
-		assert.equal(player2.avatar, 'dawn-gen4pt');
+		assert.equal(player2.avatar, 'silver');
+		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), '|player|p1|pvpalpha|blue|');
+		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p2|')).at(-1), '|player|p2|pvpgamma|silver|');
 	});
 
 	it('preserves the initial avatar when a later ticket disagrees', async () => {
@@ -308,12 +348,49 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		setupMockNet(response);
 
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const playerLineCount = battle.log.log.filter(line => line.startsWith('|player|p1|')).length;
 		conn2 = makeConnection();
 		guest2 = makeUser('', conn2);
 		response.trainerAvatar = 'red';
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
 
 		assert.equal(player1.avatar, 'blue');
+		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), '|player|p1|pvpalpha|blue|');
+		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).length, playerLineCount);
+	});
+
+	it('keeps the existing avatar when trainerAvatar is absent', async () => {
+		const initialAvatar = player1.avatar;
+		const initialPlayerLine = battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1);
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: battle.roomid,
+			side: 1,
+		});
+
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
+		assert.equal(player1.avatar, initialAvatar);
+		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), initialPlayerLine);
+	});
+
+	it('does not update the battle for an unrelated authenticated user', async () => {
+		const initialLog = [...battle.log.log];
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: guest.id,
+			roomId: battle.roomid,
+			side: 1,
+			trainerAvatar: 'blue',
+		});
+
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
+		assert.deepEqual(battle.log.log, initialLog);
+		assert.equal(player1.avatar, initialLog.find(line => line.startsWith('|player|p1|')).split('|')[4]);
 	});
 
 	it('rejects an avatar outside the TicoMon allowlist', async () => {
@@ -519,6 +596,34 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 		const title = roomMessages.some(m => m.includes('|title|'));
 		assert(initBattle, 'spectator should receive |init|battle');
 		assert(title, 'spectator should receive |title|');
+	});
+
+	it('receives the updated player avatar in the battle log', async () => {
+		conn2 = makeConnection();
+		guest2 = makeUser('', conn2);
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'spectestp1',
+			roomId: battle.roomid,
+			side: 1,
+			trainerAvatar: 'blue',
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		conn.sendTo = (roomid, msg) => {
+			sent.push(msg);
+		};
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
+		assert(sent.some(message => message.includes('|player|p1|spectestp1|blue|')));
 	});
 
 	it('cannot /choose (move 1)', async () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -6,6 +6,7 @@ const { makeConnection, makeUser, destroyUser } = require('../users-utils');
 
 const PACKED_TEAM = 'Pikachu||||thunderbolt||||||';
 let commands;
+let mockNet;
 
 function createBattle(first, second) {
 	return Rooms.createBattle({
@@ -17,6 +18,26 @@ function createBattle(first, second) {
 	});
 }
 
+function setupMockNet(responseData) {
+	const libNet = require('../../dist/lib/net');
+	if (!mockNet) mockNet = libNet.Net;
+	libNet.Net = () => ({
+		post: async () => JSON.stringify(responseData),
+	});
+	// Clear cache so the commands module re-imports the mocked Net
+	delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
+	({ commands } = require('../../dist/server/chat-commands/core'));
+}
+
+function restoreNet() {
+	if (mockNet) {
+		const libNet = require('../../dist/lib/net');
+		libNet.Net = mockNet;
+		mockNet = null;
+		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
+	}
+}
+
 describe('TicoMon pvptest2 visual connections', () => {
 	let first;
 	let second;
@@ -26,15 +47,10 @@ describe('TicoMon pvptest2 visual connections', () => {
 	let otherBattle;
 	let visualConnection;
 	let replacementConnection;
+	let guest;
 
 	before(() => {
 		({ commands } = require('../../dist/server/chat-commands/core'));
-	});
-
-	it('accepts the documented hyphenated ticket command', () => {
-		assert.equal(commands['ticomon-auth'], 'ticomonauth');
-		assert.equal(typeof commands.ticomonauth, 'function');
-		assert.equal(commands[commands['ticomon-auth']], commands.ticomonauth);
 	});
 
 	afterEach(() => {
@@ -46,6 +62,7 @@ describe('TicoMon pvptest2 visual connections', () => {
 		destroyUser(second);
 		destroyUser(third);
 		destroyUser(fourth);
+		destroyUser(guest);
 		first = null;
 		second = null;
 		third = null;
@@ -54,11 +71,18 @@ describe('TicoMon pvptest2 visual connections', () => {
 		otherBattle = null;
 		visualConnection = null;
 		replacementConnection = null;
+		guest = null;
+	});
+
+	it('accepts the documented hyphenated ticket command', () => {
+		assert.equal(commands['ticomon-auth'], 'ticomonauth');
+		assert.equal(typeof commands.ticomonauth, 'function');
+		assert.equal(commands[commands['ticomon-auth']], commands.ticomonauth);
 	});
 
 	it('rejects a missing ticket before any internal request', async () => {
 		visualConnection = makeConnection();
-		const guest = makeUser('', visualConnection);
+		guest = makeUser('', visualConnection);
 		const sent = [];
 		visualConnection.send = message => sent.push(message);
 
@@ -68,12 +92,23 @@ describe('TicoMon pvptest2 visual connections', () => {
 		assert.equal(visualConnection.user, guest);
 	});
 
+	it('rejects ticket with invalid format', async () => {
+		visualConnection = makeConnection();
+		guest = makeUser('', visualConnection);
+		const sent = [];
+		visualConnection.send = message => sent.push(message);
+
+		await commands.ticomonauth('short-ticket', null, guest, visualConnection);
+
+		assert.deepEqual(sent, ['|ticomonauth|error|config']);
+	});
+
 	it('attaches only the assigned visual connection and joins its battle', () => {
 		first = makeUser('ticketplayerone');
 		second = makeUser('ticketplayertwo');
 		battle = createBattle(first, second);
 		visualConnection = makeConnection();
-		const guest = makeUser('', visualConnection);
+		guest = makeUser('', visualConnection);
 
 		assert.equal(
 			first.attachTicoMonPvptest2Connection(visualConnection, battle.roomid),
@@ -111,5 +146,452 @@ describe('TicoMon pvptest2 visual connections', () => {
 		assert.equal(Users.connections.has(visualConnection.id), false);
 		assert.equal(replacementConnection.user, first);
 		assert(first.connected);
+	});
+});
+
+describe('TicoMon pvptest2 player auth (role=player)', () => {
+	let player1;
+	let player2;
+	let battle;
+	let conn;
+	let guest;
+
+	beforeEach(() => {
+		player1 = makeUser('pvpalpha');
+		player2 = makeUser('pvpgamma');
+		battle = createBattle(player1, player2);
+		conn = makeConnection();
+		guest = makeUser('', conn);
+	});
+
+	afterEach(() => {
+		if (conn?.user) conn.destroy();
+		if (battle) battle.destroy();
+		destroyUser(player1);
+		destroyUser(player2);
+		destroyUser(guest);
+		player1 = null;
+		player2 = null;
+		battle = null;
+		conn = null;
+		guest = null;
+		restoreNet();
+	});
+
+	it('authenticates p1 with valid player ticket', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: battle.roomid,
+			side: 1,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.equal(sent.length, 1);
+		assert(sent[0].startsWith('|ticomonauth|ok'));
+		assert.equal(conn.user, player1);
+		assert(conn.inRooms.has(battle.roomid));
+	});
+
+	it('authenticates p2 with valid player ticket', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpgamma',
+			roomId: battle.roomid,
+			side: 2,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.equal(sent.length, 1);
+		assert(sent[0].startsWith('|ticomonauth|ok'));
+		assert.equal(conn.user, player2);
+		assert(conn.inRooms.has(battle.roomid));
+	});
+
+	it('rejects player ticket missing side', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: battle.roomid,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
+	});
+
+	it('rejects player ticket missing showdownUserid', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			roomId: battle.roomid,
+			side: 1,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
+	});
+
+	it('rejects player ticket when user is offline', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'nonexistentuser',
+			roomId: battle.roomid,
+			side: 1,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|user_missing']);
+	});
+
+	it('rejects player ticket when room does not exist', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: 'battle-gen9customgame-nonexistent',
+			side: 1,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|room_missing']);
+	});
+});
+
+describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
+	let player1;
+	let player2;
+	let battle;
+	let conn;
+	let conn2;
+	let guest;
+	let guest2;
+
+	beforeEach(() => {
+		player1 = makeUser('spectestp1');
+		player2 = makeUser('spectestp2');
+		battle = createBattle(player1, player2);
+		conn = makeConnection();
+		guest = makeUser('', conn);
+	});
+
+	afterEach(() => {
+		if (conn?.user) conn.destroy();
+		if (conn2?.user) conn2.destroy();
+		if (battle) battle.destroy();
+		destroyUser(player1);
+		destroyUser(player2);
+		destroyUser(guest);
+		destroyUser(guest2);
+		player1 = null;
+		player2 = null;
+		battle = null;
+		conn = null;
+		conn2 = null;
+		guest = null;
+		guest2 = null;
+		restoreNet();
+	});
+
+	it('authenticates a valid spectator ticket and joins the battle room', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.equal(sent.length, 1);
+		assert(sent[0].startsWith('|ticomonauth|ok'));
+		assert.equal(conn.user, guest);
+		assert(conn.inRooms.has(battle.roomid));
+	});
+
+	it('does not occupy p1 slot', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.equal(battle.battle.p1.id, 'spectestp1');
+	});
+
+	it('does not occupy p2 slot', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.equal(battle.battle.p2.id, 'spectestp2');
+	});
+
+	it('does not appear in battle.playerTable', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.equal(battle.battle.playerTable[guest.id], undefined);
+	});
+
+	it('does not receive |request|', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		conn.sendTo = (roomid, msg) => {
+			sent.push(msg);
+		};
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const roomMessages = sent.filter(m => !m.startsWith('|ticomonauth'));
+		const initBattle = roomMessages.some(m => m.includes('|init|battle'));
+		const hasRequest = roomMessages.some(m => m.includes('|request|'));
+		assert(initBattle, 'spectator should receive battle init');
+		assert(!hasRequest, 'spectator should not receive |request|');
+	});
+
+	it('receives public battle log and state', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		conn.sendTo = (roomid, msg) => {
+			sent.push(msg);
+		};
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const roomMessages = sent.filter(m => !m.startsWith('|ticomonauth'));
+		const initBattle = roomMessages.some(m => m.includes('|init|battle'));
+		const title = roomMessages.some(m => m.includes('|title|'));
+		assert(initBattle, 'spectator should receive |init|battle');
+		assert(title, 'spectator should receive |title|');
+	});
+
+	it('cannot /choose (move 1)', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const result = battle.battle.choose(guest, 'move 1');
+		assert.equal(result, undefined);
+	});
+
+	it('cannot /switch', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const result = battle.battle.choose(guest, 'switch 1');
+		assert.equal(result, undefined);
+	});
+
+	it('cannot /team', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const result = battle.battle.choose(guest, 'team 1');
+		assert.equal(result, undefined);
+	});
+
+	it('cannot /forfeit', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const result = battle.battle.forfeit(guest);
+		assert.equal(result, false);
+	});
+
+	it('cannot take p1/p2 after player disconnect', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		player1.disconnectAll();
+		assert.equal(battle.battle.p1.id, 'spectestp1');
+		assert.equal(battle.battle.playerTable[guest.id], undefined);
+	});
+
+	it('rejects spectator ticket with side present', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+			side: 1,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
+	});
+
+	it('rejects spectator ticket with showdownUserid present', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+			showdownUserid: 'someone',
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
+	});
+
+	it('rejects unknown role', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'admin',
+			roomId: battle.roomid,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
+	});
+
+	it('rejects expired ticket (valid=false)', async () => {
+		setupMockNet({
+			valid: false,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
+	});
+
+	it('rejects already-consumed ticket (HTTP 403)', async () => {
+		const libNet = require('../../dist/lib/net');
+		const origNet = libNet.Net;
+		libNet.Net = () => ({
+			post: async () => {
+				throw Object.assign(new Error('Forbidden'), { statusCode: 403 });
+			},
+		});
+		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
+		({ commands } = require('../../dist/server/chat-commands/core'));
+
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_403']);
+
+		libNet.Net = origNet;
+		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
+		// eslint-disable-next-line require-atomic-updates
+		({ commands } = require('../../dist/server/chat-commands/core'));
+	});
+
+	it('rejects ticket for non-existent room', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: 'battle-gen9customgame-noroomhere',
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|room_missing']);
+	});
+
+	it('rejects ticket for non-battle room', async () => {
+		const chatRoom = Rooms.createChatRoom('testlobby', 'Test Lobby');
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: 'testlobby',
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
+		chatRoom.destroy();
+	});
+
+	it('does not print ticket in logs', async () => {
+		const logs = [];
+		const origLog = console.log;
+		console.log = msg => logs.push(msg);
+		try {
+			setupMockNet({
+				valid: true,
+				role: 'spectator',
+				roomId: battle.roomid,
+			});
+			const ticket = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+			await commands.ticomonauth(ticket, null, guest, conn);
+			const allLogs = logs.join(' ');
+			assert(!allLogs.includes(ticket), 'ticket must not appear in logs');
+		} finally {
+		// eslint-disable-next-line require-atomic-updates
+			console.log = origLog;
+		}
+	});
+
+	it('battle ends normally with spectator connected', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert(!battle.battle.ended);
+		battle.battle.forfeit(player1);
+		assert(battle.battle.ended);
+	});
+
+	it('error from bridge does not leak details', async () => {
+		const libNet = require('../../dist/lib/net');
+		const origNet = libNet.Net;
+		libNet.Net = () => ({
+			post: async () => {
+				throw Object.assign(new Error('Internal server error'), { statusCode: 500 });
+			},
+		});
+		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
+		({ commands } = require('../../dist/server/chat-commands/core'));
+
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		assert(sent.length === 1);
+		assert(sent[0].startsWith('|ticomonauth|error|'));
+		assert(!sent[0].includes('Internal server error'), 'must not leak bridge error details');
+
+		libNet.Net = origNet;
+		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
+		// eslint-disable-next-line require-atomic-updates
+		({ commands } = require('../../dist/server/chat-commands/core'));
 	});
 });

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -31,6 +31,10 @@ describe('TicoMon pvptest2 visual connections', () => {
 		({ commands } = require('../../dist/server/chat-commands/core'));
 	});
 
+	it('accepts the documented hyphenated ticket command', () => {
+		assert.equal(commands['ticomon-auth'], commands.ticomonauth);
+	});
+
 	afterEach(() => {
 		if (visualConnection?.user) visualConnection.destroy();
 		if (replacementConnection?.user) replacementConnection.destroy();

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -316,7 +316,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		const player = battle.battle.p1;
 		const initialAvatar = targetUser.avatar;
 		const addedLines = [];
-		const room = battle.room;
+		const room = battle;
 		const roomBattle = battle.battle;
 		const originalRoomAdd = room.add;
 		const originalUpdatePlayerAvatar = roomBattle.updatePlayerAvatar;
@@ -391,7 +391,10 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 
 		const participantMessages = captureConnectionMessages(conn);
 		await withBattleBroadcastCapture(async broadcasts => {
+			const p1Baseline = broadcasts.length;
 			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+			const p1Broadcasts = broadcasts.slice(p1Baseline);
+			assert.equal(getLastVisiblePlayerLine(p1Broadcasts, 'p1'), '|player|p1|pvpalpha|blue|');
 
 			conn2 = makeConnection();
 			guest2 = makeUser('', conn2);
@@ -399,9 +402,12 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			response.side = 2;
 			response.trainerAvatar = 'silver';
 			const participant2Messages = captureConnectionMessages(conn2);
+			const p2Baseline = broadcasts.length;
 			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+			const p2Broadcasts = broadcasts.slice(p2Baseline);
+			assert.equal(getLastVisiblePlayerLine(p2Broadcasts, 'p2'), '|player|p2|pvpgamma|silver|');
 
-			const visibleMessages = [...participantMessages, ...participant2Messages, ...broadcasts];
+			const visibleMessages = [...participantMessages, ...participant2Messages, ...p1Broadcasts, ...p2Broadcasts];
 			assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
 			assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p2'), '|player|p2|pvpgamma|silver|');
 		});

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -269,7 +269,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 
 		assert.equal(player1.avatar, 'blue');
-		assert.equal(battle.battle.p1.avatar, 'blue');
+		assert.equal(battle.battle.p1.getUser().avatar, 'blue');
 	});
 
 	it('keeps distinct validated avatars for p1 and p2', async () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -224,9 +224,11 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		const sent = [];
 		conn.send = msg => sent.push(msg);
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
-		assert.equal(sent.length, 1);
-		assert(sent[0].startsWith('|ticomonauth|ok'));
+		const authMessages = sent.filter(message => message === '|ticomonauth|ok');
+		assert.equal(authMessages.length, 1);
 		assert.equal(conn.user, player1);
+		assert.equal(player1.connections.filter(connection => connection === conn).length, 1);
+		assert(!player2.connections.includes(conn));
 		assert(conn.inRooms.has(battle.roomid));
 	});
 
@@ -241,9 +243,11 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		const sent = [];
 		conn.send = msg => sent.push(msg);
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
-		assert.equal(sent.length, 1);
-		assert(sent[0].startsWith('|ticomonauth|ok'));
+		const authMessages = sent.filter(message => message === '|ticomonauth|ok');
+		assert.equal(authMessages.length, 1);
 		assert.equal(conn.user, player2);
+		assert.equal(player2.connections.filter(connection => connection === conn).length, 1);
+		assert(!player1.connections.includes(conn));
 		assert(conn.inRooms.has(battle.roomid));
 	});
 
@@ -588,8 +592,10 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 		});
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 		assert(!battle.battle.ended);
-		battle.battle.forfeit(player1);
+		assert.equal(battle.battle.forfeit(player1), true);
+		await battle.battle.getInputLog();
 		assert(battle.battle.ended);
+		assert(battle.log.log.some(message => message.startsWith('|win|')));
 	});
 
 	it('error from bridge does not leak details', async () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -189,7 +189,9 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	let player2;
 	let battle;
 	let conn;
+	let conn2;
 	let guest;
+	let guest2;
 
 	beforeEach(() => {
 		player1 = makeUser('pvpalpha');
@@ -201,6 +203,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 
 	afterEach(() => {
 		if (conn?.user) conn.destroy();
+		if (conn2?.user) conn2.destroy();
 		if (battle) battle.destroy();
 		destroyUser(player1);
 		destroyUser(player2);
@@ -209,7 +212,9 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		player2 = null;
 		battle = null;
 		conn = null;
+		conn2 = null;
 		guest = null;
+		guest2 = null;
 		restoreNet();
 	});
 
@@ -249,6 +254,83 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		assert.equal(player2.connections.filter(connection => connection === conn).length, 1);
 		assert(!player1.connections.includes(conn));
 		assert(conn.inRooms.has(battle.roomid));
+	});
+
+	it('assigns the validated avatar to the authenticated player', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: battle.roomid,
+			side: 1,
+			trainerAvatar: 'blue',
+		});
+
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
+		assert.equal(player1.avatar, 'blue');
+		assert.equal(battle.battle.p1.avatar, 'blue');
+	});
+
+	it('keeps distinct validated avatars for p1 and p2', async () => {
+		const response = {
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: battle.roomid,
+			side: 1,
+			trainerAvatar: 'blue',
+		};
+		setupMockNet(response);
+
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
+		conn2 = makeConnection();
+		guest2 = makeUser('', conn2);
+		response.showdownUserid = 'pvpgamma';
+		response.side = 2;
+		response.trainerAvatar = 'dawn-gen4pt';
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+
+		assert.equal(player1.avatar, 'blue');
+		assert.equal(player2.avatar, 'dawn-gen4pt');
+	});
+
+	it('preserves the initial avatar when a later ticket disagrees', async () => {
+		const response = {
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: battle.roomid,
+			side: 1,
+			trainerAvatar: 'blue',
+		};
+		setupMockNet(response);
+
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		conn2 = makeConnection();
+		guest2 = makeUser('', conn2);
+		response.trainerAvatar = 'red';
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+
+		assert.equal(player1.avatar, 'blue');
+	});
+
+	it('rejects an avatar outside the TicoMon allowlist', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'player',
+			showdownUserid: 'pvpalpha',
+			roomId: battle.roomid,
+			side: 1,
+			trainerAvatar: 'https://example.invalid/avatar.png',
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
 	});
 
 	it('rejects player ticket missing side', async () => {
@@ -354,6 +436,21 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 		assert(sent[0].startsWith('|ticomonauth|ok'));
 		assert.equal(conn.user, guest);
 		assert(conn.inRooms.has(battle.roomid));
+	});
+
+	it('rejects a spectator ticket that tries to assign an avatar', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+			trainerAvatar: 'red',
+		});
+		const sent = [];
+		conn.send = msg => sent.push(msg);
+
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
+		assert.deepEqual(sent, ['|ticomonauth|error|consume_invalid_payload']);
 	});
 
 	it('does not occupy p1 slot', async () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -333,13 +333,16 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			updateReturn = originalUpdatePlayerAvatar.call(this, user);
 			return updateReturn;
 		};
-		const initialState = {
+		await battle.battle.getInputLog();
+		const getBattleState = () => ({
 			turn: battle.battle.turn,
 			timerTurn: battle.battle.timer.turn,
 			started: battle.battle.started,
 			ended: battle.battle.ended,
 			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
-		};
+		});
+		const initialState = getBattleState();
+		assert.equal(initialState.timerTurn, 0);
 		assert.notEqual(initialAvatar, 'blue');
 
 		setupMockNet({
@@ -358,6 +361,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 				assert.notEqual(initialAvatar, 'blue');
 				await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 				await battle.battle.getInputLog();
+				assert.deepEqual(getBattleState(), initialState);
 				const authBroadcasts = broadcasts.slice(baseline);
 				const visibleMessages = [...participantMessages, ...authBroadcasts];
 				const blueLine = '|player|p1|pvpalpha|blue|';
@@ -378,13 +382,6 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		assert.equal(player.getUser().avatar, 'blue');
 		assert.equal(updateReturn, true);
 		assert(addedLines.includes('|player|p1|pvpalpha|blue|'));
-		assert.deepEqual({
-			turn: battle.battle.turn,
-			timerTurn: battle.battle.timer.turn,
-			started: battle.battle.started,
-			ended: battle.battle.ended,
-			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
-		}, initialState);
 	});
 
 	it('keeps distinct validated avatars for p1 and p2', async () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -32,7 +32,9 @@ describe('TicoMon pvptest2 visual connections', () => {
 	});
 
 	it('accepts the documented hyphenated ticket command', () => {
-		assert.equal(commands['ticomon-auth'], commands.ticomonauth);
+		assert.equal(commands['ticomon-auth'], 'ticomonauth');
+		assert.equal(typeof commands.ticomonauth, 'function');
+		assert.equal(commands[commands['ticomon-auth']], commands.ticomonauth);
 	});
 
 	afterEach(() => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -64,7 +64,7 @@ describe('TicoMon pvptest2 visual connections', () => {
 
 		await commands.ticomonauth('', null, guest, visualConnection);
 
-		assert.deepEqual(sent, ['|popup|Unable to connect this battle client.']);
+		assert.deepEqual(sent, ['|ticomonauth|error|config']);
 		assert.equal(visualConnection.user, guest);
 	});
 

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -312,6 +312,23 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	it('publishes the validated avatar to the existing battle protocol', async () => {
 		const initialLog = [...battle.log.log];
 		const initialPlayerLine = initialLog.filter(line => line.startsWith('|player|p1|')).at(-1);
+		const targetUser = player1;
+		const player = battle.battle.p1;
+		const initialAvatar = targetUser.avatar;
+		const addedLines = [];
+		const room = battle.room;
+		const roomBattle = battle.battle;
+		const originalRoomAdd = room.add;
+		const originalUpdatePlayerAvatar = roomBattle.updatePlayerAvatar;
+		let updateReturn;
+		room.add = function (message) {
+			addedLines.push(message);
+			return originalRoomAdd.call(this, message);
+		};
+		roomBattle.updatePlayerAvatar = function (user) {
+			updateReturn = originalUpdatePlayerAvatar.call(this, user);
+			return updateReturn;
+		};
 		const initialState = {
 			turn: battle.battle.turn,
 			timerTurn: battle.battle.timer.turn,
@@ -331,15 +348,27 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		});
 
 		const participantMessages = captureConnectionMessages(conn);
-		await withBattleBroadcastCapture(async broadcasts => {
-			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
-			const visibleMessages = [...participantMessages, ...broadcasts];
-			assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
-			if (initialPlayerLine) assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialPlayerLine);
-		});
+		try {
+			await withBattleBroadcastCapture(async broadcasts => {
+				const baseline = broadcasts.length;
+				assert.notEqual(initialAvatar, 'blue');
+				await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+				const authBroadcasts = broadcasts.slice(baseline);
+				const visibleMessages = [...participantMessages, ...authBroadcasts];
+				assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
+				if (initialPlayerLine) assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialPlayerLine);
+				assert(authBroadcasts.some(message => message.includes('|player|p1|pvpalpha|blue|')));
+			});
+		} finally {
+			room.add = originalRoomAdd;
+			roomBattle.updatePlayerAvatar = originalUpdatePlayerAvatar;
+		}
 
-		assert.equal(player1.avatar, 'blue');
-		assert.equal(battle.battle.p1.getUser().avatar, 'blue');
+		assert.equal(targetUser.avatar, 'blue');
+		assert.strictEqual(player.getUser(), targetUser);
+		assert.equal(player.getUser().avatar, 'blue');
+		assert.equal(updateReturn, true);
+		assert(addedLines.includes('|player|p1|pvpalpha|blue|'));
 		assert.deepEqual({
 			turn: battle.battle.turn,
 			timerTurn: battle.battle.timer.turn,
@@ -538,8 +567,10 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 	let battle;
 	let conn;
 	let conn2;
+	let conn3;
 	let guest;
 	let guest2;
+	let guest3;
 
 	beforeEach(() => {
 		player1 = makeUser('spectestp1');
@@ -552,18 +583,22 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 	afterEach(() => {
 		if (conn?.user) conn.destroy();
 		if (conn2?.user) conn2.destroy();
+		if (conn3?.user) conn3.destroy();
 		if (battle) battle.destroy();
 		destroyUser(player1);
 		destroyUser(player2);
 		destroyUser(guest);
 		destroyUser(guest2);
+		destroyUser(guest3);
 		player1 = null;
 		player2 = null;
 		battle = null;
 		conn = null;
 		conn2 = null;
+		conn3 = null;
 		guest = null;
 		guest2 = null;
+		guest3 = null;
 		restoreNet();
 	});
 
@@ -666,6 +701,14 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 	});
 
 	it('receives the updated player avatar in the battle log', async () => {
+		setupMockNet({
+			valid: true,
+			role: 'spectator',
+			roomId: battle.roomid,
+		});
+		const activeSpectatorMessages = captureConnectionMessages(conn);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+
 		conn2 = makeConnection();
 		guest2 = makeUser('', conn2);
 		setupMockNet({
@@ -676,15 +719,25 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 			side: 1,
 			trainerAvatar: 'blue',
 		});
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+		await withBattleBroadcastCapture(async broadcasts => {
+			const baseline = broadcasts.length;
+			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+			const authBroadcasts = broadcasts.slice(baseline);
+			assert.equal(
+				getLastVisiblePlayerLine([...activeSpectatorMessages, ...authBroadcasts], 'p1'),
+				'|player|p1|spectestp1|blue|'
+			);
+		});
 
+		conn3 = makeConnection();
+		guest3 = makeUser('', conn3);
 		setupMockNet({
 			valid: true,
 			role: 'spectator',
 			roomId: battle.roomid,
 		});
-		const sent = captureConnectionMessages(conn);
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const sent = captureConnectionMessages(conn3);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest3, conn3);
 
 		assert.equal(getLastVisiblePlayerLine(sent, 'p1'), '|player|p1|spectestp1|blue|');
 	});

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -40,6 +40,12 @@ function getLastVisiblePlayerLine(messages, slot) {
 		.at(-1);
 }
 
+function getVisiblePlayerLines(messages, slot) {
+	return messages
+		.flatMap(message => message.split('\n'))
+		.filter(line => line.startsWith(`|player|${slot}|`));
+}
+
 async function withBattleBroadcastCapture(callback) {
 	const broadcasts = [];
 	const originalChannelBroadcast = Sockets.channelBroadcast;
@@ -336,7 +342,8 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			ended: battle.battle.ended,
 			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
 		};
-		if (initialPlayerLine) assert(!initialPlayerLine.endsWith('|blue|'));
+		assert(initialPlayerLine);
+		assert(!initialPlayerLine.endsWith('|blue|'));
 
 		setupMockNet({
 			valid: true,
@@ -353,11 +360,17 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 				const baseline = broadcasts.length;
 				assert.notEqual(initialAvatar, 'blue');
 				await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+				await battle.battle.getInputLog();
 				const authBroadcasts = broadcasts.slice(baseline);
 				const visibleMessages = [...participantMessages, ...authBroadcasts];
-				assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
-				if (initialPlayerLine) assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialPlayerLine);
-				assert(authBroadcasts.some(message => message.includes('|player|p1|pvpalpha|blue|')));
+				const blueLine = '|player|p1|pvpalpha|blue|';
+				const authPlayerLines = getVisiblePlayerLines(authBroadcasts, 'p1');
+				const blueIndex = authPlayerLines.lastIndexOf(blueLine);
+				assert(blueIndex >= 0);
+				assert(authPlayerLines.slice(blueIndex + 1).every(line => line === blueLine));
+				assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), blueLine);
+				assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialPlayerLine);
+				assert(authBroadcasts.some(message => message.includes(blueLine)));
 			});
 		} finally {
 			room.add = originalRoomAdd;
@@ -389,10 +402,12 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		};
 		setupMockNet(response);
 
+		assert.notEqual(getLastVisiblePlayerLine(battle.log.log, 'p1'), '|player|p1|pvpalpha|blue|');
 		const participantMessages = captureConnectionMessages(conn);
 		await withBattleBroadcastCapture(async broadcasts => {
 			const p1Baseline = broadcasts.length;
 			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+			await battle.battle.getInputLog();
 			const p1Broadcasts = broadcasts.slice(p1Baseline);
 			assert.equal(getLastVisiblePlayerLine(p1Broadcasts, 'p1'), '|player|p1|pvpalpha|blue|');
 
@@ -404,6 +419,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			const participant2Messages = captureConnectionMessages(conn2);
 			const p2Baseline = broadcasts.length;
 			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+			await battle.battle.getInputLog();
 			const p2Broadcasts = broadcasts.slice(p2Baseline);
 			assert.equal(getLastVisiblePlayerLine(p2Broadcasts, 'p2'), '|player|p2|pvpgamma|silver|');
 

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -342,7 +342,6 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
 		});
 		const initialState = getBattleState();
-		assert.equal(initialState.timerTurn, 0);
 		assert.notEqual(initialAvatar, 'blue');
 
 		setupMockNet({

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const assert = require('assert').strict;
+
+const { makeConnection, makeUser, destroyUser } = require('../users-utils');
+
+const PACKED_TEAM = 'Pikachu||||thunderbolt||||||';
+let commands;
+
+function createBattle(first, second) {
+	return Rooms.createBattle({
+		format: 'gen9customgame',
+		players: [
+			{ user: first, team: PACKED_TEAM },
+			{ user: second, team: PACKED_TEAM },
+		],
+	});
+}
+
+describe('TicoMon pvptest2 visual connections', () => {
+	let first;
+	let second;
+	let third;
+	let fourth;
+	let battle;
+	let otherBattle;
+	let visualConnection;
+	let replacementConnection;
+
+	before(() => {
+		({ commands } = require('../../dist/server/chat-commands/core'));
+	});
+
+	afterEach(() => {
+		if (visualConnection?.user) visualConnection.destroy();
+		if (replacementConnection?.user) replacementConnection.destroy();
+		if (battle) battle.destroy();
+		if (otherBattle) otherBattle.destroy();
+		destroyUser(first);
+		destroyUser(second);
+		destroyUser(third);
+		destroyUser(fourth);
+		first = null;
+		second = null;
+		third = null;
+		fourth = null;
+		battle = null;
+		otherBattle = null;
+		visualConnection = null;
+		replacementConnection = null;
+	});
+
+	it('rejects a missing ticket before any internal request', async () => {
+		visualConnection = makeConnection();
+		const guest = makeUser('', visualConnection);
+		const sent = [];
+		visualConnection.send = message => sent.push(message);
+
+		await commands.ticomonauth('', null, guest, visualConnection);
+
+		assert.deepEqual(sent, ['|popup|Unable to connect this battle client.']);
+		assert.equal(visualConnection.user, guest);
+	});
+
+	it('attaches only the assigned visual connection and joins its battle', () => {
+		first = makeUser('ticketplayerone');
+		second = makeUser('ticketplayertwo');
+		battle = createBattle(first, second);
+		visualConnection = makeConnection();
+		const guest = makeUser('', visualConnection);
+
+		assert.equal(
+			first.attachTicoMonPvptest2Connection(visualConnection, battle.roomid),
+			true
+		);
+		assert.equal(visualConnection.user, first);
+		assert.equal(visualConnection.ticomonPvptest2Room, battle.roomid);
+		assert(visualConnection.inRooms.has(battle.roomid));
+		assert(!guest.connections.includes(visualConnection));
+	});
+
+	it('rejects other battle rooms and replaces only the previous visual connection', async () => {
+		first = makeUser('ticketplayerone');
+		second = makeUser('ticketplayertwo');
+		battle = createBattle(first, second);
+		third = makeUser('ticketplayerthree');
+		fourth = makeUser('ticketplayerfour');
+		otherBattle = createBattle(third, fourth);
+		visualConnection = makeConnection();
+		makeUser('', visualConnection);
+		first.attachTicoMonPvptest2Connection(visualConnection, battle.roomid);
+
+		const sent = [];
+		visualConnection.sendTo = (_roomid, message) => sent.push(message);
+		assert.equal(
+			await first.tryJoinRoom(otherBattle.roomid, visualConnection),
+			false
+		);
+		assert(sent.some(message => message.includes('|joinfailed|')));
+
+		replacementConnection = makeConnection();
+		makeUser('', replacementConnection);
+		first.attachTicoMonPvptest2Connection(replacementConnection, battle.roomid);
+
+		assert.equal(Users.connections.has(visualConnection.id), false);
+		assert.equal(replacementConnection.user, first);
+		assert(first.connected);
+	});
+});

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -6,7 +6,7 @@ const { makeConnection, makeUser, destroyUser } = require('../users-utils');
 
 const PACKED_TEAM = 'Pikachu||||thunderbolt||||||';
 let commands;
-let mockNet;
+let originalNetPost;
 
 function createBattle(first, second) {
 	return Rooms.createBattle({
@@ -18,24 +18,27 @@ function createBattle(first, second) {
 	});
 }
 
-function setupMockNet(responseData) {
-	const libNet = require('../../dist/lib/net');
-	if (!mockNet) mockNet = libNet.Net;
-	libNet.Net = () => ({
-		post: async () => JSON.stringify(responseData),
-	});
-	// Clear cache so the commands module re-imports the mocked Net
+function loadCommands() {
 	delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
 	({ commands } = require('../../dist/server/chat-commands/core'));
 }
 
+function setupMockNet(responseData, error) {
+	const { NetRequest } = require('../../dist/lib/net');
+	if (!originalNetPost) originalNetPost = NetRequest.prototype.post;
+	NetRequest.prototype.post = async function () {
+		if (error) throw error;
+		return JSON.stringify(responseData);
+	};
+	loadCommands();
+}
+
 function restoreNet() {
-	if (mockNet) {
-		const libNet = require('../../dist/lib/net');
-		libNet.Net = mockNet;
-		mockNet = null;
-		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
-	}
+	if (!originalNetPost) return;
+	const { NetRequest } = require('../../dist/lib/net');
+	NetRequest.prototype.post = originalNetPost;
+	originalNetPost = null;
+	loadCommands();
 }
 
 describe('TicoMon pvptest2 visual connections', () => {
@@ -492,25 +495,11 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 	});
 
 	it('rejects already-consumed ticket (HTTP 403)', async () => {
-		const libNet = require('../../dist/lib/net');
-		const origNet = libNet.Net;
-		libNet.Net = () => ({
-			post: async () => {
-				throw Object.assign(new Error('Forbidden'), { statusCode: 403 });
-			},
-		});
-		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
-		({ commands } = require('../../dist/server/chat-commands/core'));
-
+		setupMockNet(null, Object.assign(new Error('Forbidden'), { statusCode: 403 }));
 		const sent = [];
 		conn.send = msg => sent.push(msg);
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 		assert.deepEqual(sent, ['|ticomonauth|error|consume_403']);
-
-		libNet.Net = origNet;
-		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
-		// eslint-disable-next-line require-atomic-updates
-		({ commands } = require('../../dist/server/chat-commands/core'));
 	});
 
 	it('rejects ticket for non-existent room', async () => {
@@ -572,26 +561,12 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 	});
 
 	it('error from bridge does not leak details', async () => {
-		const libNet = require('../../dist/lib/net');
-		const origNet = libNet.Net;
-		libNet.Net = () => ({
-			post: async () => {
-				throw Object.assign(new Error('Internal server error'), { statusCode: 500 });
-			},
-		});
-		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
-		({ commands } = require('../../dist/server/chat-commands/core'));
-
+		setupMockNet(null, Object.assign(new Error('Internal server error'), { statusCode: 500 }));
 		const sent = [];
 		conn.send = msg => sent.push(msg);
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 		assert(sent.length === 1);
 		assert(sent[0].startsWith('|ticomonauth|error|'));
 		assert(!sent[0].includes('Internal server error'), 'must not leak bridge error details');
-
-		libNet.Net = origNet;
-		delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
-		// eslint-disable-next-line require-atomic-updates
-		({ commands } = require('../../dist/server/chat-commands/core'));
 	});
 });

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -25,6 +25,10 @@ function createBattle(first, second) {
 	});
 }
 
+function getLastPlayerLine(log, slot) {
+	return log.filter(line => line.startsWith(`|player|${slot}|`)).at(-1);
+}
+
 function loadCommands() {
 	delete require.cache[require.resolve('../../dist/server/chat-commands/core')];
 	({ commands } = require('../../dist/server/chat-commands/core'));
@@ -219,7 +223,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	});
 
 	it('authenticates p1 with valid player ticket', async () => {
-		const initialPlayerLine = battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1);
+		const initialPlayerLine = getLastPlayerLine(battle.log.log, 'p1');
 		setupMockNet({
 			valid: true,
 			role: 'player',
@@ -236,7 +240,13 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		assert.equal(player1.connections.filter(connection => connection === conn).length, 1);
 		assert(!player2.connections.includes(conn));
 		assert(conn.inRooms.has(battle.roomid));
-		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), initialPlayerLine);
+		const finalPlayerLine = getLastPlayerLine(battle.log.log, 'p1');
+		assert(finalPlayerLine);
+		if (initialPlayerLine) {
+			assert.equal(finalPlayerLine, initialPlayerLine);
+		} else {
+			assert.equal(finalPlayerLine, `|player|p1|pvpalpha|${player1.avatar}|`);
+		}
 	});
 
 	it('authenticates p2 with valid player ticket', async () => {
@@ -275,7 +285,8 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	});
 
 	it('publishes the validated avatar to the existing battle protocol', async () => {
-		const initialPlayerLine = battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1);
+		const initialLog = [...battle.log.log];
+		const initialPlayerLine = getLastPlayerLine(initialLog, 'p1');
 		const initialState = {
 			turn: battle.battle.turn,
 			timerTurn: battle.battle.timer.turn,
@@ -283,8 +294,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			ended: battle.battle.ended,
 			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
 		};
-		assert(initialPlayerLine);
-		assert(!initialPlayerLine.endsWith('|blue|'));
+		if (initialPlayerLine) assert(!initialPlayerLine.endsWith('|blue|'));
 
 		setupMockNet({
 			valid: true,
@@ -299,8 +309,8 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 
 		assert.equal(player1.avatar, 'blue');
 		assert.equal(battle.battle.p1.getUser().avatar, 'blue');
-		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), '|player|p1|pvpalpha|blue|');
-		assert.notEqual(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), initialPlayerLine);
+		assert.equal(getLastPlayerLine(battle.log.log, 'p1'), '|player|p1|pvpalpha|blue|');
+		if (initialPlayerLine) assert.notEqual(getLastPlayerLine(battle.log.log, 'p1'), initialPlayerLine);
 		assert.deepEqual({
 			turn: battle.battle.turn,
 			timerTurn: battle.battle.timer.turn,
@@ -332,8 +342,8 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 
 		assert.equal(player1.avatar, 'blue');
 		assert.equal(player2.avatar, 'silver');
-		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), '|player|p1|pvpalpha|blue|');
-		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p2|')).at(-1), '|player|p2|pvpgamma|silver|');
+		assert.equal(getLastPlayerLine(battle.log.log, 'p1'), '|player|p1|pvpalpha|blue|');
+		assert.equal(getLastPlayerLine(battle.log.log, 'p2'), '|player|p2|pvpgamma|silver|');
 	});
 
 	it('preserves the initial avatar when a later ticket disagrees', async () => {
@@ -355,13 +365,13 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
 
 		assert.equal(player1.avatar, 'blue');
-		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), '|player|p1|pvpalpha|blue|');
+		assert.equal(getLastPlayerLine(battle.log.log, 'p1'), '|player|p1|pvpalpha|blue|');
 		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).length, playerLineCount);
 	});
 
 	it('keeps the existing avatar when trainerAvatar is absent', async () => {
 		const initialAvatar = player1.avatar;
-		const initialPlayerLine = battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1);
+		const initialPlayerLine = getLastPlayerLine(battle.log.log, 'p1');
 		setupMockNet({
 			valid: true,
 			role: 'player',
@@ -373,11 +383,18 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 
 		assert.equal(player1.avatar, initialAvatar);
-		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).at(-1), initialPlayerLine);
+		const finalPlayerLine = getLastPlayerLine(battle.log.log, 'p1');
+		assert(finalPlayerLine);
+		if (initialPlayerLine) {
+			assert.equal(finalPlayerLine, initialPlayerLine);
+		} else {
+			assert.equal(finalPlayerLine, `|player|p1|pvpalpha|${initialAvatar}|`);
+		}
 	});
 
 	it('does not update the battle for an unrelated authenticated user', async () => {
 		const initialLog = [...battle.log.log];
+		const initialAvatar = player1.avatar;
 		setupMockNet({
 			valid: true,
 			role: 'player',
@@ -390,7 +407,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 
 		assert.deepEqual(battle.log.log, initialLog);
-		assert.equal(player1.avatar, initialLog.find(line => line.startsWith('|player|p1|')).split('|')[4]);
+		assert.equal(player1.avatar, initialAvatar);
 	});
 
 	it('rejects an avatar outside the TicoMon allowlist', async () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -376,7 +376,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		}
 
 		assert.equal(targetUser.avatar, 'blue');
-		assert.strictEqual(player.getUser(), targetUser);
+		assert.equal(player.getUser(), targetUser);
 		assert.equal(player.getUser().avatar, 'blue');
 		assert.equal(updateReturn, true);
 		assert(addedLines.includes('|player|p1|pvpalpha|blue|'));

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -316,8 +316,6 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	});
 
 	it('publishes the validated avatar to the existing battle protocol', async () => {
-		const initialLog = [...battle.log.log];
-		const initialPlayerLine = initialLog.filter(line => line.startsWith('|player|p1|')).at(-1);
 		const targetUser = player1;
 		const player = battle.battle.p1;
 		const initialAvatar = targetUser.avatar;
@@ -342,8 +340,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			ended: battle.battle.ended,
 			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
 		};
-		assert(initialPlayerLine);
-		assert(!initialPlayerLine.endsWith('|blue|'));
+		assert.notEqual(initialAvatar, 'blue');
 
 		setupMockNet({
 			valid: true,
@@ -369,7 +366,6 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 				assert(blueIndex >= 0);
 				assert(authPlayerLines.slice(blueIndex + 1).every(line => line === blueLine));
 				assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), blueLine);
-				assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialPlayerLine);
 				assert(authBroadcasts.some(message => message.includes(blueLine)));
 			});
 		} finally {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -3,6 +3,7 @@
 const assert = require('assert').strict;
 
 const { makeConnection, makeUser, destroyUser } = require('../users-utils');
+const { Sockets } = require('../../dist/server/sockets');
 
 const PACKED_TEAM = 'Pikachu||||thunderbolt||||||';
 const TEST_TICKET_CONSUME_URL = 'https://ticomon-test.invalid/tickets/consume';
@@ -37,6 +38,21 @@ function getLastVisiblePlayerLine(messages, slot) {
 		.flatMap(message => message.split('\n'))
 		.filter(line => line.startsWith(`|player|${slot}|`))
 		.at(-1);
+}
+
+async function withBattleBroadcastCapture(callback) {
+	const broadcasts = [];
+	const originalChannelBroadcast = Sockets.channelBroadcast;
+	Sockets.channelBroadcast = (roomid, message) => {
+		broadcasts.push(message);
+		return originalChannelBroadcast.call(Sockets, roomid, message);
+	};
+	try {
+		return await callback(broadcasts);
+	} finally {
+		// eslint-disable-next-line require-atomic-updates
+		Sockets.channelBroadcast = originalChannelBroadcast;
+	}
 }
 
 function loadCommands() {
@@ -204,10 +220,8 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	let battle;
 	let conn;
 	let conn2;
-	let conn3;
 	let guest;
 	let guest2;
-	let guest3;
 
 	beforeEach(() => {
 		player1 = makeUser('pvpalpha');
@@ -220,7 +234,6 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	afterEach(() => {
 		if (conn?.user) conn.destroy();
 		if (conn2?.user) conn2.destroy();
-		if (conn3?.user) conn3.destroy();
 		if (battle) battle.destroy();
 		destroyUser(player1);
 		destroyUser(player2);
@@ -230,10 +243,8 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		battle = null;
 		conn = null;
 		conn2 = null;
-		conn3 = null;
 		guest = null;
 		guest2 = null;
-		guest3 = null;
 		restoreNet();
 	});
 
@@ -319,19 +330,16 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			trainerAvatar: 'blue',
 		});
 
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const participantMessages = captureConnectionMessages(conn);
+		await withBattleBroadcastCapture(async broadcasts => {
+			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+			const visibleMessages = [...participantMessages, ...broadcasts];
+			assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
+			if (initialPlayerLine) assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialPlayerLine);
+		});
 
 		assert.equal(player1.avatar, 'blue');
 		assert.equal(battle.battle.p1.getUser().avatar, 'blue');
-
-		conn2 = makeConnection();
-		guest2 = makeUser('', conn2);
-		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
-		const visibleMessages = captureConnectionMessages(conn2);
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
-
-		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
-		if (initialPlayerLine) assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialPlayerLine);
 		assert.deepEqual({
 			turn: battle.battle.turn,
 			timerTurn: battle.battle.timer.turn,
@@ -352,26 +360,25 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		};
 		setupMockNet(response);
 
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const participantMessages = captureConnectionMessages(conn);
+		await withBattleBroadcastCapture(async broadcasts => {
+			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 
-		conn2 = makeConnection();
-		guest2 = makeUser('', conn2);
-		response.showdownUserid = 'pvpgamma';
-		response.side = 2;
-		response.trainerAvatar = 'silver';
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+			conn2 = makeConnection();
+			guest2 = makeUser('', conn2);
+			response.showdownUserid = 'pvpgamma';
+			response.side = 2;
+			response.trainerAvatar = 'silver';
+			const participant2Messages = captureConnectionMessages(conn2);
+			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+
+			const visibleMessages = [...participantMessages, ...participant2Messages, ...broadcasts];
+			assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
+			assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p2'), '|player|p2|pvpgamma|silver|');
+		});
 
 		assert.equal(player1.avatar, 'blue');
 		assert.equal(player2.avatar, 'silver');
-
-		conn3 = makeConnection();
-		guest3 = makeUser('', conn3);
-		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
-		const visibleMessages = captureConnectionMessages(conn3);
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest3, conn3);
-
-		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
-		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p2'), '|player|p2|pvpgamma|silver|');
 	});
 
 	it('preserves the initial avatar when a later ticket disagrees', async () => {
@@ -385,22 +392,21 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		};
 		setupMockNet(response);
 
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
-		conn2 = makeConnection();
-		guest2 = makeUser('', conn2);
-		response.trainerAvatar = 'red';
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+		const participantMessages = captureConnectionMessages(conn);
+		await withBattleBroadcastCapture(async broadcasts => {
+			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+			conn2 = makeConnection();
+			guest2 = makeUser('', conn2);
+			response.trainerAvatar = 'red';
+			const participant2Messages = captureConnectionMessages(conn2);
+			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+
+			const visibleMessages = [...participantMessages, ...participant2Messages, ...broadcasts];
+			assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
+			assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|red|');
+		});
 
 		assert.equal(player1.avatar, 'blue');
-
-		conn3 = makeConnection();
-		guest3 = makeUser('', conn3);
-		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
-		const visibleMessages = captureConnectionMessages(conn3);
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest3, conn3);
-
-		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
-		assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|silver|');
 	});
 
 	it('keeps the existing avatar when trainerAvatar is absent', async () => {
@@ -413,19 +419,16 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 			side: 1,
 		});
 
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+		const participantMessages = captureConnectionMessages(conn);
+		await withBattleBroadcastCapture(async broadcasts => {
+			await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
+			const visibleMessages = [...participantMessages, ...broadcasts];
+			const finalPlayerLine = getLastVisiblePlayerLine(visibleMessages, 'p1');
+			assert(finalPlayerLine);
+			assert.equal(finalPlayerLine.split('|')[4], String(initialAvatar));
+		});
 
 		assert.equal(player1.avatar, initialAvatar);
-
-		conn2 = makeConnection();
-		guest2 = makeUser('', conn2);
-		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
-		const visibleMessages = captureConnectionMessages(conn2);
-		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
-
-		const finalPlayerLine = getLastVisiblePlayerLine(visibleMessages, 'p1');
-		assert(finalPlayerLine);
-		assert.equal(finalPlayerLine.split('|')[4], String(initialAvatar));
 	});
 
 	it('does not update the battle for an unrelated authenticated user', async () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -25,8 +25,18 @@ function createBattle(first, second) {
 	});
 }
 
-function getLastPlayerLine(log, slot) {
-	return log.filter(line => line.startsWith(`|player|${slot}|`)).at(-1);
+function captureConnectionMessages(connection) {
+	const messages = [];
+	connection.send = message => messages.push(message);
+	connection.sendTo = (_roomid, message) => messages.push(message);
+	return messages;
+}
+
+function getLastVisiblePlayerLine(messages, slot) {
+	return messages
+		.flatMap(message => message.split('\n'))
+		.filter(line => line.startsWith(`|player|${slot}|`))
+		.at(-1);
 }
 
 function loadCommands() {
@@ -194,8 +204,10 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	let battle;
 	let conn;
 	let conn2;
+	let conn3;
 	let guest;
 	let guest2;
+	let guest3;
 
 	beforeEach(() => {
 		player1 = makeUser('pvpalpha');
@@ -208,6 +220,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 	afterEach(() => {
 		if (conn?.user) conn.destroy();
 		if (conn2?.user) conn2.destroy();
+		if (conn3?.user) conn3.destroy();
 		if (battle) battle.destroy();
 		destroyUser(player1);
 		destroyUser(player2);
@@ -217,13 +230,14 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		battle = null;
 		conn = null;
 		conn2 = null;
+		conn3 = null;
 		guest = null;
 		guest2 = null;
+		guest3 = null;
 		restoreNet();
 	});
 
 	it('authenticates p1 with valid player ticket', async () => {
-		const initialPlayerLine = getLastPlayerLine(battle.log.log, 'p1');
 		setupMockNet({
 			valid: true,
 			role: 'player',
@@ -240,13 +254,13 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		assert.equal(player1.connections.filter(connection => connection === conn).length, 1);
 		assert(!player2.connections.includes(conn));
 		assert(conn.inRooms.has(battle.roomid));
-		const finalPlayerLine = getLastPlayerLine(battle.log.log, 'p1');
-		assert(finalPlayerLine);
-		if (initialPlayerLine) {
-			assert.equal(finalPlayerLine, initialPlayerLine);
-		} else {
-			assert.equal(finalPlayerLine, `|player|p1|pvpalpha|${player1.avatar}|`);
-		}
+
+		conn2 = makeConnection();
+		guest2 = makeUser('', conn2);
+		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
+		const visibleMessages = captureConnectionMessages(conn2);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), `|player|p1|pvpalpha|${player1.avatar}|`);
 	});
 
 	it('authenticates p2 with valid player ticket', async () => {
@@ -286,7 +300,7 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 
 	it('publishes the validated avatar to the existing battle protocol', async () => {
 		const initialLog = [...battle.log.log];
-		const initialPlayerLine = getLastPlayerLine(initialLog, 'p1');
+		const initialPlayerLine = initialLog.filter(line => line.startsWith('|player|p1|')).at(-1);
 		const initialState = {
 			turn: battle.battle.turn,
 			timerTurn: battle.battle.timer.turn,
@@ -309,8 +323,15 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 
 		assert.equal(player1.avatar, 'blue');
 		assert.equal(battle.battle.p1.getUser().avatar, 'blue');
-		assert.equal(getLastPlayerLine(battle.log.log, 'p1'), '|player|p1|pvpalpha|blue|');
-		if (initialPlayerLine) assert.notEqual(getLastPlayerLine(battle.log.log, 'p1'), initialPlayerLine);
+
+		conn2 = makeConnection();
+		guest2 = makeUser('', conn2);
+		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
+		const visibleMessages = captureConnectionMessages(conn2);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+
+		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
+		if (initialPlayerLine) assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialPlayerLine);
 		assert.deepEqual({
 			turn: battle.battle.turn,
 			timerTurn: battle.battle.timer.turn,
@@ -342,8 +363,15 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 
 		assert.equal(player1.avatar, 'blue');
 		assert.equal(player2.avatar, 'silver');
-		assert.equal(getLastPlayerLine(battle.log.log, 'p1'), '|player|p1|pvpalpha|blue|');
-		assert.equal(getLastPlayerLine(battle.log.log, 'p2'), '|player|p2|pvpgamma|silver|');
+
+		conn3 = makeConnection();
+		guest3 = makeUser('', conn3);
+		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
+		const visibleMessages = captureConnectionMessages(conn3);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest3, conn3);
+
+		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
+		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p2'), '|player|p2|pvpgamma|silver|');
 	});
 
 	it('preserves the initial avatar when a later ticket disagrees', async () => {
@@ -358,20 +386,25 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		setupMockNet(response);
 
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
-		const playerLineCount = battle.log.log.filter(line => line.startsWith('|player|p1|')).length;
 		conn2 = makeConnection();
 		guest2 = makeUser('', conn2);
 		response.trainerAvatar = 'red';
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
 
 		assert.equal(player1.avatar, 'blue');
-		assert.equal(getLastPlayerLine(battle.log.log, 'p1'), '|player|p1|pvpalpha|blue|');
-		assert.equal(battle.log.log.filter(line => line.startsWith('|player|p1|')).length, playerLineCount);
+
+		conn3 = makeConnection();
+		guest3 = makeUser('', conn3);
+		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
+		const visibleMessages = captureConnectionMessages(conn3);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest3, conn3);
+
+		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|blue|');
+		assert.notEqual(getLastVisiblePlayerLine(visibleMessages, 'p1'), '|player|p1|pvpalpha|silver|');
 	});
 
 	it('keeps the existing avatar when trainerAvatar is absent', async () => {
 		const initialAvatar = player1.avatar;
-		const initialPlayerLine = getLastPlayerLine(battle.log.log, 'p1');
 		setupMockNet({
 			valid: true,
 			role: 'player',
@@ -383,18 +416,28 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 
 		assert.equal(player1.avatar, initialAvatar);
-		const finalPlayerLine = getLastPlayerLine(battle.log.log, 'p1');
+
+		conn2 = makeConnection();
+		guest2 = makeUser('', conn2);
+		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
+		const visibleMessages = captureConnectionMessages(conn2);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+
+		const finalPlayerLine = getLastVisiblePlayerLine(visibleMessages, 'p1');
 		assert(finalPlayerLine);
-		if (initialPlayerLine) {
-			assert.equal(finalPlayerLine, initialPlayerLine);
-		} else {
-			assert.equal(finalPlayerLine, `|player|p1|pvpalpha|${initialAvatar}|`);
-		}
+		assert.equal(finalPlayerLine.split('|')[4], String(initialAvatar));
 	});
 
 	it('does not update the battle for an unrelated authenticated user', async () => {
-		const initialLog = [...battle.log.log];
 		const initialAvatar = player1.avatar;
+		const initialPlayer2Avatar = player2.avatar;
+		conn2 = makeConnection();
+		guest2 = makeUser('', conn2);
+		setupMockNet({ valid: true, role: 'spectator', roomId: battle.roomid });
+		const visibleMessages = captureConnectionMessages(conn2);
+		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest2, conn2);
+		const initialP1Line = getLastVisiblePlayerLine(visibleMessages, 'p1');
+		const initialP2Line = getLastVisiblePlayerLine(visibleMessages, 'p2');
 		setupMockNet({
 			valid: true,
 			role: 'player',
@@ -406,8 +449,12 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 
-		assert.deepEqual(battle.log.log, initialLog);
+		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p1'), initialP1Line);
+		assert.equal(getLastVisiblePlayerLine(visibleMessages, 'p2'), initialP2Line);
 		assert.equal(player1.avatar, initialAvatar);
+		assert.equal(player2.avatar, initialPlayer2Avatar);
+		assert(!visibleMessages.some(message => message.includes(`|player|p1|${guest.name}|`)));
+		assert(!visibleMessages.some(message => message.includes(`|player|p2|${guest.name}|`)));
 	});
 
 	it('rejects an avatar outside the TicoMon allowlist', async () => {
@@ -633,14 +680,10 @@ describe('TicoMon pvptest2 spectator auth (role=spectator)', () => {
 			role: 'spectator',
 			roomId: battle.roomid,
 		});
-		const sent = [];
-		conn.send = msg => sent.push(msg);
-		conn.sendTo = (roomid, msg) => {
-			sent.push(msg);
-		};
+		const sent = captureConnectionMessages(conn);
 		await commands.ticomonauth('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, guest, conn);
 
-		assert(sent.some(message => message.includes('|player|p1|spectestp1|blue|')));
+		assert.equal(getLastVisiblePlayerLine(sent, 'p1'), '|player|p1|spectestp1|blue|');
 	});
 
 	it('cannot /choose (move 1)', async () => {

--- a/test/server/ticomon-pvptest2.js
+++ b/test/server/ticomon-pvptest2.js
@@ -336,7 +336,6 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		await battle.battle.getInputLog();
 		const getBattleState = () => ({
 			turn: battle.battle.turn,
-			timerTurn: battle.battle.timer.turn,
 			started: battle.battle.started,
 			ended: battle.battle.ended,
 			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
@@ -381,6 +380,35 @@ describe('TicoMon pvptest2 player auth (role=player)', () => {
 		assert.equal(player.getUser().avatar, 'blue');
 		assert.equal(updateReturn, true);
 		assert(addedLines.includes('|player|p1|pvpalpha|blue|'));
+	});
+
+	it('updates an avatar without changing timer or battle state', () => {
+		const roomBattle = battle.battle;
+		const playerUser = player1;
+		playerUser.avatar = 'blue';
+		const beforeState = {
+			timerTurn: roomBattle.timer.turn,
+			turn: roomBattle.turn,
+			ended: roomBattle.ended,
+			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
+			decisions: roomBattle.players.map(player => ({ ...player.request })),
+		};
+		const logBaseline = battle.log.log.length;
+
+		assert.equal(roomBattle.updatePlayerAvatar(playerUser), true);
+
+		const afterState = {
+			timerTurn: roomBattle.timer.turn,
+			turn: roomBattle.turn,
+			ended: roomBattle.ended,
+			requests: battle.log.log.filter(line => line.startsWith('|request|')).length,
+			decisions: roomBattle.players.map(player => ({ ...player.request })),
+		};
+		assert.deepEqual(afterState, beforeState);
+		assert.deepEqual(
+			battle.log.log.slice(logBaseline).filter(line => line.startsWith('|player|')),
+			['|player|p1|pvpalpha|blue|']
+		);
 	});
 
 	it('keeps distinct validated avatars for p1 and p2', async () => {


### PR DESCRIPTION
- republishes the official `|player|` line after authenticated TicoMon avatar assignment;
- updates the visible battle protocol instead of only changing `User.avatar`;
- supports distinct p1 and p2 avatars;
- preserves the initial avatar across reconnects;
- leaves older tickets without `trainerAvatar` unchanged;
- prevents spectators and unrelated users from updating player avatars;
- does not resend requests or alter turns, timers or battle state;
- adds focused protocol, reconnect, spectator and idempotency tests.

Validation:

- ESLint passed with Node v22.22.3;
- TypeScript passed;
- `git diff --check` passed;
- local Mocha was blocked by the known Windows `.//` path issue and must be validated in CI Linux.