### PR TITLE
Randomized format updates

### DIFF
--- a/data/random-battles/champions/doubles-sets.json
+++ b/data/random-battles/champions/doubles-sets.json
@@ -1604,7 +1604,7 @@
         "level": 48,
         "sets": [
             {
-                "role": "Doubles Fast Attacker",
+                "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Encore", "Fake Out", "Protect", "Thunder Wave", "U-turn"],
                 "abilities": ["Limber"]
             }

--- a/data/random-battles/champions/doubles-sets.json
+++ b/data/random-battles/champions/doubles-sets.json
@@ -1604,7 +1604,7 @@
         "level": 48,
         "sets": [
             {
-                "role": "Offensive Protect",
+                "role": "Doubles Fast Attacker",
                 "movepool": ["Close Combat", "Encore", "Fake Out", "Protect", "Thunder Wave", "U-turn"],
                 "abilities": ["Limber"]
             }

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -3019,8 +3019,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Glare", "Hyper Voice", "Morning Sun", "Surf", "Thunderbolt", "Volt Switch"],
-                "abilities": ["Dry Skin"],
-                "preferredTypes": ["Normal"]
+                "abilities": ["Dry Skin"]
             }
         ]
     },

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -70,7 +70,7 @@
         ]
     },
     "blastoise": {
-        "level": 50,
+        "level": 49,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -100,7 +100,7 @@
         ]
     },
     "beedrillmega": {
-        "level": 48,
+        "level": 47,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -109,7 +109,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Drill Run", "Knock Off", "Lunge", "Poison Jab", "Swords Dance"],
+                "movepool": ["Drill Run", "Fell Stinger", "Knock Off", "Lunge", "Poison Jab", "Swords Dance"],
                 "abilities": ["Swarm"]
             }
         ]
@@ -179,18 +179,18 @@
         ]
     },
     "raichumegax": {
-        "level": 48,
+        "level": 50,
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Fake Out", "Knock Off", "Play Rough", "Rising Voltage", "Surf", "Volt Switch", "Volt Tackle"],
+                "movepool": ["Knock Off", "Play Rough", "Rising Voltage", "Surf", "Volt Switch", "Volt Tackle"],
                 "abilities": ["Lightning Rod"],
                 "preferredTypes": ["Dark"]
             }
         ]
     },
     "raichumegay": {
-        "level": 48,
+        "level": 46,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -200,7 +200,7 @@
         ]
     },
     "raichualola": {
-        "level": 54,
+        "level": 55,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -210,7 +210,7 @@
         ]
     },
     "clefable": {
-        "level": 50,
+        "level": 51,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -259,6 +259,16 @@
             }
         ]
     },
+    "wigglytuff": {
+        "level": 57,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Fire Blast", "Knock Off", "Moonblast", "Protect", "Stealth Rock", "Thunder Wave", "Wish"],
+                "abilities": ["Competitive"]
+            }
+        ]
+    },
     "vileplume": {
         "level": 52,
         "sets": [
@@ -266,6 +276,27 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Leech Seed", "Sleep Powder", "Sludge Bomb", "Strength Sap"],
                 "abilities": ["Effect Spore"]
+            }
+        ]
+    },
+    "persian": {
+        "level": 56,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Double-Edge", "Fake Out", "Knock Off", "U-turn"],
+                "abilities": ["Technician"]
+            }
+        ]
+    },
+    "persianalola": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Burning Jealousy", "Dark Pulse", "Hypnosis", "Nasty Plot", "Taunt", "Thunderbolt"],
+                "abilities": ["Fur Coat"],
+                "preferredTypes": ["Electric"]
             }
         ]
     },
@@ -295,7 +326,7 @@
         ]
     },
     "alakazam": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -306,7 +337,7 @@
         ]
     },
     "alakazammega": {
-        "level": 46,
+        "level": 47,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -317,7 +348,7 @@
         ]
     },
     "machamp": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -353,7 +384,7 @@
         ]
     },
     "victreebelmega": {
-        "level": 51,
+        "level": 49,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -388,7 +419,7 @@
         ]
     },
     "slowbrogalar": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -399,6 +430,17 @@
                 "role": "Wallbreaker",
                 "movepool": ["Fire Blast", "Psychic", "Shell Side Arm", "Trick Room"],
                 "abilities": ["Regenerator"]
+            }
+        ]
+    },
+    "farfetchd": {
+        "level": 60,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brave Bird", "Close Combat", "Knock Off", "Leaf Blade", "Quick Attack", "Slash", "Swords Dance"],
+                "abilities": ["Defiant"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -413,7 +455,7 @@
         ]
     },
     "gengarmega": {
-        "level": 44,
+        "level": 47,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -444,7 +486,7 @@
         ]
     },
     "starmie": {
-        "level": 50,
+        "level": 51,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -469,6 +511,21 @@
             }
         ]
     },
+    "mrmime": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dazzling Gleam", "Encore", "Focus Blast", "Mystical Fire", "Psychic", "Psyshock", "Trick"],
+                "abilities": ["Filter"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dazzling Gleam", "Encore", "Focus Blast", "Mystical Fire", "Nasty Plot", "Psychic", "Psyshock"],
+                "abilities": ["Filter"]
+            }
+        ]
+    },
     "pinsir": {
         "level": 53,
         "sets": [
@@ -481,7 +538,7 @@
         ]
     },
     "pinsirmega": {
-        "level": 47,
+        "level": 46,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -511,7 +568,7 @@
         ]
     },
     "taurospaldeacombat": {
-        "level": 50,
+        "level": 51,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -701,7 +758,7 @@
         ]
     },
     "meganiummega": {
-        "level": 50,
+        "level": 48,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -762,7 +819,7 @@
         ]
     },
     "ariados": {
-        "level": 60,
+        "level": 59,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -878,7 +935,7 @@
         ]
     },
     "forretress": {
-        "level": 53,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -914,7 +971,7 @@
         ]
     },
     "steelixmega": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -929,16 +986,16 @@
         ]
     },
     "qwilfish": {
-        "level": 54,
+        "level": 53,
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Destiny Bond", "Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
+                "movepool": ["Gunk Shot", "Spikes", "Thunder Wave", "Toxic Spikes", "Waterfall"],
                 "abilities": ["Intimidate"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Flip Turn", "Gunk Shot", "Pain Split", "Thunder Wave", "Toxic", "Toxic Spikes"],
+                "movepool": ["Flip Turn", "Gunk Shot", "Spikes", "Thunder Wave", "Toxic Spikes"],
                 "abilities": ["Intimidate"]
             }
         ]
@@ -959,7 +1016,7 @@
         ]
     },
     "scizormega": {
-        "level": 46,
+        "level": 47,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1010,7 +1067,7 @@
         ]
     },
     "skarmorymega": {
-        "level": 48,
+        "level": 47,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1105,7 +1162,7 @@
         ]
     },
     "blaziken": {
-        "level": 46,
+        "level": 47,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1155,7 +1212,7 @@
         ]
     },
     "pelipper": {
-        "level": 53,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1206,7 +1263,7 @@
         ]
     },
     "sableyemega": {
-        "level": 52,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1296,7 +1353,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Flamethrower", "Overheat", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Overheat", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Lightning Rod"]
             }
         ]
@@ -1306,8 +1363,29 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Flamethrower", "Overheat", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Overheat", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "abilities": ["Lightning Rod"]
+            }
+        ]
+    },
+    "swalot": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Clear Smog", "Earthquake", "Encore", "Knock Off", "Pain Split", "Sludge Bomb", "Thunder Wave", "Toxic Spikes"],
+                "abilities": ["Liquid Ooze"],
+                "preferredTypes": ["Dark"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earthquake", "Gunk Shot", "Knock Off", "Swords Dance"],
+                "abilities": ["Liquid Ooze"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Protect", "Sludge Bomb", "Toxic"],
+                "abilities": ["Liquid Ooze"]
             }
         ]
     },
@@ -1332,7 +1410,7 @@
         ]
     },
     "camerupt": {
-        "level": 57,
+        "level": 56,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1378,7 +1456,7 @@
         ]
     },
     "altariamega": {
-        "level": 48,
+        "level": 49,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1398,7 +1476,7 @@
         ]
     },
     "castform": {
-        "level": 60,
+        "level": 61,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1459,7 +1537,7 @@
         ]
     },
     "absol": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1469,13 +1547,23 @@
         ]
     },
     "absolmega": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Knock Off", "Play Rough", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Justified"],
                 "preferredTypes": ["Fairy"]
+            }
+        ]
+    },
+    "absolmegaz": {
+        "level": 48,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Shadow Claw", "Sucker Punch", "Swords Dance", "Will-O-Wisp"],
+                "abilities": ["Sharpness"]
             }
         ]
     },
@@ -1490,7 +1578,7 @@
         ]
     },
     "glaliemega": {
-        "level": 50,
+        "level": 52,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1501,6 +1589,31 @@
                 "role": "Wallbreaker",
                 "movepool": ["Body Slam", "Earthquake", "Explosion", "Freeze-Dry"],
                 "abilities": ["Inner Focus"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Earthquake", "Explosion", "Ice Shard"],
+                "abilities": ["Inner Focus"]
+            }
+        ]
+    },
+    "salamence": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Dual Wingbeat", "Earthquake", "Outrage", "Roost"],
+                "abilities": ["Intimidate", "Moxie"]
+            }
+        ]
+    },
+    "salamencemega": {
+        "level": 46,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Double-Edge", "Dragon Dance", "Earthquake", "Roost"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -1522,7 +1635,7 @@
         ]
     },
     "metagrossmega": {
-        "level": 46,
+        "level": 45,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1583,7 +1696,7 @@
         ]
     },
     "staraptormega": {
-        "level": 47,
+        "level": 44,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1635,17 +1748,17 @@
         ]
     },
     "bastiodon": {
-        "level": 57,
+        "level": 58,
         "sets": [
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Foul Play", "Iron Defense", "Rest", "Stealth Rock"],
-                "abilities": ["Soundproof"]
+                "abilities": ["Sturdy"]
             }
         ]
     },
     "lopunny": {
-        "level": 54,
+        "level": 55,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1685,7 +1798,7 @@
         ]
     },
     "garchomp": {
-        "level": 47,
+        "level": 46,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1711,6 +1824,17 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Outrage", "Scale Shot", "Swords Dance"],
                 "abilities": ["Rough Skin"]
+            }
+        ]
+    },
+    "garchompmegaz": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Iron Head", "Stealth Rock"],
+                "abilities": ["Rough Skin"],
+                "preferredTypes": ["Fire"]
             }
         ]
     },
@@ -1740,6 +1864,16 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Aura Sphere", "Flash Cannon", "Nasty Plot", "Vacuum Wave"],
+                "abilities": ["Inner Focus"]
+            }
+        ]
+    },
+    "lucariomegaz": {
+        "level": 45,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Flash Cannon", "Nasty Plot", "Vacuum Wave"],
                 "abilities": ["Inner Focus"]
             }
         ]
