### PR TITLE
Allow datasearch params to compare weight, height, num, etc. with each other.

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1232,7 +1232,7 @@ function runDexsearch(target: string, cmd: string, message: string, isTest: bool
 					if (inequalityString.startsWith('>')) directions.push('greater');
 					if (statKey in allStatAliases) statKey = allStatAliases[statKey];
 					if (compareType in allStatAliases) compareType = allStatAliases[compareType];
-					if (!allStats.slice(0, 6).includes(statKey) || !allStats.slice(0, 6).includes(compareType))
+					if (!allStats.includes(statKey) || !allStats.includes(compareType))
 						return { error: `'${target}' did not contain a valid stat to compare with another stat.` };
 				}
 				if (inequalityString.endsWith('=')) directions.push('equal');


### PR DESCRIPTION
Guardrails existed to only allow users to use params like 'atk = spa' to compare stats, without being able to compare more esoteric ones like weight, height etc. However, I don't see a clear reason why these shouldn't be allowed to be compared, and it allows users to figure out some fun facts from ds if they are curious (which seems like the main reason this param type existed in the first place).