### PR TITLE
ChatBats: Cap Call Illumise and Call Volbeat's activations

### DIFF
--- a/data/mods/chatbats/abilities.ts
+++ b/data/mods/chatbats/abilities.ts
@@ -20,7 +20,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	callillumise: {
 		onDamagePriority: -30,
 		onDamage(damage, target, source, effect) {
-			if (damage >= target.hp) {
+			if (damage >= target.hp && !target.m.called) {
 				this.add('-ability', target, 'Call Illumise');
 				this.effectState.callillumise = true;
 				return target.hp - 1;
@@ -62,6 +62,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			// sets new ability
 			pokemon.setAbility('Tinted Lens', null, null, true);
 			pokemon.baseAbility = pokemon.ability;
+			pokemon.m.called = true;
 			this.add('-ability', pokemon, 'Tinted Lens');
 		},
 		flags: {
@@ -75,7 +76,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	callvolbeat: {
 		onDamagePriority: -30,
 		onDamage(damage, target, source, effect) {
-			if (damage >= target.hp) {
+			if (damage >= target.hp && !target.m.called) {
 				this.add('-ability', target, 'Call Volbeat');
 				this.effectState.callvolbeat = true;
 				return target.hp - 1;
@@ -117,6 +118,7 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			// sets new ability
 			pokemon.setAbility('Dancer', null, null, true);
 			pokemon.baseAbility = pokemon.ability;
+			pokemon.m.called = true;
 			this.add('-ability', pokemon, 'Dancer');
 		},
 		flags: {


### PR DESCRIPTION
In the Pet Mods room, we like to run Shared Power ChatBats, but Call Illumise and Call Volbeat re-activated every switch-in, so they could cause infinite battles. Previously it was manually enforced, but this should prevent the ability from triggering on a Pokemon who already formechanged into Volbeat/Illumise.

Edit: using the same `.m` is intended so the effects won't stack on each other.