@@ -1887,7 +2021,7 @@
         ]
     },
     "froslass": {
-        "level": 53,
+        "level": 54,
         "sets": [
             {
                 "role": "Fast Support",
@@ -1947,7 +2081,7 @@
         ]
     },
     "rotomfrost": {
-        "level": 55,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1957,7 +2091,7 @@
         ]
     },
     "rotomfan": {
-        "level": 54,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1967,7 +2101,7 @@
         ]
     },
     "rotommow": {
-        "level": 55,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1981,13 +2115,19 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dragon Pulse", "Glare", "Leaf Storm", "Leech Seed", "Substitute", "Synthesis"],
+                "movepool": ["Dragon Pulse", "Glare", "Leaf Storm", "Synthesis"],
+                "abilities": ["Contrary"],
+                "preferredTypes": ["Grass"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dragon Pulse", "Leaf Storm", "Leech Seed", "Substitute"],
                 "abilities": ["Contrary"]
             }
         ]
     },
     "emboar": {
-        "level": 53,
+        "level": 52,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2037,7 +2177,7 @@
         ]
     },
     "watchog": {
-        "level": 58,
+        "level": 60,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2129,7 +2269,7 @@
         ]
     },
     "audino": {
-        "level": 58,
+        "level": 59,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2220,7 +2360,7 @@
         ]
     },
     "scrafty": {
-        "level": 52,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2296,7 +2436,7 @@
         ]
     },
     "reuniclus": {
-        "level": 54,
+        "level": 55,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2316,7 +2456,7 @@
         ]
     },
     "emolga": {
-        "level": 58,
+        "level": 57,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2346,7 +2486,7 @@
         ]
     },
     "eelektrossmega": {
-        "level": 52,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2411,7 +2551,7 @@
         ]
     },
     "golurk": {
-        "level": 54,
+        "level": 53,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -2477,7 +2617,7 @@
         ]
     },
     "chesnaughtmega": {
-        "level": 50,
+        "level": 51,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2604,7 +2744,7 @@
         ]
     },
     "pyroarmega": {
-        "level": 50,
+        "level": 49,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2629,7 +2769,7 @@
         ]
     },
     "floettemega": {
-        "level": 48,
+        "level": 47,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2658,8 +2798,18 @@
             }
         ]
     },
+    "gogoat": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Earthquake", "Horn Leech", "Milk Drink", "Rock Slide"],
+                "abilities": ["Sap Sipper"]
+            }
+        ]
+    },
     "pangoro": {
-        "level": 55,
+        "level": 54,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2699,7 +2849,7 @@
         ]
     },
     "meowsticmmega": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2762,11 +2912,11 @@
         ]
     },
     "slurpuff": {
-        "level": 53,
+        "level": 52,
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Dazzling Gleam", "Flamethrower", "Psychic", "Sticky Web", "Yawn"],
+                "movepool": ["Dazzling Gleam", "Flamethrower", "Play Rough", "Psychic", "Sticky Web", "Yawn"],
                 "abilities": ["Unburden"],
                 "preferredTypes": ["Fire"]
             }
@@ -2804,7 +2954,7 @@
         ]
     },
     "barbaracle": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2905,7 +3055,7 @@
         ]
     },
     "hawlucha": {
-        "level": 48,
+        "level": 49,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3130,7 +3280,7 @@
         ]
     },
     "toucannon": {
-        "level": 56,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3237,7 +3387,7 @@
         ]
     },
     "tsareena": {
-        "level": 55,
+        "level": 54,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3277,6 +3427,31 @@
             }
         ]
     },
+    "golisopod": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["First Impression", "Leech Life", "Liquidation", "Spikes", "U-turn"],
+                "abilities": ["Emergency Exit"]
+            }
+        ]
+    },
+    "golisopodmega": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "First Impression", "Iron Head", "U-turn"],
+                "abilities": ["Emergency Exit"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Iron Head", "Leech Life", "Sucker Punch", "Swords Dance"],
+                "abilities": ["Emergency Exit"]
+            }
+        ]
+    },
     "mimikyu": {
         "level": 49,
         "sets": [
@@ -3288,7 +3463,7 @@
         ]
     },
     "drampa": {
-        "level": 54,
+        "level": 55,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3298,7 +3473,7 @@
         ]
     },
     "drampamega": {
-        "level": 51,
+        "level": 52,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3317,13 +3492,62 @@
             }
         ]
     },
+    "rillaboom": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Grassy Glide", "High Horsepower", "Knock Off", "Swords Dance", "Wood Hammer"],
+                "abilities": ["Grassy Surge"],
+                "preferredTypes": ["Grass"]
+            }
+        ]
+    },
+    "cinderace": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Court Change", "High Jump Kick", "Pyro Ball", "Sucker Punch", "U-turn"],
+                "abilities": ["Libero"],
+                "preferredTypes": ["Fighting"]
+            }
+        ]
+    },
+    "inteleon": {
+        "level": 49,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Flip Turn", "Hydro Pump", "Ice Beam", "Scald"],
+                "abilities": ["Torrent"],
+                "preferredTypes": ["Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Focus Energy", "Hydro Pump", "Ice Beam", "Snipe Shot"],
+                "abilities": ["Sniper"]
+            }
+        ]
+    },
     "corviknight": {
         "level": 50,
         "sets": [
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Brave Bird", "Defog", "Roost", "U-turn"],
-                "abilities": ["Mirror Armor", "Pressure"]
+                "abilities": ["Pressure"]
+            }
+        ]
+    },
+    "thievul": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Burning Jealousy", "Dark Pulse", "Grass Knot", "Nasty Plot", "Psychic"],
+                "abilities": ["Stakeout"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -3354,6 +3578,31 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Coil", "Earthquake", "Glare", "Rest", "Stealth Rock", "Stone Edge"],
                 "abilities": ["Shed Skin"]
+            }
+        ]
+    },
+    "toxtricity": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Boomburst", "Gunk Shot", "Overdrive", "Volt Switch"],
+                "abilities": ["Punk Rock"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Boomburst", "Gunk Shot", "Overdrive", "Shift Gear"],
+                "abilities": ["Punk Rock"]
+            }
+        ]
+    },
+    "grapploct": {
+        "level": 53,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Brutal Swing", "Mach Punch", "Storm Throw"],
+                "abilities": ["Technician"]
             }
         ]
     },
@@ -3388,6 +3637,36 @@
             }
         ]
     },
+    "perrserker": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Close Combat", "Iron Head", "Knock Off", "Spikes", "Stealth Rock", "Thunder Wave", "U-turn"],
+                "abilities": ["Tough Claws"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
+                "abilities": ["Tough Claws"]
+            }
+        ]
+    },
+    "sirfetchd": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Brave Bird", "Close Combat", "Defog", "First Impression", "Knock Off", "Poison Jab"],
+                "abilities": ["Scrappy"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brave Bird", "Close Combat", "Knock Off", "Poison Jab", "Swords Dance"],
+                "abilities": ["Scrappy"]
+            }
+        ]
+    },
     "mrrime": {
         "level": 57,
         "sets": [
@@ -3419,7 +3698,7 @@
         ]
     },
     "falinks": {
-        "level": 52,
+        "level": 53,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3435,6 +3714,36 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat", "Rock Slide"],
                 "abilities": ["Defiant"]
+            }
+        ]
+    },
+    "pincurchin": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Recover", "Rising Voltage", "Scald", "Spikes", "Toxic Spikes"],
+                "abilities": ["Electric Surge"]
+            }
+        ]
+    },
+    "indeedee": {
+        "level": 51,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Calm Mind", "Expanding Force", "Healing Wish", "Hyper Voice", "Mystical Fire"],
+                "abilities": ["Psychic Surge"]
+            }
+        ]
+    },
+    "indeedeef": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Calm Mind", "Healing Wish", "Hyper Voice", "Mystical Fire", "Psychic", "Psyshock"],
+                "abilities": ["Psychic Surge"]
             }
         ]
     },
@@ -3454,7 +3763,7 @@
         ]
     },
     "dragapult": {
-        "level": 49,
+        "level": 48,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3502,7 +3811,8 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Jet", "Flip Turn", "Shadow Ball", "Wave Crash"],
-                "abilities": ["Adaptability"]
+                "abilities": ["Adaptability"],
+                "preferredTypes": ["Water"]
             }
         ]
     },
@@ -3512,12 +3822,13 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Flip Turn", "Hydro Pump", "Shadow Ball", "Wave Crash"],
-                "abilities": ["Adaptability"]
+                "abilities": ["Adaptability"],
+                "preferredTypes": ["Water"]
             }
         ]
     },
     "sneasler": {
-        "level": 48,
+        "level": 47,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3542,7 +3853,7 @@
         ]
     },
     "meowscarada": {
-        "level": 48,
+        "level": 49,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3567,7 +3878,7 @@
         ]
     },
     "quaquaval": {
-        "level": 49,
+        "level": 50,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3581,6 +3892,16 @@
             }
         ]
     },
+    "pawmot": {
+        "level": 50,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Double Shock", "Ice Punch", "Knock Off", "Revival Blessing", "Volt Switch"],
+                "abilities": ["Iron Fist"]
+            }
+        ]
+    },
     "maushold": {
         "level": 48,
         "sets": [
@@ -3591,8 +3912,33 @@
             }
         ]
     },
+    "arboliva": {
+        "level": 55,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earth Power", "Energy Ball", "Hyper Voice", "Strength Sap"],
+                "abilities": ["Seed Sower"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Hyper Voice", "Leech Seed", "Protect", "Substitute"],
+                "abilities": ["Harvest"]
+            }
+        ]
+    },
+    "squawkabilly": {
+        "level": 54,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Brave Bird", "Double-Edge", "Foul Play", "Parting Shot", "Quick Attack", "Roost", "Seed Bomb"],
+                "abilities": ["Hustle"]
+            }
+        ]
+    },
     "garganacl": {
-        "level": 51,
+        "level": 53,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3617,7 +3963,7 @@
         ]
     },
     "ceruledge": {
-        "level": 46,
+        "level": 47,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3633,6 +3979,21 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Muddy Water", "Slack Off", "Thunderbolt", "Toxic", "Volt Switch"],
                 "abilities": ["Electromorphosis"]
+            }
+        ]
+    },
+    "mabosstiff": {
+        "level": 52,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Crunch", "Play Rough", "Psychic Fangs", "Taunt"],
+                "abilities": ["Stakeout"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Crunch", "Play Rough", "Psychic Fangs", "Wild Charge"],
+                "abilities": ["Stakeout"]
             }
         ]
     },
