### PR TITLE
`!lastfm`, `!track`: Allow attaching an optional comment

### DIFF
--- a/server/chat-plugins/the-studio.ts
+++ b/server/chat-plugins/the-studio.ts
@@ -472,9 +472,9 @@ export const commands: Chat.ChatCommands = {
 		this.checkChat();
 		if (!user.autoconfirmed) throw new Chat.ErrorMessage(`You cannot use this command while not autoconfirmed.`);
 		this.runBroadcast(true);
-		const targetUsername = this.splitUser(target).targetUsername || (user.named ? user.name : '');
-		const username = LastFM.getAccountName(targetUsername);
-		this.sendReplyBox(await LastFM.getScrobbleData(username, targetUsername));
+		const targetUser = this.splitOne(this.splitUser(target).targetUsername || (user.named ? user.name : ''))[0];
+		const username = LastFM.getAccountName(targetUser);
+		this.sendReplyBox(await LastFM.getScrobbleData(username, targetUser));
 	},
 	lastfmhelp: [
 		`/lastfm [username] - Displays the last scrobbled song for the person using the command or for [username] if provided.`,
@@ -485,10 +485,12 @@ export const commands: Chat.ChatCommands = {
 		if (!target) return this.parse('/help track');
 		this.checkChat();
 		if (!user.autoconfirmed) throw new Chat.ErrorMessage(`You cannot use this command while not autoconfirmed.`);
-		const [track, artist] = this.splitOne(target);
+		const [track, optionals] = this.splitOne(target);
 		if (!track) return this.parse('/help track');
+		const [artist, comment] = this.splitOne(optionals);
 		this.runBroadcast(true);
-		this.sendReplyBox(await LastFM.tryGetTrackData(track, artist || undefined));
+		const trackData = await LastFM.tryGetTrackData(track, artist || undefined);
+		this.sendReplyBox(comment ? `${trackData}<br />(${Utils.escapeHTML(comment)})` : trackData);
 	},
 	trackhelp: [
 		`/track [song name], [artist] - Displays the most relevant search result to the song name (and artist if specified) provided.`,


### PR DESCRIPTION
<img width="517" height="314" alt="image" src="https://github.com/user-attachments/assets/c613defc-8008-4d2f-9d70-be5332e029eb" />

(some hacky stuff was done with the display since I don't have an API key, removed before committing)

https://www.smogon.com/forums/threads/allow-users-to-use-lastfm-and-add-extra-text-in-the-message-without-messing-up-the-command.3786068/

`!lastfm` is treated like `!rfaq` and `!daily`, where the text just exists in the broadcast, while `!track` was treated like `!show`, where the note is attached under the track embed.