### PR TITLE
fix truant in gen4

### DIFF
--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -525,6 +525,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	truant: {
 		inherit: true,
+		onStart: undefined, // no inherit
 		onBeforeMove(pokemon) {
 			if (pokemon.volatiles['truant']) {
 				this.add('cant', pokemon, 'ability: Truant');
@@ -532,7 +533,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			}
 		},
 		onResidual(pokemon) {
-			if (!pokemon.removeVolatile('truant')) {
+			if (!pokemon.removeVolatile('truant') && pokemon.activeTurns) {
 				pokemon.addVolatile('truant');
 			}
 		},

--- a/test/sim/abilities/truant.js
+++ b/test/sim/abilities/truant.js
@@ -89,4 +89,66 @@ describe('Truant', () => {
 
 		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices('move entrainment', 'move heavyslam mega'));
 	});
+
+	it('should allow the user to act on its first turn after switching in', () => {
+		battle = common.createBattle([[
+			{ species: "Zigzagoon", ability: 'pickup', moves: ['sleeptalk'] },
+			{ species: "Slaking", ability: 'truant', moves: ['scratch'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', moves: ['irondefense'] },
+		]]);
+		const pokemon = battle.p2.active[0];
+
+		battle.makeChoices('switch 2', 'auto');
+		assert.hurts(pokemon, () => battle.makeChoices());
+		assert.false.hurts(pokemon, () => battle.makeChoices());
+	});
+});
+
+describe('Truant [Gen 4]', () => {
+	afterEach(() => {
+		battle.destroy();
+	});
+
+	it('should allow the user to act on its first turn after switching in', () => {
+		battle = common.gen(4).createBattle([[
+			{ species: "Zigzagoon", ability: 'pickup', moves: ['tackle'] },
+			{ species: "Slaking", ability: 'truant', moves: ['scratch'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', moves: ['irondefense'] },
+		]]);
+		const pokemon = battle.p2.active[0];
+
+		battle.makeChoices('switch 2', 'auto');
+		assert.hurts(pokemon, () => battle.makeChoices());
+		assert.false.hurts(pokemon, () => battle.makeChoices());
+	});
+
+	it('should allow the user to act on its first turn after being sent out as a replacement', () => {
+		battle = common.gen(4).createBattle([[
+			{ species: "Magikarp", level: 1, ability: 'swiftswim', moves: ['splash'] },
+			{ species: "Slaking", ability: 'truant', moves: ['scratch'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', moves: ['earthquake', 'irondefense'] },
+		]]);
+		const pokemon = battle.p2.active[0];
+
+		battle.makeChoices('move splash', 'move earthquake');
+		battle.makeChoices('switch 2', ''); // sent out after end-of-turn effects have run
+		assert.hurts(pokemon, () => battle.makeChoices('move scratch', 'move irondefense'));
+		assert.false.hurts(pokemon, () => battle.makeChoices('move scratch', 'move irondefense'));
+	});
+
+	it('should prevent the user from acting the turn after using a move', () => {
+		battle = common.gen(4).createBattle([[
+			{ species: "Slaking", ability: 'truant', moves: ['scratch'] },
+		], [
+			{ species: "Steelix", ability: 'sturdy', moves: ['irondefense'] },
+		]]);
+		const pokemon = battle.p2.active[0];
+
+		assert.hurts(pokemon, () => battle.makeChoices());
+		assert.false.hurts(pokemon, () => battle.makeChoices());
+		assert.hurts(pokemon, () => battle.makeChoices());
+	});
 });


### PR DESCRIPTION
fixes https://github.com/smogon/pokemon-showdown/issues/12241

## Testing:

here is the incorrect behavior in master:

https://github.com/user-attachments/assets/df7c5d3d-3363-4c1b-9835-5fa19490f1d8



here is with this fix:

https://github.com/user-attachments/assets/6749ef09-f107-4d04-8e25-2ea241a3822a

I've also confirmed correct behavior when slaking is out turn 1, and when slaking comes in after both player's pokemons simultaneously faint.