@@ -3703,12 +4064,13 @@
         ]
     },
     "palafin": {
-        "level": 47,
+        "level": 49,
         "sets": [
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Flip Turn", "Jet Punch", "Wave Crash"],
-                "abilities": ["Zero to Hero"]
+                "abilities": ["Zero to Hero"],
+                "preferredTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",
@@ -3718,7 +4080,7 @@
         ]
     },
     "orthworm": {
-        "level": 56,
+        "level": 55,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3733,7 +4095,7 @@
         ]
     },
     "glimmora": {
-        "level": 45,
+        "level": 44,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3780,7 +4142,7 @@
         ]
     },
     "farigiraf": {
-        "level": 57,
+        "level": 56,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3796,6 +4158,26 @@
                 "role": "Bulky Setup",
                 "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Supreme Overlord"]
+            }
+        ]
+    },
+    "baxcalibur": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Dance", "Earthquake", "Glaive Rush", "Icicle Crash"],
+                "abilities": ["Thermal Exchange"]
+            }
+        ]
+    },
+    "baxcaliburmega": {
+        "level": 47,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Dance", "Earthquake", "Glaive Rush", "Icicle Crash"],
+                "abilities": ["Thermal Exchange"]
             }
         ]
     },

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -3989,7 +3989,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Crunch", "Play Rough", "Psychic Fangs", "Taunt"],
+                "movepool": ["Crunch", "Play Rough", "Psychic Fangs", "Taunt", "Wild Charge"],
                 "abilities": ["Stakeout"]
             },
             {

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -3643,12 +3643,14 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "Spikes", "Stealth Rock", "Thunder Wave", "U-turn"],
-                "abilities": ["Tough Claws"]
+                "abilities": ["Tough Claws"],
+                "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
-                "abilities": ["Tough Claws"]
+                "abilities": ["Tough Claws"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },

--- a/data/random-battles/champions/sets.json
+++ b/data/random-battles/champions/sets.json
@@ -1563,7 +1563,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Shadow Claw", "Sucker Punch", "Swords Dance", "Will-O-Wisp"],
-                "abilities": ["Sharpness"]
+                "abilities": ["Justified"]
             }
         ]
     },
@@ -3601,7 +3601,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Brutal Swing", "Mach Punch", "Storm Throw"],
+                "movepool": ["Brutal Swing", "Bulk Up", "Mach Punch", "Storm Throw"],
                 "abilities": ["Technician"]
             }
         ]

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -120,9 +120,10 @@ export class RandomChampionsTeams extends RandomTeams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
-			Normal: (movePool, moves, abilities, types, counter) => (
+			Normal: (movePool, moves, abilities, types, counter, species) => (
 				!counter.get('Normal') && (
-					movePool.includes('boomburst') || ['Electric', 'Fire', 'Ghost', 'Ground'].some(t => types.has(t))
+					movePool.includes('boomburst') || ['Electric', 'Fire', 'Ghost', 'Ground'].some(t => types.has(t)) ||
+					species.baseSpecies === 'Squawkabilly'
 				)
 			),
 			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -769,7 +769,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			(!counter.get('Status') || counter.get('Status') === 1 && moves.has('partingshot'))
 		) return 'Choice Scarf';
 
