### PR TITLE
Add clauses for Max moves

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -743,7 +743,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		// searchShow: false,
 		ruleset: [
 			'Standard OMs', 'Camomons Mod', 'NatDex Mod', '!Obtainable Moves', '!Team Preview', 'Team Type Preview', 'CFZ Clause',
-			'G-Max Move Clause', 'Max Move Clause', 'Sleep Moves Clause', 'Terastal Clause',
+			'Max Move Clause', 'Sleep Moves Clause', 'Terastal Clause',
 		],
 		banlist: [
 			'Aerodactyl-Mega', 'Alakazam', 'Arceus', 'Beedrill-Mega', 'Blaziken-Mega', 'Calyrex-Ice', 'Calyrex-Shadow', 'Charizard-Mega-Y', 'Chi-Yu', 'Chien-Pao', 'Comfey',
@@ -3560,7 +3560,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		searchShow: false,
 		ruleset: [
 			'Standard AG', 'NatDex Mod', '!Obtainable', '-CAP',
-			'Forme Clause', 'Sleep Moves Clause', 'Ability Clause = 2', 'OHKO Clause', 'Evasion Moves Clause', 'CFZ Clause', 'G-Max Move Clause', 'Max Move Clause', 'Terastal Clause',
+			'Forme Clause', 'Sleep Moves Clause', 'Ability Clause = 2', 'OHKO Clause', 'Evasion Moves Clause', 'CFZ Clause', 'Max Move Clause', 'Terastal Clause',
 		],
 		banlist: [
 			'Cramorant-Gorging', 'Calyrex-Shadow', 'Darmanitan-Galar-Zen', 'Eternatus-Eternamax', 'Greninja-Ash', 'Groudon-Primal', 'Rayquaza-Mega', 'Shedinja', 'Terapagos-Stellar', 'Arena Trap',

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -742,7 +742,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen9',
 		// searchShow: false,
 		ruleset: [
-			'Standard OMs', 'Camomons Mod', 'NatDex Mod', '!Obtainable Moves', '!Team Preview', 'Team Type Preview', 'CFZ Clause', 'Sleep Moves Clause', 'Terastal Clause',
+			'Standard OMs', 'Camomons Mod', 'NatDex Mod', '!Obtainable Moves', '!Team Preview', 'Team Type Preview', 'CFZ Clause',
+			'G-Max Move Clause', 'Max Move Clause', 'Sleep Moves Clause', 'Terastal Clause',
 		],
 		banlist: [
 			'Aerodactyl-Mega', 'Alakazam', 'Arceus', 'Beedrill-Mega', 'Blaziken-Mega', 'Calyrex-Ice', 'Calyrex-Shadow', 'Charizard-Mega-Y', 'Chi-Yu', 'Chien-Pao', 'Comfey',
@@ -3558,8 +3559,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		mod: 'gen9',
 		searchShow: false,
 		ruleset: [
-			'Standard AG', 'NatDex Mod', '!Obtainable',
-			'Forme Clause', 'Sleep Moves Clause', 'Ability Clause = 2', 'OHKO Clause', 'Evasion Moves Clause', 'Dynamax Clause', 'CFZ Clause', 'Terastal Clause', '-CAP',
+			'Standard AG', 'NatDex Mod', '!Obtainable', '-CAP',
+			'Forme Clause', 'Sleep Moves Clause', 'Ability Clause = 2', 'OHKO Clause', 'Evasion Moves Clause', 'CFZ Clause', 'G-Max Move Clause', 'Max Move Clause', 'Terastal Clause',
 		],
 		banlist: [
 			'Cramorant-Gorging', 'Calyrex-Shadow', 'Darmanitan-Galar-Zen', 'Eternatus-Eternamax', 'Greninja-Ash', 'Groudon-Primal', 'Rayquaza-Mega', 'Shedinja', 'Terapagos-Stellar', 'Arena Trap',

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1338,6 +1338,22 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 			this.add('rule', 'Z-Move Clause: Z-Moves are banned');
 		},
 	},
+	gmaxmoveclause: {
+		effectType: 'ValidatorRule',
+		name: "G-Max Move Clause",
+		desc: "Bans the use of G-Max moves",
+		banlist: [
+			'G-Max Befuddle', 'G-Max Cannonade', 'G-Max Centiferno', 'G-Max Chi Strike', 'G-Max Cuddle', 'G-Max Depletion',
+			'G-Max Drum Solo', 'G-Max Finale', 'G-Max Fireball', 'G-Max Foam Burst', 'G-Max Gold Rush', 'G-Max Gravitas',
+			'G-Max Hydrosnipe', 'G-Max Malodor', 'G-Max Meltdown', 'G-Max One Blow', 'G-Max Rapid Flow', 'G-Max Replenish',
+			'G-Max Resonance', 'G-Max Sandblast', 'G-Max Smite', 'G-Max Snooze', 'G-Max Steelsurge', 'G-Max Stonesurge',
+			'G-Max Stun Shock', 'G-Max Sweetness', 'G-Max Tartness', 'G-Max Terror', 'G-Max Vine Lash', 'G-Max Volcalith',
+			'G-Max Volt Crash', 'G-Max Wildfire', 'G-Max Wind Rage',
+		],
+		onBegin() {
+			this.add('rule', 'G-Max Move Clause: G-Max moves are banned');
+		},
+	},
 	notfullyevolved: {
 		effectType: 'ValidatorRule',
 		name: 'Not Fully Evolved',

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1354,6 +1354,19 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 			this.add('rule', 'G-Max Move Clause: G-Max moves are banned');
 		},
 	},
+	maxmoveclause: {
+		effectType: 'ValidatorRule',
+		name: "Max Move Clause",
+		desc: "Bans the use of Max moves",
+		banlist: [
+			'Max Airstream', 'Max Darkness', 'Max Flare', 'Max Flutterby', 'Max Geyser', 'Max Guard', 'Max Hailstorm',
+			'Max Knuckle', 'Max Lightning', 'Max Mindstorm', 'Max Ooze', 'Max Overgrowth', 'Max Phantasm', 'Max Quake',
+			'Max Rockfall', 'Max Starfall', 'Max Steelspike', 'Max Strike', 'Max Wyrmwind',
+		],
+		onBegin() {
+			this.add('rule', 'Max Move Clause: Max moves are banned');
+		},
+	},
 	notfullyevolved: {
 		effectType: 'ValidatorRule',
 		name: 'Not Fully Evolved',

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1338,30 +1338,20 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 			this.add('rule', 'Z-Move Clause: Z-Moves are banned');
 		},
 	},
