### PR TITLE
Remove redundant Champions descriptions

### DIFF
--- a/data/mods/champions/abilities.ts
+++ b/data/mods/champions/abilities.ts
@@ -53,8 +53,6 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 				}
 			}
 		},
-		desc: "50% chance this Pokemon's ally has its non-volatile status condition cured at the end of each turn.",
-		shortDesc: "50% chance this Pokemon's ally has its status cured at the end of each turn.",
 	},
 	megasol: {
 		inherit: true,
@@ -95,6 +93,5 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			}
 		},
 		inherit: true,
-		shortDesc: "This Pokemon's contact moves ignore a target's protection and deal 1/4 the usual damage.",
 	},
 };

--- a/data/mods/champions/items.ts
+++ b/data/mods/champions/items.ts
@@ -870,7 +870,6 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	slowbronite: {
 		inherit: true,
 		isNonstandard: null,
-		shortDesc: "If held by a Slowbro (not Galarian Slowbro), this item allows it to Mega Evolve.",
 	},
 	snowball: {
 		inherit: true,

--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -52,8 +52,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	belch: {
 		inherit: true,
 		onDisableMove: undefined, // no inherit
-		desc: "Fails unless the user has eaten a Berry, either by eating one that was held, stealing and eating one off another Pokemon with Bug Bite or Pluck, or eating one that was thrown at it with Fling. Once the condition is met, this move can be selected and used for the rest of the battle even if the user gains or uses another item or switches out. Consuming a Berry with Natural Gift does not count for the purposes of eating one.",
-		shortDesc: "Fails unless the user has eaten a Berry.",
 	},
 	behemothbash: {
 		inherit: true,
@@ -198,8 +196,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				target.trySetStatus(status, source);
 			},
 		},
-		desc: "Has a 30% chance to cause the target to either fall asleep, become poisoned, or become paralyzed.",
-		shortDesc: "30% chance to sleep, poison, or paralyze target.",
 	},
 	disarmingvoice: {
 		inherit: true,
@@ -326,7 +322,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				pokemon.disableMove('fakeout');
 			}
 		},
-		desc: "Has a 100% chance to make the target flinch. This move cannot be selected unless it is the user's first turn on the field.",
 	},
 	falsesurrender: {
 		inherit: true,
@@ -360,7 +355,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				pokemon.disableMove('firstimpression');
 			}
 		},
-		desc: "This move cannot be selected unless it is the user's first turn on the field.",
 	},
 	fishiousrend: {
 		inherit: true,
@@ -385,8 +379,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	freezedry: {
 		inherit: true,
 		secondary: undefined, // no inherit
-		desc: "This move's type effectiveness against Water is changed to be super effective no matter what this move's type is.",
-		shortDesc: "Super effective on Water.",
 	},
 	freezeshock: {
 		inherit: true,
@@ -524,8 +516,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			chance: 20,
 			volatileStatus: 'flinch',
 		},
-		desc: "Has a 20% chance to make the target flinch.",
-		shortDesc: "20% chance to make the target flinch.",
 	},
 	ivycudgel: {
 		inherit: true,
@@ -596,8 +586,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				spa: -2,
 			},
 		},
-		desc: "Lowers the user's Special Attack by 2 stages.",
-		shortDesc: "Lowers the user's Sp. Atk by 2. Hits foe(s).",
 	},
 	malignantchain: {
 		inherit: true,
@@ -648,8 +636,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				spa: -1,
 			},
 		},
-		desc: "Has a 10% chance to lower the target's Special Attack by 1 stage.",
-		shortDesc: "10% chance to lower the target's Sp. Atk by 1.",
 	},
 	moongeistbeam: {
 		inherit: true,
@@ -778,8 +764,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	ragefist: {
 		inherit: true,
 		// Hit counter reset is implemented in Pokemon#clearVolatile
-		desc: "Power is equal to 50+(X*50), where X is the total number of times the user has been hit by a damaging attack during the battle, even if the user did not lose HP from the attack. X cannot be greater than 6 and resets to 0 when the user leaves the field. Each hit of a multi-hit attack is counted, but confusion damage is not counted.",
-		shortDesc: "+50 BP/hit on user. Max 6 hits. Resets on switch-out.",
 	},
 	razorleaf: {
 		inherit: true,
@@ -834,8 +818,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				this.damage(pokemon.baseMaxhp / (pokemon.hasType(['Water', 'Steel']) ? 8 : 16));
 			},
 		},
-		desc: "Causes damage to the target equal to 1/16 of its maximum HP (1/8 if the target is Steel or Water type), rounded down, at the end of each turn during effect. This effect ends when the target is no longer active.",
-		shortDesc: "Deals 1/16 max HP each turn; 1/8 on Steel, Water.",
 	},
 	sandattack: {
 		inherit: true,
@@ -979,8 +961,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	stuffcheeks: {
 		inherit: true,
 		onDisableMove: undefined, // no inherit
-		desc: "Fails if the user is not holding a Berry. The user eats its Berry and raises its Defense by 2 stages. This effect is not prevented by the Klutz or Unnerve Abilities, or the effects of Embargo or Magic Room.",
-		shortDesc: "Fails unless the user has a berry. User eats Berry, Def +2.",
 	},
 	sunsteelstrike: {
 		inherit: true,
@@ -1063,8 +1043,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		boosts: {
 			spe: -2,
 		},
-		desc: "Lowers the target's Speed by 2 stages and poisons it.",
-		shortDesc: "Lowers the target's Speed by 2 and poisons it.",
 	},
 	trickortreat: {
 		inherit: true,


### PR DESCRIPTION
When Champions was first added, the descriptions were placed in the mod data, but when they were moved to the main `data/text` dir, they weren't cleared, so they are currently duplicated in `data/text` and `data/mods/champions/`.