-		if (['flamecharge', 'kingsshield', 'nuzzle', 'rapidspin', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
+		if (['flamecharge', 'kingsshield', 'nuzzle', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
 
 		// Give physically bulky Pokemon with either Regenerator or a recovery move a chance at Rocky Helmet

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -707,7 +707,7 @@ export class RandomChampionsTeams extends RandomTeams {
 		// Move this back to getDoublesItem() if Choice Band/Specs get added
 		if (role === 'Choice Item user') return 'Choice Scarf';
 		if (
-			['Cheek Pouch', 'Cud Chew', 'Harvest', 'Ripen'].some(m => ability === m) || moves.has('bellydrum')
+			['Cheek Pouch', 'Cud Chew', 'Emergency Exit', 'Harvest', 'Ripen'].some(m => ability === m) || moves.has('bellydrum')
 		) return 'Sitrus Berry';
 		if (species.id === 'alakazam' && this.randomChance(1, 2)) return 'Focus Sash';
 		if (species.id === 'glimmora') return 'Focus Sash';

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -768,6 +768,9 @@ export class RandomChampionsTeams extends RandomTeams {
 			(!counter.get('Status') || counter.get('Status') === 1 && moves.has('partingshot'))
 		) return 'Choice Scarf';
 
+		if (['flamecharge', 'kingsshield', 'nuzzle', 'rapidspin', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
+		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
+
 		// Give physically bulky Pokemon with either Regenerator or a recovery move a chance at Rocky Helmet
 		if (
 			ability === 'Rough Skin' || (
@@ -778,10 +781,6 @@ export class RandomChampionsTeams extends RandomTeams {
 				(species.baseStats.hp + species.baseStats.def) > 200 && this.randomChance(1, 2)
 			)
 		) return 'Rocky Helmet';
-
-		if (['flamecharge', 'kingsshield', 'nuzzle', 'rapidspin', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
-		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
-		if (ability === 'Rough Skin') return 'Rocky Helmet';
 
 		// Default to Leftovers for Bulky roles
 		if (role.includes('Bulky')) return 'Leftovers';

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -8,7 +8,7 @@ const RECOVERY_MOVES = [
 ];
 // Moves that boost Attack:
 const PHYSICAL_SETUP = [
-	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'meditate', 'poweruppunch', 'swordsdance', 'tidyup', 'victorydance',
+	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'fellstinger', 'honeclaws', 'howl', 'meditate', 'poweruppunch', 'swordsdance', 'tidyup', 'victorydance',
 ];
 // Some moves that only boost Speed:
 const SPEED_SETUP = [
@@ -17,8 +17,8 @@ const SPEED_SETUP = [
 // Conglomerate for ease of access
 const SETUP = [
 	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'clangoroussoul', 'coil', 'cosmicpower', 'curse', 'dragondance',
-	'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance', 'raindance',
-	'rockpolish', 'shellsmash', 'shelter', 'shiftgear', 'sunnyday', 'swordsdance', 'tailglow', 'takeheart', 'tidyup', 'trailblaze', 'workup',
+	'fellstinger', 'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance',
+	'raindance', 'rockpolish', 'shellsmash', 'shelter', 'shiftgear', 'sunnyday', 'swordsdance', 'tailglow', 'takeheart', 'tidyup', 'trailblaze', 'workup',
 	'victorydance',
 ];
 // Speed control moves (for doubles)
@@ -28,7 +28,7 @@ const SPEED_CONTROL = [
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
 	'acidspray', 'accelerock', 'aquajet', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
-	'dragontail', 'doomdesire', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'futuresight',
+	'dragontail', 'doomdesire', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'fellstinger', 'flamecharge', 'flipturn', 'futuresight',
 	'grassyglide', 'iceshard', 'icywind', 'incinerate', 'infestation', 'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit',
 	'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skydrop', 'snarl', 'snaptrap', 'strugglebug', 'suckerpunch', 'trailblaze',
 	'uturn', 'vacuumwave', 'voltswitch', 'watershuriken', 'waterspout',
@@ -56,7 +56,16 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'lopunnymega', 'mimikyu', 'palafin', 'scizor', 'scizormega',
+	'golisopod', 'mimikyu', 'palafin', 'scizor', 'scizormega',
+];
+
+/** Pokemon who should never be in the lead slot. Currently just Kingambit, but more may be added in the future */
+const NO_LEAD_POKEMON = [
+	'Kingambit',
+];
+
+const DOUBLES_NO_LEAD_POKEMON = [
+	'basculegion', 'basculegionf', 'houndstone',
 ];
 
 // 1.2x type boosting items
@@ -229,7 +238,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			[['psychic', 'psychicnoise'], ['psyshock', 'psychicnoise']],
 			[['muddywater', 'scald', 'surf', 'waterfall'], 'hydropump'],
 			[['gigadrain', 'hornleech', 'tropkick'], ['leafstorm', 'powerwhip', 'woodhammer']],
-			['dazzlinggleam', ['alluringvoice', 'moonblast']],
+			['dazzlinggleam', ['alluringvoice', 'moonblast', 'playrough']],
 			[['fireblast', 'flamethrower'], ['fierydance', 'heatwave', 'overheat']],
 			['aurasphere', 'focusblast'],
 			['closecombat', 'drainpunch'],
@@ -239,7 +248,7 @@ export class RandomChampionsTeams extends RandomTeams {
 			['foulplay', 'knockoff'],
 
 			// Status move incompatibilities
-			['taunt', 'encore'],
+			[['taunt', 'clearsmog'], 'encore'],
 			['roar', 'yawn'],
 			[statusInflictingMoves, 'toxicspikes'],
 			[statusInflictingMoves, statusInflictingMoves],
@@ -258,8 +267,9 @@ export class RandomChampionsTeams extends RandomTeams {
 		// This space reserved for assorted hardcodes that make little sense out of context and can't fit in the const:
 		if (!isDoubles) {
 			// To force Stealth Rock on Camerupt
-			if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
 			if (species.id === 'cameruptmega') this.incompatibleMoves(moves, movePool, 'ancientpower', 'willowisp');
+			// To force Grassy Glide on Rillaboom
+			if (species.id === 'rillaboom') this.incompatibleMoves(moves, movePool, 'highhorsepower', 'knockoff');
 		}
 	}
 
@@ -306,8 +316,8 @@ export class RandomChampionsTeams extends RandomTeams {
 
 		// Add other moves you really want to have, e.g. STAB, recovery, setup.
 
-		// Enforce Aurora Veil, Blizzard, and Sticky Web
-		for (const moveid of ['auroraveil', 'blizzard', 'stickyweb']) {
+		// Enforce Aurora Veil, Blizzard, Court Change, Revival Blessing, and Sticky Web
+		for (const moveid of ['auroraveil', 'blizzard', 'courtchange', 'revivalblessing', 'stickyweb']) {
 			if (movePool.includes(moveid)) {
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role, isDoubles);
@@ -338,6 +348,14 @@ export class RandomChampionsTeams extends RandomTeams {
 		if (movePool.includes('irondefense') || movePool.includes('shelter')) {
 			if (movePool.includes('bodypress')) {
 				counter = this.addMove('bodypress', moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role, isDoubles);
+			}
+		}
+
+		// Enforce Stealth Rock on sets with phazing moves
+		if (['dragontail', 'roar', 'whirlwind'].some(m => movePool.includes(m))) {
+			if (movePool.includes('stealthrock')) {
+				counter = this.addMove('stealthrock', moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role, isDoubles);
 			}
 		}
@@ -684,6 +702,7 @@ export class RandomChampionsTeams extends RandomTeams {
 	): string | undefined {
 		if (species.requiredItems) return this.sample(species.requiredItems);
 		if (species.id === 'pikachu') return 'Light Ball';
+		if (['farfetchd', 'sirfetchd'].includes(species.id)) return 'Leek';
 		// Move this back to getDoublesItem() if Choice Band/Specs get added
 		if (role === 'Choice Item user') return 'Choice Scarf';
 		if (
@@ -693,6 +712,7 @@ export class RandomChampionsTeams extends RandomTeams {
 		if (species.id === 'glimmora') return 'Focus Sash';
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (species.id === 'ditto' && !isDoubles) return 'Choice Scarf';
+		if (species.id === 'inteleon' && moves.has('focusenergy')) return 'Scope Lens';
 		if (['healingwish', 'switcheroo', 'trick'].some(m => moves.has(m))) return 'Choice Scarf';
 		if (ability === 'Unburden') return (moves.has('closecombat') || moves.has('leafstorm')) ? 'White Herb' : 'Sitrus Berry';
 		if (moves.has('shellsmash')) return 'White Herb';
@@ -706,9 +726,11 @@ export class RandomChampionsTeams extends RandomTeams {
 		if (types.has('Normal') && moves.has('doubleedge') && moves.has('fakeout')) return 'Silk Scarf';
 		if (
 			(species.id === 'froslass' && moves.has('tripleaxel')) || moves.has('populationbomb') ||
-			(ability === 'Hustle' && counter.get('setup') && this.randomChance(1, 2)) ||
+			(ability === 'Hustle' && this.randomChance(1, 2)) ||
 			(species.id === 'tsareena' && role === 'Offensive Protect')
 		) return 'Wide Lens';
+		// 1.2x type boosting items
+		if (types.has(preferredType)) return TYPE_BOOSTING_ITEMS[preferredType];
 	}
 
 	override getDoublesItem(
@@ -722,8 +744,6 @@ export class RandomChampionsTeams extends RandomTeams {
 		preferredType: string,
 		role: RandomTeamsTypes.Role,
 	): string {
-		// 1.2x type boosting items
-		if (types.has(preferredType)) return TYPE_BOOSTING_ITEMS[preferredType];
 		if (role === 'Doubles Fast Attacker') return 'Focus Sash';
 		if (role === 'Doubles Bulky Setup' && !moves.has('dragondance')) return 'Leftovers';
 		if (['Offensive Protect', 'Doubles Wallbreaker', 'Doubles Setup Sweeper'].includes(role)) return 'Life Orb';
@@ -747,17 +767,29 @@ export class RandomChampionsTeams extends RandomTeams {
 			['fakeout', 'trailblaze'].every(m => !moves.has(m)) &&
 			(!counter.get('Status') || counter.get('Status') === 1 && moves.has('partingshot'))
 		) return 'Choice Scarf';
+
+		// Give physically bulky Pokemon with either Regenerator or a recovery move a chance at Rocky Helmet
+		if (
+			ability === 'Rough Skin' || (
+				ability === 'Regenerator' && (role === 'Bulky Support' || role === 'Bulky Attacker') &&
+				(species.baseStats.hp + species.baseStats.def) >= 180 && this.randomChance(1, 2)
+			) || (
+				ability !== 'Regenerator' && !counter.get('setup') && counter.get('recovery') &&
+				(species.baseStats.hp + species.baseStats.def) > 200 && this.randomChance(1, 2)
+			)
+		) return 'Rocky Helmet';
+
 		if (['flamecharge', 'kingsshield', 'nuzzle', 'rapidspin', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
+		if (ability === 'Rough Skin') return 'Rocky Helmet';
 
 		// Default to Leftovers for Bulky roles
 		if (role.includes('Bulky')) return 'Leftovers';
 
 		// Default to Life Orb for offensive roles
-		if (['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].includes(role)) {
-			if (['basculegion', 'palafin'].includes(species.id)) return 'Mystic Water';
-			if (this.dex.getEffectiveness('Rock', species) < 2) return 'Life Orb';
-		}
+		if (
+			['Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].includes(role) && this.dex.getEffectiveness('Rock', species) < 2
+		) return 'Life Orb';
 
 		// Fast Support defaults to Life Orb if >= 3 attacks and Leftovers otherwise. It can generate Focus Sash in the lead slot with hazards
 		if (role === 'Fast Support') {
@@ -1085,8 +1117,11 @@ export class RandomChampionsTeams extends RandomTeams {
 				!ruleTable.has('pickedteamsize') && !ruleTable.has('teampreview')
 			);
 			const set = this.randomSet(species, teamDetails, isLead, isDoubles);
-			// Last Respects shouldn't appear in the lead slot
-			if (set.moves.includes('lastrespects') && pokemon.length >= this.maxTeamSize - 2) {
+			// Some Pokemon should not be in the lead slot
+			if (
+				(isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.baseSpecies) && isLead) ||
+				(!isDoubles && NO_LEAD_POKEMON.includes(species.baseSpecies) && isLead)
+			) {
 				pokemon.push(set);
 			} else {
 				pokemon.unshift(set);

--- a/data/random-battles/champions/teams.ts
+++ b/data/random-battles/champions/teams.ts
@@ -61,7 +61,7 @@ const PRIORITY_POKEMON = [
 
 /** Pokemon who should never be in the lead slot. Currently just Kingambit, but more may be added in the future */
 const NO_LEAD_POKEMON = [
-	'Kingambit',
+	'kingambit',
 ];
 
 const DOUBLES_NO_LEAD_POKEMON = [
@@ -354,7 +354,7 @@ export class RandomChampionsTeams extends RandomTeams {
 
 		// Enforce Stealth Rock on sets with phazing moves
 		if (['dragontail', 'roar', 'whirlwind'].some(m => movePool.includes(m))) {
-			if (movePool.includes('stealthrock')) {
+			if (movePool.includes('stealthrock') && !teamDetails.stealthRock) {
 				counter = this.addMove('stealthrock', moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role, isDoubles);
 			}
@@ -1119,8 +1119,8 @@ export class RandomChampionsTeams extends RandomTeams {
 			const set = this.randomSet(species, teamDetails, isLead, isDoubles);
 			// Some Pokemon should not be in the lead slot
 			if (
-				(isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.baseSpecies) && isLead) ||
-				(!isDoubles && NO_LEAD_POKEMON.includes(species.baseSpecies) && isLead)
+				(isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.id) && isLead) ||
+				(!isDoubles && NO_LEAD_POKEMON.includes(species.id) && isLead)
 			) {
 				pokemon.push(set);
 			} else {

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -401,7 +401,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "encore", "firepunch", "hiddenpowerdark", "psychic", "recover", "substitute", "thunderpunch"],
+                "movepool": ["calmmind", "encore", "firepunch", "hiddenpowerdark", "psychic", "recover", "substitute"],
                 "abilities": ["Synchronize"],
                 "preferredTypes": ["Fire"]
             }
@@ -773,7 +773,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "rest", "return", "shadowball", "toxic"],
+                "movepool": ["earthquake", "rest", "return", "toxic"],
                 "abilities": ["Early Bird"],
                 "preferredTypes": ["Ground"]
             },
@@ -790,6 +790,11 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "megahorn", "raindance"],
+                "abilities": ["Swift Swim"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["megahorn", "protect", "surf", "toxic"],
                 "abilities": ["Swift Swim"]
             }
         ]
@@ -857,13 +862,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crosschop", "fireblast", "flamethrower", "focuspunch", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderpunch", "toxic"],
+                "movepool": ["crosschop", "fireblast", "flamethrower", "focuspunch", "hiddenpowergrass", "hiddenpowerice", "hiddenpowerwater", "substitute", "thunderpunch", "toxic"],
                 "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             },
             {
                 "role": "Berry Sweeper",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderpunch"],
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "hiddenpowerwater", "substitute", "thunderpunch"],
                 "abilities": ["Flame Body"],
                 "preferredTypes": ["Electric"]
             }
@@ -966,7 +971,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["flamethrower", "hiddenpowergrass", "protect", "toxic", "wish"],
+                "movepool": ["flamethrower", "protect", "toxic", "wish"],
                 "abilities": ["Flash Fire"]
             },
             {
@@ -1087,7 +1092,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["doubleedge", "dragondance", "earthquake", "healbell", "hiddenpowerflying", "substitute"],
+                "movepool": ["brickbreak", "dragondance", "earthquake", "healbell", "hiddenpowerflying"],
                 "abilities": ["Inner Focus"],
                 "preferredTypes": ["Ground"]
             },
@@ -1157,7 +1162,7 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderpunch"],
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "hiddenpowerwater", "substitute", "thunderpunch"],
                 "abilities": ["Blaze"]
             },
             {
@@ -2394,7 +2399,7 @@
             },
             {
                 "role": "Generalist",
-                "movepool": ["focuspunch", "irontail", "rockslide", "substitute"],
+                "movepool": ["focuspunch", "rockslide", "substitute", "thunderwave", "toxic"],
                 "abilities": ["Rock Head"]
             }
         ]
@@ -2642,12 +2647,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dragonclaw", "earthquake", "flamethrower", "haze", "healbell", "rest", "toxic"],
+                "movepool": ["dragonclaw", "earthquake", "flamethrower", "healbell", "rest", "toxic"],
                 "abilities": ["Natural Cure"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "fireblast", "healbell", "hiddenpowerflying", "rest"],
+                "movepool": ["dragondance", "earthquake", "healbell", "hiddenpowerflying", "rest"],
                 "abilities": ["Natural Cure"],
                 "preferredTypes": ["Ground"]
             }
@@ -2866,9 +2871,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["doubleedge", "hiddenpowerfighting", "quickattack", "shadowball", "swordsdance"],
-                "abilities": ["Pressure"],
-                "preferredTypes": ["Fighting", "Ghost"]
+                "movepool": ["doubleedge", "hiddenpowerfighting", "shadowball", "swordsdance"],
+                "abilities": ["Pressure"]
             },
             {
                 "role": "Wallbreaker",
@@ -2949,7 +2953,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "fireblast", "hiddenpowerflying", "rockslide"],
+                "movepool": ["brickbreak", "dragondance", "earthquake", "hiddenpowerflying", "rockslide"],
                 "abilities": ["Intimidate"],
                 "preferredTypes": ["Ground"]
             },

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -26,6 +26,11 @@ const MOVE_PAIRS = [
 	['batonpass', 'spiderweb'],
 ];
 
+/** Pokemon who should never be in the lead slot */
+const NO_LEAD_POKEMON = [
+	'dugtrio', 'wobbuffet',
+];
+
 export class RandomGen3Teams extends RandomGen4Teams {
 	battleHasDitto: boolean;
 	battleHasWobbuffet: boolean;
@@ -489,8 +494,6 @@ export class RandomGen3Teams extends RandomGen4Teams {
 
 		const salacReqs = species.baseStats.spe >= 60 && species.baseStats.spe <= 100 && !counter.get('priority');
 
-		if (moves.has('bulkup') && moves.has('substitute') && counter.get('Status') === 2 && salacReqs) return 'Salac Berry';
-
 		if (moves.has('swordsdance') && moves.has('substitute') && counter.get('Status') === 2) {
 			if (salacReqs) return 'Salac Berry';
 			if (species.baseStats.spe > 100 && counter.get('Physical') >= 2) return 'Liechi Berry';
@@ -676,6 +679,8 @@ export class RandomGen3Teams extends RandomGen4Teams {
 
 		const pokemonList = Object.keys(this.randomSets);
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+		let leadsRemaining = 1;
+		if (ruleTable.has('pickedteamsize') || ruleTable.has('teampreview')) leadsRemaining = 0;
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
@@ -734,9 +739,23 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				if (!this.getPokemonCompatibility(species, pokemon)) continue;
 			}
 
-			// Okay, the set passes, add it to our team
-			const set = this.randomSet(species, teamDetails);
-			pokemon.push(set);
+			let set: RandomTeamsTypes.RandomSet;
+
+			// Some Pokemon shouldn't be in the lead slot
+			if (leadsRemaining) {
+				if (NO_LEAD_POKEMON.includes(species.id)) {
+					if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
+					set = this.randomSet(species, teamDetails, false);
+					pokemon.push(set);
+				} else {
+					set = this.randomSet(species, teamDetails, true);
+					pokemon.unshift(set);
+					leadsRemaining--;
+				}
+			} else {
+				set = this.randomSet(species, teamDetails, false);
+				pokemon.push(set);
+			}
 
 			// Don't bother tracking details for the last Pokemon
 			if (pokemon.length === this.maxTeamSize) break;

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -273,10 +273,9 @@
         "level": 82,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["earthquake", "nightslash", "stoneedge", "suckerpunch"],
-                "abilities": ["Arena Trap"],
-                "preferredTypes": ["Rock"]
+                "abilities": ["Arena Trap"]
             }
         ]
     },

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -19,7 +19,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "dragonpulse", "fireblast", "hiddenpowergrass", "roost"],
+                "movepool": ["airslash", "fireblast", "focusblast", "hiddenpowergrass", "roost"],
+                "abilities": ["Blaze"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["airslash", "earthquake", "fireblast", "roost", "willowisp"],
                 "abilities": ["Blaze"]
             }
         ]
@@ -1455,11 +1460,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "iceshard", "rapidspin", "stoneedge", "toxic"],
                 "abilities": ["Sturdy"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["earthquake", "protect", "stoneedge", "toxic"],
-                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1616,7 +1616,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+                "movepool": ["bravebird", "earthquake", "recover", "sacredfire", "substitute", "toxic"],
                 "abilities": ["Pressure"]
             }
         ]
@@ -1692,7 +1692,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["crunch", "doubleedge", "firefang", "suckerpunch", "superfang", "taunt", "toxic"],
+                "movepool": ["crunch", "healbell", "suckerpunch", "superfang", "taunt", "toxic"],
                 "abilities": ["Intimidate"]
             }
         ]
@@ -2145,7 +2145,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "roost", "uturn"],
+                "movepool": ["dracometeor", "earthquake", "fireblast", "roost", "toxic", "uturn"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -2614,9 +2614,8 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfire", "psychic", "substitute", "thunderbolt", "wish"],
-                "abilities": ["Serene Grace"],
-                "preferredTypes": ["Electric"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "signalbeam", "thunderbolt"],
+                "abilities": ["Serene Grace"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -19,7 +19,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "dragonpulse", "fireblast", "focusblast", "hiddenpowergrass", "roost"],
+                "movepool": ["airslash", "fireblast", "focusblast", "hiddenpowergrass", "roost"],
                 "abilities": ["Blaze", "Solar Power"]
             },
             {
@@ -1554,11 +1554,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "iceshard", "rapidspin", "stoneedge", "toxic"],
                 "abilities": ["Sturdy"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["earthquake", "protect", "stoneedge", "toxic"],
-                "abilities": ["Sturdy"]
             }
         ]
     },
@@ -1675,7 +1670,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "icebeam", "rest", "scald", "substitute"],
+                "movepool": ["calmmind", "icebeam", "rest", "scald", "substitute"],
                 "abilities": ["Pressure"]
             },
             {
@@ -1715,7 +1710,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+                "movepool": ["bravebird", "earthquake", "recover", "sacredfire", "substitute", "toxic"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -1790,10 +1785,9 @@
         "level": 96,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["crunch", "doubleedge", "firefang", "suckerpunch", "taunt"],
-                "abilities": ["Intimidate"],
-                "preferredTypes": ["Fire"]
+                "role": "Bulky Support",
+                "movepool": ["crunch", "healbell", "suckerpunch", "superfang", "taunt", "toxic"],
+                "abilities": ["Intimidate"]
             }
         ]
     },
@@ -2235,7 +2229,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "roost", "uturn"],
+                "movepool": ["dracometeor", "earthquake", "fireblast", "roost", "toxic", "uturn"],
                 "abilities": ["Levitate"]
             }
         ]
@@ -3246,7 +3240,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["icebeam", "protect", "scald", "toxic", "uturn"],
+                "movepool": ["icebeam", "protect", "scald", "toxic"],
                 "abilities": ["Storm Drain"]
             },
             {

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -307,7 +307,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["earthquake", "honeclaws", "stoneedge", "suckerpunch"],
                 "abilities": ["Arena Trap"]
             },

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -50,6 +50,11 @@ const PRIORITY_POKEMON = [
 	'bisharp', 'breloom', 'cacturne', 'dusknoir', 'honchkrow', 'scizor', 'shedinja', 'shiftry',
 ];
 
+/** Pokemon who should never be in the lead slot */
+const NO_LEAD_POKEMON = [
+	'dugtrio', 'gothitelle', 'wobbuffet',
+];
+
 export class RandomGen5Teams extends RandomGen6Teams {
 	override randomSets: { [species: string]: RandomTeamsTypes.RandomSpeciesData } = require('./sets.json');
 
@@ -863,6 +868,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		const pokemonList = Object.keys(this.randomSets);
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+		let leadsRemaining = 1;
+		if (ruleTable.has('pickedteamsize') || ruleTable.has('teampreview')) leadsRemaining = 0;
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
@@ -926,12 +933,23 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				if (!this.getPokemonCompatibility(species, pokemon)) continue;
 			}
 
-			const set = this.randomSet(species, teamDetails,
-				pokemon.length === 0 && !ruleTable.has('pickedteamsize') && !ruleTable.has('teampreview')
-			);
+			let set: RandomTeamsTypes.RandomSet;
 
-			// Okay, the set passes, add it to our team
-			pokemon.push(set);
+			// Some Pokemon shouldn't be in the lead slot
+			if (leadsRemaining) {
+				if (NO_LEAD_POKEMON.includes(species.id)) {
+					if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
+					set = this.randomSet(species, teamDetails, false);
+					pokemon.push(set);
+				} else {
+					set = this.randomSet(species, teamDetails, true);
+					pokemon.unshift(set);
+					leadsRemaining--;
+				}
+			} else {
+				set = this.randomSet(species, teamDetails, false);
+				pokemon.push(set);
+			}
 
 			// Don't bother tracking details for the last Pokemon
 			if (pokemon.length === this.maxTeamSize) break;

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -310,7 +310,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["earthquake", "honeclaws", "stealthrock", "stoneedge", "suckerpunch"],
                 "abilities": ["Arena Trap"]
             },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1862,7 +1862,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+                "movepool": ["bravebird", "defog", "earthquake", "recover", "sacredfire", "substitute", "toxic"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -3634,7 +3634,7 @@
         "level": 100,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["knockoff", "powerwhip", "sleeppowder", "swordsdance", "synthesis", "toxic"],
                 "abilities": ["Levitate"]
             }
@@ -4014,12 +4014,6 @@
     "mesprit": {
         "level": 85,
         "sets": [
-            {
-                "role": "Fast Attacker",
-                "movepool": ["calmmind", "healingwish", "hiddenpowerfire", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"],
-                "abilities": ["Levitate"],
-                "preferredTypes": ["Bug"]
-            },
             {
                 "role": "Bulky Support",
                 "movepool": ["knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"],

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -342,10 +342,12 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			}
 		}
 
-		// Enforce Thunder Wave on Prankster users
-		if (movePool.includes('thunderwave') && abilities.includes('Prankster')) {
-			counter = this.addMove('thunderwave', moves, types, abilities, teamDetails, species, isLead,
-				movePool, preferredType, role);
+		// Enforce Thunder Wave and Encore on Prankster users
+		for (const moveid of ['encore', 'thunderwave']) {
+			if (movePool.includes(moveid) && abilities.includes('Prankster')) {
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
 		}
 
 		// Enforce Shadow Sneak on Kecleon

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -2084,7 +2084,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+                "movepool": ["bravebird", "defog", "earthquake", "recover", "sacredfire", "substitute", "toxic"],
                 "abilities": ["Regenerator"]
             }
         ]
@@ -4340,12 +4340,6 @@
     "mesprit": {
         "level": 86,
         "sets": [
-            {
-                "role": "Fast Attacker",
-                "movepool": ["calmmind", "healingwish", "hiddenpowerfire", "psychic", "psyshock", "signalbeam", "thunderbolt", "uturn"],
-                "abilities": ["Levitate"],
-                "preferredTypes": ["Bug"]
-            },
             {
                 "role": "Bulky Support",
                 "movepool": ["knockoff", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"],
@@ -7636,15 +7630,20 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["autotomize", "earthquake", "knockoff", "photongeyser", "sunsteelstrike", "swordsdance"],
+                "movepool": ["autotomize", "earthquake", "knockoff", "photongeyser", "sunsteelstrike"],
                 "abilities": ["Prism Armor"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["autotomize", "earthquake", "knockoff", "photongeyser", "sunsteelstrike", "swordsdance"],
+                "movepool": ["autotomize", "earthquake", "knockoff", "photongeyser", "sunsteelstrike"],
                 "abilities": ["Prism Armor"],
-                "preferredTypes": ["Psychic"]
+                "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["earthquake", "outrage", "photongeyser", "swordsdance"],
+                "abilities": ["Prism Armor"]
             }
         ]
     },
@@ -7653,12 +7652,17 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "signalbeam"],
+                "movepool": ["autotomize", "calmmind", "moongeistbeam", "photongeyser", "signalbeam"],
                 "abilities": ["Prism Armor"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "signalbeam"],
+                "movepool": ["autotomize", "calmmind", "moongeistbeam", "photongeyser", "signalbeam"],
+                "abilities": ["Prism Armor"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["earthquake", "outrage", "photongeyser", "swordsdance"],
                 "abilities": ["Prism Armor"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -397,7 +397,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["earthquake", "honeclaws", "stealthrock", "stoneedge", "suckerpunch"],
                 "abilities": ["Arena Trap"]
             },

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -87,9 +87,9 @@ const PRIORITY_POKEMON = [
 	'aegislash', 'banette', 'breloom', 'cacturne', 'doublade', 'dusknoir', 'golisopod', 'honchkrow', 'mimikyu', 'scizor', 'scizormega', 'shedinja',
 ];
 
-/** Pokemon who should not be in the lead slot for some reason or another */
+/** Pokemon who should never be in the lead slot */
 const NO_LEAD_POKEMON = [
-	'dugtrio', 'gothitelle',
+	'dugtrio', 'gothitelle', 'wobbuffet',
 ];
 
 export class RandomGen7Teams extends RandomGen8Teams {
@@ -376,10 +376,12 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			}
 		}
 
-		// Enforce Thunder Wave on Prankster users
-		if (movePool.includes('thunderwave') && abilities.includes('Prankster')) {
-			counter = this.addMove('thunderwave', moves, types, abilities, teamDetails, species, isLead,
-				movePool, preferredType, role);
+		// Enforce Thunder Wave and Encore on Prankster users
+		for (const moveid of ['encore', 'thunderwave']) {
+			if (movePool.includes(moveid) && abilities.includes('Prankster')) {
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
+					movePool, preferredType, role);
+			}
 		}
 
 		// Enforce Shadow Sneak on Kecleon
@@ -676,8 +678,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			if (species.name === 'Mew') return 'Mewnium Z';
 			if (species.name === 'Mimikyu') return 'Mimikium Z';
 			if (species.name === 'Necrozma-Dusk-Mane' || species.name === 'Necrozma-Dawn-Wings') {
-				if (moves.has('autotomize') && moves.has('sunsteelstrike')) return 'Solganium Z';
-				if (moves.has('autotomize') && moves.has('moongeistbeam')) return 'Lunalium Z';
+				if (!moves.has('outrage')) return (species.name === 'Necrozma-Dusk-Mane') ? 'Solganium Z' : 'Lunalium Z';
 				return 'Ultranecrozium Z';
 			}
 			// General Z-Crystals
@@ -1193,8 +1194,15 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				// Prevent Shedinja from generating for Chimera 1v1 (for Randomized Format Spotlight)
 				if (set.ability === 'Wonder Guard' && ruleTable.has('chimera1v1rule')) continue;
 
-				// Okay, the set passes, add it to our team
-				pokemon.unshift(set);
+				// Some Pokemon should not be in the lead slot; otherwise, the set passes, add it to the team.
+				if (
+					NO_LEAD_POKEMON.includes(species.id) &&
+					pokemon.length === this.maxTeamSize - 1 && !ruleTable.has('pickedteamsize') && !ruleTable.has('teampreview')
+				) {
+					pokemon.push(set);
+				} else {
+					pokemon.unshift(set);
+				}
 
 				// Don't bother tracking details for the last Pokemon
 				if (pokemon.length === this.maxTeamSize) break;

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -87,6 +87,11 @@ const PRIORITY_POKEMON = [
 	'aegislash', 'banette', 'breloom', 'cacturne', 'doublade', 'dusknoir', 'golisopod', 'honchkrow', 'mimikyu', 'scizor', 'scizormega', 'shedinja',
 ];
 
+/** Pokemon who should not be in the lead slot for some reason or another */
+const NO_LEAD_POKEMON = [
+	'dugtrio', 'gothitelle',
+];
+
 export class RandomGen7Teams extends RandomGen8Teams {
 	override randomSets: { [species: string]: RandomTeamsTypes.RandomSpeciesData } = require('./sets.json');
 

--- a/data/random-battles/gen8/sets.json
+++ b/data/random-battles/gen8/sets.json
@@ -888,7 +888,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
+                "movepool": ["Calm Mind", "Hurricane", "Psyshock", "Recover"],
                 "abilities": ["Competitive"]
             }
         ]
@@ -923,7 +923,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Brave Bird", "Defog", "Fire Blast", "Roost", "Scorching Sands", "Toxic", "U-turn", "Will-O-Wisp"],
+                "movepool": ["Brave Bird", "Defog", "Fire Blast", "Roost", "Toxic", "U-turn", "Will-O-Wisp"],
                 "abilities": ["Flame Body"]
             }
         ]
@@ -1478,7 +1478,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Brave Bird", "Defog", "Earthquake", "Roost", "Sacred Fire", "Toxic"],
+                "movepool": ["Brave Bird", "Defog", "Earthquake", "Recover", "Sacred Fire", "Toxic"],
                 "abilities": ["Regenerator"]
             }
         ]