-	gmaxmoveclause: {
+	maxmoveclause: {
 		effectType: 'ValidatorRule',
-		name: "G-Max Move Clause",
-		desc: "Bans the use of G-Max moves",
+		name: "Max Move Clause",
+		desc: "Bans the use of Dynamax-free Max moves",
 		banlist: [
 			'G-Max Befuddle', 'G-Max Cannonade', 'G-Max Centiferno', 'G-Max Chi Strike', 'G-Max Cuddle', 'G-Max Depletion',
 			'G-Max Drum Solo', 'G-Max Finale', 'G-Max Fireball', 'G-Max Foam Burst', 'G-Max Gold Rush', 'G-Max Gravitas',
 			'G-Max Hydrosnipe', 'G-Max Malodor', 'G-Max Meltdown', 'G-Max One Blow', 'G-Max Rapid Flow', 'G-Max Replenish',
 			'G-Max Resonance', 'G-Max Sandblast', 'G-Max Smite', 'G-Max Snooze', 'G-Max Steelsurge', 'G-Max Stonesurge',
 			'G-Max Stun Shock', 'G-Max Sweetness', 'G-Max Tartness', 'G-Max Terror', 'G-Max Vine Lash', 'G-Max Volcalith',
-			'G-Max Volt Crash', 'G-Max Wildfire', 'G-Max Wind Rage',
-		],
-		onBegin() {
-			this.add('rule', 'G-Max Move Clause: G-Max moves are banned');
-		},
-	},
-	maxmoveclause: {
-		effectType: 'ValidatorRule',
-		name: "Max Move Clause",
-		desc: "Bans the use of Max moves",
-		banlist: [
-			'Max Airstream', 'Max Darkness', 'Max Flare', 'Max Flutterby', 'Max Geyser', 'Max Guard', 'Max Hailstorm',
-			'Max Knuckle', 'Max Lightning', 'Max Mindstorm', 'Max Ooze', 'Max Overgrowth', 'Max Phantasm', 'Max Quake',
-			'Max Rockfall', 'Max Starfall', 'Max Steelspike', 'Max Strike', 'Max Wyrmwind',
+			'G-Max Volt Crash', 'G-Max Wildfire', 'G-Max Wind Rage', 'Max Airstream', 'Max Darkness', 'Max Flare',
+			'Max Flutterby', 'Max Geyser', 'Max Guard', 'Max Hailstorm', 'Max Knuckle', 'Max Lightning', 'Max Mindstorm',
+			'Max Ooze', 'Max Overgrowth', 'Max Phantasm', 'Max Quake', 'Max Rockfall', 'Max Starfall', 'Max Steelspike',
+			'Max Strike', 'Max Wyrmwind',
 		],
 		onBegin() {
 			this.add('rule', 'Max Move Clause: Max moves are banned');


### PR DESCRIPTION
Current NatDex formats without Obtainable Moves clause such as NDBH and Camove Chaos permits use of all max moves.
Not sure if this is a proper solution even if it works. If there's a better way to fix this then close this.