### PR TITLE
Champions: Fix multiple M-A bugs

### DIFF
--- a/data/mods/champions/abilities.ts
+++ b/data/mods/champions/abilities.ts
@@ -11,26 +11,6 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 			this.effectState.checkedBerserk = !(effect.effectType === "Move" && !effect.multihit);
 		},
 	},
-	disguise: {
-		inherit: true,
-		onEffectiveness(typeMod, target, type, move) {
-			if (!target || move.category === 'Status') return;
-
-			if (move.hit === 1) delete this.effectState.neutral;
-			if (this.effectState.neutral) return 0;
-
-			if (!['mimikyu', 'mimikyutotem'].includes(target.species.id)) {
-				return;
-			}
-
-			const hitSub = target.volatiles['substitute'] && !move.flags['bypasssub'] && !(move.infiltrates && this.gen >= 6);
-			if (hitSub) return;
-
-			if (!target.runImmunity(move)) return;
-			this.effectState.neutral = true;
-			return 0;
-		},
-	},
 	dragonize: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/champions/items.ts
+++ b/data/mods/champions/items.ts
@@ -1019,21 +1019,6 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
-	whiteherb: {
-		inherit: true,
-		onAnyAfterMove() {
-			// Desync: proceed from Parting Shot's point of view
-			this.queue.insertChoice({
-				choice: 'event',
-				event: 'WhiteHerb',
-				order: 99, // before switches
-				pokemon: this.effectState.target,
-			});
-		},
-		onWhiteHerb(pokemon) {
-			((this.effect as any).onStart as (p: Pokemon) => void).call(this, this.effectState.target);
-		},
-	},
 	wikiberry: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -197,6 +197,18 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			},
 		},
 	},
+	disable: {
+		inherit: true,
+		condition: {
+			inherit: true,
+			onBeforeMove(attacker, defender, move) {
+				if (!(move.isZ && move.isZOrMaxPowered) && move.id === this.effectState.move && !move.flags['cantusetwice']) {
+					this.add('cant', attacker, 'Disable', move);
+					return false;
+				}
+			},
+		},
+	},
 	disarmingvoice: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/championsregma/abilities.ts
+++ b/data/mods/championsregma/abilities.ts
@@ -1,4 +1,24 @@
 export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
+	disguise: {
+		inherit: true,
+		onEffectiveness(typeMod, target, type, move) {
+			if (!target || move.category === 'Status') return;
+
+			if (move.hit === 1) delete this.effectState.neutral;
+			if (this.effectState.neutral) return 0;
+
+			if (!['mimikyu', 'mimikyutotem'].includes(target.species.id)) {
+				return;
+			}
+
+			const hitSub = target.volatiles['substitute'] && !move.flags['bypasssub'] && !(move.infiltrates && this.gen >= 6);
+			if (hitSub) return;
+
+			if (!target.runImmunity(move)) return;
+			this.effectState.neutral = true;
+			return 0;
+		},
+	},
 	spicyspray: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/championsregma/items.ts
+++ b/data/mods/championsregma/items.ts
@@ -111,6 +111,21 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	whiteherb: {
+		inherit: true,
+		onAnyAfterMove() {
+			// Desync: proceed from Parting Shot's point of view
+			this.queue.insertChoice({
+				choice: 'event',
+				event: 'WhiteHerb',
+				order: 99, // before switches
+				pokemon: this.effectState.target,
+			});
+		},
+		onWhiteHerb(pokemon) {
+			((this.effect as any).onStart as (p: Pokemon) => void).call(this, this.effectState.target);
+		},
+	},
 	wiseglasses: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/championsregma/moves.ts
+++ b/data/mods/championsregma/moves.ts
@@ -1,4 +1,14 @@
 export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
+	ceaselessedge: {
+		inherit: true,
+		onAfterHit(target, source, move) {
+			if (!move.hasSheerForce && source.hp) {
+				for (const side of source.side.foeSidesWithConditions()) {
+					side.addSideCondition('spikes');
+				}
+			}
+		},
+	},
 	direclaw: {
 		inherit: true,
 		secondary: {
@@ -15,6 +25,26 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				}
 				target.trySetStatus(status, source);
 			},
+		},
+	},
+	growth: {
+		inherit: true,
+		onModifyMove(move, pokemon) {
+			if (pokemon.hasAbility('megasol') && !this.field.isWeather('sunnyday')) {
+				delete move.boosts;
+			} else if (['sunnyday', 'desolateland'].includes(pokemon.effectiveWeather())) {
+				move.boosts = { atk: 2, spa: 2 };
+			}
+		},
+	},
+	stoneaxe: {
+		inherit: true,
+		onAfterHit(target, source, move) {
+			if (!move.hasSheerForce && source.hp) {
+				for (const side of source.side.foeSidesWithConditions()) {
+					side.addSideCondition('stealthrock');
+				}
+			}
 		},
 	},
 };

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2227,7 +2227,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		priority: 0,
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
 		onAfterHit(target, source, move) {
-			if (!move.hasSheerForce && source.hp) {
+			if (!move.hasSheerForce) {
 				for (const side of source.side.foeSidesWithConditions()) {
 					side.addSideCondition('spikes');
 				}
@@ -7868,9 +7868,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		priority: 0,
 		flags: { snatch: 1, metronome: 1 },
 		onModifyMove(move, pokemon) {
-			if (pokemon.hasAbility('megasol') && !this.field.isWeather('sunnyday')) {
-				delete move.boosts;
-			} else if (['sunnyday', 'desolateland'].includes(pokemon.effectiveWeather())) {
+			if (['sunnyday', 'desolateland'].includes(pokemon.effectiveWeather())) {
 				move.boosts = { atk: 2, spa: 2 };
 			}
 		},
@@ -18070,7 +18068,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		priority: 0,
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
 		onAfterHit(target, source, move) {
-			if (!move.hasSheerForce && source.hp) {
+			if (!move.hasSheerForce) {
 				for (const side of source.side.foeSidesWithConditions()) {
 					side.addSideCondition('stealthrock');
 				}


### PR DESCRIPTION
https://www.smogon.com/forums/threads/champions-battle-mechanics-research.3780372/post-11125444
All these M-A bugs were fixed:
- The multi-hit interaction with Disguise was fixed: the effectiveness of subsequent hits after breaking Disguise is now calculated correctly.
- Ceaseless Edge now behaves like Rapid Spin, and Spikes are still set on the field if the user faints to Rough Skin.
- The White Herb + Parting Shot asymmetrical bug was fixed, now it activates before the switch on both sides.
- The Mega Sol + Growth bug was fixed, Growth raises both Attack and Sp. Attack twice.