--- a/data/random-battles/gen8/sets.json
+++ b/data/random-battles/gen8/sets.json
@@ -224,7 +224,7 @@
         "level": 81,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Hone Claws", "Stealth Rock", "Stone Edge", "Sucker Punch"],
                 "abilities": ["Arena Trap"]
             },

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -71,6 +71,11 @@ const PRIORITY_POKEMON = [
 	'aegislash', 'doublade', 'golisopod', 'mimikyu', 'scizor',
 ];
 
+/** Pokemon who should never be in the lead slot */
+const NO_LEAD_POKEMON = [
+	'dugtrio', 'gothitelle', 'wobbuffet',
+];
+
 export class RandomGen8Teams extends RandomTeams {
 	override randomSets: { [species: string]: RandomTeamsTypes.RandomSpeciesData } = require('./sets.json');
 
@@ -996,6 +1001,8 @@ export class RandomGen8Teams extends RandomTeams {
 
 		const pokemonList = Object.keys(this.randomSets);
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+		let leadsRemaining = this.format.gameType === 'doubles' ? 2 : 1;
+		if (ruleTable.has('pickedteamsize') || ruleTable.has('teampreview')) leadsRemaining = 0;
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
@@ -1081,10 +1088,21 @@ export class RandomGen8Teams extends RandomTeams {
 			// Limit three of any type combination in Monotype
 			if (!this.forceMonotype && isMonotype && (typeComboCount[typeCombo] >= 3 * limitFactor)) continue;
 
-			const set = this.randomSet(species, teamDetails,
-				pokemon.length === 0 && !ruleTable.has('pickedteamsize') && !ruleTable.has('teampreview')
-			);
-			pokemon.push(set);
+			let set: RandomTeamsTypes.RandomSet;
+			if (leadsRemaining) {
+				if (NO_LEAD_POKEMON.includes(species.id)) {
+					if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
+					set = this.randomSet(species, teamDetails, false);
+					pokemon.push(set);
+				} else {
+					set = this.randomSet(species, teamDetails, true);
+					pokemon.unshift(set);
+					leadsRemaining--;
+				}
+			} else {
+				set = this.randomSet(species, teamDetails, false);
+				pokemon.push(set);
+			}
 
 			// Don't bother tracking details for the last Pokemon
 			if (pokemon.length === this.maxTeamSize) break;

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -991,13 +991,13 @@
             },
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": [ "Fire Blast", "Nasty Plot", "Pollen Puff", "Protect", "Psychic"],
+                "movepool": ["Fire Blast", "Nasty Plot", "Pollen Puff", "Protect", "Psychic"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Imprison", "Pollen Puff", "Psychic", "Transform"],
+                "movepool": ["Coaching", "Imprison", "Pollen Puff", "Psychic", "Transform"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -3599,7 +3599,7 @@
         "level": 81,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
+                "role": "Doubles Support",
                 "movepool": ["Encore", "Moonblast", "Tailwind", "Taunt"],
                 "abilities": ["Prankster"],
                 "teraTypes": ["Fire", "Ghost", "Steel"]

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -585,10 +585,16 @@
         "level": 86,
         "sets": [
             {
-                "role": "Offensive Protect",
-                "movepool": ["Close Combat", "Fake Out", "Knock Off", "Poison Jab", "Protect"],
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Close Combat", "Fake Out", "Knock Off", "Poison Jab"],
                 "abilities": ["Unburden"],
                 "teraTypes": ["Dark", "Poison"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Close Combat", "Fake Out", "Knock Off", "Protect"],
+                "abilities": ["Unburden"],
+                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -597,7 +603,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Close Combat", "Coaching", "Fake Out", "Knock Off", "Poison Jab"],
+                "movepool": ["Close Combat",  "Fake Out", "Knock Off", "Poison Jab"],
                 "abilities": ["Inner Focus"],
                 "teraTypes": ["Dark", "Poison"]
             }
@@ -742,7 +748,7 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Dragon Dance", "Earthquake", "Protect", "Temper Flare", "Waterfall"],
+                "movepool": ["Dragon Dance", "Earthquake", "Protect", "Waterfall"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Ground"]
             },
@@ -778,7 +784,7 @@
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Transform"],
                 "abilities": ["Imposter"],
-                "teraTypes": ["Bug", "Dark", "Dragon", "Electric", "Fairy", "Fighting", "Fire", "Flying", "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic", "Rock", "Steel", "Water"]
+                "teraTypes": ["Ghost", "Steel"]
             }
         ]
     },
@@ -787,13 +793,19 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Helping Hand", "Icy Wind", "Muddy Water", "Protect", "Scald", "Yawn"],
+                "movepool": ["Icy Wind", "Muddy Water", "Protect", "Scald", "Yawn"],
                 "abilities": ["Water Absorb"],
                 "teraTypes": ["Dragon", "Fire", "Ground"]
             },
             {
                 "role": "Bulky Protect",
-                "movepool": ["Icy Wind", "Muddy Water", "Protect", "Scald", "Wish", "Yawn"],
+                "movepool": ["Icy Wind", "Muddy Water", "Protect", "Scald", "Wish"],
+                "abilities": ["Water Absorb"],
+                "teraTypes": ["Dragon", "Fire", "Ground"]
+            },
+            {
+                "role": "Doubles Support",
+                "movepool": ["Helping Hand", "Icy Wind", "Muddy Water", "Protect", "Scald"],
                 "abilities": ["Water Absorb"],
                 "teraTypes": ["Dragon", "Fire", "Ground"]
             }
@@ -973,19 +985,19 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Coaching", "Encore", "Pollen Puff", "Tailwind", "Thunder Wave", "Will-O-Wisp"],
+                "movepool": ["Encore", "Pollen Puff", "Psychic", "Tailwind", "Thunder Wave", "Will-O-Wisp"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Baton Pass", "Fire Blast", "Nasty Plot", "Pollen Puff", "Psychic"],
+                "movepool": [ "Fire Blast", "Nasty Plot", "Pollen Puff", "Protect", "Psychic"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Coaching", "Imprison", "Pollen Puff", "Transform"],
+                "movepool": ["Imprison", "Pollen Puff", "Psychic", "Transform"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]
             }
@@ -1494,13 +1506,7 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Baton Pass", "No Retreat", "Population Bomb", "Spiky Shield"],
-                "abilities": ["Technician"],
-                "teraTypes": ["Ghost"]
-            },
-            {
-                "role": "Doubles Support",
-                "movepool": ["Decorate", "Fake Out", "Follow Me", "Tailwind"],
+                "movepool": ["Baneful Bunker", "Baton Pass", "No Retreat", "Population Bomb", "Spiky Shield"],
                 "abilities": ["Technician"],
                 "teraTypes": ["Ghost"]
             }
@@ -1975,8 +1981,8 @@
         "level": 90,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Brave Bird", "Draco Meteor", "Fire Blast", "Helping Hand", "Roost", "Tailwind", "Will-O-Wisp"],
+                "role": "Doubles Support",
+                "movepool": ["Brave Bird", "Draco Meteor", "Fire Blast", "Helping Hand", "Tailwind", "Will-O-Wisp"],
                 "abilities": ["Natural Cure"],
                 "teraTypes": ["Steel"]
             },
@@ -3701,7 +3707,13 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Close Combat", "Coaching", "Fake Out", "Knock Off", "Poison Jab", "Snarl"],
+                "movepool": ["Close Combat", "Fake Out", "Knock Off", "Poison Jab", "Snarl"],
+                "abilities": ["Intimidate"],
+                "teraTypes": ["Poison"]
+            },
+            {
+                "role": "Bulky Protect",
+                "movepool": ["Bulk Up", "Drain Punch", "Knock Off", "Protect"],
                 "abilities": ["Intimidate"],
                 "teraTypes": ["Poison"]
             }
