### PR TITLE
Remove Slowbro-Base + Slowbronite clause from Gen 9 National Dex UU

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3638,7 +3638,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		name: "[Gen 9] National Dex UU",
 		mod: 'gen9',
 		ruleset: ['[Gen 9] National Dex'],
-		banlist: ['ND OU', 'ND UUBL', 'Drizzle', 'Drought', 'Light Clay', 'Slowbro-Base + Slowbronite'],
+		banlist: ['ND OU', 'ND UUBL', 'Drizzle', 'Drought', 'Light Clay'],
 	},
 	{
 		name: "[Gen 9] National Dex RU",


### PR DESCRIPTION
Slowbro returned to National Dex UU a bit ago, but the previous ban of Slowbro-Base + Slowbronite (which was added to fix an issue with Slowbro-Base still being legal if it had Slowbronite despite Slowbro-Base being OU) was not removed, leaving Mega Slowbro erroneously banned. This PR removes the clause from National Dex UU, making Mega Slowbro legal again (albeit not very good at the minute).