### PR TITLE
Prevent replay URL from changing when reuploading

### DIFF
--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -857,7 +857,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 		// If the room's replay was hidden, don't let users join after the game is over
 		if (this.room.hideReplay) {
 			this.room.settings.modjoin = '%';
-			this.room.setPrivate('hidden');
+			this.room.setPrivate('hidden', this.password);
 		}
 		this.room.update();
 

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -2069,7 +2069,7 @@ export class GameRoom extends BasicRoom {
 			options === 'forpunishment' || (this as any).unlistReplay ? 2 :
 			isPrivate ? 1 :
 			0;
-		if (isPrivate && hidden === 10) {
+		if (isPrivate && hidden === 10 || this.hideReplay) {
 			password = (battle.password ||= Replays.generatePassword());
 		}
 		if (battle.replaySaved !== true && hidden === 10) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -825,7 +825,7 @@ export abstract class BasicRoom {
 		// this doesn't update parentid or subroom user symbols because it's
 		// intended to be used for cleanup only
 	}
-	setPrivate(privacy: PrivacySetting) {
+	setPrivate(privacy: PrivacySetting, password?: string) {
 		this.settings.isPrivate = privacy;
 		this.saveSettings();
 
@@ -842,10 +842,12 @@ export abstract class BasicRoom {
 			if (privacy) {
 				if (this.roomid.endsWith('pw')) return true;
 
-				// This is the same password generation approach as genPassword in the client replays.lib.php
-				// but obviously will not match given mt_rand there uses a different RNG and seed.
-				let password = '';
-				for (let i = 0; i < 31; i++) password += ALPHABET[crypto.randomInt(0, ALPHABET.length - 1)];
+				if (!password) {
+					// This is the same password generation approach as genPassword in the client replays.lib.php
+					// but obviously will not match given mt_rand there uses a different RNG and seed.
+					password = '';
+					for (let i = 0; i < 31; i++) password += ALPHABET[crypto.randomInt(0, ALPHABET.length - 1)];
+				}
 
 				this.rename(this.title, `${this.roomid}-${password}pw` as RoomID, true);
 			} else {
@@ -2069,7 +2071,7 @@ export class GameRoom extends BasicRoom {
 			options === 'forpunishment' || (this as any).unlistReplay ? 2 :
 			isPrivate ? 1 :
 			0;
-		if (isPrivate && hidden === 10 || this.hideReplay) {
+		if (isPrivate && hidden !== 2) {
 			password = (battle.password ||= Replays.generatePassword());
 		}
 		if (battle.replaySaved !== true && hidden === 10) {


### PR DESCRIPTION
Zarel edit: Previously, every upload of a private battle would generate a new URL, because the server would never have access to the URL that the loginserver generated. This fixes it so the server generates its own URL.

---

Based on my understanding of how the battles db works, this _should_ be right, but I don't have an environment to properly test it.