@@ -3712,13 +3724,13 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Protect", "Sludge Bomb"],
+                "movepool": ["Dark Pulse", "Focus Blast", "Protect", "Sludge Bomb", "Snarl"],
                 "abilities": ["Illusion"],
                 "teraTypes": ["Poison"]
             },
             {
                 "role": "Offensive Protect",
-                "movepool": ["Flamethrower", "Focus Blast", "Knock Off", "Protect", "Sludge Bomb"],
+                "movepool": ["Dark Pulse", "Nasty Plot", "Protect", "Sludge Bomb"],
                 "abilities": ["Illusion"],
                 "teraTypes": ["Poison"]
             }
@@ -6439,6 +6451,12 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Body Press", "Last Respects", "Shadow Sneak", "Trick"],
+                "abilities": ["Fluffy"],
+                "teraTypes": ["Ghost"]
+            },
+            {
+                "role": "Choice Item user",
+                "movepool": ["Body Press", "Last Respects", "Trick", "Will-O-Wisp"],
                 "abilities": ["Fluffy"],
                 "teraTypes": ["Ghost"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -996,7 +996,7 @@
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
-                "role": "Doubles Bulky Attacker",
+                "role": "Doubles Support",
                 "movepool": ["Coaching", "Imprison", "Pollen Puff", "Psychic", "Transform"],
                 "abilities": ["Synchronize"],
                 "teraTypes": ["Fairy", "Steel"]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -228,7 +228,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Stone Edge", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Arena Trap"],
                 "teraTypes": ["Dark", "Fairy", "Flying", "Ghost", "Ground"]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -3397,6 +3397,12 @@
                 "movepool": ["Encore", "Knock Off", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
                 "abilities": ["Levitate"],
                 "teraTypes": ["Dark", "Electric", "Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Draining Kiss", "Nasty Plot"],
+                "abilities": ["Levitate"],
+                "teraTypes": ["Dark", "Electric", "Steel"]
             }
         ]
     },
