### PR TITLE
Prevent using Force Select in randomized formats

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -569,6 +569,7 @@ export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 		desc: `Forces a Pokemon to be on the team and selected at Team Preview. Usage: Force Select = [Pokemon], e.g. "Force Select = Magikarp"`,
 		hasValue: true,
 		onValidateRule(value) {
+			if (this.format.team) throw new Error(`Randomized formats do not currently support Force Select.`);
 			if (!this.dex.species.get(value).exists) throw new Error(`Misspelled Pokemon "${value}"`);
 		},
 		onValidateTeam(team) {


### PR DESCRIPTION
The teambuilding algorithm can generate a team without the force selected Pokemon, which locks them at preview.