### PR TITLE
Fix /repeatfaq failing to catch aliases

### DIFF
--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -50,7 +50,7 @@ export function visualizeFaq(faq: RoomFAQ) {
 
 export function getAlias(roomid: RoomID, key: string) {
 	if (!roomFaqs[roomid]) return false;
-	const value = roomFaqs[roomid][key];
+	const value = roomFaqs[roomid][toID(key)];
 	if (value?.alias) return value.source;
 	return false;
 }


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-report-unsure.3787004/
`/repeatfaq` tries to catch FAQ aliases so that the contents of the actual FAQ is displayed, but only when written exactly as `/repeatfaq [time],[alias]`. As such, if you have an FAQ named `test` and an alias named `test2`, `/repeatfaq 1,test2` will correctly set the FAQ `test` to repeat, but `/repeatfaq 1, test2` or `/repeatfaq 1,test 2` don't work, and will try to repeat `test2` instead. Notably, this behavior can result in a crash, because if `test` is deleted, the repeat tied to `test2` will not be deleted, and trying to display the contents of the repeat is what causes the crash.