@@ -7347,12 +7353,6 @@
         "level": 83,
         "sets": [
             {
-                "role": "Fast Support",
-                "movepool": ["Earthquake", "Ice Punch", "Spikes", "Stealth Rock", "Stone Edge", "Volt Switch", "Wild Charge"],
-                "abilities": ["Quark Drive"],
-                "teraTypes": ["Flying", "Grass", "Water"]
-            },
-            {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Stone Edge", "Wild Charge"],
                 "abilities": ["Quark Drive"],
@@ -7591,7 +7591,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Fake Out", "Psychic Noise", "Sludge Wave", "U-turn"],
+                "movepool": ["Fake Out", "Focus Blast", "Psychic Noise", "Sludge Wave", "U-turn"],
                 "abilities": ["Toxic Chain"],
                 "teraTypes": ["Dark"]
             }

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -971,7 +971,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
+                "movepool": ["Calm Mind", "Hurricane", "Psyshock", "Recover"],
                 "abilities": ["Competitive"],
                 "teraTypes": ["Steel"]
             }
@@ -2719,7 +2719,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roar", "Roost", "Stealth Rock", "Surf", "Yawn"],
+                "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roost", "Stealth Rock", "Surf", "Yawn"],
                 "abilities": ["Competitive"],
                 "teraTypes": ["Flying", "Grass"]
             }
@@ -3079,7 +3079,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Acrobatics", "Close Combat", "Dire Claw", "Gunk Shot", "Swords Dance"],
+                "movepool": ["Acrobatics", "Close Combat", "Dire Claw", "Swords Dance"],
                 "abilities": ["Unburden"],
                 "teraTypes": ["Flying"]
             }
@@ -3400,9 +3400,9 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Draining Kiss", "Nasty Plot"],
+                "movepool": ["Draining Kiss", "Encore", "Nasty Plot", "Psychic Noise", "Psyshock", "Substitute"],
                 "abilities": ["Levitate"],
-                "teraTypes": ["Dark", "Electric", "Steel"]
+                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -3830,7 +3830,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Ice Beam", "Judgment", "Recover"],
                 "abilities": ["Multitype"],
-                "teraTypes": ["Dragon", "Ground"]
+                "teraTypes": ["Dragon", "Fire", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
@@ -4723,9 +4723,9 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Draco Meteor", "Earth Power", "Freeze-Dry", "Fusion Flare"],
+                "movepool": ["Draco Meteor", "Earth Power", "Freeze-Dry", "Ice Beam"],
                 "abilities": ["Turboblaze"],
-                "teraTypes": ["Dragon", "Fire"]
+                "teraTypes": ["Dragon", "Ice"]
             },
             {
                 "role": "Bulky Attacker",
@@ -6196,7 +6196,7 @@
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Crunch", "Iron Defense", "Iron Head", "Rest", "Stone Edge", "Substitute"],
                 "abilities": ["Dauntless Shield"],
-                "teraTypes": ["Fighting", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -7141,7 +7141,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Swords Dance"],
                 "abilities": ["Supreme Overlord"],
-                "teraTypes": ["Dark", "Flying"]
+                "teraTypes": ["Dark", "Flying", "Ghost"]
             }
         ]
     },
@@ -7260,7 +7260,7 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Knock Off", "Outrage", "Roost"],
                 "abilities": ["Protosynthesis"],
