### PR TITLE
Include helptext for offline PM blocking options

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -541,8 +541,10 @@ export const commands: Chat.ChatCommands = {
 		return true;
 	},
 	blockpmshelp: [
-		`/blockpms - Blocks private messages except from staff. Unblock them with /unblockpms.`,
-		`/blockpms [unlocked, ac, trusted, friends, +] - Blocks PMs, except for staff, friends, and the specified group(s).`,
+		`/blockpms [group] - Blocks PMs, except for staff and the target, if specified.`,
+		`/blockofflinepms [group] - Blocks private messages except from staff and the target, if specified.`,
+		`Valid groups are unlocked, autoconfirmed, trusted, + (global voices), and friends.`,
+		`You can unblock PMs with /unblockpms, and offline PMs with /unblockofflinepms.`,
 	],
 
 	unblockpm: 'unblockpms',

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -541,8 +541,8 @@ export const commands: Chat.ChatCommands = {
 		return true;
 	},
 	blockpmshelp: [
-		`/blockpms [group] - Blocks PMs, except from staff and the target group, if specified.`,
-		`/blockofflinepms [group] - Blocks private messages except from staff and the target group, if specified.`,
+		`/blockpms [group] - Blocks private messages, except from staff and the target group, if specified.`,
+		`/blockofflinepms [group] - Blocks offline private messages, except from staff and the target group, if specified.`,
 		`Valid groups are unlocked, autoconfirmed, trusted, + (global Voices), and friends.`,
 		`You can unblock PMs with /unblockpms, and offline PMs with /unblockofflinepms.`,
 	],

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -541,9 +541,9 @@ export const commands: Chat.ChatCommands = {
 		return true;
 	},
 	blockpmshelp: [
-		`/blockpms [group] - Blocks PMs, except for staff and the target, if specified.`,
-		`/blockofflinepms [group] - Blocks private messages except from staff and the target, if specified.`,
-		`Valid groups are unlocked, autoconfirmed, trusted, + (global voices), and friends.`,
+		`/blockpms [group] - Blocks PMs, except from staff and the target group, if specified.`,
+		`/blockofflinepms [group] - Blocks private messages except from staff and the target group, if specified.`,
+		`Valid groups are unlocked, autoconfirmed, trusted, + (global Voices), and friends.`,
 		`You can unblock PMs with /unblockpms, and offline PMs with /unblockofflinepms.`,
 	],
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-report-chat.3786310/

`/blockofflinepms` didn't have have help text. Not very "/help" of it...