-                "teraTypes": ["Dark", "Dragon", "Ground", "Poison", "Steel"]
+                "teraTypes": ["Dark", "Dragon", "Fairy", "Ground", "Poison", "Steel"]
             },
             {
                 "role": "Fast Bulky Setup",

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -141,7 +141,7 @@ const NO_LEAD_POKEMON = [
 	'dugtrio', 'gothitelle', 'ironthorns', 'kingambit', 'zacian', 'zamazenta',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
-	'basculegion', 'basculegionf', 'houndstone', 'ironbundle', 'roaringmoon', 'zacian', 'zamazenta',
+	'basculegion', 'basculegionf', 'dugtrio', 'gothitelle', 'houndstone', 'ironbundle', 'roaringmoon', 'zacian', 'zamazenta',
 ];
 
 const DEFENSIVE_TERA_BLAST_USERS = [

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -555,7 +555,7 @@ export class RandomTeams {
 				['energyball', 'leafstorm'],
 				['earthpower', 'sandsearstorm'],
 				[PROTECT_MOVES, PROTECT_MOVES],
-				['coaching', ['helpinghand', 'howl']],
+				['coaching', ['helpinghand', 'howl', 'pollenpuff']],
 			];
 
 			for (const pair of doublesIncompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -138,10 +138,10 @@ const PRIORITY_POKEMON = [
 
 /** Pokemon who should never be in the lead slot */
 const NO_LEAD_POKEMON = [
-	'dugtrio', 'gothitelle', 'ironthorns', 'kingambit', 'zacian', 'zamazenta',
+	'dugtrio', 'gothitelle', 'ironthorns', 'kingambit', 'zacian', 'zaciancrowned', 'zamazenta', 'zamazentacrowned',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
-	'basculegion', 'basculegionf', 'dugtrio', 'gothitelle', 'houndstone', 'ironbundle', 'roaringmoon', 'zacian', 'zamazenta',
+	'basculegion', 'basculegionf', 'dugtrio', 'gothitelle', 'houndstone', 'ironbundle', 'roaringmoon', 'zacian', 'zaciancrowned', 'zamazenta', 'zamazentacrowned',
 ];
 
 const DEFENSIVE_TERA_BLAST_USERS = [

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -138,7 +138,7 @@ const PRIORITY_POKEMON = [
 
 /** Pokemon who should never be in the lead slot */
 const NO_LEAD_POKEMON = [
-	'Zacian', 'Zamazenta',
+	'Dugtrio', 'Gothitelle', 'Iron Thorns', 'Kingambit', 'Zacian', 'Zamazenta',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Iron Bundle', 'Roaring Moon', 'Zacian', 'Zamazenta',
@@ -1459,6 +1459,9 @@ export class RandomTeams {
 		}
 		if (species.baseSpecies === 'Basculin') return 'Basculin' + this.sample(['', '-Blue-Striped']);
 		if (species.baseSpecies === 'Magearna') return 'Magearna' + this.sample(['', '-Original']);
+		if (species.baseSpecies === 'Squawkabilly' && this.format.mod.startsWith('champions')) {
+			return 'Squawkabilly' + this.sample(['', '-Blue', '-White', '-Yellow']);
+		}
 		if (species.baseSpecies === 'Keldeo' && this.gen <= 7) return 'Keldeo' + this.sample(['', '-Resolute']);
 		if (species.baseSpecies === 'Pikachu' && this.gen >= 8 && !this.format.mod.startsWith('champions')) {
 			return 'Pikachu' + this.sample(

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -138,10 +138,10 @@ const PRIORITY_POKEMON = [
 
 /** Pokemon who should never be in the lead slot */
 const NO_LEAD_POKEMON = [
-	'Dugtrio', 'Gothitelle', 'Iron Thorns', 'Kingambit', 'Zacian', 'Zamazenta',
+	'dugtrio', 'gothitelle', 'ironthorns', 'kingambit', 'zacian', 'zamazenta',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
-	'Basculegion', 'Houndstone', 'Iron Bundle', 'Roaring Moon', 'Zacian', 'Zamazenta',
+	'basculegion', 'basculegionf', 'houndstone', 'ironbundle', 'roaringmoon', 'zacian', 'zamazenta',
 ];
 
 const DEFENSIVE_TERA_BLAST_USERS = [
@@ -554,6 +554,7 @@ export class RandomTeams {
 				['freezedry', 'icebeam'],
 				['energyball', 'leafstorm'],
 				['earthpower', 'sandsearstorm'],
+				[PROTECT_MOVES, PROTECT_MOVES],
 				['coaching', ['helpinghand', 'howl']],
 			];
 
@@ -636,8 +637,6 @@ export class RandomTeams {
 		if (species.id === 'quagsire') this.incompatibleMoves(moves, movePool, 'spikes', 'icebeam');
 		// Taunt/Knock should be Cyclizar's flex moveslot
 		if (species.id === 'cyclizar') this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
-		// To force Stealth Rock on Camerupt
-		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
 		// nothing else rolls these lol
 		if (species.id === 'coalossal') this.incompatibleMoves(moves, movePool, 'flamethrower', 'overheat');
 	}
@@ -792,6 +791,14 @@ export class RandomTeams {
 			}
 			if (movePool.includes('defog')) {
 				counter = this.addMove('defog', moves, types, abilities, teamDetails, species, isLead,
+					movePool, teraType, role, isDoubles);
+			}
+		}
+
+		// Enforce Stealth Rock on sets with phazing moves and low Speed
+		if (['dragontail', 'roar', 'whirlwind'].some(m => movePool.includes(m)) && species.baseStats.spe <= 60) {
+			if (movePool.includes('stealthrock') && !teamDetails.stealthRock) {
+				counter = this.addMove('stealthrock', moves, types, abilities, teamDetails, species, isLead,
 					movePool, teraType, role, isDoubles);
 			}
 		}
@@ -1284,7 +1291,7 @@ export class RandomTeams {
 			(!types.has('Flying') || this.dex.getEffectiveness('Rock', species) >= 2)
 		) return 'Heavy-Duty Boots';
 		if (
-			role === 'Doubles Support' && ability === 'Prankster' && moves.has('tailwind') && this.randomChance(3, 4)
+			role === 'Doubles Support' && ability === 'Prankster' && moves.has('tailwind') && this.randomChance(1, 4)
 		) return 'Covert Cloak';
 		if (
 			(role === 'Bulky Protect' && counter.get('setup')) ||
@@ -1845,8 +1852,8 @@ export class RandomTeams {
 
 			if (leadsRemaining) {
 				if (
-					isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.baseSpecies) ||
-					!isDoubles && NO_LEAD_POKEMON.includes(species.baseSpecies)
+					isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.id) ||
+					!isDoubles && NO_LEAD_POKEMON.includes(species.id)
 				) {
 					if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
 					set = this.randomSet(species, teamDetails, false, isDoubles);


### PR DESCRIPTION
This code has been practically tested on a locally hosted server.

**Champions Random Battle**:
-added new sets for all Pokemon additions from Regulation M-C
-Stealth Rock is now enforced on any Pokemon that could potentially roll a phazing move, even if they do not end up rolling said phazing move. Think Hippowdon and the like.
-Rocky Helmet now exists in mostly the same conditions as in Gen 9; it now sometimes generates on Skeledirge, Hippowdon, Hydrapple, Garchomp, Slowbro, Slowbro-Galar, Musharna, Chesnaught, Skarmory, Toxapex, Corviknight, Avalugg, Avalugg-Hisui, Garganacl, and Audino.
-Kingambit is now prevented from being in the lead slot, per council decision.
-Mega Glalie is now Body Slam / EQ / Explosion / any of [Ice Shard / Spikes / Freeze-Dry]
-Swords Dance Mega Lopunny now always gets Close Combat.
-Qwilfish is now water move / gunk shot / spikes / [tspikes or thunder wave]
-Bastiodon now runs Sturdy instead of Soundproof.
-Mega Raichu X: -Fake Out
-Slurpuff: +Play Rough; rolls with DGleam
-Setup Mega Beedrill: +Fell Stinger; rolls with Swords Dance
-non-Scarf Manectric/Mega Manectric sets: -Flamethrower

-The following levels were adjusted manually based on winrate data:
-3 levels: Staraptor-Mega
-2 levels: Victreebel-Mega, Rotom-Fan, Raichu-Mega-Y, Toucannon, Eelektross-Mega, Meganium-Mega
-1 level: Qwilfish, Beedrill-Mega, Garchomp, Emboar, Pinsir-Mega, Tsareena, Forretress, Golurk, Blastoise, Farigiraf, Skarmory-Mega, Orthworm, Pyroar-Mega, Sneasler, Emolga, Rotom-Mow, Dragapult, Glimmora, Slurpuff, Floette-Mega, Metagross-Mega, Camerupt, Pangoro, Ariados, Pelipper, Rotom-Frost

+1 level: Drampa-Mega, Audino, Raichu-Alola, Altaria-Mega, Barbaracle, Bastiodon, Alakazam-Mega, Meowstic-M-Mega, Castform, Blaziken, Scizor-Mega, Falinks, Absol, Steelix-Mega, Starmie, Quaquaval, Lopunny, Ceruledge, Absol-Mega, Hawlucha, Tauros-Paldea-Combat, Meowscarada, Drampa, Reuniclus, Slowbro-Galar, Clefable, Chesnaught-Mega, Machamp, Froslass, Alakazam
+2 levels: Raichu-Mega-X, Garganacl, Glalie-Mega, Scrafty, Palafin, Watchog, Sableye-Mega
+3 levels: Gengar-Mega

**Gen 9 Random Battle**:
-Kingambit, Dugtrio, Gothitelle, and Iron Thorns are now prevented from being in the lead slot, per council decision.
-Pokemon of 60 base Speed or below now always get Stealth Rock if the set they have rolled could possibly contain a phazing move, even if they don't end up rolling that phazing move. This applies to support Hippowdon, the first set of Ting-Lu, Swampert, Piloswine, and Mudsdale. AV Swampert now only generates when the team already has a Stealth Rock user.
-Iron Thorns no longer has its Fast Support set and is now always Dragon Dance Booster Energy. (This is why it can't lead now)
-Uxie now has a second set of Nasty Plot, Draining Kiss, Psyshock/Psynoise, and Sub/Encore with Tera Fairy.
-Kyurem-White's sets have been adjusted so it always has Ice Beam and just rolls between Fusion Flare and Earth Power.
-AV Munkidori: +Focus Blast (rolled with Fake Out)
-Galarian Articuno: -Freezing Glare, +Psyshock
-Swords Dance Sneasler: -Gunk Shot
-Empoleon: -Roar (So it doesn't get caught up in the enforcement)
-Kingambit: +Tera Ghost
-Roaring Moon set 1: +Tera Fairy (as if it didn't have enough teras)
-CM Arceus-Ground: -Tera Ground, +Tera Fire, +Tera Steel
-Iron Defense Zamazenta: -Tera Fighting

**Gen 9 Random Doubles**:
-Decorate Smeargle no longer exists. Its No Retreat set now rolls Baneful Bunker with Spiky Shield.
-Dugtrio and Gothitelle are now prevented from being in the lead slots, per doubles council annex decision.
-Covert Cloak now only generates on Prankster Tailwind users 1/4 of the time instead of 3/4.
-Vaporeon is now Scald/Muddy Water, Icy Wind, Protect, and Helping Hand/Yawn/Wish.
-Scrafty now has a set of Bulk Up, Drain Punch, Knock Off, and Protect with Leftovers. Its preexisting set no longer runs Coaching.
-Zoroark set 1: -Flamethrower, +Snarl
-Zoroark set 2: changed to Dark Pulse, Nasty Plot, Sludge Bomb, and Protect.
-Houndstone: now rolls Will-O-Wisp with Shadow Sneak
-Gyarados: -Temper Flare
-Hitmonchan is now a fixed set with Fake Out, Drain Punch, Knock Off, and Poison Jab with an Assault Vest.
-Hitmonlee now always gets Fake Out and Knock Off and rolls between Poison Jab and Protect.
-Altaria set 1: renamed to Doubles Support to force Tailwind, and Roost removed (still exists on set 2)
-Nasty Plot Mew: -Baton Pass, +Protect
-Other Mew sets: -Coaching, +Psychic
-Ditto: now only Tera Steel and Ghost.

**Old Gens**:
-In Gens 3-8, Wobbuffet, Dugtrio, and Gothitelle (when applicable) are now prevented from being in the lead slot, per council decision.
-In Gens 4-8, Ho-Oh now runs Recover instead of Roost.
-In Gen 8, Galarian Articuno now runs Psyshock instead of Freezing Glare.
-In Gen 8, Moltres no longer runs Scorching Sands.
-In Gens 6-7, offensive Mesprit no longer exists.
-In Gens 6-7, Prankster users that can get Encore will always get Encore. This applies to Liepard and Whimsicott.
-In Gen 7, Necrozma-Ultra now has the same physical set of Photon + Outrage + SD + EQ, no matter which forme it originates from.
-In Gen 7, Necrozma-DW no longer runs Heat Wave.
-In Gen 7, Necrozma-DM no longer runs Swords Dance when it isn't Ultra Necrozma.
-In Gen 6, Carnivine now always gets Knock Off.
-In Gens 4-5, Staller Donphan no longer exists.
-In Gens 4-5, Mightyena now runs Crunch and any of Heal Bell, Sucker Punch, Super Fang, Taunt, or Toxic.
-In Gens 4-5, Charizard no longer runs Dragon Pulse. In Gen 4, it now runs Focus Blast and has a second set with Earthquake and Will-O-Wisp.
-In Gens 4-5, Bulky Attacker Flygon now runs Toxic sometimes.
-In Gen 5, Staller Lumineon no longer runs U-turn
-In Gen 5, Suicune now always gets Scald and never gets Hydro Pump.
-In Gen 4, Calm Mind Jirachi now runs CM + Psychic with any 2 of Thunderbolt, HP Fighting, and Signal Beam.
-In Gen 3, Magmar and Petaya Typhlosion can now occasionally run HP Water.
-In Gen 3, Alakazam no longer runs Thunderpunch.
-In Gen 3, Pokemon with Substitute and Bulk Up will always get Leftovers instead of Salac Berry (unless they are a Berry Sweeper specifically)
-In Gen 3, Dragon Dance Salamence now runs Brick Break instead of Fire Blast.
-In Gen 3, Dragon Dance Dragonite now runs Brick Break instead of Double-Edge or Substitute.
-In Gen 3, Dragon Dance Altaria no longer runs Fire Blast and non-Dragon Dance Altaria no longer runs Haze.
-In  Gen 3, SubPunch Aggron no longer runs Iron Tail and instead rolls between Toxic and Thunder Wave.
-In Gen 3, WishTect Flareon no longer runs HP Grass.
-In Gen 3, Fast Attacker Kangaskhan no longer runs Shadow Ball or Double-Edge
-In Gen 3, Swords Dance Absol no longer runs Quick Attack.
-In Gen 3, Seaking now has a Staller set with Surf, Toxic, Protect, and Megahorn.
